### PR TITLE
Refactor dashboard dailies to table layout with status history

### DIFF
--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -1,9 +1,9 @@
 import type { DailyCompletionStatus } from "@emstack/types/src";
 
 import {
-  CheckIcon,
+  CircleCheckIcon,
   CircleDashedIcon,
-  CircleIcon,
+  CircleSlashIcon,
   SparklesIcon,
 } from "lucide-react";
 
@@ -12,32 +12,37 @@ export interface DailyStatusOption {
   label: string;
   icon: React.ReactNode;
   circleClass: string;
+  pillClass: string;
 }
 
 export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
   {
     value: "incomplete",
     label: "Incomplete",
-    icon: <CircleIcon className="size-4" />,
+    icon: <CircleDashedIcon className="size-4" />,
     circleClass: "bg-muted text-muted-foreground border-muted-foreground/40",
+    pillClass: "bg-muted text-muted-foreground border-muted-foreground/40",
   },
   {
     value: "touched",
     label: "Touched",
-    icon: <CircleDashedIcon className="size-4" />,
+    icon: <CircleSlashIcon className="size-4" />,
     circleClass: "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
+    pillClass: "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
   },
   {
     value: "goal",
     label: "Goal",
-    icon: <CheckIcon className="size-4" />,
+    icon: <CircleCheckIcon className="size-4" />,
     circleClass: "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
+    pillClass: "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
   },
   {
     value: "exceeded",
     label: "Exceeded",
     icon: <SparklesIcon className="size-4" />,
     circleClass: "bg-violet-100 text-violet-800 border-violet-500 dark:bg-violet-900/40 dark:text-violet-200",
+    pillClass: "bg-violet-100 text-violet-800 border-violet-500 dark:bg-violet-900/40 dark:text-violet-200",
   },
 ];
 

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -1,24 +1,124 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
+import { useState } from "react";
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { FlameIcon } from "lucide-react";
+import { ChevronRightIcon, FlameIcon, PencilIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
-  DailyRecentDaysStrip,
-  DailyStatusButtons,
+  DAILY_STATUS_OPTIONS,
+  DailyStatusCircle,
+  getDailyStatusOption,
 } from "@/components/dailies";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import {
   fetchDailies,
   findStatusForDate,
   getCurrentChain,
+  getRecentDays,
   getTodayKey,
   upsertDaily,
   withCompletion,
 } from "@/utils";
