### PR TITLE
Fixes #10: Add provider create and edit functionality

### DIFF
--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
+import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
 import { Route as CoursesIdEditRouteImport } from './routes/courses.$id.edit'
 
 const TopicsRoute = TopicsRouteImport.update({
@@ -101,6 +102,11 @@ const TopicsIdEditRoute = TopicsIdEditRouteImport.update({
   path: '/edit',
   getParentRoute: () => TopicsIdRoute,
 } as any)
+const ProvidersIdEditRoute = ProvidersIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => ProvidersIdRoute,
+} as any)
 const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -120,6 +126,7 @@ export interface FileRoutesByFullPath {
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
@@ -132,6 +139,7 @@ export interface FileRoutesByTo {
   '/providers': typeof ProvidersIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id': typeof CoursesIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
@@ -151,6 +159,7 @@ export interface FileRoutesById {
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
@@ -171,6 +180,7 @@ export interface FileRouteTypes {
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
     | '/providers/$id/'
@@ -183,6 +193,7 @@ export interface FileRouteTypes {
     | '/providers'
     | '/topics'
     | '/courses/$id/edit'
+    | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id'
     | '/providers/$id'
@@ -201,6 +212,7 @@ export interface FileRouteTypes {
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
     | '/providers/$id/'
@@ -322,6 +334,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicsIdEditRouteImport
       parentRoute: typeof TopicsIdRoute
     }
+    '/providers/$id/edit': {
+      id: '/providers/$id/edit'
+      path: '/edit'
+      fullPath: '/providers/$id/edit'
+      preLoaderRoute: typeof ProvidersIdEditRouteImport
+      parentRoute: typeof ProvidersIdRoute
+    }
     '/courses/$id/edit': {
       id: '/courses/$id/edit'
       path: '/edit'
@@ -360,10 +379,12 @@ const CoursesRouteWithChildren =
   CoursesRoute._addFileChildren(CoursesRouteChildren)
 
 interface ProvidersIdRouteChildren {
+  ProvidersIdEditRoute: typeof ProvidersIdEditRoute
   ProvidersIdIndexRoute: typeof ProvidersIdIndexRoute
 }
 
 const ProvidersIdRouteChildren: ProvidersIdRouteChildren = {
+  ProvidersIdEditRoute: ProvidersIdEditRoute,
   ProvidersIdIndexRoute: ProvidersIdIndexRoute,
 }
 

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -1,0 +1,310 @@
+import { useMemo, useRef } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createProvider,
+  fetchSingleProvider,
+  formHasChanges,
+  upsertProvider,
+} from "@/utils";
+
+export const Route = createFileRoute("/providers/$id/edit")({
+  component: SingleProviderEdit,
+});
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(500),
+  url: z.string().min(1, "URL is required").max(255),
+  cost: z.number().min(0).nullable(),
+  isRecurring: z.string(),
+  recurDate: z.date().nullable(),
+  recurPeriodUnit: z.string(),
+  recurPeriod: z.number().int().min(1).nullable(),
+  isCourseFeesShared: z.string(),
+});
+
+function SingleProviderEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["provider", id],
+    queryFn: () => fetchSingleProvider(id),
+    enabled: !isNew,
+  });
+
+  const startingValues = useMemo(
+    () => ({
+      name: data?.name ?? "",
+      description: data?.description ?? "",
+      url: data?.url ?? "",
+      cost: data?.cost != null ? Number(data.cost) : null,
+      isRecurring: data?.isRecurring ? "true" : "false",
+      recurDate: data?.recurDate ? new Date(data.recurDate) : null,
+      recurPeriodUnit: data?.recurPeriodUnit ?? "years",
+      recurPeriod: data?.recurPeriod ?? null,
+      isCourseFeesShared: data?.isCourseFeesShared ? "true" : "false",
+    }),
+    [data],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const providerData = {
+        name: value.name,
+        description: value.description || null,
+        url: value.url,
+        cost: value.cost != null ? String(value.cost) : null,
+        isRecurring: value.isRecurring === "true",
+        recurDate: value.recurDate
+          ? value.recurDate.toISOString().split("T")[0]
+          : null,
+        recurPeriodUnit:
+          value.isRecurring === "true" ? value.recurPeriodUnit : null,
+        recurPeriod: value.isRecurring === "true" ? value.recurPeriod : null,
+        isCourseFeesShared: value.isCourseFeesShared === "true",
+      };
+
+      try {
+        let providerId: string;
+        if (isNew) {
+          const result = await createProvider(providerData);
+          providerId = result.id;
+        }
+        else {
+          await upsertProvider(id, providerData);
+          providerId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["provider", id],
+          });
+        }
+
+        await queryClient.invalidateQueries({
+          queryKey: ["providers"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/providers/$id",
+          params: {
+            id: providerId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create provider. Please try again."
+            : "Failed to save provider. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  const isRecurring = useStore(
+    form.store,
+    state => state.values.isRecurring === "true",
+  );
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Provider" : "Edit Provider"}
+        pageSection="providers"
+      >
+        {!isNew && (
+          <Link
+            to="/providers/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Provider
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="container flex-col">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-2xl flex-col gap-8"
+        >
+          <form.AppField name="name">
+            {field => <field.InputField label="Provider Name" />}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What does this provider offer?"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="url">
+            {field => <field.InputField label="URL" />}
+          </form.AppField>
+
+          <form.AppField name="cost">
+            {field => (
+              <field.NumberField
+                label="Cost ($)"
+                min={0}
+                step="0.01"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="isCourseFeesShared">
+            {field => (
+              <field.RadioGroupField
+                label="Course Fees Shared?"
+                options={[
+                  {
+                    value: "true",
+                    label: "Yes",
+                  },
+                  {
+                    value: "false",
+                    label: "No",
+                  },
+                ]}
+                labelClassName=""
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="isRecurring">
+            {field => (
+              <field.RadioGroupField
+                label="Recurring Subscription?"
+                options={[
+                  {
+                    value: "true",
+                    label: "Yes",
+                  },
+                  {
+                    value: "false",
+                    label: "No",
+                  },
+                ]}
+                labelClassName=""
+              />
+            )}
+          </form.AppField>
+
+          {isRecurring && (
+            <>
+              <form.AppField name="recurDate">
+                {field => <field.DatePickerField label="Renewal Date" />}
+              </form.AppField>
+
+              <form.AppField name="recurPeriodUnit">
+                {field => (
+                  <field.RadioGroupField
+                    label="Recurrence Period"
+                    options={[
+                      {
+                        value: "days",
+                        label: "Days",
+                      },
+                      {
+                        value: "months",
+                        label: "Months",
+                      },
+                      {
+                        value: "years",
+                        label: "Years",
+                      },
+                    ]}
+                    labelClassName=""
+                  />
+                )}
+              </form.AppField>
+
+              <form.AppField name="recurPeriod">
+                {field => (
+                  <field.NumberField
+                    label="Every N Periods"
+                    min={1}
+                  />
+                )}
+              </form.AppField>
+            </>
+          )}
+
+          <div className="flex flex-row gap-4">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Provider" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/providers",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/providers/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/providers.$id.index.tsx
+++ b/packages/client/src/routes/providers.$id.index.tsx
@@ -94,16 +94,12 @@ function SingleProviders() {
             </a>
           )}
           <Link
-            to="/courses/$id/edit"
+            to="/providers/$id/edit"
             params={{
               id: data?.id + "",
             }}
-            disabled={true}
           >
-            <Button
-              variant="secondary"
-              disabled={true}
-            >
+            <Button variant="secondary">
               Edit Provider
               {" "}
               <EditIcon />

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -2,8 +2,9 @@ import type { CourseProvider } from "@emstack/types/src";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
+import { ContentBox } from "@/components/boxes/ContentBox";
 import { ProviderBox } from "@/components/boxes/ProviderBox";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -87,6 +88,24 @@ function Topics() {
                 />
               );
             })}
+
+          <Link
+            to="/providers/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <ContentBox
+              className="
+                h-full items-center justify-center border-dashed p-8
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
+              "
+            >
+              <PlusIcon size={32} />
+              <span className="text-lg font-medium">Add New Provider</span>
+            </ContentBox>
+          </Link>
         </div>
       </div>
     </div>

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -142,6 +142,40 @@ export async function upsertTopic(
   return await response.json();
 }
 
+export async function createProvider(
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch("/api/providers", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create provider: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function upsertProvider(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<SuccessObj> {
+  const response = await fetch(`/api/providers/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update provider: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
 export async function postOnboardForm(
   formData: OnboardData,
 ): Promise<SuccessObj> {

--- a/packages/middleware/src/routes/api/providers/createProvider.ts
+++ b/packages/middleware/src/routes/api/providers/createProvider.ts
@@ -1,0 +1,76 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { courseProviders } from "@/db/schema";
+import { v4 as uuidv4 } from "uuid";
+
+const createSchema = {
+  schema: {
+    description: "Create a new provider",
+    body: {
+      type: "object",
+      required: ["name", "url"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        url: {
+          type: "string",
+        },
+        cost: {
+          type: ["string", "null"],
+        },
+        isRecurring: {
+          type: ["boolean", "null"],
+        },
+        recurDate: {
+          type: ["string", "null"],
+        },
+        recurPeriodUnit: {
+          type: ["string", "null"],
+          enum: ["days", "months", "years", null],
+        },
+        recurPeriod: {
+          type: ["integer", "null"],
+        },
+        isCourseFeesShared: {
+          type: ["boolean", "null"],
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request, reply) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(courseProviders).values({
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        url: body.url,
+        cost: body.cost ?? null,
+        isRecurring: body.isRecurring ?? null,
+        recurDate: body.recurDate ?? null,
+        recurPeriodUnit: body.recurPeriodUnit as "days" | "months" | "years" | undefined,
+        recurPeriod: body.recurPeriod ?? null,
+        isCourseFeesShared: body.isCourseFeesShared ?? null,
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/providers/routes.ts
+++ b/packages/middleware/src/routes/api/providers/routes.ts
@@ -3,6 +3,8 @@ import { FastifyInstance } from "fastify";
 
 import courseRoot from "./root";
 import getProviders from "./getProviders";
+import createProvider from "./createProvider";
+import upsertProvider from "./upsertProvider";
 import deleteProviders from "./deleteProviders";
 
 export default async function (server: FastifyInstance) {
@@ -10,5 +12,7 @@ export default async function (server: FastifyInstance) {
 
   fastify.register(courseRoot);
   fastify.register(getProviders);
+  fastify.register(createProvider);
+  fastify.register(upsertProvider);
   fastify.register(deleteProviders);
 }

--- a/packages/middleware/src/routes/api/providers/upsertProvider.ts
+++ b/packages/middleware/src/routes/api/providers/upsertProvider.ts
@@ -1,0 +1,103 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { courseProviders } from "@/db/schema";
+
+const upsertSchema = {
+  schema: {
+    description: "Create or update a provider",
+    params: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+      },
+      required: ["id"],
+    },
+    body: {
+      type: "object",
+      required: ["name", "url"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        url: {
+          type: "string",
+        },
+        cost: {
+          type: ["string", "null"],
+        },
+        isRecurring: {
+          type: ["boolean", "null"],
+        },
+        recurDate: {
+          type: ["string", "null"],
+        },
+        recurPeriodUnit: {
+          type: ["string", "null"],
+          enum: ["days", "months", "years", null],
+        },
+        recurPeriod: {
+          type: ["integer", "null"],
+        },
+        isCourseFeesShared: {
+          type: ["boolean", "null"],
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:id",
+    upsertSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const body = request.body;
+
+      const providerData = {
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        url: body.url,
+        cost: body.cost ?? null,
+        isRecurring: body.isRecurring ?? null,
+        recurDate: body.recurDate ?? null,
+        recurPeriodUnit: body.recurPeriodUnit as "days" | "months" | "years" | undefined,
+        recurPeriod: body.recurPeriod ?? null,
+        isCourseFeesShared: body.isCourseFeesShared ?? null,
+      };
+
+      await db
+        .insert(courseProviders)
+        .values(providerData)
+        .onConflictDoUpdate({
+          target: courseProviders.id,
+          set: {
+            name: providerData.name,
+            description: providerData.description,
+            url: providerData.url,
+            cost: providerData.cost,
+            isRecurring: providerData.isRecurring,
+            recurDate: providerData.recurDate,
+            recurPeriodUnit: providerData.recurPeriodUnit,
+            recurPeriod: providerData.recurPeriod,
+            isCourseFeesShared: providerData.isCourseFeesShared,
+          },
+        });
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}


### PR DESCRIPTION
## ELI5
Providers (like Udemy or Coursera) could only be viewed and deleted before. Now you can create new providers and edit existing ones, just like you already could with courses and topics.

## Summary
- Add POST and PUT API endpoints for providers in the middleware
- Add provider edit/create page with form fields for name, description, URL, cost, subscription settings, and fee sharing
- Add "Add New Provider" button to the providers list page
- Fix the disabled edit button on the provider detail page

## Test plan
- [ ] Navigate to `/providers` and click "Add New Provider" card
- [ ] Fill out the form and create a new provider — verify it appears in the list
- [ ] Click into a provider, click "Edit Provider", change fields, and save
- [ ] Verify unsaved changes dialog appears when navigating away with changes
- [ ] Test recurring subscription fields show/hide when toggling "Recurring Subscription"
- [ ] Verify cancel button navigates back appropriately (list for new, detail for edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)