### PR TITLE
Fixes #75: Fix cost displaying 'No cost given' when value is 0

### DIFF
--- a/packages/client/src/components/boxElements/CourseMetaItem.tsx
+++ b/packages/client/src/components/boxElements/CourseMetaItem.tsx
@@ -20,12 +20,9 @@ export function CourseMetaItem({
     <div className="flex flex-row items-center gap-1">
       {iconNode && iconNode}
       <span className="text-sm">
-        {value && (`${value}`)}
-        {!value && (
-          <i
-            className="italic"
-          >{emptyText}
-          </i>
+        {value != null && value !== "" && `${value}`}
+        {(value == null || value === "") && (
+          <i className="italic">{emptyText}</i>
         )}
       </span>
     </div>

--- a/packages/client/src/components/boxes/CourseBox.tsx
+++ b/packages/client/src/components/boxes/CourseBox.tsx
@@ -15,7 +15,9 @@ import {
   ContentBox,
   ContentBoxBody,
   ContentBoxFooter,
-  ContentBoxHeader, ContentBoxHeaderBar, ContentBoxTitle,
+  ContentBoxHeader,
+  ContentBoxHeaderBar,
+  ContentBoxTitle,
 } from "@/components/boxes/ContentBox";
 import { Button } from "@/components/ui/button";
 import { ProgressBar } from "@/components/ui/ProgressBar";
@@ -34,12 +36,11 @@ export function CourseBox({
   cost,
 }: Course) {
   const costValue = cost.isCostFromPlatform
-    ? `${(Number(cost.cost) / cost.splitBy)}*`
+    ? `${Number(cost.cost) / cost.splitBy}*`
     : Number(cost.cost);
   return (
     <ContentBox>
       <ContentBoxHeader>
-
         <ContentBoxHeaderBar>
           <div className="flex flex-row items-center gap-2">
             <StatusIndicator status={status} />
@@ -71,13 +72,14 @@ export function CourseBox({
                 id: id + "",
               }}
               className="hover:text-blue-600"
-            >{name}
+            >
+              {name}
             </Link>
           </h3>
         </ContentBoxTitle>
       </ContentBoxHeader>
       <ContentBoxBody>
-        { provider && (
+        {provider && (
           <h4 className="text-xs font-semibold uppercase">
             From
             {" "}
@@ -95,7 +97,7 @@ export function CourseBox({
               {provider?.name}
             </Link>
           </h4>
-        ) }
+        )}
         <p>{description ? description : <i>No description provided.</i>}</p>
       </ContentBoxBody>
       <ContentBoxFooter>
@@ -106,14 +108,18 @@ export function CourseBox({
           emptyText="No course expiry given"
         />
         <CourseMetaItem
-          value={progressCurrent && progressTotal ? `${progressCurrent} / ${progressTotal}` : 0}
+          value={
+            progressCurrent && progressTotal
+              ? `${progressCurrent} / ${progressTotal}`
+              : 0
+          }
           condition={!!progressCurrent && !!progressTotal}
           iconNode={<CheckCheckIcon size={16} />}
           emptyText="No progress"
         />
         <CourseMetaItem
           value={costValue}
-          condition={!!cost.cost}
+          condition={cost.cost != null && cost.cost !== ""}
           iconNode={<DollarSignIcon size={16} />}
           emptyText="No cost given"
         />

--- a/packages/client/src/components/boxes/CourseBox.tsx
+++ b/packages/client/src/components/boxes/CourseBox.tsx
@@ -35,9 +35,12 @@ export function CourseBox({
   progressTotal = 0,
   cost,
 }: Course) {
-  const costValue = cost.isCostFromPlatform
-    ? `${Number(cost.cost) / cost.splitBy}*`
-    : Number(cost.cost);
+  const costValue
+    = cost.cost != null
+      ? cost.isCostFromPlatform
+        ? `${Number(cost.cost) / cost.splitBy}*`
+        : Number(cost.cost)
+      : null;
   return (
     <ContentBox>
       <ContentBoxHeader>

--- a/packages/client/src/components/boxes/CourseBox.tsx
+++ b/packages/client/src/components/boxes/CourseBox.tsx
@@ -122,8 +122,10 @@ export function CourseBox({
         />
         <CourseMetaItem
           value={costValue}
-          condition={cost.cost != null && cost.cost !== ""}
-          iconNode={<DollarSignIcon size={16} />}
+          condition={true}
+          iconNode={
+            costValue != null ? <DollarSignIcon size={16} /> : undefined
+          }
           emptyText="No cost given"
         />
       </ContentBoxFooter>

--- a/packages/client/src/components/boxes/ProviderBox.tsx
+++ b/packages/client/src/components/boxes/ProviderBox.tsx
@@ -1,15 +1,14 @@
 import type { CourseProvider } from "@emstack/types/src";
 
 import { Link } from "@tanstack/react-router";
-import {
-  BookIcon, DollarSignIcon, RefreshCwIcon,
-} from "lucide-react";
+import { BookIcon, DollarSignIcon, RefreshCwIcon } from "lucide-react";
 
 import { CourseMetaItem } from "@/components/boxElements/CourseMetaItem";
 import {
   ContentBox,
   ContentBoxBody,
-  ContentBoxFooter, ContentBoxHeader,
+  ContentBoxFooter,
+  ContentBoxHeader,
   ContentBoxHeaderBar,
   ContentBoxTitle,
 } from "@/components/boxes/ContentBox";
@@ -35,7 +34,8 @@ export function ProviderBox({
                 id: id + "",
               }}
               className="hover:text-blue-600"
-            >{name}
+            >
+              {name}
             </Link>
           </h3>
         </ContentBoxTitle>
@@ -51,7 +51,7 @@ export function ProviderBox({
         />
         <CourseMetaItem
           value={cost}
-          condition={!!cost}
+          condition={cost != null && cost !== ""}
           iconNode={<DollarSignIcon size={16} />}
         />
         <CourseMetaItem

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -60,7 +60,7 @@ function SingleCourseEdit() {
       status: data?.status ?? ("active" as const),
       progressCurrent: data?.progressCurrent ?? null,
       progressTotal: data?.progressTotal ?? null,
-      cost: data?.cost ? Number(data.cost.cost) : null,
+      cost: data?.cost?.cost != null ? Number(data.cost.cost) : null,
       dateExpires: data?.dateExpires ? new Date(data.dateExpires) : null,
     }),
     [data],
@@ -81,7 +81,7 @@ function SingleCourseEdit() {
         status: value.status,
         progressCurrent: value.progressCurrent ?? 0,
         progressTotal: value.progressTotal ?? 0,
-        cost: value.cost ? String(value.cost) : null,
+        cost: value.cost != null ? String(value.cost) : null,
         isCostFromPlatform: data?.cost?.isCostFromPlatform ?? false,
         dateExpires: value.dateExpires
           ? value.dateExpires.toISOString().split("T")[0]

--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -113,7 +113,7 @@ function SingleCourse() {
         )}
       </InfoRow>
       <InfoRow
-        condition={!!data?.cost}
+        condition={data?.cost != null}
         header="Money Things"
       >
         <div className="flex flex-row gap-1">

--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -113,7 +113,7 @@ function SingleCourse() {
         )}
       </InfoRow>
       <InfoRow
-        condition={data?.cost != null}
+        condition={data?.cost?.cost != null}
         header="Money Things"
       >
         <div className="flex flex-row gap-1">

--- a/packages/middleware/src/utils/processCost.ts
+++ b/packages/middleware/src/utils/processCost.ts
@@ -3,13 +3,13 @@ import { CourseFromServer } from "@emstack/types/src";
 
 export function processCost(course: CourseFromServer): CostData {
   let costData: CostData = {
-    cost: "0",
+    cost: null,
     isCostFromPlatform: false,
   };
   if (course) {
     if (course.isCostFromPlatform === true && course.courseProvider) {
       costData = {
-        cost: course.courseProvider.cost ?? "0",
+        cost: course.courseProvider.cost ?? null,
         isCostFromPlatform: course.isCostFromPlatform,
         splitBy: course.courseProvider.courses
           ? course.courseProvider.courses.length
@@ -18,7 +18,7 @@ export function processCost(course: CourseFromServer): CostData {
     }
     else {
       costData = {
-        cost: course.cost ?? "0",
+        cost: course.cost ?? null,
         isCostFromPlatform: course.isCostFromPlatform,
       };
     }

--- a/packages/types/src/CostData.ts
+++ b/packages/types/src/CostData.ts
@@ -1,5 +1,5 @@
 export interface CostData {
-  cost: string;
+  cost: string | null;
   isCostFromPlatform: boolean;
   splitBy?: number;
 }

--- a/packages/types/src/CourseInCourses.ts
+++ b/packages/types/src/CourseInCourses.ts
@@ -7,7 +7,7 @@ export interface CourseInCourses {
   url: string;
   dateExpires: string;
   cost: {
-    cost: string;
+    cost: string | null;
     isCostFromPlatform: boolean;
     splitBy: number;
   };


### PR DESCRIPTION
## ELI5
When a course costs $0, the app was showing "No cost given" instead of showing "0". This fix makes it so only courses with no cost entered at all say "No cost given", while courses that actually cost $0 correctly display that.

## Summary
- Replace falsy checks (`!!value`, `value && ...`) with explicit null/empty-string checks in `CourseMetaItem`, `CourseBox`, `ProviderBox`, and the single course page
- JavaScript treats `0` as falsy, so the old checks couldn't distinguish between "no value" and "zero value"

## Test plan
- [ ] Create or edit a course with cost = 0, verify it displays "0" (not "No cost given")
- [ ] Create or edit a course with no cost entered, verify it displays "No cost given"
- [ ] Check provider boxes with cost = 0 display correctly
- [ ] Verify the single course detail page shows cost correctly for both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)