### PR TITLE
Add Dailies CRUD routes and link them to main nav

### DIFF
--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   pageTitle?: string;
-  pageSection?: "" | "courses" | "topics" | "providers" | "domains";
+  pageSection?: "" | "courses" | "topics" | "providers" | "domains" | "dailies";
   children?: React.ReactNode;
   progressCurrent?: number;
   progressTotal?: number;
@@ -63,6 +63,14 @@ export function PageHeader({
                   className="text-sm uppercase"
                 >
                   Domains
+                </Link>
+              )}
+              {pageSection === "dailies" && (
+                <Link
+                  to="/dailies"
+                  className="text-sm uppercase"
+                >
+                  Dailies
                 </Link>
               )}
             </div>

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -14,23 +14,28 @@ import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
 import { Route as DomainsRouteImport } from './routes/domains'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as DailiesRouteImport } from './routes/dailies'
 import { Route as CoursesRouteImport } from './routes/courses'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as DomainsIndexRouteImport } from './routes/domains.index'
+import { Route as DailiesIndexRouteImport } from './routes/dailies.index'
 import { Route as CoursesIndexRouteImport } from './routes/courses.index'
 import { Route as TopicsIdRouteImport } from './routes/topics.$id'
 import { Route as ProvidersIdRouteImport } from './routes/providers.$id'
 import { Route as DomainsIdRouteImport } from './routes/domains.$id'
+import { Route as DailiesIdRouteImport } from './routes/dailies.$id'
 import { Route as CoursesIdRouteImport } from './routes/courses.$id'
 import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
 import { Route as DomainsIdIndexRouteImport } from './routes/domains.$id.index'
+import { Route as DailiesIdIndexRouteImport } from './routes/dailies.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
 import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
 import { Route as DomainsIdEditRouteImport } from './routes/domains.$id.edit'
+import { Route as DailiesIdEditRouteImport } from './routes/dailies.$id.edit'
 import { Route as CoursesIdEditRouteImport } from './routes/courses.$id.edit'
 
 const TopicsRoute = TopicsRouteImport.update({
@@ -58,6 +63,11 @@ const DashboardRoute = DashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DailiesRoute = DailiesRouteImport.update({
+  id: '/dailies',
+  path: '/dailies',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CoursesRoute = CoursesRouteImport.update({
   id: '/courses',
   path: '/courses',
@@ -83,6 +93,11 @@ const DomainsIndexRoute = DomainsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => DomainsRoute,
 } as any)
+const DailiesIndexRoute = DailiesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DailiesRoute,
+} as any)
 const CoursesIndexRoute = CoursesIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -102,6 +117,11 @@ const DomainsIdRoute = DomainsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => DomainsRoute,
+} as any)
+const DailiesIdRoute = DailiesIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => DailiesRoute,
 } as any)
 const CoursesIdRoute = CoursesIdRouteImport.update({
   id: '/$id',
@@ -123,6 +143,11 @@ const DomainsIdIndexRoute = DomainsIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => DomainsIdRoute,
 } as any)
+const DailiesIdIndexRoute = DailiesIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DailiesIdRoute,
+} as any)
 const CoursesIdIndexRoute = CoursesIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -143,6 +168,11 @@ const DomainsIdEditRoute = DomainsIdEditRouteImport.update({
   path: '/edit',
   getParentRoute: () => DomainsIdRoute,
 } as any)
+const DailiesIdEditRoute = DailiesIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => DailiesIdRoute,
+} as any)
 const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -152,24 +182,29 @@ const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/dailies': typeof DailiesRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
