### PR TITLE
Fixes #71: Allow number fields to be cleared to blank

### DIFF
--- a/packages/client/src/components/formFields/NumberField.tsx
+++ b/packages/client/src/components/formFields/NumberField.tsx
@@ -15,7 +15,7 @@ export function NumberField({
   min,
   step,
 }: NumberFieldProps) {
-  const field = useFieldContext<number>();
+  const field = useFieldContext<number | null>();
   const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
 
   return (
@@ -35,7 +35,7 @@ export function NumberField({
         value={field.state.value ?? ""}
         onBlur={field.handleBlur}
         onChange={e =>
-          field.handleChange(e.target.value ? Number(e.target.value) : 0)}
+          field.handleChange(e.target.value ? Number(e.target.value) : null)}
         aria-invalid={isInvalid}
       />
       {isInvalid && <FieldError errors={field.state.meta.errors} />}

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -27,9 +27,9 @@ const formSchema = z.object({
   description: z.string().max(500),
   url: z.string().max(255),
   status: z.enum(["active", "inactive", "complete"]),
-  progressCurrent: z.number().int().min(0),
-  progressTotal: z.number().int().min(0),
-  cost: z.number().min(0),
+  progressCurrent: z.number().int().min(0).nullable(),
+  progressTotal: z.number().int().min(0).nullable(),
+  cost: z.number().min(0).nullable(),
   dateExpires: z.date().nullable(),
 });
 
@@ -57,9 +57,9 @@ function SingleCourseEdit() {
       description: data?.description ?? "",
       url: data?.url ?? "",
       status: data?.status ?? ("active" as const),
-      progressCurrent: data?.progressCurrent ?? 0,
-      progressTotal: data?.progressTotal ?? 0,
-      cost: data?.cost ? Number(data.cost.cost) : 0,
+      progressCurrent: data?.progressCurrent ?? null,
+      progressTotal: data?.progressTotal ?? null,
+      cost: data?.cost ? Number(data.cost.cost) : null,
       dateExpires: data?.dateExpires ? new Date(data.dateExpires) : null,
     }),
     [data],
@@ -78,8 +78,8 @@ function SingleCourseEdit() {
         description: value.description || null,
         url: value.url || null,
         status: value.status,
-        progressCurrent: value.progressCurrent,
-        progressTotal: value.progressTotal,
+        progressCurrent: value.progressCurrent ?? 0,
+        progressTotal: value.progressTotal ?? 0,
         cost: value.cost ? String(value.cost) : null,
         isCostFromPlatform: data?.cost?.isCostFromPlatform ?? false,
         dateExpires: value.dateExpires
@@ -185,11 +185,11 @@ function SingleCourseEdit() {
                 value,
                 fieldApi,
               }: {
-                value: number;
+                value: number | null;
                 fieldApi: AnyFieldApi;
               }) => {
                 const total = fieldApi.form.getFieldValue("progressTotal");
-                if (value > total) {
+                if (value != null && total != null && value > total) {
                   return {
                     message: "Current progress cannot exceed total modules",
                   };


### PR DESCRIPTION
## ELI5
When editing a course, number fields like progress and cost always showed "0" and couldn't be emptied. This made it hard to type new values (you had to select and replace the 0) and made optional fields like cost look like they had a value when they didn't. Now those fields start blank and can be cleared.

## Summary
- Changed `NumberField` to use `null` instead of `0` for empty inputs, so fields display as blank
- Made the form schema and default values nullable for progress and cost fields
- Null progress values coerce to `0` at submit time so the API still receives valid integers

## Test plan
- [ ] Create a new course — verify progress and cost fields start blank (not 0)
- [ ] Edit an existing course with progress/cost values — verify they display correctly
- [ ] Clear a number field and save — verify it submits without errors
- [ ] Type a new value in a blank number field — verify no awkward 0 prefix
- [ ] Set current progress higher than total modules — verify validation still works
- [ ] Leave cost blank and save — verify it saves as null (no cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)