### PR TITLE
Fixes #91: Add Domains entity with full CRUD and topic associations

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "3.4.0",
     "tailwindcss": "4.2.2",
-    "vite": "8.0.8",
+    "vite": "8.0.10",
     "zod": "4.1.12"
   },
   "devDependencies": {

--- a/packages/client/src/components/boxes/DomainBox.tsx
+++ b/packages/client/src/components/boxes/DomainBox.tsx
@@ -1,0 +1,59 @@
+import type { Domain } from "@emstack/types/src";
+
+import { Link } from "@tanstack/react-router";
+import { BookIcon, RadarIcon } from "lucide-react";
+
+import { CourseMetaItem } from "@/components/boxElements/CourseMetaItem";
+import {
+  ContentBox,
+  ContentBoxBody,
+  ContentBoxFooter,
+  ContentBoxHeader,
+  ContentBoxHeaderBar,
+  ContentBoxTitle,
+} from "@/components/boxes/ContentBox";
+
+export function DomainBox({
+  id,
+  title,
+  description,
+  topicCount,
+  hasRadar,
+}: Domain) {
+  return (
+    <ContentBox>
+      <ContentBoxHeader>
+        <ContentBoxHeaderBar />
+        <ContentBoxTitle>
+          <h3 className="text-2xl">
+            <Link
+              to="/domains/$id"
+              from="/domains"
+              params={{
+                id: id + "",
+              }}
+              className="hover:text-blue-600"
+            >
+              {title}
+            </Link>
+          </h3>
+        </ContentBoxTitle>
+      </ContentBoxHeader>
+      <ContentBoxBody>
+        <p>{description ? description : <i>No description provided.</i>}</p>
+      </ContentBoxBody>
+      <ContentBoxFooter>
+        <CourseMetaItem
+          value={topicCount}
+          condition={true}
+          iconNode={<BookIcon size={16} />}
+        />
+        <CourseMetaItem
+          value="Radar"
+          condition={!!hasRadar}
+          iconNode={<RadarIcon size={16} />}
+        />
+      </ContentBoxFooter>
+    </ContentBox>
+  );
+}

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -1,0 +1,75 @@
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  useComboboxAnchor,
+} from "@/components/combobox";
+import { Field, FieldError, FieldLabel } from "@/components/forms/field";
+import { useFieldContext } from "@/utils/fieldContext";
+
+interface MultiComboboxFieldProps {
+  label: string;
+  options: { value: string;
+    label: string; }[];
+  placeholder?: string;
+  className?: string;
+}
+
+export function MultiComboboxField({
+  label,
+  options,
+  placeholder,
+  className = "text-2xl",
+}: MultiComboboxFieldProps) {
+  const field = useFieldContext<string[]>();
+  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+  const anchor = useComboboxAnchor();
+
+  const optionsMap = new Map(options.map(o => [o.value, o.label]));
+
+  return (
+    <Field data-invalid={isInvalid}>
+      <FieldLabel className={className}>{label}</FieldLabel>
+      <Combobox
+        multiple
+        value={field.state.value || []}
+        onValueChange={val => field.handleChange(val)}
+        itemToStringLabel={val => optionsMap.get(val) ?? ""}
+      >
+        <ComboboxChips ref={anchor}>
+          {(field.state.value || []).map(val => (
+            <ComboboxChip
+              key={val}
+              value={val}
+            >
+              {optionsMap.get(val) ?? val}
+            </ComboboxChip>
+          ))}
+          <ComboboxChipsInput
+            placeholder={placeholder}
+            onBlur={field.handleBlur}
+          />
+        </ComboboxChips>
+        <ComboboxContent anchor={anchor}>
+          <ComboboxEmpty>No items found.</ComboboxEmpty>
+          <ComboboxList>
+            {options.map(option => (
+              <ComboboxItem
+                key={option.value}
+                value={option.value}
+              >
+                {option.label}
+              </ComboboxItem>
+            ))}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+      {isInvalid && <FieldError errors={field.state.meta.errors} />}
+    </Field>
+  );
+}

--- a/packages/client/src/components/formFields/index.ts
+++ b/packages/client/src/components/formFields/index.ts
@@ -4,4 +4,5 @@ export { InputField } from "./InputField";
 export { NumberField } from "./NumberField";
 export { RadioGroupField } from "./RadioGroupField";
 export { TextareaField } from "./TextareaField";
+export { MultiComboboxField } from "./MultiComboboxField";
 export { useAppForm } from "@/hooks/useAppForm";

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   pageTitle?: string;
-  pageSection?: "" | "courses" | "topics" | "providers";
+  pageSection?: "" | "courses" | "topics" | "providers" | "domains";
   children?: React.ReactNode;
   progressCurrent?: number;
   progressTotal?: number;
@@ -57,6 +57,14 @@ export function PageHeader({
                   Providers
                 </Link>
               )}
+              {pageSection === "domains" && (
+                <Link
+                  to="/domains"
+                  className="text-sm uppercase"
+                >
+                  Domains
+                </Link>
+              )}
             </div>
           )}
           <div
@@ -68,11 +76,7 @@ export function PageHeader({
             <div>
               <h1 className="text-3xl">{pageTitle}</h1>
             </div>
-            {children && (
-              <div>
-                {children}
-              </div>
-            )}
+            {children && <div>{children}</div>}
           </div>
         </div>
       </div>
@@ -86,7 +90,9 @@ export function PageHeader({
             className="mt-6 bg-gray-300"
           />
         )
-        : <></>}
+        : (
+          <></>
+        )}
     </div>
   );
 }

--- a/packages/client/src/hooks/useAppForm.ts
+++ b/packages/client/src/hooks/useAppForm.ts
@@ -3,6 +3,7 @@ import { createFormHook } from "@tanstack/react-form";
 import { ComboboxField } from "@/components/formFields/ComboboxField";
 import { DatePickerField } from "@/components/formFields/DatePickerField";
 import { InputField } from "@/components/formFields/InputField";
+import { MultiComboboxField } from "@/components/formFields/MultiComboboxField";
 import { NumberField } from "@/components/formFields/NumberField";
 import { RadioGroupField } from "@/components/formFields/RadioGroupField";
 import { TextareaField } from "@/components/formFields/TextareaField";
