### PR TITLE
Add dashboard page with dailies and courses in progress

### DIFF
--- a/packages/client/src/components/boxes/DashboardCard.tsx
+++ b/packages/client/src/components/boxes/DashboardCard.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+interface DashboardCardProps extends React.ComponentProps<"section"> {
+  title: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+function DashboardCard({
+  className,
+  title,
+  action,
+  children,
+  ...props
+}: DashboardCardProps) {
+  return (
+    <section
+      className={cn(`
+        flex flex-col gap-3 rounded-md border bg-card text-card-foreground
+        shadow-sm
+      `, className)}
+      {...props}
+    >
+      <header
+        className="
+          flex flex-row items-center justify-between gap-2 border-b bg-border
+          px-3 py-2
+        "
+      >
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {action ? <div className="flex items-center gap-1">{action}</div> : null}
+      </header>
+      <div className="flex flex-col gap-2 px-3 pb-3">{children}</div>
+    </section>
+  );
+}
+
+export { DashboardCard };

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as TopicsRouteImport } from './routes/topics'
 import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
 import { Route as DomainsRouteImport } from './routes/domains'
+import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as CoursesRouteImport } from './routes/courses'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
@@ -50,6 +51,11 @@ const OnboardRoute = OnboardRouteImport.update({
 const DomainsRoute = DomainsRouteImport.update({
   id: '/domains',
   path: '/domains',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CoursesRoute = CoursesRouteImport.update({
@@ -146,6 +152,7 @@ const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/dashboard': typeof DashboardRoute
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
@@ -169,6 +176,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/dashboard': typeof DashboardRoute
   '/onboard': typeof OnboardRoute
   '/courses': typeof CoursesIndexRoute
   '/domains': typeof DomainsIndexRoute
@@ -187,6 +195,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/dashboard': typeof DashboardRoute
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
@@ -213,6 +222,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/courses'
+    | '/dashboard'
     | '/domains'
     | '/onboard'
     | '/providers'
@@ -236,6 +246,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/dashboard'
     | '/onboard'
     | '/courses'
     | '/domains'
@@ -253,6 +264,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/courses'
+    | '/dashboard'
     | '/domains'
     | '/onboard'
     | '/providers'
@@ -278,6 +290,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CoursesRoute: typeof CoursesRouteWithChildren
+  DashboardRoute: typeof DashboardRoute
   DomainsRoute: typeof DomainsRouteWithChildren
   OnboardRoute: typeof OnboardRoute
   ProvidersRoute: typeof ProvidersRouteWithChildren
@@ -312,6 +325,13 @@ declare module '@tanstack/react-router' {
       path: '/domains'
       fullPath: '/domains'
       preLoaderRoute: typeof DomainsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/courses': {
@@ -555,6 +575,7 @@ const TopicsRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CoursesRoute: CoursesRouteWithChildren,
+  DashboardRoute: DashboardRoute,
   DomainsRoute: DomainsRouteWithChildren,
   OnboardRoute: OnboardRoute,
   ProvidersRoute: ProvidersRouteWithChildren,

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -123,6 +123,17 @@ const RootComponent: React.FunctionComponent = () => {
     <>
       <div className="container items-center justify-between gap-2 py-2">
         <div className="flex gap-4">
+          <Link
+            to="/dashboard"
+            className={`
+              underline-offset-2
+              hover:underline
+              [&.active]:font-bold
+            `}
+          >
+            Dashboard
+          </Link>
+
           {showOnboard && (
             <Link
               to="/onboard"

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
@@ -1,0 +1,91 @@
+import type { CourseInCourses } from "@emstack/types/src";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import { DashboardCard } from "@/components/boxes/DashboardCard";
+import { ProgressBar } from "@/components/ui/ProgressBar";
+import { fetchCourses } from "@/utils";
+
+function isInProgress(course: CourseInCourses): boolean {
+  if (course.status !== "active") return false;
+  if (!course.progressTotal || course.progressTotal === 0) return false;
+  return course.progressCurrent > 0
+    && course.progressCurrent < course.progressTotal;
+}
+
+export function DashboardCoursesInProgress() {
+  const {
+    data: courses, isPending, error,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchCourses(),
+  });
+
+  const inProgress = (courses ?? []).filter(isInProgress);
+
+  return (
+    <DashboardCard
+      title="Courses in Progress"
+      action={(
+        <Link
+          to="/courses"
+          className="
+            text-sm text-primary underline-offset-2
+            hover:underline
+          "
+        >
+          View all
+        </Link>
+      )}
+    >
+      {isPending && (
+        <p className="text-sm text-muted-foreground">Loading courses...</p>
+      )}
+      {error && (
+        <p className="text-sm text-destructive">Failed to load courses.</p>
+      )}
+      {courses && inProgress.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          <i>No courses in progress.</i>
+        </p>
+      )}
+      {inProgress.length > 0 && (
+        <ul className="flex flex-col divide-y">
+          {inProgress.map(course => (
+            <li
+              key={course.id}
+              className="flex flex-col gap-1 py-2"
+            >
+              <div className="flex flex-row items-center justify-between gap-2">
+                <Link
+                  to="/courses/$id"
+                  params={{
+                    id: course.id,
+                  }}
+                  className="
+                    font-medium
+                    hover:text-blue-600
+                  "
+                >
+                  {course.name}
+                </Link>
+                <span className="text-xs text-muted-foreground">
+                  {course.progressCurrent}
+                  {" / "}
+                  {course.progressTotal}
+                </span>
+              </div>
+              <ProgressBar
+                progressCurrent={course.progressCurrent}
+                progressTotal={course.progressTotal}
+                status={course.status}
+                className="mt-0"
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -1,0 +1,156 @@
+import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckIcon,
+  CircleDashedIcon,
+  CircleIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { DashboardCard } from "@/components/boxes/DashboardCard";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { fetchDailies, upsertDaily } from "@/utils";
+
+const STATUS_OPTIONS: {
+  value: DailyCompletionStatus;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    value: "incomplete",
+    label: "Incomplete",
+    icon: <CircleIcon className="size-4" />,
+  },
+  {
+    value: "touched",
+    label: "Touched",
+    icon: <CircleDashedIcon className="size-4" />,
+  },
+  {
+    value: "goal",
+    label: "Goal",
+    icon: <CheckIcon className="size-4" />,
+  },
+  {
+    value: "exceeded",
+    label: "Exceeded",
+    icon: <SparklesIcon className="size-4" />,
+  },
+];
+
+function getTodayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function findTodayStatus(daily: Daily, todayKey: string): DailyCompletionStatus {
+  return (
+    daily.completions.find(c => c.date === todayKey)?.status ?? "incomplete"
+  );
+}
+
+export function DashboardDailies() {
+  const queryClient = useQueryClient();
+  const todayKey = getTodayKey();
+
+  const {
+    data: dailies, isPending, error,
+  } = useQuery({
+    queryKey: ["dailies"],
+    queryFn: () => fetchDailies(),
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({
+      daily, status,
+    }: { daily: Daily;
+      status: DailyCompletionStatus; }) => {
+      const others = daily.completions.filter(c => c.date !== todayKey);
+      const completions = [
+        ...others,
+        {
+          date: todayKey,
+          status,
+        },
+      ];
+      return upsertDaily(daily.id, {
+        name: daily.name,
+        location: daily.location ?? null,
+        description: daily.description ?? null,
+        completions,
+        courseProviderId: daily.provider?.id ?? null,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to update daily.");
+    },
+  });
+
+  return (
+    <DashboardCard title="Dailies">
+      {isPending && (
+        <p className="text-sm text-muted-foreground">Loading dailies...</p>
+      )}
+      {error && (
+        <p className="text-sm text-destructive">Failed to load dailies.</p>
+      )}
+      {dailies && dailies.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          <i>No dailies yet.</i>
+        </p>
+      )}
+      {dailies && dailies.length > 0 && (
+        <ul className="flex flex-col divide-y">
+          {dailies.map((daily) => {
+            const currentStatus = findTodayStatus(daily, todayKey);
+            return (
+              <li
+                key={daily.id}
+                className="flex flex-col gap-2 py-2"
+              >
+                <div
+                  className="flex flex-row items-center justify-between gap-2"
+                >
+                  <span className="font-medium">{daily.name}</span>
+                  {daily.provider && (
+                    <span className="text-xs text-muted-foreground">
+                      {daily.provider.name}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-row flex-wrap gap-1">
+                  {STATUS_OPTIONS.map(opt => (
+                    <Button
+                      key={opt.value}
+                      type="button"
+                      size="sm"
+                      variant={currentStatus === opt.value ? "default" : "outline"}
+                      disabled={mutation.isPending}
+                      onClick={() => mutation.mutate({
+                        daily,
+                        status: opt.value,
+                      })}
+                      className={cn({
+                        "ring-2 ring-ring": currentStatus === opt.value,
+                      })}
+                    >
+                      {opt.icon}
+                      {opt.label}
+                    </Button>
+                  ))}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -5,6 +5,7 @@ import {
   CheckIcon,
   CircleDashedIcon,
   CircleIcon,
+  FlameIcon,
   SparklesIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -49,6 +50,35 @@ function findTodayStatus(daily: Daily, todayKey: string): DailyCompletionStatus 
   return (
     daily.completions.find(c => c.date === todayKey)?.status ?? "incomplete"
   );
+}
+
+function shiftDateKey(key: string, deltaDays: number): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().slice(0, 10);
+}
+
+function getCurrentChain(daily: Daily, todayKey: string): number {
+  const completedDates = new Set(
+    daily.completions
+      .filter(c => c.status !== "incomplete")
+      .map(c => c.date),
+  );
+
+  let cursor = todayKey;
+  if (!completedDates.has(cursor)) {
+    cursor = shiftDateKey(cursor, -1);
+    if (!completedDates.has(cursor)) {
+      return 0;
+    }
+  }
+
+  let count = 0;
+  while (completedDates.has(cursor)) {
+    count++;
+    cursor = shiftDateKey(cursor, -1);
+  }
+  return count;
 }
 
 export function DashboardDailies() {
@@ -110,6 +140,7 @@ export function DashboardDailies() {
         <ul className="flex flex-col divide-y">
           {dailies.map((daily) => {
             const currentStatus = findTodayStatus(daily, todayKey);
+            const chain = getCurrentChain(daily, todayKey);
             return (
               <li
                 key={daily.id}
@@ -119,11 +150,26 @@ export function DashboardDailies() {
                   className="flex flex-row items-center justify-between gap-2"
                 >
                   <span className="font-medium">{daily.name}</span>
-                  {daily.provider && (
-                    <span className="text-xs text-muted-foreground">
-                      {daily.provider.name}
+                  <div className="flex flex-row items-center gap-2">
+                    <span
+                      className={cn("inline-flex items-center gap-1 text-xs", chain > 0
+                        ? "text-orange-600"
+                        : "text-muted-foreground")}
+                      title={
+                        chain > 0
+                          ? `${chain}-day chain`
+                          : "No active chain"
+                      }
+                    >
+                      <FlameIcon className="size-3.5" />
+                      {chain}
                     </span>
-                  )}
+                    {daily.provider && (
+                      <span className="text-xs text-muted-foreground">
+                        {daily.provider.name}
+                      </span>
+                    )}
+                  </div>
                 </div>
                 <div className="flex flex-row flex-wrap gap-1">
                   {STATUS_OPTIONS.map(opt => (

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { DashboardCoursesInProgress } from "./dashboard.-components/-DashboardCoursesInProgress";
+import { DashboardDailies } from "./dashboard.-components/-DashboardDailies";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+
+export const Route = createFileRoute("/dashboard")({
+  component: Dashboard,
+});
+
+function Dashboard() {
+  return (
+    <div>
+      <PageHeader pageTitle="Dashboard" />
+      <div
+        className="
+          container grid grid-cols-1 gap-4
+          md:grid-cols-2
+        "
+      >
+        <DashboardDailies />
+        <DashboardCoursesInProgress />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/")({
   beforeLoad: () => {
     throw redirect({
-      to: "/courses",
+      to: "/dashboard",
     });
   },
 });

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -6,6 +6,7 @@ import type {
   TopicForTopicsPage,
   CourseProvider,
   Domain,
+  Daily,
 } from "@emstack/types/src/index.js";
 import type { OnboardData } from "@emstack/types/src/OnboardData";
 import type { Topic } from "@emstack/types/src/Topic";
@@ -218,6 +219,28 @@ export async function upsertDomain(
   });
   if (!response.ok) {
     throw new Error(`Failed to update domain: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function fetchDailies(): Promise<Daily[]> {
+  return await fetch("/api/dailies").then(res => res.json());
+}
+
+export async function upsertDaily(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(`/api/dailies/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update daily: ${response.statusText}`);
   }
   return await response.json();
 }


### PR DESCRIPTION
## Summary
This PR introduces a new dashboard page that serves as the primary landing page for users, displaying their daily tasks and courses currently in progress.

## Key Changes
- **New Dashboard Route** (`/dashboard`): Created a new dashboard page that displays two main sections:
  - Dailies: Shows all daily tasks with status tracking (incomplete, touched, goal, exceeded)
  - Courses in Progress: Displays active courses with progress bars

- **Dashboard Components**:
  - `DashboardDailies`: Manages daily task display and status updates with mutation support
  - `DashboardCoursesInProgress`: Shows courses filtered by active status and progress state
  - `DashboardCard`: Reusable card component for dashboard sections with title and optional action

- **API Integration**: Added `fetchDailies()` and `upsertDaily()` utility functions to handle daily task data fetching and updates

- **Navigation**: 
  - Added Dashboard link to main navigation header
  - Changed root route redirect from `/courses` to `/dashboard` as the new default landing page

- **Route Tree**: Updated generated route types to include the new `/dashboard` route

## Implementation Details
- Daily status updates use React Query mutations with optimistic UI feedback via toast notifications
- Daily completion tracking stores date-specific status entries, allowing historical tracking
- Courses in progress are filtered based on active status and having partial progress (0 < current < total)
- Dashboard uses responsive grid layout (1 column on mobile, 2 columns on medium+ screens)
- Status options for dailies include visual icons (circle, dashed circle, check, sparkles) for quick visual feedback

https://claude.ai/code/session_01474TcLZJVxYkdLWdLCVsKa