### PR TITLE
Fixes #82: Nest Providers under Courses as hover dropdown in navbar

### DIFF
--- a/packages/client/src/components/layout/NavDropdown.tsx
+++ b/packages/client/src/components/layout/NavDropdown.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useRef, useState } from "react";
+
+import { Link } from "@tanstack/react-router";
+import { ChevronDownIcon } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface NavDropdownProps {
+  label: string;
+  to: React.ComponentProps<typeof Link>["to"];
+  children: React.ReactNode;
+}
+
+export function NavDropdown({
+  label, to, children,
+}: NavDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+    setOpen(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    closeTimeout.current = setTimeout(() => setOpen(false), 150);
+  }, []);
+
+  return (
+    <div
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <DropdownMenu
+        open={open}
+        onOpenChange={setOpen}
+      >
+        <DropdownMenuTrigger asChild>
+          <span className="inline-flex items-center gap-0.5">
+            <Link
+              to={to}
+              className={`
+                underline-offset-2
+                hover:underline
+                [&.active]:font-bold
+              `}
+            >
+              {label}
+            </Link>
+            <ChevronDownIcon className="size-3.5" />
+          </span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">{children}</DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -7,14 +7,9 @@ import {
   Outlet,
   useNavigate,
 } from "@tanstack/react-router";
-import {
-  ChevronDownIcon,
-  EraserIcon,
-  MoonIcon,
-  SproutIcon,
-  SunIcon,
-} from "lucide-react";
+import { EraserIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
 
+import { NavDropdown } from "@/components/layout/NavDropdown";
 import { Toaster } from "@/components/sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,59 +30,6 @@ import {
   fetchSeed,
   fetchTopics,
 } from "@/utils";
-
-function CoursesNavItem() {
-  const [open, setOpen] = useState(false);
-  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleMouseEnter = useCallback(() => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-      closeTimeout.current = null;
-    }
-    setOpen(true);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    closeTimeout.current = setTimeout(() => setOpen(false), 150);
-  }, []);
-
-  return (
-    <div
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <DropdownMenu
-        open={open}
-        onOpenChange={setOpen}
-      >
-        <DropdownMenuTrigger asChild>
-          <span className="inline-flex items-center gap-0.5">
-            <Link
-              to="/courses"
-              className={`
-                underline-offset-2
-                hover:underline
-                [&.active]:font-bold
-              `}
-            >
-              Courses
-            </Link>
-            <ChevronDownIcon className="size-3.5" />
-          </span>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuItem
-            asChild
-            className="cursor-pointer"
-          >
-            <Link to="/providers">Providers</Link>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-}
 
 const RootComponent: React.FunctionComponent = () => {
   const navigate = useNavigate();
@@ -182,7 +124,17 @@ const RootComponent: React.FunctionComponent = () => {
             </Link>
           )}
 
-          <CoursesNavItem />
+          <NavDropdown
+            label="Courses"
+            to="/courses"
+          >
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer"
+            >
+              <Link to="/providers">Providers</Link>
+            </DropdownMenuItem>
+          </NavDropdown>
 
           <Link
             to="/topics"

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -7,7 +7,13 @@ import {
   Outlet,
   useNavigate,
 } from "@tanstack/react-router";
-import { EraserIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  EraserIcon,
+  MoonIcon,
+  SproutIcon,
+  SunIcon,
+} from "lucide-react";
 
 import { Toaster } from "@/components/sonner";
 import { Button } from "@/components/ui/button";
@@ -29,6 +35,59 @@ import {
   fetchSeed,
   fetchTopics,
 } from "@/utils";
+
+function CoursesNavItem() {
+  const [open, setOpen] = useState(false);
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+    setOpen(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    closeTimeout.current = setTimeout(() => setOpen(false), 150);
+  }, []);
+
+  return (
+    <div
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <DropdownMenu
+        open={open}
+        onOpenChange={setOpen}
+      >
+        <DropdownMenuTrigger asChild>
+          <span className="inline-flex items-center gap-0.5">
+            <Link
+              to="/courses"
+              className={`
+                underline-offset-2
+                hover:underline
+                [&.active]:font-bold
+              `}
+            >
+              Courses
+            </Link>
+            <ChevronDownIcon className="size-3.5" />
+          </span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem
+            asChild
+            className="cursor-pointer"
+          >
+            <Link to="/providers">Providers</Link>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 const RootComponent: React.FunctionComponent = () => {
   const navigate = useNavigate();
@@ -123,16 +182,7 @@ const RootComponent: React.FunctionComponent = () => {
             </Link>
           )}
 
-          <Link
-            to="/courses"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
-          >
-            Courses
-          </Link>
+          <CoursesNavItem />
 
           <Link
             to="/topics"
@@ -143,17 +193,6 @@ const RootComponent: React.FunctionComponent = () => {
             `}
           >
             Topics
-          </Link>
-
-          <Link
-            to="/providers"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
-          >
-            Providers
           </Link>
         </div>
         <div className="flex flex-row gap-2">

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -29,7 +29,7 @@ const formSchema = z.object({
   cost: z.number().min(0).nullable(),
   isRecurring: z.string(),
   recurDate: z.date().nullable(),
-  recurPeriodUnit: z.string(),
+  recurPeriodUnit: z.enum(["days", "months", "years"]),
   recurPeriod: z.number().int().min(1).nullable(),
   isCourseFeesShared: z.string(),
 });


### PR DESCRIPTION
## ELI5
The Providers page link used to sit alongside Courses and Topics in the top navigation bar. Now it's tucked inside Courses as a dropdown — hover over Courses and you'll see Providers pop up underneath. This keeps the nav cleaner since Providers is conceptually part of Courses.

## Summary
- Replaced the standalone Providers nav link with a hover-triggered dropdown under Courses, including a chevron indicator and cursor-pointer styling
- Fixed a TypeScript type error in the provider edit form by narrowing `recurPeriodUnit` from `z.string()` to `z.enum(["days", "months", "years"])`

## Test plan
- [ ] Hover over "Courses" in the navbar — dropdown appears with "Providers" item
- [ ] Click "Courses" text — navigates to `/courses`
- [ ] Click "Providers" in dropdown — navigates to `/providers`
- [ ] Verify the standalone "Providers" link is gone from the navbar
- [ ] Navigate to provider edit page — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)