@@ -18,6 +19,7 @@ export const {
     RadioGroupField,
     DatePickerField,
     ComboboxField,
+    MultiComboboxField,
   },
   formComponents: {},
   fieldContext,

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -12,19 +12,24 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as TopicsRouteImport } from './routes/topics'
 import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
+import { Route as DomainsRouteImport } from './routes/domains'
 import { Route as CoursesRouteImport } from './routes/courses'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
+import { Route as DomainsIndexRouteImport } from './routes/domains.index'
 import { Route as CoursesIndexRouteImport } from './routes/courses.index'
 import { Route as TopicsIdRouteImport } from './routes/topics.$id'
 import { Route as ProvidersIdRouteImport } from './routes/providers.$id'
+import { Route as DomainsIdRouteImport } from './routes/domains.$id'
 import { Route as CoursesIdRouteImport } from './routes/courses.$id'
 import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
+import { Route as DomainsIdIndexRouteImport } from './routes/domains.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
 import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
+import { Route as DomainsIdEditRouteImport } from './routes/domains.$id.edit'
 import { Route as CoursesIdEditRouteImport } from './routes/courses.$id.edit'
 
 const TopicsRoute = TopicsRouteImport.update({
@@ -40,6 +45,11 @@ const ProvidersRoute = ProvidersRouteImport.update({
 const OnboardRoute = OnboardRouteImport.update({
   id: '/onboard',
   path: '/onboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DomainsRoute = DomainsRouteImport.update({
+  id: '/domains',
+  path: '/domains',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CoursesRoute = CoursesRouteImport.update({
@@ -62,6 +72,11 @@ const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ProvidersRoute,
 } as any)
+const DomainsIndexRoute = DomainsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DomainsRoute,
+} as any)
 const CoursesIndexRoute = CoursesIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -76,6 +91,11 @@ const ProvidersIdRoute = ProvidersIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => ProvidersRoute,
+} as any)
+const DomainsIdRoute = DomainsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => DomainsRoute,
 } as any)
 const CoursesIdRoute = CoursesIdRouteImport.update({
   id: '/$id',
@@ -92,6 +112,11 @@ const ProvidersIdIndexRoute = ProvidersIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ProvidersIdRoute,
 } as any)
+const DomainsIdIndexRoute = DomainsIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DomainsIdRoute,
+} as any)
 const CoursesIdIndexRoute = CoursesIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -107,6 +132,11 @@ const ProvidersIdEditRoute = ProvidersIdEditRouteImport.update({
   path: '/edit',
   getParentRoute: () => ProvidersIdRoute,
 } as any)
+const DomainsIdEditRoute = DomainsIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => DomainsIdRoute,
+} as any)
 const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -116,19 +146,24 @@ const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
+  '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
+  '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
 }
@@ -136,12 +171,15 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/onboard': typeof OnboardRoute
   '/courses': typeof CoursesIndexRoute
+  '/domains': typeof DomainsIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id': typeof CoursesIdIndexRoute
+  '/domains/$id': typeof DomainsIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
 }
@@ -149,19 +187,24 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
+  '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
+  '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
+  '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
 }
@@ -170,19 +213,24 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/courses'
+    | '/domains'
     | '/onboard'
     | '/providers'
     | '/topics'
     | '/courses/$id'
+    | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
     | '/courses/'
+    | '/domains/'
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
+    | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
   fileRoutesByTo: FileRoutesByTo