+
+const RECENT_DAYS_COUNT = 7;
+
+function formatMmDd(dateKey: string): string {
+  const d = new Date(`${dateKey}T00:00:00Z`);
+  return `${String(d.getUTCMonth() + 1).padStart(2, "0")}/${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+
+interface TodayStatusCellProps {
+  daily: Daily;
+  currentStatus: DailyCompletionStatus | null;
+  disabled: boolean;
+  onChange: (status: DailyCompletionStatus) => void;
+}
+
+function TodayStatusCell({
+  daily,
+  currentStatus,
+  disabled,
+  onChange,
+}: TodayStatusCellProps) {
+  const [editing, setEditing] = useState(false);
+  const showSelect = editing || currentStatus === null;
+  const option = currentStatus ? getDailyStatusOption(currentStatus) : null;
+
+  if (showSelect) {
+    return (
+      <Select
+        value={currentStatus ?? undefined}
+        disabled={disabled}
+        onValueChange={(value) => {
+          onChange(value as DailyCompletionStatus);
+          setEditing(false);
+        }}
+        open={editing || undefined}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditing(false);
+          }
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          aria-label={`Set today's status for ${daily.name}`}
+        >
+          <SelectValue placeholder="Select…" />
+        </SelectTrigger>
+        <SelectContent>
+          {DAILY_STATUS_OPTIONS.map(opt => (
+            <SelectItem
+              key={opt.value}
+              value={opt.value}
+            >
+              {opt.icon}
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <div className="flex flex-row items-center gap-1">
+      <span
+        className={cn(`
+          inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs
+          font-medium
+        `, option?.pillClass)}
+      >
+        {option?.icon}
+        {option?.label}
+      </span>
+      <button
+        type="button"
+        aria-label={`Edit today's status for ${daily.name}`}
+        className="
+          rounded-md p-1 text-muted-foreground
+          hover:bg-muted hover:text-foreground
+          disabled:cursor-not-allowed disabled:opacity-50
+        "
+        disabled={disabled}
+        onClick={() => setEditing(true)}
+      >
+        <PencilIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}
 
 export function DashboardDailies() {
   const queryClient = useQueryClient();
@@ -55,6 +155,22 @@ export function DashboardDailies() {
     },
   });
 
+  const sortedDailies = dailies
+    ? [...dailies].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, {
+        sensitivity: "base",
+      }))
+    : undefined;
+
+  const dayHeaders = sortedDailies && sortedDailies.length > 0
+    ? getRecentDays(sortedDailies[0], RECENT_DAYS_COUNT, todayKey, "mmdd")
+      .map(d => ({
+        dateKey: d.dateKey,
+        label: formatMmDd(d.dateKey),
+        isToday: d.isToday,
+      }))
+    : [];
+
   return (
     <DashboardCard
       title="Dailies"
@@ -76,73 +192,135 @@ export function DashboardDailies() {
       {error && (
         <p className="text-sm text-destructive">Failed to load dailies.</p>
       )}
-      {dailies && dailies.length === 0 && (
+      {sortedDailies && sortedDailies.length === 0 && (
         <p className="text-sm text-muted-foreground">
           <i>No dailies yet.</i>
         </p>
       )}
-      {dailies && dailies.length > 0 && (
-        <ul className="flex flex-col divide-y">
-          {dailies.map((daily) => {
-            const currentStatus = findStatusForDate(daily, todayKey);
-            const chain = getCurrentChain(daily, todayKey);
-            return (
-              <li
-                key={daily.id}
-                className="flex flex-col gap-3 py-3"
-              >
-                <div
-                  className="flex flex-row items-center justify-between gap-2"
-                >
-                  <Link
-                    to="/dailies/$id"
-                    params={{
-                      id: daily.id,
-                    }}
+      {sortedDailies && sortedDailies.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="text-left text-xs text-muted-foreground">
+                <th className="p-2 font-medium">Title</th>
+                <th className="p-2 font-medium">Streak</th>
+                {dayHeaders.map(d => (
+                  <th
+                    key={d.dateKey}
+                    className={cn(
+                      "px-1 py-2 text-center font-medium",
+                      d.isToday && "text-foreground",
+                    )}
+                  >
+                    {d.label}
+                  </th>
+                ))}
+                <th className="p-2 font-medium">Today&apos;s Status</th>
+                <th className="p-2">
+                  <span className="sr-only">View</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedDailies.map((daily) => {
+                const currentStatus = findStatusForDate(daily, todayKey);
+                const chain = getCurrentChain(daily, todayKey);
+                const days = getRecentDays(
+                  daily,
+                  RECENT_DAYS_COUNT,
+                  todayKey,
+                  "mmdd",
+                );
+                return (
+                  <tr
+                    key={daily.id}
                     className="
-                      font-medium
-                      hover:text-blue-600
+                      group border-t
+                      hover:bg-muted/40
                     "
                   >
-                    {daily.name}
-                  </Link>
-                  <div className="flex flex-row items-center gap-2">
-                    <span
-                      className={cn("inline-flex items-center gap-1 text-xs", chain > 0
-                        ? "text-orange-600"
-                        : "text-muted-foreground")}
-                      title={
-                        chain > 0
-                          ? `${chain}-day chain`
-                          : "No active chain"
-                      }
-                    >
-                      <FlameIcon className="size-3.5" />
-                      {chain}
-                    </span>
-                    {daily.provider && (
-                      <span className="text-xs text-muted-foreground">
-                        {daily.provider.name}
+                    <td className="p-2">
+                      <Link
+                        to="/dailies/$id"
+                        params={{
+                          id: daily.id,
+                        }}
+                        className="
+                          font-medium
+                          hover:text-blue-600
+                        "
+                      >
+                        {daily.name}
+                      </Link>
+                    </td>
+                    <td className="p-2">
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 text-xs",
+                          chain > 0
+                            ? "text-orange-600"
+                            : "text-muted-foreground",
+                        )}
+                        title={
+                          chain > 0
+                            ? `${chain}-day chain`
+                            : "No active chain"
+                        }
+                      >
+                        <FlameIcon className="size-3.5" />
+                        {chain}
                       </span>
-                    )}
-                  </div>
-                </div>
-                <DailyRecentDaysStrip
-                  daily={daily}
-                  labelFormat="mmdd"
-                />
-                <DailyStatusButtons
-                  currentStatus={currentStatus}
-                  disabled={mutation.isPending}
-                  onChange={status => mutation.mutate({
-                    daily,
-                    status,
-                  })}
-                />
-              </li>
-            );
-          })}
-        </ul>
+                    </td>
+                    {days.map(day => (
+                      <td
+                        key={day.dateKey}
+                        className="px-1 py-2"
+                      >
+                        <div className="flex justify-center">
+                          <DailyStatusCircle
+                            status={day.status}
+                            size="sm"
+                            highlight={day.isToday}
+                            title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+                          />
+                        </div>
+                      </td>
+                    ))}
+                    <td className="p-2">
+                      <TodayStatusCell
+                        daily={daily}
+                        currentStatus={currentStatus}
+                        disabled={mutation.isPending}
+                        onChange={status => mutation.mutate({
+                          daily,
+                          status,
+                        })}
+                      />
+                    </td>
+                    <td className="p-2 text-right">
+                      <Link
+                        to="/dailies/$id"
+                        params={{
+                          id: daily.id,
+                        }}
+                        aria-label={`View ${daily.name}`}
+                        className="
+                          inline-flex rounded-md p-1 text-muted-foreground
+                          opacity-0
+                          group-hover:opacity-100
+                          hover:bg-muted hover:text-foreground
+                          focus-visible:opacity-100
+                        "
+                      >
+                        <ChevronRightIcon className="size-4" />
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       )}
     </DashboardCard>
   );


### PR DESCRIPTION
## Summary
Redesigned the dashboard dailies view from a vertical list layout to a horizontal table layout that displays recent completion history alongside today's status management.

## Key Changes

- **Layout Transformation**: Converted from a flex list (`<ul>`) to a data table (`<table>`) with columns for daily title, streak, recent days (7-day history), today's status, and view link
- **Status History Display**: Added visual representation of completion status for the past 7 days using `DailyStatusCircle` components, with today's column highlighted
- **Enhanced Status Cell**: Created new `TodayStatusCell` component that:
  - Shows current status as a pill badge with edit button
  - Displays a dropdown select when editing or when no status is set
  - Provides inline editing without page navigation
- **Sorting**: Dailies are now sorted alphabetically by name for better organization
- **Visual Improvements**:
  - Added hover states to table rows for better interactivity
  - Implemented a "view" chevron icon that appears on hover
  - Improved accessibility with proper ARIA labels
  - Date headers show MM/DD format for recent days
- **Icon Updates**: Updated status option icons for better visual consistency:
  - "Incomplete" now uses `CircleDashedIcon`
  - "Touched" now uses `CircleSlashIcon`
  - "Goal" now uses `CircleCheckIcon`
- **Styling**: Added `pillClass` styling to status options for use in the new pill badge display

## Implementation Details

- Reused existing `getRecentDays()` utility to fetch 7-day history for each daily
- Maintained existing mutation logic for status updates
- Table is horizontally scrollable on smaller screens via `overflow-x-auto`
- Today's column is visually distinguished with different text color

https://claude.ai/code/session_019z4SpohmcodBSXcsu4pGmU