### PR TITLE
Fixes #70: Add loading spinner to course edit submit button

### DIFF
--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -5,6 +5,7 @@ import { useMemo, useRef } from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
@@ -126,6 +127,7 @@ function SingleCourseEdit() {
   const currentValues = useStore(form.store, state => ({
     ...state.values,
   }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
   const hasChanges = formHasChanges(currentValues, startingValues);
 
   return (
@@ -231,7 +233,11 @@ function SingleCourseEdit() {
         </form.AppField>
 
         <div className="flex flex-row gap-4">
-          <Button type="submit">
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting && <Loader2 className="animate-spin" />}
             {isNew ? "Create Course" : "Save Changes"}
           </Button>
           <Button


### PR DESCRIPTION
## ELI5
When you click "Save Changes" or "Create Course", the button now shows a spinning icon and becomes unclickable until the save finishes. This way you know something is happening and won't accidentally click it twice.

## Summary
- Added a `Loader2` spinner icon to the submit button on the course edit page
- Button is disabled during form submission to prevent double-clicks
- Uses `isSubmitting` state from TanStack Form's store

## Test plan
- [ ] Navigate to an existing course edit page, make a change, and click "Save Changes" — verify the spinner appears and button is disabled until navigation completes
- [ ] Navigate to `/courses/new/edit`, fill in the form, and click "Create Course" — verify the same spinner behavior
- [ ] Verify the button shows reduced opacity (50%) while disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)