@@ -190,31 +238,39 @@ export interface FileRouteTypes {
     | '/'
     | '/onboard'
     | '/courses'
+    | '/domains'
     | '/providers'
     | '/topics'
     | '/courses/$id/edit'
+    | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id'
+    | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
   id:
     | '__root__'
     | '/'
     | '/courses'
+    | '/domains'
     | '/onboard'
     | '/providers'
     | '/topics'
     | '/courses/$id'
+    | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
     | '/courses/'
+    | '/domains/'
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
+    | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
   fileRoutesById: FileRoutesById
@@ -222,6 +278,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CoursesRoute: typeof CoursesRouteWithChildren
+  DomainsRoute: typeof DomainsRouteWithChildren
   OnboardRoute: typeof OnboardRoute
   ProvidersRoute: typeof ProvidersRouteWithChildren
   TopicsRoute: typeof TopicsRouteWithChildren
@@ -248,6 +305,13 @@ declare module '@tanstack/react-router' {
       path: '/onboard'
       fullPath: '/onboard'
       preLoaderRoute: typeof OnboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/domains': {
+      id: '/domains'
+      path: '/domains'
+      fullPath: '/domains'
+      preLoaderRoute: typeof DomainsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/courses': {
@@ -278,6 +342,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersIndexRouteImport
       parentRoute: typeof ProvidersRoute
     }
+    '/domains/': {
+      id: '/domains/'
+      path: '/'
+      fullPath: '/domains/'
+      preLoaderRoute: typeof DomainsIndexRouteImport
+      parentRoute: typeof DomainsRoute
+    }
     '/courses/': {
       id: '/courses/'
       path: '/'
@@ -298,6 +369,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/providers/$id'
       preLoaderRoute: typeof ProvidersIdRouteImport
       parentRoute: typeof ProvidersRoute
+    }
+    '/domains/$id': {
+      id: '/domains/$id'
+      path: '/$id'
+      fullPath: '/domains/$id'
+      preLoaderRoute: typeof DomainsIdRouteImport
+      parentRoute: typeof DomainsRoute
     }
     '/courses/$id': {
       id: '/courses/$id'
@@ -320,6 +398,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersIdIndexRouteImport
       parentRoute: typeof ProvidersIdRoute
     }
+    '/domains/$id/': {
+      id: '/domains/$id/'
+      path: '/'
+      fullPath: '/domains/$id/'
+      preLoaderRoute: typeof DomainsIdIndexRouteImport
+      parentRoute: typeof DomainsIdRoute
+    }
     '/courses/$id/': {
       id: '/courses/$id/'
       path: '/'
@@ -340,6 +425,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/providers/$id/edit'
       preLoaderRoute: typeof ProvidersIdEditRouteImport
       parentRoute: typeof ProvidersIdRoute
+    }
+    '/domains/$id/edit': {
+      id: '/domains/$id/edit'
+      path: '/edit'
+      fullPath: '/domains/$id/edit'
+      preLoaderRoute: typeof DomainsIdEditRouteImport
+      parentRoute: typeof DomainsIdRoute
     }
     '/courses/$id/edit': {
       id: '/courses/$id/edit'
@@ -377,6 +469,33 @@ const CoursesRouteChildren: CoursesRouteChildren = {
 
 const CoursesRouteWithChildren =
   CoursesRoute._addFileChildren(CoursesRouteChildren)
+
+interface DomainsIdRouteChildren {
+  DomainsIdEditRoute: typeof DomainsIdEditRoute
+  DomainsIdIndexRoute: typeof DomainsIdIndexRoute
+}
+
+const DomainsIdRouteChildren: DomainsIdRouteChildren = {
+  DomainsIdEditRoute: DomainsIdEditRoute,
+  DomainsIdIndexRoute: DomainsIdIndexRoute,
+}
+
+const DomainsIdRouteWithChildren = DomainsIdRoute._addFileChildren(
+  DomainsIdRouteChildren,
+)
+
+interface DomainsRouteChildren {
+  DomainsIdRoute: typeof DomainsIdRouteWithChildren
+  DomainsIndexRoute: typeof DomainsIndexRoute
+}
+
+const DomainsRouteChildren: DomainsRouteChildren = {
+  DomainsIdRoute: DomainsIdRouteWithChildren,
+  DomainsIndexRoute: DomainsIndexRoute,
+}
+
+const DomainsRouteWithChildren =
+  DomainsRoute._addFileChildren(DomainsRouteChildren)
 
 interface ProvidersIdRouteChildren {
   ProvidersIdEditRoute: typeof ProvidersIdEditRoute
@@ -436,6 +555,7 @@ const TopicsRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CoursesRoute: CoursesRouteWithChildren,
+  DomainsRoute: DomainsRouteWithChildren,
   OnboardRoute: OnboardRoute,
   ProvidersRoute: ProvidersRouteWithChildren,
   TopicsRoute: TopicsRouteWithChildren,

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -26,6 +26,7 @@ import { useTheme } from "@/hooks/useTheme.ts";
 import {
   fetchClear,
   fetchCourses,
+  fetchDomains,
   fetchProviders,
   fetchSeed,
   fetchTopics,
@@ -78,13 +79,24 @@ const RootComponent: React.FunctionComponent = () => {
     queryFn: () => fetchProviders(),
   });
 
+  const {
+    data: domainsData,
+  } = useQuery({
+    queryKey: ["domains"],
+    queryFn: () => fetchDomains(),
+  });
+
   const allLoaded
     = coursesData !== undefined
       && topicsData !== undefined
-      && providersData !== undefined;
+      && providersData !== undefined
+      && domainsData !== undefined;
   const showOnboard
     = !allLoaded
-      || (!coursesData?.length && !topicsData?.length && !providersData?.length);
+      || (!coursesData?.length
+        && !topicsData?.length
+        && !providersData?.length
+        && !domainsData?.length);
 
   async function handleClearLocal() {
     const clearRefetchResult = await clearRefetch();
@@ -136,16 +148,17 @@ const RootComponent: React.FunctionComponent = () => {
             </DropdownMenuItem>
           </NavDropdown>
 
-          <Link
+          <NavDropdown
+            label="Topics"
             to="/topics"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
           >
-            Topics
-          </Link>
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer"
+            >
+              <Link to="/domains">Domains</Link>
+            </DropdownMenuItem>
+          </NavDropdown>
         </div>
         <div className="flex flex-row gap-2">
           <DropdownMenu>

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -1,0 +1,241 @@
+import { useMemo, useRef } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createDomain,
+  fetchSingleDomain,
+  fetchTopics,
+  formHasChanges,
+  upsertDomain,
+} from "@/utils";
+
+export const Route = createFileRoute("/domains/$id/edit")({
+  component: SingleDomainEdit,
+});
+
+const formSchema = z.object({
+  title: z.string().min(1, "Title is required").max(255),
+  description: z.string().max(500),
+  hasRadar: z.string(),
+  topicIds: z.array(z.string()),
+});
+
+function SingleDomainEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["domain", id],
+    queryFn: () => fetchSingleDomain(id),
+    enabled: !isNew,
+  });
+
+  const {
+    data: topicsData,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const topicOptions = useMemo(
+    () =>
+      (topicsData ?? []).map(t => ({
+        value: t.id,
+        label: t.name,
+      })),
+    [topicsData],
+  );
+
+  const startingValues = useMemo(
+    () => ({
+      title: data?.title ?? "",
+      description: data?.description ?? "",
+      hasRadar: data?.hasRadar ? "true" : "false",
+      topicIds: data?.topics?.map(t => t.id) ?? [],
+    }),
+    [data],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const domainData = {
+        title: value.title,
+        description: value.description || null,
+        hasRadar: value.hasRadar === "true",
+        topicIds: value.topicIds,
+      };
+
+      try {
+        let domainId: string;
+        if (isNew) {
+          const result = await createDomain(domainData);
+          domainId = result.id;
+        }
+        else {
+          await upsertDomain(id, domainData);
+          domainId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["domain", id],
+          });
+        }
+
+        await queryClient.invalidateQueries({
+          queryKey: ["domains"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/domains/$id",
+          params: {
+            id: domainId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create domain. Please try again."
+            : "Failed to save domain. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Domain" : "Edit Domain"}
+        pageSection="domains"
+      >
+        {!isNew && (
+          <Link
+            to="/domains/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Domain
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="container flex-col">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-2xl flex-col gap-8"
+        >
+          <form.AppField name="title">
+            {field => <field.InputField label="Domain Title" />}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What is this domain about?"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="hasRadar">
+            {field => (
+              <field.RadioGroupField
+                label="Has Radar?"
+                options={[
+                  {
+                    value: "true",
+                    label: "Yes",
+                  },
+                  {
+                    value: "false",
+                    label: "No",
+                  },
+                ]}
+                labelClassName=""
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="topicIds">
+            {field => (
+              <field.MultiComboboxField
+                label="Topics"
+                options={topicOptions}
+                placeholder="Search topics..."
+              />
+            )}
+          </form.AppField>
+
+          <div className="flex flex-row gap-4">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Domain" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/domains",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/domains/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -1,0 +1,125 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EditIcon } from "lucide-react";
+
+import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
+import { InfoArea } from "@/components/layout/InfoArea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { DeleteButton } from "@/components/ui/DeleteButton";
+import { deleteSingleDomain, fetchSingleDomain } from "@/utils";
+
+export const Route = createFileRoute("/domains/$id/")({
+  component: SingleDomain,
+});
+
+function SingleDomain() {
+  const {
+    id,
+  } = Route.useParams();
+  const navigate = useNavigate();
+
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["domain", id],
+    queryFn: () => fetchSingleDomain(id),
+  });
+
+  const {
+    refetch: deleteDomain,
+  } = useQuery({
+    queryKey: ["domain", "delete", id],
+    enabled: false,
+    queryFn: () => deleteSingleDomain(id),
+  });
+
+  if (isPending) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">Hold on, loading your domain...</h1>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">
+          There was an error loading this domain.
+        </h1>
+      </div>
+    );
+  }
+
+  async function handleDelete() {
+    await deleteDomain();
+    await navigate({
+      to: "/domains",
+    });
+  }
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={data?.title}
+        pageSection="domains"
+      >
+        <div className="flex flex-row gap-2">
+          <Link
+            to="/domains/$id/edit"
+            params={{
+              id: data?.id + "",
+            }}
+          >
+            <Button variant="secondary">
+              Edit Domain
+              {" "}
+              <EditIcon />
+            </Button>
+          </Link>
+        </div>
+      </PageHeader>
+      <div className="container flex flex-col gap-12">
+        <InfoArea
+          header="About"
+          condition={!!data?.description}
+        >
+          <p>{data?.description}</p>
+        </InfoArea>
+        <InfoArea header="Has Radar?">
+          <YesNoDisplay value={!!data?.hasRadar} />
+        </InfoArea>
+        <div>
+          <InfoArea
+            header="Topics"
+            condition={!!data?.topicCount && data.topicCount > 0}
+          >
+            <ul className="ml-5 list-disc">
+              {data?.topics
+                && data.topics.map(topic => (
+                  <li key={topic.id}>
+                    <Link
+                      to="/topics/$id"
+                      params={{
+                        id: topic.id + "",
+                      }}
+                      className={`
+                        font-bold text-blue-800
+                        hover:text-blue-600
+                      `}
+                    >
+                      {topic.name}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </InfoArea>
+        </div>
+        <div>
+          <DeleteButton onClick={handleDelete}>Delete Domain</DeleteButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.$id.tsx
+++ b/packages/client/src/routes/domains.$id.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/domains/$id")({
+  component: SingleDomainLayout,
+});
+
+function SingleDomainLayout() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -1,0 +1,115 @@
+import type { Domain } from "@emstack/types/src";
+
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRightIcon, PlusIcon } from "lucide-react";
+
+import { ContentBox } from "@/components/boxes/ContentBox";
+import { DomainBox } from "@/components/boxes/DomainBox";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { fetchDomains } from "@/utils";
+
+export const Route = createFileRoute("/domains/")({
+  component: DomainsIndex,
+  errorComponent: DomainsError,
+  pendingComponent: DomainsPending,
+});
+
+function DomainsPending() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">Hold on, loading your domains...</h1>
+    </div>
+  );
+}
+
+function DomainsError() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">
+        There was an error loading your domains.
+      </h1>
+      <p>
+        Try to use the
+        {" "}
+        <Link to="/onboard">Onboarding Wizard</Link>
+        {" "}
+        again, or
+        load in properly formed data.
+      </p>
+    </div>
+  );
+}
+
+function DomainsIndex() {
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["domains"],
+    queryFn: () => fetchDomains(),
+  });
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Domains"
+        pageSection=""
+      />
+      <div className="container">
+        <div className="card-grid">
+          {(!data || data.length === 0) && (
+            <div className="flex flex-col gap-6">
+              <i>No domains yet!</i>
+
+              <Link
+                to="/domains/$id/edit"
+                params={{
+                  id: "new",
+                }}
+              >
+                <Button>
+                  Create your first domain
+                  {" "}
+                  <ArrowRightIcon />
+                </Button>
+              </Link>
+            </div>
+          )}
+
+          {data
+            && data.length > 0
+            && data.map((domain: Domain) => {
+              if (domain.title === "") {
+                return;
+              }
+              return (
+                <DomainBox
+                  {...domain}
+                  key={domain.id}
+                />
+              );
+            })}
+
+          <Link
+            to="/domains/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <ContentBox
+              className="
+                h-full items-center justify-center border-dashed p-8
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
+              "
+            >
+              <PlusIcon size={32} />
+              <span className="text-lg font-medium">Add New Domain</span>
+            </ContentBox>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.tsx
+++ b/packages/client/src/routes/domains.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/domains")({
+  component: Domains,
+});
+
+export function Domains() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -5,6 +5,7 @@ import type {
   CourseInCourses,
   TopicForTopicsPage,
   CourseProvider,
+  Domain,
 } from "@emstack/types/src/index.js";
 import type { OnboardData } from "@emstack/types/src/OnboardData";
 import type { Topic } from "@emstack/types/src/Topic";