+  '/dailies/$id': typeof DailiesIdRouteWithChildren
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
+  '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
+  '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
@@ -179,14 +214,17 @@ export interface FileRoutesByTo {
   '/dashboard': typeof DashboardRoute
   '/onboard': typeof OnboardRoute
   '/courses': typeof CoursesIndexRoute
+  '/dailies': typeof DailiesIndexRoute
   '/domains': typeof DomainsIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id': typeof CoursesIdIndexRoute
+  '/dailies/$id': typeof DailiesIdIndexRoute
   '/domains/$id': typeof DomainsIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
@@ -195,24 +233,29 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/courses': typeof CoursesRouteWithChildren
+  '/dailies': typeof DailiesRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
+  '/dailies/$id': typeof DailiesIdRouteWithChildren
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
+  '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
+  '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
+  '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
@@ -222,24 +265,29 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/courses'
+    | '/dailies'
     | '/dashboard'
     | '/domains'
     | '/onboard'
     | '/providers'
     | '/topics'
     | '/courses/$id'
+    | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
     | '/courses/'
+    | '/dailies/'
     | '/domains/'
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
+    | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
@@ -249,14 +297,17 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/onboard'
     | '/courses'
+    | '/dailies'
     | '/domains'
     | '/providers'
     | '/topics'
     | '/courses/$id/edit'
+    | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id'
+    | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
@@ -264,24 +315,29 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/courses'
+    | '/dailies'
     | '/dashboard'
     | '/domains'
     | '/onboard'
     | '/providers'
     | '/topics'
     | '/courses/$id'
+    | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
     | '/courses/'
+    | '/dailies/'
     | '/domains/'
     | '/providers/'
     | '/topics/'
     | '/courses/$id/edit'
+    | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
+    | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
@@ -290,6 +346,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CoursesRoute: typeof CoursesRouteWithChildren
+  DailiesRoute: typeof DailiesRouteWithChildren
   DashboardRoute: typeof DashboardRoute
   DomainsRoute: typeof DomainsRouteWithChildren
   OnboardRoute: typeof OnboardRoute
@@ -334,6 +391,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/dailies': {
+      id: '/dailies'
+      path: '/dailies'
+      fullPath: '/dailies'
+      preLoaderRoute: typeof DailiesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/courses': {
       id: '/courses'
       path: '/courses'
@@ -369,6 +433,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DomainsIndexRouteImport
       parentRoute: typeof DomainsRoute
     }
+    '/dailies/': {
+      id: '/dailies/'
+      path: '/'
+      fullPath: '/dailies/'
+      preLoaderRoute: typeof DailiesIndexRouteImport
+      parentRoute: typeof DailiesRoute
+    }
     '/courses/': {
       id: '/courses/'
       path: '/'
@@ -396,6 +467,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/domains/$id'
       preLoaderRoute: typeof DomainsIdRouteImport
       parentRoute: typeof DomainsRoute
+    }
+    '/dailies/$id': {
+      id: '/dailies/$id'
+      path: '/$id'
+      fullPath: '/dailies/$id'
+      preLoaderRoute: typeof DailiesIdRouteImport
+      parentRoute: typeof DailiesRoute
     }
     '/courses/$id': {
       id: '/courses/$id'
@@ -425,6 +503,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DomainsIdIndexRouteImport
       parentRoute: typeof DomainsIdRoute
     }
