### PR TITLE
Improve daily tracking UX and dashboard course filter

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -1,0 +1,250 @@
+import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
+
+import { useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { CalendarIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+
+import { DailyStatusButtons } from "./DailyStatusButtons";
+import { DailyStatusCircle } from "./DailyStatusCircle";
+
+import { Calendar } from "@/components/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  getDateKey,
+  getTodayKey,
+  upsertDaily,
+  withCompletion,
+} from "@/utils";
+
+interface DailyCompletionsManagerProps {
+  daily: Daily;
+}
+
+function formatDateLabel(dateKey: string): string {
+  const d = new Date(`${dateKey}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function DailyCompletionsManager({
+  daily,
+}: DailyCompletionsManagerProps) {
+  const queryClient = useQueryClient();
+  const todayKey = getTodayKey();
+  const [selectedDateKey, setSelectedDateKey] = useState<string>(todayKey);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  const sortedCompletions = [...daily.completions].sort((a, b) =>
+    a.date < b.date ? 1 : -1);
+
+  const selectedStatus
+    = daily.completions.find(c => c.date === selectedDateKey)?.status ?? null;
+
+  const mutation = useMutation({
+    mutationFn: ({
+      dateKey, status,
+    }: { dateKey: string;
+      status: DailyCompletionStatus | null; }) => {
+      const completions = withCompletion(daily, dateKey, status);
+      return upsertDaily(daily.id, {
+        name: daily.name,
+        location: daily.location ?? null,
+        description: daily.description ?? null,
+        completions,
+        courseProviderId: daily.provider?.id ?? null,
+      });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["daily", daily.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["dailies"],
+        }),
+      ]);
+    },
+    onError: () => {
+      toast.error("Failed to update completion.");
+    },
+  });
+
+  const selectedDate = new Date(`${selectedDateKey}T00:00:00Z`);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Set status for a date</h3>
+        <div className="flex flex-row flex-wrap items-center gap-2">
+          <Popover
+            open={calendarOpen}
+            onOpenChange={setCalendarOpen}
+          >
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-[260px] justify-start text-left font-normal"
+              >
+                <CalendarIcon className="mr-2 size-4" />
+                {formatDateLabel(selectedDateKey)}
+                {selectedDateKey === todayKey && (
+                  <span
+                    className="
+                      ml-2 rounded-sm bg-muted px-1.5 py-0.5 text-xs
+                      text-muted-foreground uppercase
+                    "
+                  >
+                    today
+                  </span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-auto p-0"
+              align="start"
+            >
+              <Calendar
+                mode="single"
+                selected={selectedDate}
+                onSelect={(date) => {
+                  if (date) {
+                    setSelectedDateKey(getDateKey(date));
+                    setCalendarOpen(false);
+                  }
+                }}
+                disabled={{
+                  after: new Date(),
+                }}
+              />
+            </PopoverContent>
+          </Popover>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setSelectedDateKey(todayKey)}
+            disabled={selectedDateKey === todayKey}
+          >
+            Jump to today
+          </Button>
+        </div>
+        <div className="flex flex-row flex-wrap items-center gap-2">
+          <DailyStatusCircle
+            status={selectedStatus}
+            size="md"
+          />
+          <DailyStatusButtons
+            currentStatus={selectedStatus}
+            disabled={mutation.isPending}
+            onChange={status => mutation.mutate({
+              dateKey: selectedDateKey,
+              status,
+            })}
+          />
+          {selectedStatus !== null && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate({
+                dateKey: selectedDateKey,
+                status: null,
+              })}
+              className="text-destructive"
+            >
+              <Trash2Icon className="size-4" />
+              Clear entry
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Logged entries</h3>
+        {sortedCompletions.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            <i>No entries logged yet.</i>
+          </p>
+        )}
+        {sortedCompletions.length > 0 && (
+          <ul className="flex flex-col divide-y rounded-md border">
+            {sortedCompletions.map(c => (
+              <li
+                key={c.date}
+                className={cn(
+                  `
+                    flex flex-row flex-wrap items-center justify-between gap-2
+                    p-2
+                  `,
+                  c.date === selectedDateKey && "bg-muted/40",
+                )}
+              >
+                <button
+                  type="button"
+                  className="
+                    flex flex-row items-center gap-2 text-left
+                    hover:underline
+                  "
+                  onClick={() => setSelectedDateKey(c.date)}
+                >
+                  <DailyStatusCircle
+                    status={c.status}
+                    size="sm"
+                  />
+                  <span className="text-sm font-medium">
+                    {formatDateLabel(c.date)}
+                  </span>
+                  {c.date === todayKey && (
+                    <span
+                      className="
+                        rounded-sm bg-muted px-1.5 py-0.5 text-xs
+                        text-muted-foreground uppercase
+                      "
+                    >
+                      today
+                    </span>
+                  )}
+                </button>
+                <div className="flex flex-row items-center gap-1">
+                  <DailyStatusButtons
+                    currentStatus={c.status}
+                    disabled={mutation.isPending}
+                    onChange={status => mutation.mutate({
+                      dateKey: c.date,
+                      status,
+                    })}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={mutation.isPending}
+                    onClick={() => mutation.mutate({
+                      dateKey: c.date,
+                      status: null,
+                    })}
+                    className="text-destructive"
+                    title="Delete entry"
+                  >
+                    <Trash2Icon className="size-4" />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -1,0 +1,48 @@
+import type { Daily } from "@emstack/types/src";
+
+import { DailyStatusCircle } from "./DailyStatusCircle";
+
+import { cn } from "@/lib/utils";
+import { getRecentDays } from "@/utils/dailyHelpers";
+
+interface DailyRecentDaysStripProps {
+  daily: Daily;
+  count?: number;
+  className?: string;
+}
+
+export function DailyRecentDaysStrip({
+  daily,
+  count = 7,
+  className,
+}: DailyRecentDaysStripProps) {
+  const days = getRecentDays(daily, count);
+
+  return (
+    <div className={cn("flex flex-row gap-1.5", className)}>
+      {days.map(day => (
+        <div
+          key={day.dateKey}
+          className="flex flex-col items-center gap-0.5"
+        >
+          <DailyStatusCircle
+            status={day.status}
+            size="sm"
+            highlight={day.isToday}
+            title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+          />
+          <span
+            className={cn(
+              "text-[0.65rem] leading-none",
+              day.isToday
+                ? "font-semibold text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            {day.dayLabel}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/DailyStatusButtons.tsx
+++ b/packages/client/src/components/dailies/DailyStatusButtons.tsx
@@ -1,0 +1,46 @@
+import type { DailyCompletionStatus } from "@emstack/types/src";
+
+import { DAILY_STATUS_OPTIONS } from "./dailyStatusMeta";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DailyStatusButtonsProps {
+  currentStatus: DailyCompletionStatus | null;
+  disabled?: boolean;
+  onChange: (status: DailyCompletionStatus) => void;
+  size?: "sm" | "default";
+  className?: string;
+}
+
+export function DailyStatusButtons({
+  currentStatus,
+  disabled = false,
+  onChange,
+  size = "sm",
+  className,
+}: DailyStatusButtonsProps) {
+  return (
+    <div className={cn("flex flex-row flex-wrap gap-1", className)}>
+      {DAILY_STATUS_OPTIONS.map((opt) => {
+        const isActive = currentStatus === opt.value;
+        return (
+          <Button
+            key={opt.value}
+            type="button"
+            size={size}
+            variant={isActive ? "default" : "outline"}
+            disabled={disabled}
+            onClick={() => onChange(opt.value)}
+            className={cn({
+              "ring-2 ring-ring": isActive,
+            })}
+          >
+            {opt.icon}
+            {opt.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/DailyStatusCircle.tsx
+++ b/packages/client/src/components/dailies/DailyStatusCircle.tsx
@@ -1,0 +1,49 @@
+import type { DailyCompletionStatus } from "@emstack/types/src";
+
+import { getDailyStatusOption } from "./dailyStatusMeta";
+
+import { cn } from "@/lib/utils";
+
+interface DailyStatusCircleProps {
+  status: DailyCompletionStatus | null;
+  size?: "sm" | "md" | "lg";
+  highlight?: boolean;
+  title?: string;
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<NonNullable<DailyStatusCircleProps["size"]>, string> = {
+  sm: "size-6 [&_svg]:size-3",
+  md: "size-8 [&_svg]:size-4",
+  lg: "size-10 [&_svg]:size-5",
+};
+
+export function DailyStatusCircle({
+  status,
+  size = "md",
+  highlight = false,
+  title,
+  className,
+}: DailyStatusCircleProps) {
+  const option = status ? getDailyStatusOption(status) : null;
+
+  return (
+    <span
+      title={title}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full border-2",
+        SIZE_CLASSES[size],
+        option
+          ? option.circleClass
+          : `
+            border-dashed border-muted-foreground/40 bg-transparent
+            text-muted-foreground/60
+          `,
+        highlight && "ring-2 ring-ring ring-offset-1 ring-offset-background",
+        className,
+      )}
+    >
+      {option?.icon}
+    </span>
+  );
+}

--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -1,0 +1,50 @@
+import type { DailyCompletionStatus } from "@emstack/types/src";
+
+import {
+  CheckIcon,
+  CircleDashedIcon,
+  CircleIcon,
+  SparklesIcon,
+} from "lucide-react";
+
+export interface DailyStatusOption {
+  value: DailyCompletionStatus;
+  label: string;
+  icon: React.ReactNode;
+  circleClass: string;
+}
+
+export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
+  {
+    value: "incomplete",
+    label: "Incomplete",
+    icon: <CircleIcon className="size-4" />,
+    circleClass: "bg-muted text-muted-foreground border-muted-foreground/40",
+  },
+  {
+    value: "touched",
+    label: "Touched",
+    icon: <CircleDashedIcon className="size-4" />,
+    circleClass: "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
+  },
+  {
+    value: "goal",
+    label: "Goal",
+    icon: <CheckIcon className="size-4" />,
+    circleClass: "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
+  },
+  {
+    value: "exceeded",
+    label: "Exceeded",
+    icon: <SparklesIcon className="size-4" />,
+    circleClass: "bg-violet-100 text-violet-800 border-violet-500 dark:bg-violet-900/40 dark:text-violet-200",
+  },
+];
+
+export function getDailyStatusOption(
+  status: DailyCompletionStatus,
+): DailyStatusOption {
+  return (
+    DAILY_STATUS_OPTIONS.find(o => o.value === status) ?? DAILY_STATUS_OPTIONS[0]
+  );
+}

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -1,0 +1,5 @@
+export { DailyCompletionsManager } from "./DailyCompletionsManager";
+export { DailyRecentDaysStrip } from "./DailyRecentDaysStrip";
+export { DailyStatusButtons } from "./DailyStatusButtons";
+export { DailyStatusCircle } from "./DailyStatusCircle";
+export { DAILY_STATUS_OPTIONS, getDailyStatusOption } from "./dailyStatusMeta";

--- a/packages/client/src/components/layout/NavDropdown.tsx
+++ b/packages/client/src/components/layout/NavDropdown.tsx
@@ -37,25 +37,36 @@ export function NavDropdown({
     <div
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      className="inline-flex items-center gap-0.5"
     >
+      <Link
+        to={to}
+        className={`
+          underline-offset-2
+          hover:underline
+          [&.active]:font-bold
+        `}
+        onClick={() => setOpen(false)}
+      >
+        {label}
+      </Link>
       <DropdownMenu
         open={open}
         onOpenChange={setOpen}
       >
         <DropdownMenuTrigger asChild>
-          <span className="inline-flex items-center gap-0.5">
-            <Link
-              to={to}
-              className={`
-                underline-offset-2
-                hover:underline
-                [&.active]:font-bold
-              `}
-            >
-              {label}
-            </Link>
+          <button
+            type="button"
+            aria-label={`Open ${label} menu`}
+            className="
+              inline-flex size-5 items-center justify-center rounded-sm
+              text-muted-foreground
+              hover:bg-accent hover:text-accent-foreground
+              focus:outline-none
+            "
+          >
             <ChevronDownIcon className="size-3.5" />
-          </span>
+          </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">{children}</DropdownMenuContent>
       </DropdownMenu>

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -7,6 +7,7 @@ import { EyeIcon, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
+import { DailyCompletionsManager } from "@/components/dailies";
 import { useAppForm } from "@/components/formFields";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -222,6 +223,15 @@ function SingleDailyEdit() {
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}
         />
+        {!isNew && data && (
+          <div className="mt-12 flex max-w-2xl flex-col gap-4 border-t pt-8">
+            <h2 className="text-2xl">Completions</h2>
+            <p className="text-sm text-muted-foreground">
+              Pick a date below to retroactively set or change the status for that day.
+            </p>
+            <DailyCompletionsManager daily={data} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,12 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon } from "lucide-react";
+import { EditIcon, FlameIcon } from "lucide-react";
 
+import {
+  DailyCompletionsManager,
+  DailyRecentDaysStrip,
+} from "@/components/dailies";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { DeleteButton } from "@/components/ui/DeleteButton";
-import { deleteSingleDaily, fetchSingleDaily } from "@/utils";
+import {
+  deleteSingleDaily,
+  fetchSingleDaily,
+  getCurrentChain,
+} from "@/utils";
 
 export const Route = createFileRoute("/dailies/$id/")({
   component: SingleDaily,
@@ -50,11 +58,11 @@ function SingleDaily() {
   });
 
   if (isPending) {
-    <DailyPending />;
+    return <DailyPending />;
   }
 
-  if (error) {
-    <DailyError />;
+  if (error || !data) {
+    return <DailyError />;
   }
 
   async function handleDelete() {
@@ -64,21 +72,22 @@ function SingleDaily() {
     });
   }
 
-  const completionsCount = data?.completions?.filter(
+  const completionsCount = data.completions?.filter(
     c => c.status !== "incomplete",
   ).length ?? 0;
+  const chain = getCurrentChain(data);
 
   return (
     <div>
       <PageHeader
-        pageTitle={data?.name}
+        pageTitle={data.name}
         pageSection="dailies"
       >
         <div className="flex flex-row gap-2">
           <Link
             to="/dailies/$id/edit"
             params={{
-              id: data?.id + "",
+              id: data.id + "",
             }}
           >
             <Button variant="secondary">
@@ -92,27 +101,58 @@ function SingleDaily() {
       <div className="container flex flex-col gap-12">
         <InfoArea
           header="Description"
-          condition={!!data?.description}
+          condition={!!data.description}
         >
-          <p>{data?.description}</p>
+          <p>{data.description}</p>
         </InfoArea>
         <InfoArea
           header="Location"
-          condition={!!data?.location}
+          condition={!!data.location}
         >
-          <p>{data?.location}</p>
+          <p>{data.location}</p>
         </InfoArea>
         <InfoArea
           header="Provider"
-          condition={!!data?.provider}
+          condition={!!data.provider}
         >
-          <p>{data?.provider?.name}</p>
+          <p>{data.provider?.name}</p>
         </InfoArea>
         <InfoArea
-          header="Completions logged"
-          condition={!!data}
+          header="Last 14 days"
+          condition={true}
         >
-          <p>{completionsCount}</p>
+          <DailyRecentDaysStrip
+            daily={data}
+            count={14}
+          />
+        </InfoArea>
+        <InfoArea
+          header="Stats"
+          condition={true}
+        >
+          <div className="flex flex-row flex-wrap gap-6 text-sm">
+            <span className="inline-flex items-center gap-1">
+              <FlameIcon
+                size={16}
+                className={chain > 0
+                  ? "text-orange-600"
+                  : "text-muted-foreground"}
+              />
+              <strong>{chain}</strong>
+              <span className="text-muted-foreground">day chain</span>
+            </span>
+            <span>
+              <strong>{completionsCount}</strong>
+              {" "}
+              <span className="text-muted-foreground">completions logged</span>
+            </span>
+          </div>
+        </InfoArea>
+        <InfoArea
+          header="Day entries"
+          condition={true}
+        >
+          <DailyCompletionsManager daily={data} />
         </InfoArea>
         <div>
           <DeleteButton onClick={handleDelete}>Delete Daily</DeleteButton>

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -1,12 +1,21 @@
-import type { Daily } from "@emstack/types/src";
+import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { FlameIcon, PlusIcon } from "lucide-react";
+import { toast } from "sonner";
 
 import { ContentBox, ContentBoxBody, ContentBoxFooter, ContentBoxHeader, ContentBoxHeaderBar, ContentBoxTitle } from "@/components/boxes/ContentBox";
+import { DailyRecentDaysStrip, DailyStatusButtons } from "@/components/dailies";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { fetchDailies } from "@/utils";
+import {
+  fetchDailies,
+  findStatusForDate,
+  getCurrentChain,
+  getTodayKey,
+  upsertDaily,
+  withCompletion,
+} from "@/utils";
 
 export const Route = createFileRoute("/dailies/")({
   component: Dailies,
@@ -28,36 +37,6 @@ function DailiesError() {
       <h1 className="mb-4 text-3xl">There was an error loading your dailies.</h1>
     </div>
   );
-}
-
-function shiftDateKey(key: string, deltaDays: number): string {
-  const d = new Date(`${key}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + deltaDays);
-  return d.toISOString().slice(0, 10);
-}
-
-function getCurrentChain(daily: Daily): number {
-  const todayKey = new Date().toISOString().slice(0, 10);
-  const completedDates = new Set(
-    daily.completions
-      .filter(c => c.status !== "incomplete")
-      .map(c => c.date),
-  );
-
-  let cursor = todayKey;
-  if (!completedDates.has(cursor)) {
-    cursor = shiftDateKey(cursor, -1);
-    if (!completedDates.has(cursor)) {
-      return 0;
-    }
-  }
-
-  let count = 0;
-  while (completedDates.has(cursor)) {
-    count++;
-    cursor = shiftDateKey(cursor, -1);
-  }
-  return count;
 }
 
 function Dailies() {
@@ -117,7 +96,32 @@ function Dailies() {
 function DailyBox({
   daily,
 }: { daily: Daily }) {
-  const chain = getCurrentChain(daily);
+  const queryClient = useQueryClient();
+  const todayKey = getTodayKey();
+  const chain = getCurrentChain(daily, todayKey);
+  const currentStatus = findStatusForDate(daily, todayKey);
+
+  const mutation = useMutation({
+    mutationFn: (status: DailyCompletionStatus) => {
+      const completions = withCompletion(daily, todayKey, status);
+      return upsertDaily(daily.id, {
+        name: daily.name,
+        location: daily.location ?? null,
+        description: daily.description ?? null,
+        completions,
+        courseProviderId: daily.provider?.id ?? null,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to update daily.");
+    },
+  });
+
   return (
     <ContentBox>
       <ContentBoxHeader>
@@ -141,6 +145,17 @@ function DailyBox({
         <p>
           {daily.description ? daily.description : <i>No description provided.</i>}
         </p>
+        <DailyRecentDaysStrip daily={daily} />
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground uppercase">
+            Today&apos;s status
+          </span>
+          <DailyStatusButtons
+            currentStatus={currentStatus}
+            disabled={mutation.isPending}
+            onChange={status => mutation.mutate(status)}
+          />
+        </div>
       </ContentBoxBody>
       <ContentBoxFooter>
         <span

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
@@ -1,18 +1,9 @@
-import type { CourseInCourses } from "@emstack/types/src";
-
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { fetchCourses } from "@/utils";
-
-function isInProgress(course: CourseInCourses): boolean {
-  if (course.status !== "active") return false;
-  if (!course.progressTotal || course.progressTotal === 0) return false;
-  return course.progressCurrent > 0
-    && course.progressCurrent < course.progressTotal;
-}
 
 export function DashboardCoursesInProgress() {
   const {
@@ -22,7 +13,7 @@ export function DashboardCoursesInProgress() {
     queryFn: () => fetchCourses(),
   });
 
-  const inProgress = (courses ?? []).filter(isInProgress);
+  const inProgress = (courses ?? []).filter(c => c.status === "active");
 
   return (
     <DashboardCard
@@ -70,11 +61,13 @@ export function DashboardCoursesInProgress() {
                 >
                   {course.name}
                 </Link>
-                <span className="text-xs text-muted-foreground">
-                  {course.progressCurrent}
-                  {" / "}
-                  {course.progressTotal}
-                </span>
+                {course.progressTotal > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {course.progressCurrent}
+                    {" / "}
+                    {course.progressTotal}
+                  </span>
+                )}
               </div>
               <ProgressBar
                 progressCurrent={course.progressCurrent}

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -1,85 +1,23 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  CheckIcon,
-  CircleDashedIcon,
-  CircleIcon,
-  FlameIcon,
-  SparklesIcon,
-} from "lucide-react";
+import { FlameIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
-import { Button } from "@/components/ui/button";
+import {
+  DailyRecentDaysStrip,
+  DailyStatusButtons,
+} from "@/components/dailies";
 import { cn } from "@/lib/utils";
-import { fetchDailies, upsertDaily } from "@/utils";
-
-const STATUS_OPTIONS: {
-  value: DailyCompletionStatus;
-  label: string;
-  icon: React.ReactNode;
-}[] = [
-  {
-    value: "incomplete",
-    label: "Incomplete",
-    icon: <CircleIcon className="size-4" />,
-  },
-  {
-    value: "touched",
-    label: "Touched",
-    icon: <CircleDashedIcon className="size-4" />,
-  },
-  {
-    value: "goal",
-    label: "Goal",
-    icon: <CheckIcon className="size-4" />,
-  },
-  {
-    value: "exceeded",
-    label: "Exceeded",
-    icon: <SparklesIcon className="size-4" />,
-  },
-];
-
-function getTodayKey(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function findTodayStatus(daily: Daily, todayKey: string): DailyCompletionStatus {
-  return (
-    daily.completions.find(c => c.date === todayKey)?.status ?? "incomplete"
-  );
-}
-
-function shiftDateKey(key: string, deltaDays: number): string {
-  const d = new Date(`${key}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + deltaDays);
-  return d.toISOString().slice(0, 10);
-}
-
-function getCurrentChain(daily: Daily, todayKey: string): number {
-  const completedDates = new Set(
-    daily.completions
-      .filter(c => c.status !== "incomplete")
-      .map(c => c.date),
-  );
-
-  let cursor = todayKey;
-  if (!completedDates.has(cursor)) {
-    cursor = shiftDateKey(cursor, -1);
-    if (!completedDates.has(cursor)) {
-      return 0;
-    }
-  }
-
-  let count = 0;
-  while (completedDates.has(cursor)) {
-    count++;
-    cursor = shiftDateKey(cursor, -1);
-  }
-  return count;
-}
+import {
+  fetchDailies,
+  findStatusForDate,
+  getCurrentChain,
+  getTodayKey,
+  upsertDaily,
+  withCompletion,
+} from "@/utils";
 
 export function DashboardDailies() {
   const queryClient = useQueryClient();
@@ -97,14 +35,7 @@ export function DashboardDailies() {
       daily, status,
     }: { daily: Daily;
       status: DailyCompletionStatus; }) => {
-      const others = daily.completions.filter(c => c.date !== todayKey);
-      const completions = [
-        ...others,
-        {
-          date: todayKey,
-          status,
-        },
-      ];
+      const completions = withCompletion(daily, todayKey, status);
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -139,12 +70,12 @@ export function DashboardDailies() {
       {dailies && dailies.length > 0 && (
         <ul className="flex flex-col divide-y">
           {dailies.map((daily) => {
-            const currentStatus = findTodayStatus(daily, todayKey);
+            const currentStatus = findStatusForDate(daily, todayKey);
             const chain = getCurrentChain(daily, todayKey);
             return (
               <li
                 key={daily.id}
-                className="flex flex-col gap-2 py-2"
+                className="flex flex-col gap-3 py-3"
               >
                 <div
                   className="flex flex-row items-center justify-between gap-2"
@@ -171,27 +102,15 @@ export function DashboardDailies() {
                     )}
                   </div>
                 </div>
-                <div className="flex flex-row flex-wrap gap-1">
-                  {STATUS_OPTIONS.map(opt => (
-                    <Button
-                      key={opt.value}
-                      type="button"
-                      size="sm"
-                      variant={currentStatus === opt.value ? "default" : "outline"}
-                      disabled={mutation.isPending}
-                      onClick={() => mutation.mutate({
-                        daily,
-                        status: opt.value,
-                      })}
-                      className={cn({
-                        "ring-2 ring-ring": currentStatus === opt.value,
-                      })}
-                    >
-                      {opt.icon}
-                      {opt.label}
-                    </Button>
-                  ))}
-                </div>
+                <DailyRecentDaysStrip daily={daily} />
+                <DailyStatusButtons
+                  currentStatus={currentStatus}
+                  disabled={mutation.isPending}
+                  onChange={status => mutation.mutate({
+                    daily,
+                    status,
+                  })}
+                />
               </li>
             );
           })}

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -1,0 +1,94 @@
+import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
+
+export function getDateKey(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function getTodayKey(): string {
+  return getDateKey(new Date());
+}
+
+export function shiftDateKey(key: string, deltaDays: number): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + deltaDays);
+  return d.toISOString().slice(0, 10);
+}
+
+export function findStatusForDate(
+  daily: Daily,
+  dateKey: string,
+): DailyCompletionStatus | null {
+  return daily.completions.find(c => c.date === dateKey)?.status ?? null;
+}
+
+export function getCurrentChain(daily: Daily, todayKey: string = getTodayKey()): number {
+  const completedDates = new Set(
+    daily.completions
+      .filter(c => c.status !== "incomplete")
+      .map(c => c.date),
+  );
+
+  let cursor = todayKey;
+  if (!completedDates.has(cursor)) {
+    cursor = shiftDateKey(cursor, -1);
+    if (!completedDates.has(cursor)) {
+      return 0;
+    }
+  }
+
+  let count = 0;
+  while (completedDates.has(cursor)) {
+    count++;
+    cursor = shiftDateKey(cursor, -1);
+  }
+  return count;
+}
+
+const SHORT_DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export interface RecentDay {
+  dateKey: string;
+  dayLabel: string;
+  isToday: boolean;
+  status: DailyCompletionStatus | null;
+}
+
+export function getRecentDays(
+  daily: Daily,
+  count = 7,
+  todayKey: string = getTodayKey(),
+): RecentDay[] {
+  const days: RecentDay[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const dateKey = shiftDateKey(todayKey, -i);
+    const date = new Date(`${dateKey}T00:00:00Z`);
+    days.push({
+      dateKey,
+      dayLabel: SHORT_DAY_LABELS[date.getUTCDay()],
+      isToday: dateKey === todayKey,
+      status: findStatusForDate(daily, dateKey),
+    });
+  }
+  return days;
+}
+
+export function withCompletion(
+  daily: Daily,
+  dateKey: string,
+  status: DailyCompletionStatus | null,
+): Daily["completions"] {
+  const others = daily.completions.filter(c => c.date !== dateKey);
+  if (status === null) {
+    return others;
+  }
+  return [
+    ...others,
+    {
+      date: dateKey,
+      status,
+    },
+  ];
+}

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./dailyHelpers";
 export * from "./fetchFunctions";
 export * from "./fieldContext";
 export * from "./formHasChanges";


### PR DESCRIPTION
- Show recent-days status circles (with weekday labels) for each daily on
  the dashboard and dailies index, distinguishing un-entered days from
  explicit "incomplete" entries.
- Don't highlight any status button on the dashboard or dailies list when
  no entry exists yet for today.
- Allow setting today's status from the dailies index cards.
- Add a DailyCompletionsManager that lets users pick any past date and
  retroactively set, change, or clear a status, plus an inline list of
  all logged entries to edit/delete. Used on both the daily view page
  and the daily edit form.
- Filter dashboard "Courses in Progress" by active status only.
- Make top-level nav items with dropdowns (Courses, Topics) directly
  clickable; the chevron now hosts the dropdown trigger separately.