@@ -169,4 +170,54 @@ export async function postOnboardForm(
     },
     body: JSON.stringify(formData),
   }).then(res => res.json());
+}
+
+export async function fetchDomains(): Promise<Domain[]> {
+  return await fetch("/api/domains").then(res => res.json());
+}
+
+export async function fetchSingleDomain(id: string): Promise<Domain> {
+  return await fetch(`/api/domains/${id}`).then(res => res.json());
+}
+
+export async function deleteSingleDomain(
+  id: string,
+): Promise<{ status: string }> {
+  return await fetch(`/api/domains/${id}`, {
+    method: "DELETE",
+  }).then(res => res.json());
+}
+
+export async function createDomain(
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch("/api/domains", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create domain: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function upsertDomain(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<SuccessObj> {
+  const response = await fetch(`/api/domains/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update domain: ${response.statusText}`);
+  }
+  return await response.json();
 }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -12,8 +12,8 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@fastify/http-proxy": "^11.4.3",
-    "@fastify/static": "^9.0.0",
-    "fastify": "^5.8.3"
+    "@fastify/http-proxy": "^11.4.4",
+    "@fastify/static": "^9.1.1",
+    "fastify": "^5.8.5"
   }
 }

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -10,10 +10,10 @@
     "@neondatabase/serverless": "1.0.2",
     "dotenv": "17.2.3",
     "dotenv-cli": "11.0.0",