+    '/dailies/$id/': {
+      id: '/dailies/$id/'
+      path: '/'
+      fullPath: '/dailies/$id/'
+      preLoaderRoute: typeof DailiesIdIndexRouteImport
+      parentRoute: typeof DailiesIdRoute
+    }
     '/courses/$id/': {
       id: '/courses/$id/'
       path: '/'
@@ -452,6 +537,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/domains/$id/edit'
       preLoaderRoute: typeof DomainsIdEditRouteImport
       parentRoute: typeof DomainsIdRoute
+    }
+    '/dailies/$id/edit': {
+      id: '/dailies/$id/edit'
+      path: '/edit'
+      fullPath: '/dailies/$id/edit'
+      preLoaderRoute: typeof DailiesIdEditRouteImport
+      parentRoute: typeof DailiesIdRoute
     }
     '/courses/$id/edit': {
       id: '/courses/$id/edit'
@@ -489,6 +581,33 @@ const CoursesRouteChildren: CoursesRouteChildren = {
 
 const CoursesRouteWithChildren =
   CoursesRoute._addFileChildren(CoursesRouteChildren)
+
+interface DailiesIdRouteChildren {
+  DailiesIdEditRoute: typeof DailiesIdEditRoute
+  DailiesIdIndexRoute: typeof DailiesIdIndexRoute
+}
+
+const DailiesIdRouteChildren: DailiesIdRouteChildren = {
+  DailiesIdEditRoute: DailiesIdEditRoute,
+  DailiesIdIndexRoute: DailiesIdIndexRoute,
+}
+
+const DailiesIdRouteWithChildren = DailiesIdRoute._addFileChildren(
+  DailiesIdRouteChildren,
+)
+
+interface DailiesRouteChildren {
+  DailiesIdRoute: typeof DailiesIdRouteWithChildren
+  DailiesIndexRoute: typeof DailiesIndexRoute
+}
+
+const DailiesRouteChildren: DailiesRouteChildren = {
+  DailiesIdRoute: DailiesIdRouteWithChildren,
+  DailiesIndexRoute: DailiesIndexRoute,
+}
+
+const DailiesRouteWithChildren =
+  DailiesRoute._addFileChildren(DailiesRouteChildren)
 
 interface DomainsIdRouteChildren {
   DomainsIdEditRoute: typeof DomainsIdEditRoute
@@ -575,6 +694,7 @@ const TopicsRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CoursesRoute: CoursesRouteWithChildren,
+  DailiesRoute: DailiesRouteWithChildren,
   DashboardRoute: DashboardRoute,
   DomainsRoute: DomainsRouteWithChildren,
   OnboardRoute: OnboardRoute,

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -170,6 +170,17 @@ const RootComponent: React.FunctionComponent = () => {
               <Link to="/domains">Domains</Link>
             </DropdownMenuItem>
           </NavDropdown>
+
+          <Link
+            to="/dailies"
+            className={`
+              underline-offset-2
+              hover:underline
+              [&.active]:font-bold
+            `}
+          >
+            Dailies
+          </Link>
         </div>
         <div className="flex flex-row gap-2">
           <DropdownMenu>

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -1,0 +1,228 @@
+import { useMemo, useRef } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createDaily,
+  fetchProviders,
+  fetchSingleDaily,
+  formHasChanges,
+  upsertDaily,
+} from "@/utils";
+
+export const Route = createFileRoute("/dailies/$id/edit")({
+  component: SingleDailyEdit,
+});
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  location: z.string().max(255),
+  description: z.string().max(500),
+  courseProviderId: z.string(),
+});
+
+function SingleDailyEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["daily", id],
+    queryFn: () => fetchSingleDaily(id),
+    enabled: !isNew,
+  });
+
+  const {
+    data: providers,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
+
+  const providerOptions = (providers ?? []).map(p => ({
+    value: p.id,
+    label: p.name,
+  }));
+
+  const startingValues = useMemo(
+    () => ({
+      name: data?.name ?? "",
+      location: data?.location ?? "",
+      description: data?.description ?? "",
+      courseProviderId: data?.provider?.id ?? "",
+    }),
+    [data],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const dailyData = {
+        name: value.name,
+        location: value.location || null,
+        description: value.description || null,
+        completions: data?.completions ?? [],
+        courseProviderId: value.courseProviderId || null,
+      };
+
+      try {
+        let dailyId: string;
+        if (isNew) {
+          const result = await createDaily(dailyData);
+          dailyId = result.id;
+        }
+        else {
+          await upsertDaily(id, dailyData);
+          dailyId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["daily", id],
+          });
+        }
+
+        await queryClient.invalidateQueries({
+          queryKey: ["dailies"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/dailies/$id",
+          params: {
+            id: dailyId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create daily. Please try again."
+            : "Failed to save daily. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Daily" : "Edit Daily"}
+        pageSection="dailies"
+      >
+        {!isNew && (
+          <Link
+            to="/dailies/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Daily
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="container flex-col">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-2xl flex-col gap-8"
+        >
+          <form.AppField name="name">
+            {field => <field.InputField label="Daily Name" />}
+          </form.AppField>
+
+          <form.AppField name="location">
+            {field => (
+              <field.InputField
+                label="Location"
+                placeholder="e.g. Spanish app, gym, journal"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What is this daily about?"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="courseProviderId">
+            {field => (
+              <field.ComboboxField
+                label="Provider"
+                options={providerOptions}
+                placeholder="Search providers..."
+              />
+            )}
+          </form.AppField>
+
+          <div className="flex flex-row gap-4">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Daily" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/dailies",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/dailies/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,0 +1,123 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EditIcon } from "lucide-react";
+
+import { InfoArea } from "@/components/layout/InfoArea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { DeleteButton } from "@/components/ui/DeleteButton";
+import { deleteSingleDaily, fetchSingleDaily } from "@/utils";
+
+export const Route = createFileRoute("/dailies/$id/")({
+  component: SingleDaily,
+});
+
+function DailyPending() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">Hold on, loading your daily...</h1>
+    </div>
+  );
+}
+
+function DailyError() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">There was an error loading this daily.</h1>
+    </div>
+  );
+}
+
+function SingleDaily() {
+  const {
+    id,
+  } = Route.useParams();
+  const navigate = useNavigate();
+
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["daily", id],
+    queryFn: () => fetchSingleDaily(id),
+  });
+
+  const {
+    refetch: deleteDaily,
+  } = useQuery({
+    queryKey: ["dailies", "delete", id],
+    enabled: false,
+    queryFn: () => deleteSingleDaily(id),
+  });
+
+  if (isPending) {
+    <DailyPending />;
+  }
+
+  if (error) {
+    <DailyError />;
+  }
+
+  async function handleDelete() {
+    await deleteDaily();
+    await navigate({
+      to: "/dailies",
+    });
+  }
+
+  const completionsCount = data?.completions?.filter(
+    c => c.status !== "incomplete",
+  ).length ?? 0;
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={data?.name}
+        pageSection="dailies"
+      >
+        <div className="flex flex-row gap-2">
+          <Link
+            to="/dailies/$id/edit"
+            params={{
+              id: data?.id + "",
+            }}
+          >
+            <Button variant="secondary">
+              Edit Daily
+              {" "}
+              <EditIcon />
+            </Button>
+          </Link>
+        </div>
+      </PageHeader>
+      <div className="container flex flex-col gap-12">
+        <InfoArea
+          header="Description"
+          condition={!!data?.description}
+        >
+          <p>{data?.description}</p>
+        </InfoArea>
+        <InfoArea
+          header="Location"
+          condition={!!data?.location}
+        >
+          <p>{data?.location}</p>
+        </InfoArea>
+        <InfoArea
+          header="Provider"
+          condition={!!data?.provider}
+        >
+          <p>{data?.provider?.name}</p>
+        </InfoArea>
+        <InfoArea
+          header="Completions logged"
+          condition={!!data}
+        >
+          <p>{completionsCount}</p>
+        </InfoArea>
+        <div>
+          <DeleteButton onClick={handleDelete}>Delete Daily</DeleteButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/dailies.$id.tsx
+++ b/packages/client/src/routes/dailies.$id.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/dailies/$id")({
+  component: SingleDailyIndex,
+});
+
+function SingleDailyIndex() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -1,0 +1,165 @@
+import type { Daily } from "@emstack/types/src";
+
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { FlameIcon, PlusIcon } from "lucide-react";
+
+import { ContentBox, ContentBoxBody, ContentBoxFooter, ContentBoxHeader, ContentBoxHeaderBar, ContentBoxTitle } from "@/components/boxes/ContentBox";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { fetchDailies } from "@/utils";
+
+export const Route = createFileRoute("/dailies/")({
+  component: Dailies,
+  errorComponent: DailiesError,
+  pendingComponent: DailiesPending,
+});
+
+function DailiesPending() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">Hold on, loading your dailies...</h1>
+    </div>
+  );
+}
+
+function DailiesError() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">There was an error loading your dailies.</h1>
+    </div>
+  );
+}
+
+function shiftDateKey(key: string, deltaDays: number): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().slice(0, 10);
+}
+
+function getCurrentChain(daily: Daily): number {
+  const todayKey = new Date().toISOString().slice(0, 10);
+  const completedDates = new Set(
+    daily.completions
+      .filter(c => c.status !== "incomplete")
+      .map(c => c.date),
+  );
+
+  let cursor = todayKey;
+  if (!completedDates.has(cursor)) {
+    cursor = shiftDateKey(cursor, -1);
+    if (!completedDates.has(cursor)) {
+      return 0;
+    }
+  }
+
+  let count = 0;
+  while (completedDates.has(cursor)) {
+    count++;
+    cursor = shiftDateKey(cursor, -1);
+  }
+  return count;
+}
+
+function Dailies() {
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["dailies"],
+    queryFn: () => fetchDailies(),
+  });
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Dailies"
+        pageSection=""
+      />
+      <div className="container">
+        <div className="card-grid">
+          {(!data || data.length === 0) && (
+            <div className="flex flex-col gap-6">
+              <i>No dailies yet!</i>
+            </div>
+          )}
+
+          {data
+            && data.length > 0
+            && data.map(daily => (
+              <DailyBox
+                daily={daily}
+                key={daily.id}
+              />
+            ))}
+
+          <Link
+            to="/dailies/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <ContentBox
+              className="
+                h-full items-center justify-center border-dashed p-8
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
+              "
+            >
+              <PlusIcon size={32} />
+              <span className="text-lg font-medium">Add New Daily</span>
+            </ContentBox>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DailyBox({
+  daily,
+}: { daily: Daily }) {
+  const chain = getCurrentChain(daily);
+  return (
+    <ContentBox>
+      <ContentBoxHeader>
+        <ContentBoxHeaderBar />
+        <ContentBoxTitle>
+          <h3 className="text-2xl">
+            <Link
+              to="/dailies/$id"
+              from="/dailies"
+              params={{
+                id: daily.id,
+              }}
+              className="hover:text-blue-600"
+            >
+              {daily.name}
+            </Link>
+          </h3>
+        </ContentBoxTitle>
+      </ContentBoxHeader>
+      <ContentBoxBody>
+        <p>
+          {daily.description ? daily.description : <i>No description provided.</i>}
+        </p>
+      </ContentBoxBody>
+      <ContentBoxFooter>
+        <span
+          className={
+            chain > 0
+              ? "inline-flex items-center gap-1 text-sm text-orange-600"
+              : "inline-flex items-center gap-1 text-sm text-muted-foreground"
+          }
+          title={chain > 0 ? `${chain}-day chain` : "No active chain"}
+        >
+          <FlameIcon size={16} />
+          {chain}
+        </span>
+        {daily.provider && (
+          <span className="text-sm text-muted-foreground">
+            {daily.provider.name}
+          </span>
+        )}
+      </ContentBoxFooter>
+    </ContentBox>
+  );
+}

