### PR TITLE
Improve daily status UI layout and editing behavior

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -261,6 +261,8 @@ export function DailyCompletionsManager({
             const note = entry?.note ?? null;
             const hasStatusEntry = status !== null;
             const isFuture = dateKey > todayKey;
+            const isToday = dateKey === todayKey;
+            const isEditable = !readOnly || isToday;
             return (
               <li
                 key={dateKey}
@@ -280,17 +282,7 @@ export function DailyCompletionsManager({
                   <span className="text-sm font-medium">
                     {formatDateLabel(dateKey)}
                   </span>
-                  {dateKey === todayKey && (
-                    <span
-                      className="
-                        rounded-sm bg-muted px-1.5 py-0.5 text-xs
-                        text-muted-foreground uppercase
-                      "
-                    >
-                      today
-                    </span>
-                  )}
-                  {readOnly && note && (
+                  {!isEditable && note && (
                     <span
                       className="truncate text-sm text-muted-foreground"
                       title={note}
@@ -299,7 +291,7 @@ export function DailyCompletionsManager({
                     </span>
                   )}
                 </div>
-                {!readOnly && !isFuture && (
+                {isEditable && !isFuture && (
                   <div className="flex flex-row items-center gap-1">
                     <DailyStatusButtons
                       currentStatus={status}

--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -18,6 +18,16 @@ interface DailyRecentDaysStripProps {
   showLabels?: boolean;
 }
 
+const CONNECTOR_TOP_BY_SIZE: Record<
+  NonNullable<DailyRecentDaysStripProps["size"]>,
+  string
+> = {
+  sm: "mt-[11px]",
+  md: "mt-[15px]",
+  lg: "mt-[19px]",
+  xl: "mt-[23px]",
+};
+
 export function DailyRecentDaysStrip({
   daily,
   count = 7,
@@ -29,14 +39,14 @@ export function DailyRecentDaysStrip({
   const days = getRecentDays(daily, count, getTodayKey(), labelFormat);
 
   return (
-    <div className={cn("flex flex-row items-end", className)}>
+    <div className={cn("flex flex-row items-start", className)}>
       {days.map((day, i) => (
         <Fragment key={day.dateKey}>
           {i > 0 && (
             <DailyStatusConnector
               left={days[i - 1].status}
               right={day.status}
-              className={showLabels ? "mb-3" : undefined}
+              className={CONNECTOR_TOP_BY_SIZE[size]}
             />
           )}
           <div className="flex flex-col items-center gap-0.5">

--- a/packages/client/src/components/dailies/DailyStatusButtons.tsx
+++ b/packages/client/src/components/dailies/DailyStatusButtons.tsx
@@ -39,7 +39,7 @@ export function DailyStatusButtons({
               className={cn(
                 isActive && opt.pillClass,
                 isActive && `
-                  border-2
+                  min-w-32 border-2
                   hover:opacity-80
                 `,
               )}

--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -34,43 +34,46 @@ export function TodayStatusCell({
 
   if (showSelect) {
     return (
-      <Select
-        value={currentStatus ?? undefined}
-        disabled={disabled}
-        onValueChange={(value) => {
-          onChange(value as DailyCompletionStatus);
-          setEditing(false);
-        }}
-        open={editing || undefined}
-        onOpenChange={(open) => {
-          if (!open) {
+      <div className="flex w-36">
+        <Select
+          value={currentStatus ?? undefined}
+          disabled={disabled}
+          onValueChange={(value) => {
+            onChange(value as DailyCompletionStatus);
             setEditing(false);
-          }
-        }}
-      >
-        <SelectTrigger
-          size="sm"
-          aria-label={`Set today's status for ${daily.name}`}
+          }}
+          open={editing || undefined}
+          onOpenChange={(open) => {
+            if (!open) {
+              setEditing(false);
+            }
+          }}
         >
-          <SelectValue placeholder="Select…" />
-        </SelectTrigger>
-        <SelectContent>
-          {DAILY_STATUS_OPTIONS.map(opt => (
-            <SelectItem
-              key={opt.value}
-              value={opt.value}
-            >
-              {opt.icon}
-              {opt.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          <SelectTrigger
+            size="sm"
+            aria-label={`Set today's status for ${daily.name}`}
+            className="w-full"
+          >
+            <SelectValue placeholder="Select…" />
+          </SelectTrigger>
+          <SelectContent>
+            {DAILY_STATUS_OPTIONS.map(opt => (
+              <SelectItem
+                key={opt.value}
+                value={opt.value}
+              >
+                {opt.icon}
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
     );
   }
 
   return (
-    <div className="flex flex-row items-center gap-1">
+    <div className="flex w-36 flex-row items-center gap-1">
       <span
         className={cn(`
           inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -195,7 +195,8 @@ export function DashboardDailies() {
                             left={days[i - 1].status}
                             right={day.status}
                             className="
-                              absolute top-5 -left-1 z-0 w-3 -translate-y-1/2
+                              absolute top-5 right-[calc(50%+12px)]
+                              left-[calc(-50%+12px)] z-0 w-auto -translate-y-1/2
                             "
                           />
                         )}

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -15,14 +15,24 @@ function Dashboard() {
       <PageHeader pageTitle="Dashboard" />
       <div
         className="
-          container flex flex-col gap-4
+          container flex flex-col gap-3
           md:flex-row md:items-start
         "
       >
-        <div className="md:shrink-0 md:basis-[60%]">
+        <div
+          className="
+            min-w-0
+            md:flex-1
+          "
+        >
           <DashboardDailies />
         </div>
-        <div className="md:shrink-0 md:basis-[40%]">
+        <div
+          className="
+            min-w-0
+            md:flex-1
+          "
+        >
           <DashboardCoursesInProgress />
         </div>
       </div>


### PR DESCRIPTION
## Summary
This PR refines the daily status UI components to improve layout consistency, fix responsive behavior, and enhance the editing experience for daily completions.

## Key Changes

- **TodayStatusCell**: Wrapped the Select component in a flex container with fixed width (`w-36`) and added `w-full` to the trigger to ensure consistent sizing and proper layout
- **DailyCompletionsManager**: 
  - Simplified logic by introducing `isEditable` variable that allows editing for today's entry even in read-only mode
  - Removed the "today" badge display
  - Changed note visibility to only show when not editable (instead of only in read-only mode)
  - Updated status button visibility to use the new `isEditable` logic
- **Dashboard layout**: Changed from fixed basis percentages (`basis-[60%]` and `basis-[40%]`) to flexible equal-width layout using `flex-1` with `min-w-0` for proper text truncation
- **DailyRecentDaysStrip**: 
  - Changed container alignment from `items-end` to `items-start`
  - Introduced `CONNECTOR_TOP_BY_SIZE` constant to dynamically position connectors based on component size instead of using a fixed margin
- **DashboardDailies**: Updated connector positioning to use calculated left/right offsets for better centering
- **DailyStatusButtons**: Added `min-w-32` to active status buttons for better visual consistency

## Notable Implementation Details
- The `isEditable` logic now treats today's entry as always editable, even in read-only mode, allowing users to update their current day's status
- Connector positioning now scales with component size rather than being hardcoded, improving visual consistency across different sizes
- Layout improvements use `min-w-0` to prevent flex children from overflowing their containers

https://claude.ai/code/session_019wTXctkV7bZ44jVFHyhvXA