-    "drizzle-orm": "0.44.7",
-    "fastify": "5.8.3",
+    "drizzle-orm": "0.45.2",
+    "fastify": "5.8.5",
     "pg": "8.16.3",
-    "uuid": "13.0.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@emstack/types": "workspace:*",

--- a/packages/middleware/src/db/clearData.ts
+++ b/packages/middleware/src/db/clearData.ts
@@ -1,9 +1,11 @@
-import { courseProviders, courses, topics, topicsToCourses } from "@/db/schema";
+import { courseProviders, courses, domains, topics, topicsToCourses, topicsToDomains } from "@/db/schema";
 import { db } from "@/db/index";
 
 export async function clearData() {
   await db.delete(topicsToCourses);
+  await db.delete(topicsToDomains);
   await db.delete(topics);
   await db.delete(courses);
   await db.delete(courseProviders);
+  await db.delete(domains);
 }

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -80,6 +80,52 @@ export const topicsRelations = relations(topics, ({
   many,
 }) => ({
   topicsToCourses: many(topicsToCourses),
+  topicsToDomains: many(topicsToDomains),
+}));
+
+export const domains = pgTable("domains", {
+  id: varchar().primaryKey(),
+  title: varchar({
+    length: 255,
+  }).notNull(),
+  description: varchar(),
+  hasRadar: boolean(),
+});
+
+export const domainsRelations = relations(domains, ({
+  many,
+}) => ({
+  topicsToDomains: many(topicsToDomains),
+}));
+
+export const topicsToDomains = pgTable(
+  "topics_to_domains",
+  {
+    topicId: varchar("topic_id")
+      .notNull()
+      .references(() => topics.id),
+    domainId: varchar("domain_id")
+      .notNull()
+      .references(() => domains.id),
+  },
+  t => [
+    primaryKey({
+      columns: [t.topicId, t.domainId],
+    }),
+  ],
+);
+
+export const topicsToDomainsRelation = relations(topicsToDomains, ({
+  one,
+}) => ({
+  topic: one(topics, {
+    fields: [topicsToDomains.topicId],
+    references: [topics.id],
+  }),
+  domain: one(domains, {
+    fields: [topicsToDomains.domainId],
+    references: [domains.id],
+  }),
 }));
 
 export const topicsToCourses = pgTable(

--- a/packages/middleware/src/db/seed.ts
+++ b/packages/middleware/src/db/seed.ts
@@ -1,8 +1,10 @@
 import {
   courseProviders,
   courses,
+  domains,
   topics,
   topicsToCourses,
+  topicsToDomains,
   usersTable,
 } from "@/db/schema";
 import { db } from "@/db/index";
@@ -229,6 +231,59 @@ export async function seed() {
           topicId: topicJapanese[0].id,
         },
       ])