--- a/packages/client/src/routes/dailies.tsx
+++ b/packages/client/src/routes/dailies.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/dailies")({
+  component: Dailies,
+});
+
+export function Dailies() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -227,6 +227,27 @@ export async function fetchDailies(): Promise<Daily[]> {
   return await fetch("/api/dailies").then(res => res.json());
 }
 
+export async function fetchSingleDaily(id: string): Promise<Daily> {
+  return await fetch(`/api/dailies/${id}`).then(res => res.json());
+}
+
+export async function createDaily(
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch("/api/dailies", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create daily: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
 export async function upsertDaily(
   id: string,
   data: Record<string, unknown>,
@@ -243,4 +264,12 @@ export async function upsertDaily(
     throw new Error(`Failed to update daily: ${response.statusText}`);
   }
   return await response.json();
+}
+
+export async function deleteSingleDaily(
+  id: string,
+): Promise<{ status: string }> {
+  return await fetch(`/api/dailies/${id}`, {
+    method: "DELETE",
+  }).then(res => res.json());
 }


### PR DESCRIPTION
Creates /dailies index, view, and edit routes mirroring the topics CRUD
pattern, plus a top-level Dailies link in the navigation. Adds the
fetchSingleDaily, createDaily, and deleteSingleDaily client helpers and
extends PageHeader's pageSection to support "dailies".