### PR TITLE
Add navigation links and improve daily details display

### DIFF
--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -1,22 +1,25 @@
+import type { DayLabelFormat } from "@/utils/dailyHelpers";
 import type { Daily } from "@emstack/types/src";
 
 import { DailyStatusCircle } from "./DailyStatusCircle";
 
 import { cn } from "@/lib/utils";
-import { getRecentDays } from "@/utils/dailyHelpers";
+import { getRecentDays, getTodayKey } from "@/utils/dailyHelpers";
 
 interface DailyRecentDaysStripProps {
   daily: Daily;
   count?: number;
   className?: string;
+  labelFormat?: DayLabelFormat;
 }
 
 export function DailyRecentDaysStrip({
   daily,
   count = 7,
   className,
+  labelFormat = "dow",
 }: DailyRecentDaysStripProps) {
-  const days = getRecentDays(daily, count);
+  const days = getRecentDays(daily, count, getTodayKey(), labelFormat);
 
   return (
     <div className={cn("flex flex-row gap-1.5", className)}>

--- a/packages/client/src/components/dailies/DailyStatusButtons.tsx
+++ b/packages/client/src/components/dailies/DailyStatusButtons.tsx
@@ -32,9 +32,6 @@ export function DailyStatusButtons({
             variant={isActive ? "default" : "outline"}
             disabled={disabled}
             onClick={() => onChange(opt.value)}
-            className={cn({
-              "ring-2 ring-ring": isActive,
-            })}
           >
             {opt.icon}
             {opt.label}

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, FlameIcon } from "lucide-react";
+import { EditIcon, ExternalLink, FlameIcon } from "lucide-react";
 
 import {
   DailyCompletionsManager,
@@ -15,6 +15,16 @@ import {
   fetchSingleDaily,
   getCurrentChain,
 } from "@/utils";
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+  catch {
+    return false;
+  }
+}
 
 export const Route = createFileRoute("/dailies/$id/")({
   component: SingleDaily,
@@ -109,7 +119,23 @@ function SingleDaily() {
           header="Location"
           condition={!!data.location}
         >
-          <p>{data.location}</p>
+          {data.location && isHttpUrl(data.location)
+            ? (
+              <a
+                href={data.location}
+                target="_blank"
+                rel="noreferrer"
+                className="self-start"
+              >
+                <Button>
+                  Open Location
+                  <ExternalLink />
+                </Button>
+              </a>
+            )
+            : (
+              <p>{data.location}</p>
+            )}
         </InfoArea>
         <InfoArea
           header="Provider"

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -1,6 +1,7 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { FlameIcon } from "lucide-react";
 import { toast } from "sonner";
 
@@ -55,7 +56,20 @@ export function DashboardDailies() {
   });
 
   return (
-    <DashboardCard title="Dailies">
+    <DashboardCard
+      title="Dailies"
+      action={(
+        <Link
+          to="/dailies"
+          className="
+            text-sm text-primary underline-offset-2
+            hover:underline
+          "
+        >
+          View all
+        </Link>
+      )}
+    >
       {isPending && (
         <p className="text-sm text-muted-foreground">Loading dailies...</p>
       )}
@@ -80,7 +94,18 @@ export function DashboardDailies() {
                 <div
                   className="flex flex-row items-center justify-between gap-2"
                 >
-                  <span className="font-medium">{daily.name}</span>
+                  <Link
+                    to="/dailies/$id"
+                    params={{
+                      id: daily.id,
+                    }}
+                    className="
+                      font-medium
+                      hover:text-blue-600
+                    "
+                  >
+                    {daily.name}
+                  </Link>
                   <div className="flex flex-row items-center gap-2">
                     <span
                       className={cn("inline-flex items-center gap-1 text-xs", chain > 0
@@ -102,7 +127,10 @@ export function DashboardDailies() {
                     )}
                   </div>
                 </div>
-                <DailyRecentDaysStrip daily={daily} />
+                <DailyRecentDaysStrip
+                  daily={daily}
+                  labelFormat="mmdd"
+                />
                 <DailyStatusButtons
                   currentStatus={currentStatus}
                   disabled={mutation.isPending}

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -49,6 +49,8 @@ export function getCurrentChain(daily: Daily, todayKey: string = getTodayKey()):
 
 const SHORT_DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
+export type DayLabelFormat = "dow" | "mmdd";
+
 export interface RecentDay {
   dateKey: string;
   dayLabel: string;
@@ -60,14 +62,18 @@ export function getRecentDays(
   daily: Daily,
   count = 7,
   todayKey: string = getTodayKey(),
+  labelFormat: DayLabelFormat = "dow",
 ): RecentDay[] {
   const days: RecentDay[] = [];
   for (let i = count - 1; i >= 0; i--) {
     const dateKey = shiftDateKey(todayKey, -i);
     const date = new Date(`${dateKey}T00:00:00Z`);
+    const dayLabel = labelFormat === "mmdd"
+      ? `${String(date.getUTCMonth() + 1).padStart(2, "0")}/${String(date.getUTCDate()).padStart(2, "0")}`
+      : SHORT_DAY_LABELS[date.getUTCDay()];
     days.push({
       dateKey,
-      dayLabel: SHORT_DAY_LABELS[date.getUTCDay()],
+      dayLabel,
       isToday: dateKey === todayKey,
       status: findStatusForDate(daily, dateKey),
     });


### PR DESCRIPTION
## Summary
This PR enhances navigation and display functionality for the dailies feature by adding clickable links to navigate between views and improving how daily location information is presented.

## Key Changes
- **Dashboard Navigation**: Added a "View all" link in the DashboardDailies card header to navigate to the full dailies page
- **Daily Item Links**: Made daily names in the dashboard clickable, linking to individual daily detail pages
- **Location Display Enhancement**: Updated the single daily view to detect HTTP/HTTPS URLs in the location field and render them as clickable buttons with an external link icon, while keeping non-URL text as plain text
- **Date Label Format Support**: Added configurable date label formatting to `DailyRecentDaysStrip` component, supporting both day-of-week ("dow") and month/day ("mmdd") formats
  - Updated `getRecentDays()` utility function to accept a `labelFormat` parameter
  - Dashboard dailies now use "mmdd" format for the recent days strip
  - Exported `DayLabelFormat` type for type safety

## Implementation Details
- Added `isHttpUrl()` utility function to validate whether a string is a valid HTTP/HTTPS URL
- Updated imports to include `Link` from `@tanstack/react-router` and `ExternalLink` icon from lucide-react
- Location links open in a new tab with `target="_blank"` and `rel="noreferrer"` for security
- Maintained backward compatibility by defaulting `labelFormat` to "dow" in the component

https://claude.ai/code/session_01VMDyiphs2JvC1ftKEgVbK9