### PR TITLE
Fixes #24: Clean up repetitive onboarding form code and remove Vercel config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,5 @@ Ports: client on 3000, middleware on 3001
 
 ## Deployment
 
-- **Client:** Vercel (SPA with rewrite rules in `vercel.json`)
 - **Containers:** Docker Compose for local multi-service; Dockerfiles use multi-stage builds with distroless base
 - **Environment:** Middleware uses `.env` (local) / `.env.production` with `DATABASE_URL` as the key variable

--- a/packages/client/src/routes/onboard.tsx
+++ b/packages/client/src/routes/onboard.tsx
@@ -24,7 +24,7 @@ const FIELD_INDICES = Array.from(
 );
 
 const fieldSchema = (label: string, max: number) =>
-  z.string().min(0, `${label} is required`).max(max, `${label} must be at most ${max} characters.`);
+  z.string().max(max, `${label} must be at most ${max} characters.`);
 
 const formSchema = z.object({
   name: fieldSchema("Name", 32),
@@ -45,15 +45,13 @@ function NextButton({
   onClick: () => void;
 }) {
   return (
-    <div>
-      <Button
-        className="inline-flex grow-0"
-        onClick={onClick}
-      >
-        Next
-        <ArrowRight />
-      </Button>
-    </div>
+    <Button
+      className="inline-flex grow-0"
+      onClick={onClick}
+    >
+      Next
+      <ArrowRight />
+    </Button>
   );
 }
 

--- a/packages/client/vercel.json
+++ b/packages/client/vercel.json
@@ -1,6 +1,0 @@
-{
-  "rewrites": [{
-    "source": "/(.*)",
-    "destination": "/index.html"
-  }]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "rewrites": [{
-    "source": "/(.*)",
-    "destination": "/index.html"
-  }]
-}


### PR DESCRIPTION
## ELI5
The onboarding form had a lot of copy-pasted code that made it harder to maintain and had a bug where error messages showed wrong character limits. This PR consolidates the duplicated code, fixes the bug, removes dead code that could never run, and removes the Vercel deployment configuration since we no longer use it.

## Summary
- Consolidate three identical Zod schemas into a `fieldSchema` factory, fixing a bug where course field error messages said "32 characters" but enforced 200
- Extract repeated Next button markup into a `NextButton` component and remove dead code (unreachable `!isStep3Revealed` block inside `isStep3Revealed`-guarded section)
- Remove Vercel deployment config (`vercel.json` files and CLAUDE.md reference)

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [ ] Navigate to /onboard, verify 3-step flow works (name → topics → courses → submit)
- [ ] Verify validation error messages show correct character limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)