### PR TITLE
Fixes #16: Add search, filtering, and sorting to courses page

### DIFF
--- a/packages/client/src/components/ui/select.tsx
+++ b/packages/client/src/components/ui/select.tsx
@@ -1,0 +1,255 @@
+import * as React from "react";
+
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      {...props}
+    />
+  );
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      {...props}
+    />
+  );
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        `
+          flex w-fit items-center justify-between gap-2 rounded-md border
+          border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap
+          shadow-xs transition-[color,box-shadow] outline-none
+          focus-visible:border-ring focus-visible:ring-[3px]
+          focus-visible:ring-ring/50
+          disabled:cursor-not-allowed disabled:opacity-50
+          aria-invalid:border-destructive aria-invalid:ring-destructive/20
+          data-placeholder:text-muted-foreground
+          data-[size=default]:h-9
+          data-[size=sm]:h-8
+          *:data-[slot=select-value]:line-clamp-1
+          *:data-[slot=select-value]:flex
+          *:data-[slot=select-value]:items-center
+          *:data-[slot=select-value]:gap-2
+          dark:bg-input/30
+          dark:hover:bg-input/50
+          dark:aria-invalid:ring-destructive/40
+          [&_svg]:pointer-events-none [&_svg]:shrink-0
+          [&_svg:not([class*='size-'])]:size-4
+          [&_svg:not([class*='text-'])]:text-muted-foreground
+        `,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          `
+            relative z-50 max-h-(--radix-select-content-available-height)
+            min-w-32 origin-(--radix-select-content-transform-origin)
+            overflow-x-hidden overflow-y-auto rounded-md border bg-popover
+            text-popover-foreground shadow-md
+            data-[side=bottom]:slide-in-from-top-2
+            data-[side=left]:slide-in-from-right-2
+            data-[side=right]:slide-in-from-left-2
+            data-[side=top]:slide-in-from-bottom-2
+            data-[state=closed]:animate-out data-[state=closed]:fade-out-0
+            data-[state=closed]:zoom-out-95
+            data-[state=open]:animate-in data-[state=open]:fade-in-0
+            data-[state=open]:zoom-in-95
+          `,
+          position === "popper"
+          && `
+            data-[side=bottom]:translate-y-1
+            data-[side=left]:-translate-x-1
+            data-[side=right]:translate-x-1
+            data-[side=top]:-translate-y-1
+          `,
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper"
+            && `
+              h-(--radix-select-trigger-height) w-full
+              min-w-(--radix-select-trigger-width) scroll-my-1
+            `,
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        `
+          relative flex w-full cursor-default items-center gap-2 rounded-sm
+          py-1.5 pr-8 pl-2 text-sm outline-hidden select-none
+          focus:bg-accent focus:text-accent-foreground
+          data-disabled:pointer-events-none data-disabled:opacity-50
+          [&_svg]:pointer-events-none [&_svg]:shrink-0
+          [&_svg:not([class*='size-'])]:size-4
+          [&_svg:not([class*='text-'])]:text-muted-foreground
+          *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2
+        `,
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -1,14 +1,32 @@
-import type { Course } from "@emstack/types/src";
+import type { Course, CourseInCourses } from "@emstack/types/src";
+
+import { useMemo, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRightIcon, PlusIcon } from "lucide-react";
+import {
+  ArrowDownAZIcon,
+  ArrowRightIcon,
+  ArrowUpAZIcon,
+  PlusIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { CourseBox } from "@/components/boxes/CourseBox";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { fetchCourses } from "@/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { fetchCourses, fetchProviders, fetchTopics } from "@/utils";
+
+type SortOption = "alpha" | "progress" | "provider" | "topic";
 
 export const Route = createFileRoute("/courses/")({
   component: Courses,
@@ -42,9 +60,37 @@ function CoursesError() {
   );
 }
 
+function getProgressPercent(course: CourseInCourses): number {
+  if (course.progressTotal === 0) return 0;
+  return course.progressCurrent / course.progressTotal;
+}
+
+function sortCourses(
+  courses: CourseInCourses[],
+  sortBy: SortOption,
+): CourseInCourses[] {
+  return [...courses].sort((a, b) => {
+    switch (sortBy) {
+      case "alpha":
+        return a.name.localeCompare(b.name);
+      case "progress":
+        return getProgressPercent(b) - getProgressPercent(a);
+      case "provider":
+        return (a.provider?.name ?? "").localeCompare(b.provider?.name ?? "");
+      case "topic":
+        return (a.topics?.[0]?.name ?? "").localeCompare(
+          b.topics?.[0]?.name ?? "",
+        );
+    }
+  });
+}
+
 function Courses() {
-  // const localItem = localStorage.getItem("courseData");
-  // const local = JSON.parse(localItem ? localItem : "");
+  const [search, setSearch] = useState("");
+  const [filterProvider, setFilterProvider] = useState<string | undefined>();
+  const [filterTopic, setFilterTopic] = useState<string | undefined>();
+  const [sortBy, setSortBy] = useState<SortOption>("alpha");
+  const [sortAsc, setSortAsc] = useState(true);
 
   const {
     data,
@@ -53,13 +99,178 @@ function Courses() {
     queryFn: () => fetchCourses(),
   });
 
+  const {
+    data: providers,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
+
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const filteredAndSorted = useMemo(() => {
+    if (!data) return [];
+
+    let result = data;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(c => c.name.toLowerCase().includes(q));
+    }
+
+    if (filterProvider === "none") {
+      result = result.filter(c => !c.provider);
+    }
+    else if (filterProvider) {
+      result = result.filter(c => c.provider?.id === filterProvider);
+    }
+
+    if (filterTopic === "none") {
+      result = result.filter(c => !c.topics || c.topics.length === 0);
+    }
+    else if (filterTopic) {
+      result = result.filter(c =>
+        c.topics?.some(t => t.id === filterTopic));
+    }
+
+    const sorted = sortCourses(result, sortBy);
+    return sortAsc ? sorted : sorted.reverse();
+  }, [data, search, filterProvider, filterTopic, sortBy, sortAsc]);
+
+  const hasActiveFilters = filterProvider || filterTopic;
+
   return (
     <div>
       <PageHeader
         pageTitle="Your Courses"
         pageSection=""
       />
-      <div className="container">
+      <div className="container flex flex-col gap-4">
+        <div>
+          {data && data.length > 0 && (
+            <div
+              className="mb-4 flex flex-wrap items-center justify-between gap-3"
+            >
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="relative">
+                  <SearchIcon
+                    className="
+                      absolute top-1/2 left-2.5 size-4 -translate-y-1/2
+                      text-muted-foreground
+                    "
+                  />
+                  <input
+                    type="text"
+                    placeholder="Search courses..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    className="
+                      h-9 rounded-md border border-input bg-transparent pr-3
+                      pl-8 text-sm shadow-xs transition-[color,box-shadow]
+                      outline-none
+                      placeholder:text-muted-foreground
+                      focus-visible:border-ring focus-visible:ring-[3px]
+                      focus-visible:ring-ring/50
+                    "
+                  />
+                </div>
+                <Select
+                  value={filterProvider ?? "all"}
+                  onValueChange={v =>
+                    setFilterProvider(v === "all" ? undefined : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Provider" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Providers</SelectItem>
+                    <SelectItem value="none">No Provider</SelectItem>
+                    {providers?.map(p => (
+                      <SelectItem
+                        key={p.id}
+                        value={p.id}
+                      >
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <Select
+                  value={filterTopic ?? "all"}
+                  onValueChange={v =>
+                    setFilterTopic(v === "all" ? undefined : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Topic" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Topics</SelectItem>
+                    <SelectItem value="none">No Topic</SelectItem>
+                    {topics?.map(t => (
+                      <SelectItem
+                        key={t.id}
+                        value={t.id}
+                      >
+                        {t.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                {hasActiveFilters && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setFilterProvider(undefined);
+                      setFilterTopic(undefined);
+                    }}
+                  >
+                    <XIcon className="size-4" />
+                    Clear filters
+                  </Button>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Sort</span>
+                <Select
+                  value={sortBy}
+                  onValueChange={v => setSortBy(v as SortOption)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort by" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="alpha">A-Z</SelectItem>
+                    <SelectItem value="progress">Progress</SelectItem>
+                    <SelectItem value="provider">Provider</SelectItem>
+                    <SelectItem value="topic">Topic</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setSortAsc(prev => !prev)}
+                >
+                  {sortAsc
+                    ? (
+                      <ArrowDownAZIcon className="size-4" />
+                    )
+                    : (
+                      <ArrowUpAZIcon className="size-4" />
+                    )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="card-grid">
           {(!data || data.length === 0) && (
             <div className="flex flex-col gap-6">
@@ -78,9 +289,8 @@ function Courses() {
             </div>
           )}
 
-          {data
-            && data.length > 0
-            && data.map((course: Course) => {
+          {filteredAndSorted.length > 0
+            && filteredAndSorted.map((course: Course) => {
               if (!course) {
                 return <></>;
               }
@@ -91,6 +301,12 @@ function Courses() {
                 />
               );
             })}
+
+          {data && data.length > 0 && filteredAndSorted.length === 0 && (
+            <div className="text-muted-foreground">
+              <i>No courses match your filters.</i>
+            </div>
+          )}
 
           <Link
             to="/courses/$id/edit"


### PR DESCRIPTION
## ELI5
The courses page now has a toolbar at the top that lets you search for courses by name, narrow down the list by provider or topic, and change how courses are ordered. This makes it much easier to find specific courses when you have a lot of them.

## Summary
- Add search bar, provider/topic filter dropdowns (with "No Provider"/"No Topic" options), and sort dropdown (A-Z, Progress, Provider, Topic) with ascending/descending toggle
- Filters are combinable — you can search, filter by provider, and filter by topic all at the same time
- Add shadcn Select component to the project

## Test plan
- [ ] Verify search filters courses by name as you type
- [ ] Verify provider dropdown filters to only courses from that provider
- [ ] Verify topic dropdown filters to only courses with that topic
- [ ] Verify "No Provider" and "No Topic" options show unassigned courses
- [ ] Verify filters can be combined (e.g., search + provider filter)
- [ ] Verify "Clear filters" button resets provider and topic filters
- [ ] Verify each sort option orders courses correctly
- [ ] Verify ascending/descending toggle reverses sort order
- [ ] Verify "No courses match your filters" message appears when filters produce no results
- [ ] Verify toolbar only appears when courses exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)