### PR TITLE
Fixes #47: Exclude TanStack Router plugin in Vitest test mode

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -15,7 +15,9 @@ const dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
-export default defineConfig({
+export default defineConfig(({
+  mode,
+}) => ({
   preview: {
     port: 4173,
   },
@@ -25,10 +27,12 @@ export default defineConfig({
     },
   },
   plugins: [
-    tanstackRouter({
-      target: "react",
-      autoCodeSplitting: true,
-    }),
+    ...(mode !== "test"
+      ? [tanstackRouter({
+        target: "react",
+        autoCodeSplitting: true,
+      })]
+      : []),
     react(),
     tailwindcss(),
   ],
@@ -84,4 +88,4 @@ export default defineConfig({
       },
     ],
   },
-});
+}));


### PR DESCRIPTION
## ELI5
Tests were crashing because a development tool (TanStack Router plugin) was running code meant for live browser reloading inside the test environment, where that feature doesn't fully exist. This fix tells the build system to skip that plugin when running tests.

## Summary
- Conditionally exclude `tanstackRouter` Vite plugin when `mode === "test"` to avoid HMR crash in Vitest's jsdom environment where `import.meta.hot.data` is undefined

## Test plan
- [ ] Run `pnpm --filter=@emstack/client test` — all tests pass without the `TypeError: Cannot set properties of undefined` error
- [ ] Run `pnpm dev` — dev server starts normally with hot reloading working
- [ ] Run `pnpm build` — production build completes with code splitting intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)