### PR TITLE
Conditionally show onboard tab, remove home route, fix mobile header layout

### DIFF
--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -60,7 +60,10 @@ export function PageHeader({
             </div>
           )}
           <div
-            className="m-auto flex w-full flex-row items-start justify-between"
+            className="
+              m-auto flex w-full flex-col items-start gap-2
+              sm:flex-row sm:justify-between
+            "
           >
             <div>
               <h1 className="text-3xl">{pageTitle}</h1>

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useTheme } from "@/hooks/useTheme.ts";
-import { fetchClear, fetchSeed } from "@/utils/fetchFunctions";
+import { fetchClear, fetchCourses, fetchProviders, fetchSeed, fetchTopics } from "@/utils/fetchFunctions";
 
 const RootComponent: React.FunctionComponent = () => {
   const navigate = useNavigate();
@@ -50,6 +50,30 @@ const RootComponent: React.FunctionComponent = () => {
     queryFn: () => fetchClear(),
   });
 
+  const {
+    data: coursesData,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchCourses(),
+  });
+
+  const {
+    data: topicsData,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: providersData,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
+
+  const allLoaded = coursesData !== undefined && topicsData !== undefined && providersData !== undefined;
+  const showOnboard = !allLoaded || (!coursesData?.length && !topicsData?.length && !providersData?.length);
+
   async function handleClearLocal() {
     const clearRefetchResult = await clearRefetch();
 
@@ -75,27 +99,18 @@ const RootComponent: React.FunctionComponent = () => {
     <>
       <div className="container items-center justify-between gap-2 py-2">
         <div className="flex gap-4">
-          <Link
-            to="/"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
-          >
-            Home
-          </Link>
-
-          <Link
-            to="/onboard"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
-          >
-            Onboard
-          </Link>
+          {showOnboard && (
+            <Link
+              to="/onboard"
+              className={`
+                underline-offset-2
+                hover:underline
+                [&.active]:font-bold
+              `}
+            >
+              Onboard
+            </Link>
+          )}
 
           <Link
             to="/courses"

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -1,51 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-
-import { fetchDbTest, fetchTest } from "@/utils/fetchFunctions";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
-  component: Index,
+  beforeLoad: () => {
+    throw redirect({
+      to: "/courses",
+    });
+  },
 });
-
-function Index() {
-  const {
-    isPending, error, data,
-  } = useQuery({
-    queryKey: ["test"],
-    queryFn: () => fetchTest(),
-  });
-
-  const {
-    isPending: dbPending, error: dbError, data: dbData,
-  } = useQuery({
-    queryKey: ["dbtest"],
-    queryFn: () => fetchDbTest(),
-  });
-  return (
-    <div className="container">
-      <div
-        className={`
-          bg-white text-black
-          dark:bg-gray-800 dark:text-white
-        `}
-      >
-        <h3 className="text-3xl font-bold">Welcome Home!</h3>
-
-        <p data-testid="status-message">
-          Test data is{" "}
-          {isPending && "Pending"}
-          {error && "Erroring"}
-          {data && "loaded!"}
-        </p>
-        {data && data.item}
-        <p data-testid="status-message-db">
-          Test DB data is{" "}
-          {dbPending && "Pending"}
-          {dbError && "Erroring"}
-          {dbData && "loaded!"}
-        </p>
-        {dbData && <span>Sample name (should be &#34;John&#34;): {dbData[0].name}</span>}
-      </div>
-    </div>
-  );
-}


### PR DESCRIPTION
- Only show the Onboard nav link when no courses, topics, or providers exist
- Replace the home route (/) with a redirect to /courses
- Make PageHeader buttons stack vertically on mobile (flex-col → sm:flex-row)

https://claude.ai/code/session_01X26dPQtdwuJVpjLJmsvugL