### PR TITLE
Migrate Fastify validation from JSON Schema to Zod

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -12,12 +12,14 @@
     "dotenv-cli": "^11.0.0",
     "drizzle-orm": "^0.44.7",
     "fastify": "^5.6.2",
+    "fastify-type-provider-zod": "^6.1.0",
     "pg": "^8.16.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@emstack/types": "workspace:*",
-    "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
+    "openapi-types": "^12.1.3",
     "@types/node": "^24.10.1",
     "@types/pg": "^8.15.6",
     "drizzle-kit": "^0.31.7",

--- a/packages/middleware/src/app.ts
+++ b/packages/middleware/src/app.ts
@@ -2,7 +2,11 @@ import fastifyCors from "@fastify/cors";
 import fastifyEnv from "@fastify/env";
 import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  ZodTypeProvider,
+} from "fastify-type-provider-zod";
 import Fastify from "fastify";
 
 import routes from "./routes/routes";
@@ -25,7 +29,10 @@ declare module "fastify" {
 
 const fastify = Fastify({
   logger: false,
-}).withTypeProvider<JsonSchemaToTsProvider>();
+}).withTypeProvider<ZodTypeProvider>();
+
+fastify.setValidatorCompiler(validatorCompiler);
+fastify.setSerializerCompiler(serializerCompiler);
 
 await fastify.register(fastifyCors, {
   methods: ["GET", "HEAD", "DELETE", "POST"],

--- a/packages/middleware/src/routes/api/clearData.ts
+++ b/packages/middleware/src/routes/api/clearData.ts
@@ -1,9 +1,9 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { clearData } from "@/db/clearData";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/clearData",

--- a/packages/middleware/src/routes/api/courses/deleteCourse.ts
+++ b/packages/middleware/src/routes/api/courses/deleteCourse.ts
@@ -1,30 +1,25 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { courses, topicsToCourses } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 
-const testSchema = {
+const deleteCourseSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.delete(
     "/:id",
-    testSchema,
+    deleteCourseSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/courses/getCourse.ts
+++ b/packages/middleware/src/routes/api/courses/getCourse.ts
@@ -1,31 +1,26 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { processCost } from "@/utils/processCost";
 import { processTopics } from "@/utils/processTopics";
 import type { Course, CourseFromServer } from "@emstack/types/src";
+import { z } from "zod";
 
-const testSchema = {
+const getCourseSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/:id",
-    testSchema,
+    getCourseSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/courses/root.ts
+++ b/packages/middleware/src/routes/api/courses/root.ts
@@ -1,4 +1,4 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { processCost } from "@/utils/processCost";
@@ -6,7 +6,7 @@ import { processTopics } from "@/utils/processTopics";
 import type { Course, CourseFromServer } from "@emstack/types/src";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/",

--- a/packages/middleware/src/routes/api/dbTest.ts
+++ b/packages/middleware/src/routes/api/dbTest.ts
@@ -1,10 +1,10 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { usersTable } from "@/db/schema";
 import { db } from "@/db";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/dbTest",

--- a/packages/middleware/src/routes/api/providers/deleteProviders.ts
+++ b/packages/middleware/src/routes/api/providers/deleteProviders.ts
@@ -1,30 +1,25 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { courseProviders } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 
-const testSchema = {
+const deleteProviderSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.delete(
     "/:id",
-    testSchema,
+    deleteProviderSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/providers/getProviders.ts
+++ b/packages/middleware/src/routes/api/providers/getProviders.ts
@@ -1,28 +1,23 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
+import { z } from "zod";
 
-const testSchema = {
+const getProviderSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/:id",
-    testSchema,
+    getProviderSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/providers/root.ts
+++ b/packages/middleware/src/routes/api/providers/root.ts
@@ -1,10 +1,10 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import type { CourseProvider } from "@emstack/types/src";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/",

--- a/packages/middleware/src/routes/api/root.ts
+++ b/packages/middleware/src/routes/api/root.ts
@@ -1,9 +1,9 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { Test } from "@emstack/types/src";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/",

--- a/packages/middleware/src/routes/api/seed.ts
+++ b/packages/middleware/src/routes/api/seed.ts
@@ -1,9 +1,9 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { seed } from "@/db/seed";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/seed",

--- a/packages/middleware/src/routes/api/submitOnboardData.ts
+++ b/packages/middleware/src/routes/api/submitOnboardData.ts
@@ -1,52 +1,27 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { courses, topics, topicsToCourses } from "@/db/schema";
 import { db } from "@/db";
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
 
-const testSchema = {
+const submitSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    body: {
-      type: "object",
-      properties: {
-        name: {
-          type: "string",
-        },
-        topics: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-        courses: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["name"],
-            properties: {
-              name: {
-                type: "string",
-              },
-              topic: {
-                type: "string",
-              },
-              url: {
-                type: "string",
-              },
-              id: {
-                type: "string",
-              },
-            },
-          },
-        },
-      },
-    },
+    body: z.object({
+      name: z.string(),
+      topics: z.array(z.string()),
+      courses: z.array(z.object({
+        name: z.string(),
+        topic: z.string().optional(),
+        url: z.string().optional(),
+        id: z.string().optional(),
+      })),
+    }),
   },
-} as const;
+};
 
 interface FormCourseData {
-  [x: string]: unknown;
   name: string;
   topic?: string;
   url?: string;
@@ -80,11 +55,11 @@ function makeCourseData(courseData: FormCourseData[] | undefined) {
 }
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.post(
     "/submitOnboardData",
-    testSchema,
+    submitSchema,
     async (request, reply) => {
       // make user or edit user with name, url param for user? session thing? idk
 

--- a/packages/middleware/src/routes/api/testRoute.ts
+++ b/packages/middleware/src/routes/api/testRoute.ts
@@ -1,24 +1,19 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { DynamicTest } from "@emstack/types/src";
+import { z } from "zod";
 
 const testSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        test: {
-          type: "string",
-        },
-      },
-      required: ["test"],
-    },
+    params: z.object({
+      test: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/:test",

--- a/packages/middleware/src/routes/api/topics/deleteTopic.ts
+++ b/packages/middleware/src/routes/api/topics/deleteTopic.ts
@@ -1,30 +1,25 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { topics, topicsToCourses } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 
-const testSchema = {
+const deleteTopicSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.delete(
     "/:id",
-    testSchema,
+    deleteTopicSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/topics/getTopic.ts
+++ b/packages/middleware/src/routes/api/topics/getTopic.ts
@@ -1,30 +1,25 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { TopicsFromServer } from "@emstack/types/src/TopicsFromServer";
 import { processCourses } from "@/utils/processCourses";
+import { z } from "zod";
 
-const testSchema = {
+const getTopicSchema = {
   schema: {
     description: "It's like looking into a mirror...",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: z.object({
+      id: z.string(),
+    }),
   },
-} as const;
+};
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/:id",
-    testSchema,
+    getTopicSchema,
     async function (request, reply) {
       const {
         id,

--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -1,11 +1,11 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { ZodTypeProvider } from "fastify-type-provider-zod";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import type { TopicForTopicsPage } from "@emstack/types/src";
 import { TopicsFromServer } from "@emstack/types/src/TopicsFromServer";
 
 export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+  const fastify = server.withTypeProvider<ZodTypeProvider>();
 
   fastify.get(
     "/",

--- a/packages/middleware/src/services/swaggerOptions.ts
+++ b/packages/middleware/src/services/swaggerOptions.ts
@@ -1,15 +1,18 @@
-const swaggerOptions = {
-  swagger: {
+import { jsonSchemaTransform } from "fastify-type-provider-zod";
+import type { FastifyDynamicSwaggerOptions } from "@fastify/swagger";
+
+const swaggerOptions: FastifyDynamicSwaggerOptions = {
+  openapi: {
     info: {
       title: "Docs title",
       description: "Docs description",
       version: "0.0.0",
     },
-    host: "localhost:3001",
-    schemes: ["http"],
-    consumes: ["application/json"],
-    produces: ["application/json"],
+    servers: [{
+      url: "http://localhost:3001",
+    }],
   },
+  transform: jsonSchemaTransform,
 };
 
 export default swaggerOptions;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,19 +230,22 @@ importers:
       fastify:
         specifier: ^5.6.2
         version: 5.6.2
+      fastify-type-provider-zod:
+        specifier: ^6.1.0
+        version: 6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.1.12)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@emstack/types':
         specifier: workspace:*
         version: link:../types
-      '@fastify/type-provider-json-schema-to-ts':
-        specifier: ^5.0.0
-        version: 5.0.0
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -261,6 +264,9 @@ importers:
       nodemon:
         specifier: ^3.1.11
         version: 3.1.11
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
@@ -900,9 +906,6 @@ packages:
 
   '@fastify/swagger@9.6.1':
     resolution: {integrity: sha512-fKlpJqFMWoi4H3EdUkDaMteEYRCfQMEkK0HJJ0eaf4aRlKd8cbq0pVkOfXDXmtvMTXYcnx3E+l023eFDBsA1HA==}
-
-  '@fastify/type-provider-json-schema-to-ts@5.0.0':
-    resolution: {integrity: sha512-erEJvxucxc09XLdHygdQua4QFyxBp+QParhXl3hrB6UvE2R6ZB9KG6TznUTz6I5HK7t5xm/vn4DG7EIOAPOO4w==}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -3086,6 +3089,14 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
+  fastify-type-provider-zod@6.1.0:
+    resolution: {integrity: sha512-Sl19VZFSX4W/+AFl3hkL5YgWk3eDXZ4XYOdrq94HunK+o7GQBCAqgk7+3gPXoWkF0bNxOiIgfnFGJJ3i9a2BtQ==}
+    peerDependencies:
+      '@fastify/swagger': '>=9.5.1'
+      fastify: ^5.5.0
+      openapi-types: ^12.1.3
+      zod: '>=4.1.5'
+
   fastify@5.6.2:
     resolution: {integrity: sha512-dPugdGnsvYkBlENLhCgX8yhyGCsCPrpA8lFWbTNU428l+YOnLgYHR69hzV8HWPC79n536EqzqQtvhtdaCE0dKg==}
 
@@ -3553,10 +3564,6 @@ packages:
   json-schema-resolver@3.0.0:
     resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
     engines: {node: '>=20'}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4645,9 +4652,6 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -5561,10 +5565,6 @@ snapshots:
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
-
-  '@fastify/type-provider-json-schema-to-ts@5.0.0':
-    dependencies:
-      json-schema-to-ts: 3.1.1
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -7831,6 +7831,14 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.1.12):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/swagger': 9.6.1
+      fastify: 5.6.2
+      openapi-types: 12.1.3
+      zod: 4.1.12
+
   fastify@5.6.2:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
@@ -8337,11 +8345,6 @@ snapshots:
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.28.4
-      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -9470,8 +9473,6 @@ snapshots:
       punycode: 2.3.1
 
   tree-kill@1.2.2: {}
-
-  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes #4

## Summary
- Replace `@fastify/type-provider-json-schema-to-ts` with `fastify-type-provider-zod` + `zod`
- Convert all inline JSON Schema objects to Zod schemas across 18 middleware files
- Migrate Swagger config from Swagger 2.0 to OpenAPI 3.0 format (required by zod provider)
- Set validator/serializer compilers in server setup

## Test plan
- [x] `pnpm --filter=@emstack/middleware build` passes (pre-existing TS2877 unrelated)
- [x] `pnpm lint` — no new errors
- [x] `pnpm --filter=@emstack/middleware test` — all tests pass
- [ ] Manual: `pnpm dev` starts, Swagger UI at `/docs` renders correctly