### PR TITLE
Fixes #9: Add topic create and edit functionality

### DIFF
--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as CoursesIdRouteImport } from './routes/courses.$id'
 import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
+import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
 import { Route as CoursesIdEditRouteImport } from './routes/courses.$id.edit'
 
 const TopicsRoute = TopicsRouteImport.update({
@@ -95,6 +96,11 @@ const CoursesIdIndexRoute = CoursesIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => CoursesIdRoute,
 } as any)
+const TopicsIdEditRoute = TopicsIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => TopicsIdRoute,
+} as any)
 const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -114,6 +120,7 @@ export interface FileRoutesByFullPath {
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
@@ -125,6 +132,7 @@ export interface FileRoutesByTo {
   '/providers': typeof ProvidersIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id': typeof CoursesIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
@@ -143,6 +151,7 @@ export interface FileRoutesById {
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
@@ -162,6 +171,7 @@ export interface FileRouteTypes {
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/topics/$id/edit'
     | '/courses/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
@@ -173,6 +183,7 @@ export interface FileRouteTypes {
     | '/providers'
     | '/topics'
     | '/courses/$id/edit'
+    | '/topics/$id/edit'
     | '/courses/$id'
     | '/providers/$id'
     | '/topics/$id'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/topics/$id/edit'
     | '/courses/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
@@ -303,6 +315,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CoursesIdIndexRouteImport
       parentRoute: typeof CoursesIdRoute
     }
+    '/topics/$id/edit': {
+      id: '/topics/$id/edit'
+      path: '/edit'
+      fullPath: '/topics/$id/edit'
+      preLoaderRoute: typeof TopicsIdEditRouteImport
+      parentRoute: typeof TopicsIdRoute
+    }
     '/courses/$id/edit': {
       id: '/courses/$id/edit'
       path: '/edit'
@@ -367,10 +386,12 @@ const ProvidersRouteWithChildren = ProvidersRoute._addFileChildren(
 )
 
 interface TopicsIdRouteChildren {
+  TopicsIdEditRoute: typeof TopicsIdEditRoute
   TopicsIdIndexRoute: typeof TopicsIdIndexRoute
 }
 
 const TopicsIdRouteChildren: TopicsIdRouteChildren = {
+  TopicsIdEditRoute: TopicsIdEditRoute,
   TopicsIdIndexRoute: TopicsIdIndexRoute,
 }
 

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useRef } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createTopic,
+  fetchSingleTopic,
+  formHasChanges,
+  upsertTopic,
+} from "@/utils";
+
+export const Route = createFileRoute("/topics/$id/edit")({
+  component: SingleTopicEdit,
+});
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(500),
+  reason: z.string().max(500),
+});
+
+function SingleTopicEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["topic", id],
+    queryFn: () => fetchSingleTopic(id),
+    enabled: !isNew,
+  });
+
+  const startingValues = useMemo(
+    () => ({
+      name: data?.name ?? "",
+      description: data?.description ?? "",
+      reason: data?.reason ?? "",
+    }),
+    [data],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const topicData = {
+        name: value.name,
+        description: value.description || null,
+        reason: value.reason || null,
+      };
+
+      try {
+        let topicId: string;
+        if (isNew) {
+          const result = await createTopic(topicData);
+          topicId = result.id;
+        }
+        else {
+          await upsertTopic(id, topicData);
+          topicId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["topic", id],
+          });
+        }
+
+        await queryClient.invalidateQueries({
+          queryKey: ["topics"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/topics/$id",
+          params: {
+            id: topicId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create topic. Please try again."
+            : "Failed to save topic. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Topic" : "Edit Topic"}
+        pageSection="topics"
+      >
+        {!isNew && (
+          <Link
+            to="/topics/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Topic
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="container flex-col">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-2xl flex-col gap-8"
+        >
+          <form.AppField name="name">
+            {field => <field.InputField label="Topic Name" />}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What is this topic about?"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="reason">
+            {field => (
+              <field.TextareaField
+                label="Reason"
+                placeholder="Why are you learning this?"
+              />
+            )}
+          </form.AppField>
+
+          <div className="flex flex-row gap-4">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Topic" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/topics",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/topics/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -80,16 +80,12 @@ function SingleTopic() {
       >
         <div className="flex flex-row gap-2">
           <Link
-            to="/courses/$id/edit"
+            to="/topics/$id/edit"
             params={{
               id: data?.id + "",
             }}
-            disabled={true}
           >
-            <Button
-              variant="secondary"
-              disabled={true}
-            >
+            <Button variant="secondary">
               Edit Topic
               {" "}
               <EditIcon />

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -2,8 +2,9 @@ import type { TopicForTopicsPage } from "@emstack/types/src";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
+import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -87,6 +88,24 @@ function Topics() {
                 />
               );
             })}
+
+          <Link
+            to="/topics/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <ContentBox
+              className="
+                h-full items-center justify-center border-dashed p-8
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
+              "
+            >
+              <PlusIcon size={32} />
+              <span className="text-lg font-medium">Add New Topic</span>
+            </ContentBox>
+          </Link>
         </div>
       </div>
     </div>

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -108,6 +108,40 @@ export async function upsertCourse(
   return await response.json();
 }
 
+export async function createTopic(
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch("/api/topics", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create topic: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function upsertTopic(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<SuccessObj> {
+  const response = await fetch(`/api/topics/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update topic: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
 export async function postOnboardForm(
   formData: OnboardData,
 ): Promise<SuccessObj> {

--- a/packages/middleware/src/routes/api/topics/createTopic.ts
+++ b/packages/middleware/src/routes/api/topics/createTopic.ts
@@ -1,0 +1,51 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { topics } from "@/db/schema";
+import { v4 as uuidv4 } from "uuid";
+
+const createSchema = {
+  schema: {
+    description: "Create a new topic",
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        reason: {
+          type: ["string", "null"],
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request, reply) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(topics).values({
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        reason: body.reason ?? null,
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/topics/routes.ts
+++ b/packages/middleware/src/routes/api/topics/routes.ts
@@ -3,12 +3,16 @@ import { FastifyInstance } from "fastify";
 
 import courseRoot from "./root";
 import getTopic from "./getTopic";
+import createTopic from "./createTopic";
 import deleteTopic from "./deleteTopic";
+import upsertTopic from "./upsertTopic";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
 
   fastify.register(courseRoot);
   fastify.register(getTopic);
+  fastify.register(createTopic);
   fastify.register(deleteTopic);
+  fastify.register(upsertTopic);
 }

--- a/packages/middleware/src/routes/api/topics/upsertTopic.ts
+++ b/packages/middleware/src/routes/api/topics/upsertTopic.ts
@@ -1,0 +1,72 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { topics } from "@/db/schema";
+
+const upsertSchema = {
+  schema: {
+    description: "Update a topic",
+    params: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+      },
+      required: ["id"],
+    },
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        reason: {
+          type: ["string", "null"],
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:id",
+    upsertSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const body = request.body;
+
+      const topicData = {
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        reason: body.reason ?? null,
+      };
+
+      await db
+        .insert(topics)
+        .values(topicData)
+        .onConflictDoUpdate({
+          target: topics.id,
+          set: {
+            name: topicData.name,
+            description: topicData.description,
+            reason: topicData.reason,
+          },
+        });
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}


### PR DESCRIPTION
## ELI5
You can now create new topics and edit existing ones directly from the app, instead of only being able to add them during the initial onboarding process. The topics page also has a handy "Add New Topic" button.

## Summary
- Add backend POST and PUT API endpoints for creating and updating topics
- Add frontend edit/create form at `/topics/$id/edit` with unsaved changes dialog, View Topic button, and PageHeader
- Enable the previously disabled Edit Topic button on the topic detail page and add an "Add New Topic" card to the topics list page

## Test plan
- [ ] Navigate to `/topics` — verify "Add New Topic" card appears
- [ ] Click "Add New Topic" — verify create form loads with empty fields
- [ ] Fill in name, description, reason and submit — verify redirect to new topic detail page with correct data
- [ ] On topic detail page, click "Edit Topic" — verify edit form loads with current values
- [ ] Modify fields and submit — verify changes are saved and reflected on detail page
- [ ] On edit form, make changes then try to navigate away — verify unsaved changes dialog appears
- [ ] On edit form, click "View Topic" button — verify it links back to the topic detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)