### PR TITLE
Fixes #83: Use provider cost when isCourseFeesShared is enabled

### DIFF
--- a/packages/client/src/components/formFields/NumberField.tsx
+++ b/packages/client/src/components/formFields/NumberField.tsx
@@ -7,6 +7,7 @@ interface NumberFieldProps {
   className?: string;
   min?: number;
   step?: string;
+  disabled?: boolean;
 }
 
 export function NumberField({
@@ -14,6 +15,7 @@ export function NumberField({
   className = "text-2xl",
   min,
   step,
+  disabled,
 }: NumberFieldProps) {
   const field = useFieldContext<number | null>();
   const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
@@ -32,6 +34,7 @@ export function NumberField({
         type="number"
         min={min}
         step={step}
+        disabled={disabled}
         value={field.state.value ?? ""}
         onBlur={field.handleBlur}
         onChange={e =>

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -96,7 +96,11 @@ function SingleCourseEdit() {
         status: value.status,
         progressCurrent: value.progressCurrent ?? 0,
         progressTotal: value.progressTotal ?? 0,
-        cost: value.cost != null ? String(value.cost) : null,
+        cost: data?.cost?.isCostFromPlatform
+          ? null
+          : value.cost != null
+            ? String(value.cost)
+            : null,
         isCostFromPlatform: data?.cost?.isCostFromPlatform ?? false,
         dateExpires: value.dateExpires
           ? value.dateExpires.toISOString().split("T")[0]
@@ -253,6 +257,7 @@ function SingleCourseEdit() {
               label="Cost ($)"
               min={0}
               step="0.01"
+              disabled={data?.cost?.isCostFromPlatform ?? false}
             />
           )}
         </form.AppField>

--- a/packages/middleware/src/utils/processCost.ts
+++ b/packages/middleware/src/utils/processCost.ts
@@ -7,10 +7,10 @@ export function processCost(course: CourseFromServer): CostData {
     isCostFromPlatform: false,
   };
   if (course) {
-    if (course.isCostFromPlatform === true && course.courseProvider) {
+    if (course.courseProvider?.isCourseFeesShared === true) {
       costData = {
         cost: course.courseProvider.cost ?? null,
-        isCostFromPlatform: course.isCostFromPlatform,
+        isCostFromPlatform: true,
         splitBy: course.courseProvider.courses
           ? course.courseProvider.courses.length
           : 1,
@@ -19,7 +19,7 @@ export function processCost(course: CourseFromServer): CostData {
     else {
       costData = {
         cost: course.cost ?? null,
-        isCostFromPlatform: course.isCostFromPlatform,
+        isCostFromPlatform: false,
       };
     }
   }


### PR DESCRIPTION
## ELI5
When a course platform charges one fee for all its courses (like a Netflix subscription), the cost now automatically comes from the platform instead of each individual course. The cost field on the course edit page is grayed out so you can't accidentally override it.

## Summary
- `processCost` now checks `courseProvider.isCourseFeesShared` instead of the per-course `isCostFromPlatform` flag to determine cost source
- Added `disabled` prop to `NumberField` component
- Course edit form grays out the cost field and sends `null` for cost when provider fees are shared

## Test plan
- [ ] Edit a course whose provider has `isCourseFeesShared = true` — cost field should be grayed out showing the provider cost
- [ ] Edit a course whose provider does NOT have shared fees — cost field should be editable as normal
- [ ] GET `/api/courses` — verify courses under a shared-fee provider return provider cost with `isCostFromPlatform: true`
- [ ] GET `/api/courses/:id` — same verification for single course endpoint
- [ ] Save a course with shared fees — verify cost is not overwritten on the course record

🤖 Generated with [Claude Code](https://claude.com/claude-code)