+      .onConflictDoNothing();
+  }
+
+  const domainWebDevData: typeof domains.$inferInsert = {
+    id: "c1a2b3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    title: "Web Development",
+    description: "Building applications for the web.",
+    hasRadar: true,
+  };
+  const domainLanguageLearningData: typeof domains.$inferInsert = {
+    id: "d2b3c4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+    title: "Language Learning",
+    description: "Studying foreign languages.",
+    hasRadar: false,
+  };
+
+  const domainWebDev = await db
+    .insert(domains)
+    .values([domainWebDevData])
+    .onConflictDoNothing()
+    .returning();
+
+  const domainLanguageLearning = await db
+    .insert(domains)
+    .values([domainLanguageLearningData])
+    .onConflictDoNothing()
+    .returning();
+
+  if (domainWebDev[0] && topicReact[0]) {
+    await db
+      .insert(topicsToDomains)
+      .values([{
+        domainId: domainWebDev[0].id,
+        topicId: topicReact[0].id,
+      }])
+      .onConflictDoNothing();
+  }
+  if (domainWebDev[0] && topicTypescript[0]) {
+    await db
+      .insert(topicsToDomains)
+      .values([{
+        domainId: domainWebDev[0].id,
+        topicId: topicTypescript[0].id,
+      }])
+      .onConflictDoNothing();
+  }
+  if (domainLanguageLearning[0] && topicJapanese[0]) {
+    await db
+      .insert(topicsToDomains)
+      .values([{
+        domainId: domainLanguageLearning[0].id,
+        topicId: topicJapanese[0].id,
+      }])
       .onConflictDoNothing();
   }
 

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -1,0 +1,66 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { domains, topicsToDomains } from "@/db/schema";
+import { v4 as uuidv4 } from "uuid";
+
+const createSchema = {
+  schema: {
+    description: "Create a new domain",
+    body: {
+      type: "object",
+      required: ["title"],
+      properties: {
+        title: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        hasRadar: {
+          type: ["boolean", "null"],
+        },
+        topicIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request, reply) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(domains).values({
+        id,
+        title: body.title,
+        description: body.description ?? null,
+        hasRadar: body.hasRadar ?? null,
+      });
+
+      if (body.topicIds && body.topicIds.length > 0) {
+        await db.insert(topicsToDomains).values(
+          body.topicIds.map(topicId => ({
+            topicId,
+            domainId: id,
+          })),
+        );
+      }
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -1,0 +1,40 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { domains, topicsToDomains } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+const deleteSchema = {
+  schema: {
+    description: "Delete a domain by ID",
+    params: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+      },
+      required: ["id"],
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete(
+    "/:id",
+    deleteSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      await db.delete(topicsToDomains).where(eq(topicsToDomains.domainId, id));
+      await db.delete(domains).where(eq(domains.id, id));
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -1,0 +1,64 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+
+const getDomainSchema = {
+  schema: {
+    description: "Get a single domain by ID",
+    params: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+      },
+      required: ["id"],
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id",
+    getDomainSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const domain = await db.query.domains.findFirst({
+        where: (domains, {
+          eq,
+        }) => (eq(domains.id, id)),
+        with: {
+          topicsToDomains: {
+            with: {
+              topic: true,
+            },
+          },
+        },
+      });
+
+      if (domain) {
+        const topics = domain.topicsToDomains.map((ttd) => {
+          if (ttd.topic) {
+            return {
+              name: ttd.topic.name,
+              id: ttd.topic.id,
+            };
+          }
+        }).filter(Boolean);
+
+        return {
+          id: domain.id,
+          title: domain.title,
+          description: domain.description,
+          hasRadar: domain.hasRadar,
+          topicCount: topics.length,
+          topics: topics,
+        };
+      }
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/root.ts
+++ b/packages/middleware/src/routes/api/domains/root.ts
@@ -1,0 +1,37 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import type { Domain } from "@emstack/types/src";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/",
+    async (request, reply) => {
+      const rawData = await db.query.domains.findMany({
+        with: {
+          topicsToDomains: {
+            columns: {
+              topicId: true,
+            },
+          },
+        },
+      });
+
+      const processedData: Partial<Domain>[] = rawData.map((domain) => {
+        const topicCount = domain.topicsToDomains?.length ?? 0;
+
+        return {
+          id: domain.id,
+          title: domain.title,
+          description: domain.description,
+          hasRadar: domain.hasRadar,
+          topicCount: topicCount,
+        };
+      });
+
+      return processedData;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/routes.ts
+++ b/packages/middleware/src/routes/api/domains/routes.ts
@@ -1,0 +1,18 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import domainRoot from "./root";
+import getDomain from "./getDomain";
+import createDomain from "./createDomain";
+import upsertDomain from "./upsertDomain";
+import deleteDomain from "./deleteDomain";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(domainRoot);
+  fastify.register(getDomain);
+  fastify.register(createDomain);
+  fastify.register(upsertDomain);
+  fastify.register(deleteDomain);
+}

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -1,0 +1,90 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { domains, topicsToDomains } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+const upsertSchema = {
+  schema: {
+    description: "Create or update a domain",
+    params: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+      },
+      required: ["id"],
+    },
+    body: {
+      type: "object",
+      required: ["title"],
+      properties: {
+        title: {
+          type: "string",
+        },
+        description: {
+          type: ["string", "null"],
+        },
+        hasRadar: {
+          type: ["boolean", "null"],
+        },
+        topicIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:id",
+    upsertSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const body = request.body;
+
+      const domainData = {
+        id,
+        title: body.title,
+        description: body.description ?? null,
+        hasRadar: body.hasRadar ?? null,
+      };
+
+      await db
+        .insert(domains)
+        .values(domainData)
+        .onConflictDoUpdate({
+          target: domains.id,
+          set: {
+            title: domainData.title,
+            description: domainData.description,
+            hasRadar: domainData.hasRadar,
+          },
+        });
+
+      await db.delete(topicsToDomains).where(eq(topicsToDomains.domainId, id));
+
+      if (body.topicIds && body.topicIds.length > 0) {
+        await db.insert(topicsToDomains).values(
+          body.topicIds.map(topicId => ({
+            topicId,
+            domainId: id,
+          })),
+        );
+      }
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -10,6 +10,7 @@ import apiFormSubmit from "./submitOnboardData";
 import courses from "./courses/routes";
 import topics from "./topics/routes";
 import providers from "./providers/routes";
+import domains from "./domains/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -28,5 +29,8 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(providers, {
     prefix: "/providers",
+  });
+  fastify.register(domains, {
+    prefix: "/domains",
   });
 }

--- a/packages/types/src/Domain.ts
+++ b/packages/types/src/Domain.ts
@@ -1,0 +1,11 @@
+export interface Domain {
+  id: string;
+  title: string;
+  description?: string | null;
+  hasRadar?: boolean | null;
+  topicCount?: number;
+  topics?: {
+    id: string;
+    name: string;
+  }[];
+}

--- a/packages/types/src/TopicsToDomains.ts
+++ b/packages/types/src/TopicsToDomains.ts
@@ -1,0 +1,9 @@
+import { Domain } from "@/Domain";
+import { TopicsFromServer } from "@/TopicsFromServer";
+
+export interface TopicsToDomains {
+  topicId: string;
+  domainId: string;
+  topic?: Partial<TopicsFromServer>;
+  domain?: Partial<Domain>;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/max-dependencies */
 export * from "./CostData";
 export * from "./DynamicTest";
 export * from "./Test";
@@ -9,5 +10,6 @@ export * from "./CourseProvider";
 export * from "./Topic";
 export * from "./TopicsFromServer";
 export * from "./TopicForTopicsPage";
-// eslint-disable-next-line import/max-dependencies
 export * from "./TopicsToCourses";
+export * from "./Domain";
+export * from "./TopicsToDomains";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     devDependencies:
       '@emilyeserven/eslint-config':
         specifier: 1.1.4
-        version: 1.1.4(@eslint/js@9.39.4)(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@tanstack/eslint-plugin-query@5.95.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/eslint-plugin-router@1.161.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/router-plugin@1.167.20(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-better-tailwindcss@4.3.2(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@5.9.3))(eslint-plugin-import@2.32.0)(eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(globals@17.4.0)(tailwindcss@4.2.2)(typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))
+        version: 1.1.4(@eslint/js@9.39.4)(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@tanstack/eslint-plugin-query@5.95.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/eslint-plugin-router@1.161.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/router-plugin@1.167.20(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-better-tailwindcss@4.3.2(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@5.9.3))(eslint-plugin-import@2.32.0)(eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(globals@17.4.0)(tailwindcss@4.2.2)(typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))
       '@stylistic/eslint-plugin':
         specifier: 5.10.0
         version: 5.10.0(eslint@9.39.4(jiti@2.6.1))
@@ -49,7 +49,7 @@ importers:
         version: 9.1.7
       knip:
         specifier: 6.1.0
-        version: 6.1.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+        version: 6.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
@@ -91,7 +91,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tailwindcss/vite':
         specifier: 4.2.2
-        version: 4.2.2(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.2(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-form':
         specifier: 1.25.0
         version: 1.25.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -141,8 +141,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       vite:
-        specifier: 8.0.8
-        version: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: 8.0.10
+        version: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       zod:
         specifier: 4.1.12
         version: 4.1.12
@@ -158,13 +158,13 @@ importers:
         version: 10.3.3(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@storybook/addon-docs':
         specifier: 10.3.3
-        version: 10.3.3(@types/react@19.2.4)(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.3(@types/react@19.2.4)(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: 10.3.3
         version: 10.3.3(@vitest/browser-playwright@4.1.4)(@vitest/browser@4.1.4)(@vitest/runner@4.1.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vitest@4.1.4)
       '@storybook/react-vite':
         specifier: 10.3.3
-        version: 10.3.3(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.3(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/test':
         specifier: 8.6.15
         version: 8.6.15(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
@@ -176,7 +176,7 @@ importers:
         version: 1.166.23
       '@tanstack/router-plugin':
         specifier: 1.167.20
-        version: 1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -194,13 +194,13 @@ importers:
         version: 19.2.3(@types/react@19.2.4)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: 4.1.4
-        version: 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 4.1.4
-        version: 4.1.4(playwright@1.56.1)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(playwright@1.56.1)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 4.1.4
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -236,19 +236,19 @@ importers:
         version: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/gateway:
     dependencies:
       '@fastify/http-proxy':
-        specifier: ^11.4.3
-        version: 11.4.3
+        specifier: ^11.4.4
+        version: 11.4.4
       '@fastify/static':
-        specifier: ^9.0.0
-        version: 9.1.0
+        specifier: ^9.1.1
+        version: 9.1.3
       fastify:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.8.5
+        version: 5.8.5
 
   packages/middleware:
     dependencies:
@@ -274,17 +274,17 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       drizzle-orm:
-        specifier: 0.44.7
-        version: 0.44.7(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3)
+        specifier: 0.45.2
+        version: 0.45.2(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3)
       fastify:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.8.5
+        version: 5.8.5
       pg:
         specifier: 8.16.3
         version: 8.16.3
       uuid:
-        specifier: 13.0.0
-        version: 13.0.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@emstack/types':
         specifier: workspace:*
@@ -532,11 +532,11 @@ packages:
       tailwindcss: ~4.2.2
       typescript-eslint: ~8.57.2
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -768,8 +768,8 @@ packages:
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
 
-  '@fastify/http-proxy@11.4.3':
-    resolution: {integrity: sha512-j6/242ni0jZo7cs8BphwUR81PXIQewPRdJfwJCkg2fmCAlCw0UniG+BXdAeXOnhBkI3ACgKaGicyQt08aRdbzQ==}
+  '@fastify/http-proxy@11.4.4':
+    resolution: {integrity: sha512-wXoKaxW31pQc6H48Xqx//j6A2ikOiadht55DNkEFaseEUkJ9MzvURLK6Qqg0OOIEZGjTiEjjnbERv3NLFBc2Ug==}
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
@@ -777,14 +777,14 @@ packages:
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
-  '@fastify/reply-from@12.6.1':
-    resolution: {integrity: sha512-J95lfqd6wWhAF5Lx1Tt2Htaite/Bmk9bEAsGFR8+YakjCdgOPK+WX9IUeRXUX4e7bdf23rP/+xPPf/vICAs73Q==}
+  '@fastify/reply-from@12.6.2':
+    resolution: {integrity: sha512-FhMvsRJa4HMG0q0/Yi06sgwVFd/Wc8E/+RbHsqB0Q+883C66RPrS6qwZKBPje2mVzsyEb9sjq7wlyvi35zRW0A==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.1.0':
-    resolution: {integrity: sha512-EPRNQYqEYEYTK8yyGbcM0iHpyJaupb94bey5O6iCQfLTADr02kaZU+qeHSdd9H9TiMwTBVkrMa59V8CMbn3avQ==}
+  '@fastify/static@9.1.3':
+    resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
 
   '@fastify/swagger-ui@5.2.5':
     resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
@@ -866,6 +866,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1011,8 +1017,8 @@ packages:
   '@oxc-project/types@0.121.0':
     resolution: {integrity: sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==}
 
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -1862,97 +1868,97 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -3269,8 +3275,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.44.7:
-    resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -3634,8 +3640,8 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.8.3:
-    resolution: {integrity: sha512-XJXpRQ41+rsJ/GLeP9vyDC+fBXilcTlEXokMSexkdEkla4uf7ZQNaI5xl3el+kW5TZQulqYxLr659ey/KX7XmQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4510,8 +4516,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -4709,8 +4715,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5291,8 +5297,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   valibot@1.3.1:
@@ -5303,8 +5309,8 @@ packages:
       typescript:
         optional: true
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5723,13 +5729,13 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@emilyeserven/eslint-config@1.1.4(@eslint/js@9.39.4)(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@tanstack/eslint-plugin-query@5.95.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/eslint-plugin-router@1.161.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/router-plugin@1.167.20(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-better-tailwindcss@4.3.2(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@5.9.3))(eslint-plugin-import@2.32.0)(eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(globals@17.4.0)(tailwindcss@4.2.2)(typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))':
+  '@emilyeserven/eslint-config@1.1.4(@eslint/js@9.39.4)(@stylistic/eslint-plugin@5.10.0(eslint@9.39.4(jiti@2.6.1)))(@tanstack/eslint-plugin-query@5.95.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/eslint-plugin-router@1.161.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(@tanstack/router-plugin@1.167.20(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-better-tailwindcss@4.3.2(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@5.9.3))(eslint-plugin-import@2.32.0)(eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(globals@17.4.0)(tailwindcss@4.2.2)(typescript-eslint@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 9.39.4
       '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4(jiti@2.6.1))
       '@tanstack/eslint-plugin-query': 5.95.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@tanstack/eslint-plugin-router': 1.161.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@tanstack/router-plugin': 1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/router-plugin': 1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       concurrently: 9.2.1
       eslint: 9.39.4(jiti@2.6.1)
@@ -5743,13 +5749,13 @@ snapshots:
       tailwindcss: 4.2.2
       typescript-eslint: 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5924,9 +5930,9 @@ snapshots:
 
   '@fastify/forwarded@3.0.1': {}
 
-  '@fastify/http-proxy@11.4.3':
+  '@fastify/http-proxy@11.4.4':
     dependencies:
-      '@fastify/reply-from': 12.6.1
+      '@fastify/reply-from': 12.6.2
       fast-querystring: 1.1.2
       fastify-plugin: 5.1.0
       ws: 8.20.0
@@ -5943,7 +5949,7 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
-  '@fastify/reply-from@12.6.1':
+  '@fastify/reply-from@12.6.2':
     dependencies:
       '@fastify/error': 4.2.0
       end-of-stream: 1.4.5
@@ -5961,7 +5967,7 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.1.0':
+  '@fastify/static@9.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/send': 4.1.0
@@ -5972,7 +5978,7 @@ snapshots:
 
   '@fastify/swagger-ui@5.2.5':
     dependencies:
-      '@fastify/static': 9.1.0
+      '@fastify/static': 9.1.3
       fastify-plugin: 5.1.0
       openapi-types: 12.1.3
       rfdc: 1.4.1
@@ -6020,11 +6026,11 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -6057,15 +6063,22 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -6136,9 +6149,9 @@ snapshots:
   '@oxc-parser/binding-openharmony-arm64@0.121.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.121.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@oxc-parser/binding-wasm32-wasi@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -6155,7 +6168,7 @@ snapshots:
 
   '@oxc-project/types@0.121.0': {}
 
-  '@oxc-project/types@0.124.0': {}
+  '@oxc-project/types@0.127.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -6205,9 +6218,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -7009,56 +7022,56 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -7155,10 +7168,10 @@ snapshots:
       axe-core: 4.11.2
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/addon-docs@10.3.3(@types/react@19.2.4)(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.3(@types/react@19.2.4)(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.4)(react@19.2.0)
-      '@storybook/csf-plugin': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       react: 19.2.0
@@ -7178,33 +7191,33 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/browser-playwright': 4.1.4(playwright@1.56.1)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(playwright@1.56.1)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/runner': 4.1.4
-      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       ts-dedent: 2.2.0
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.0
       rollup: 4.60.1
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -7225,11 +7238,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@storybook/react-vite@10.3.3(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.3(esbuild@0.28.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.3(esbuild@0.28.0)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.3.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -7239,7 +7252,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tsconfig-paths: 4.2.0
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -7345,12 +7358,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/devtools-event-client@0.3.5': {}
 
@@ -7476,7 +7489,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.167.20(@tanstack/react-router@1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -7493,7 +7506,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7841,34 +7854,34 @@ snapshots:
     dependencies:
       valibot: 1.3.1(typescript@5.9.3)
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.4(playwright@1.56.1)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(playwright@1.56.1)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.56.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -7888,9 +7901,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -7916,13 +7929,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -8441,7 +8454,7 @@ snapshots:
       esbuild: 0.28.0
       tsx: 4.21.0
 
-  drizzle-orm@0.44.7(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3):
+  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@types/pg': 8.15.6
@@ -8861,7 +8874,7 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.8.3:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -9352,7 +9365,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@6.1.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  knip@6.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       fast-glob: 3.3.3
@@ -9360,8 +9373,8 @@ snapshots:
       get-tsconfig: 4.13.7
       jiti: 2.6.1
       minimist: 1.2.8
-      oxc-parser: 0.121.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      oxc-resolver: 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
       picomatch: 2.3.2
       smol-toml: 1.6.1
@@ -9649,7 +9662,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.121.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.121.0
     optionalDependencies:
@@ -9669,7 +9682,7 @@ snapshots:
       '@oxc-parser/binding-linux-x64-gnu': 0.121.0
       '@oxc-parser/binding-linux-x64-musl': 0.121.0
       '@oxc-parser/binding-openharmony-arm64': 0.121.0
-      '@oxc-parser/binding-wasm32-wasi': 0.121.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-parser/binding-wasm32-wasi': 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-parser/binding-win32-arm64-msvc': 0.121.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.121.0
       '@oxc-parser/binding-win32-x64-msvc': 0.121.0
@@ -9677,7 +9690,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -9695,7 +9708,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -9811,7 +9824,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -10061,26 +10074,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rollup@4.60.1:
     dependencies:
@@ -10707,18 +10720,18 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   valibot@1.3.1(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
-  vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 2.3.2
-      postcss: 8.5.9
-      rolldown: 1.0.0-rc.15
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.10.1
@@ -10728,10 +10741,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@24.10.1)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@27.2.0)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -10748,11 +10761,11 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.1
-      '@vitest/browser-playwright': 4.1.4(playwright@1.56.1)(vite@8.0.8(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(playwright@1.56.1)(vite@8.0.10(@types/node@24.10.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       jsdom: 27.2.0
     transitivePeerDependencies:


### PR DESCRIPTION
## ELI5
This adds a new "Domains" concept to the course tracker — think of domains as broad learning areas like "Web Development" or "Language Learning" that group your topics together. You can create, view, edit, and delete domains, and link topics to them. Domains show up under the Topics menu in the navbar.

## Summary
- Added `Domain` type, `domains` DB table, and `topics_to_domains` junction table for many-to-many topic associations
- Created full Fastify API (GET list, GET single, POST, PUT upsert, DELETE) at `/api/domains`
- Built frontend pages (archive grid, detail view, edit/create form with multi-select topic combobox) and nested Domains under Topics in the navbar

## Test plan
- [ ] Push DB schema: `pnpm --filter=@emstack/middleware push:dev`
- [ ] Seed data via Menu > "Clear & Seed Data" — verify two domains appear at `/domains`
- [ ] Click a domain card — verify detail page shows description, hasRadar, and linked topics
- [ ] Edit a domain — verify form pre-fills, topic multi-select works, and changes persist
- [ ] Create a new domain from the archive page — verify it appears in the list
- [ ] Delete a domain from the detail page — verify it's removed
- [ ] Verify Topics navbar dropdown shows "Domains" as a sub-item

🤖 Generated with [Claude Code](https://claude.com/claude-code)