### PR TITLE
Remove Vercel configuration and references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,5 @@ Ports: client on 3000, middleware on 3001
 
 ## Deployment
 
-- **Client:** Vercel (SPA with rewrite rules in `vercel.json`)
 - **Containers:** Docker Compose for local multi-service; Dockerfiles use multi-stage builds with distroless base
 - **Environment:** Middleware uses `.env` (local) / `.env.production` with `DATABASE_URL` as the key variable

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 App to stop me from buying courses I don't need.
 
-Currently won't work via vercel etc due to DB needs.
-
 # Ideas
 - LLM call to take info in and tell you if a course you're considering is worth it or not
 - Need to be able to add a course via a provider

--- a/packages/client/vercel.json
+++ b/packages/client/vercel.json
@@ -1,6 +1,0 @@
-{
-  "rewrites": [{
-    "source": "/(.*)",
-    "destination": "/index.html"
-  }]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "rewrites": [{
-    "source": "/(.*)",
-    "destination": "/index.html"
-  }]
-}


### PR DESCRIPTION
## ELI5
The project had leftover configuration for Vercel (a hosting service) that we're no longer using. This removes those files and cleans up the documentation so nothing references Vercel anymore.

## Summary
- Deleted `vercel.json` (root) and `packages/client/vercel.json`
- Removed Vercel mention from `README.md`
- Removed Vercel deployment line from `CLAUDE.md`

## Test plan
- [ ] Verify no remaining Vercel references in the codebase (`grep -ri vercel`)
- [ ] Confirm build still succeeds (`pnpm build`)
- [ ] Disconnect project from Vercel dashboard or via `vercel unlink` CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)