### PR TITLE
Add technology radar feature for domains

### DIFF
--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -1,0 +1,363 @@
+import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types/src";
+
+import { useMemo, useState } from "react";
+
+interface RadarChartProps {
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  blips: RadarBlip[];
+  size?: number;
+  onBlipClick?: (blip: RadarBlip) => void;
+}
+
+interface PositionedBlip {
+  blip: RadarBlip;
+  x: number;
+  y: number;
+  index: number;
+}
+
+const QUADRANT_PALETTE = [
+  "#2563eb",
+  "#16a34a",
+  "#dc2626",
+  "#9333ea",
+  "#ea580c",
+  "#0891b2",
+  "#ca8a04",
+  "#db2777",
+];
+
+// Deterministic pseudo-random in [0, 1) from a string. Used to keep blip
+// placements stable across renders without storing coordinates in the DB.
+function hashUnit(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return ((h >>> 0) % 10000) / 10000;
+}
+
+export function RadarChart({
+  quadrants,
+  rings,
+  blips,
+  size = 600,
+  onBlipClick,
+}: RadarChartProps) {
+  const [hoveredBlipId, setHoveredBlipId] = useState<string | null>(null);
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxRadius = size / 2 - 24;
+
+  const sortedQuadrants = useMemo(
+    () => [...quadrants].sort((a, b) => a.position - b.position),
+    [quadrants],
+  );
+  const sortedRings = useMemo(
+    () => [...rings].sort((a, b) => a.position - b.position),
+    [rings],
+  );
+
+  const quadrantCount = sortedQuadrants.length;
+  const ringCount = sortedRings.length;
+
+  const ringRadii = useMemo(() => {
+    if (ringCount === 0) {
+      return [];
+    }
+    return sortedRings.map((_ring, idx) => ((idx + 1) / ringCount) * maxRadius);
+  }, [sortedRings, ringCount, maxRadius]);
+
+  const positionedBlips = useMemo<PositionedBlip[]>(() => {
+    if (quadrantCount === 0 || ringCount === 0) {
+      return [];
+    }
+    const angleStep = (Math.PI * 2) / quadrantCount;
+    let displayIndex = 0;
+    return blips
+      .map((blip) => {
+        const quadrantIndex = sortedQuadrants.findIndex(
+          q => q.id === blip.quadrantId,
+        );
+        const ringIndex = sortedRings.findIndex(r => r.id === blip.ringId);
+        if (quadrantIndex < 0 || ringIndex < 0) {
+          return null;
+        }
+        const innerR = ringIndex === 0 ? 0 : ringRadii[ringIndex - 1];
+        const outerR = ringRadii[ringIndex];
+        const startAngle = -Math.PI / 2 + quadrantIndex * angleStep;
+        // Pad away from boundaries so blips don't visually escape their cell.
+        const angleSeed = hashUnit(`${blip.id}:angle`);
+        const radiusSeed = hashUnit(`${blip.id}:radius`);
+        const angleOffset = (0.1 + angleSeed * 0.8) * angleStep;
+        const radius = innerR + (0.15 + radiusSeed * 0.7) * (outerR - innerR);
+        const angle = startAngle + angleOffset;
+        displayIndex += 1;
+        return {
+          blip,
+          x: cx + radius * Math.cos(angle),
+          y: cy + radius * Math.sin(angle),
+          index: displayIndex,
+        };
+      })
+      .filter((b): b is PositionedBlip => b !== null);
+  }, [
+    blips,
+    sortedQuadrants,
+    sortedRings,
+    ringRadii,
+    quadrantCount,
+    ringCount,
+    cx,
+    cy,
+  ]);
+
+  if (quadrantCount === 0 || ringCount === 0) {
+    return (
+      <div
+        className={`
+          flex items-center justify-center rounded-sm border border-dashed p-8
+          text-muted-foreground
+        `}
+        style={{
+          minHeight: size / 2,
+        }}
+      >
+        Configure at least one quadrant and one ring to display the radar.
+      </div>
+    );
+  }
+
+  const angleStep = (Math.PI * 2) / quadrantCount;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width="100%"
+        style={{
+          maxWidth: size,
+        }}
+        role="img"
+        aria-label="Radar chart"
+      >
+        {ringRadii.map((r, idx) => (
+          <circle
+            key={sortedRings[idx].id}
+            cx={cx}
+            cy={cy}
+            r={r}
+            fill="none"
+            stroke="#d1d5db"
+            strokeWidth={1}
+          />
+        ))}
+        {sortedQuadrants.map((q, idx) => {
+          const angle = -Math.PI / 2 + idx * angleStep;
+          const x2 = cx + maxRadius * Math.cos(angle);
+          const y2 = cy + maxRadius * Math.sin(angle);
+          return (
+            <line
+              key={q.id}
+              x1={cx}
+              y1={cy}
+              x2={x2}
+              y2={y2}
+              stroke="#9ca3af"
+              strokeWidth={1}
+            />
+          );
+        })}
+        {ringRadii.map((r, idx) => {
+          // Place ring labels along the top of each ring, slightly above the
+          // arc so they sit just outside the ring boundary going inward.
+          const labelY = cy - r + 12;
+          return (
+            <text
+              key={`label-${sortedRings[idx].id}`}
+              x={cx}
+              y={labelY}
+              textAnchor="middle"
+              fontSize={11}
+              fill="#6b7280"
+              fontWeight="500"
+            >
+              {sortedRings[idx].name}
+            </text>
+          );
+        })}
+        {sortedQuadrants.map((q, idx) => {
+          // Quadrant label sits along the bisecting angle just outside the
+          // outermost ring.
+          const angle = -Math.PI / 2 + (idx + 0.5) * angleStep;
+          const labelRadius = maxRadius + 8;
+          const x = cx + labelRadius * Math.cos(angle);
+          const y = cy + labelRadius * Math.sin(angle);
+          return (
+            <text
+              key={`q-label-${q.id}`}
+              x={x}
+              y={y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={13}
+              fontWeight="600"
+              fill={QUADRANT_PALETTE[idx % QUADRANT_PALETTE.length]}
+            >
+              {q.name}
+            </text>
+          );
+        })}
+        {positionedBlips.map(({
+          blip, x, y, index,
+        }) => {
+          const quadrantIndex = sortedQuadrants.findIndex(
+            q => q.id === blip.quadrantId,
+          );
+          const color
+            = QUADRANT_PALETTE[quadrantIndex % QUADRANT_PALETTE.length];
+          const isHovered = hoveredBlipId === blip.id;
+          return (
+            <g
+              key={blip.id}
+              onMouseEnter={() => setHoveredBlipId(blip.id)}
+              onMouseLeave={() => setHoveredBlipId(null)}
+              onClick={() => onBlipClick?.(blip)}
+              style={{
+                cursor: onBlipClick ? "pointer" : "default",
+              }}
+            >
+              <circle
+                cx={x}
+                cy={y}
+                r={isHovered ? 12 : 10}
+                fill={color}
+                stroke="white"
+                strokeWidth={2}
+              />
+              <text
+                x={x}
+                y={y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={10}
+                fontWeight="700"
+                fill="white"
+                style={{
+                  pointerEvents: "none",
+                }}
+              >
+                {index}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <RadarLegend
+        quadrants={sortedQuadrants}
+        positionedBlips={positionedBlips}
+        rings={sortedRings}
+        onHover={setHoveredBlipId}
+        hoveredBlipId={hoveredBlipId}
+        onBlipClick={onBlipClick}
+      />
+    </div>
+  );
+}
+
+interface RadarLegendProps {
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  positionedBlips: PositionedBlip[];
+  hoveredBlipId: string | null;
+  onHover: (id: string | null) => void;
+  onBlipClick?: (blip: RadarBlip) => void;
+}
+
+function RadarLegend({
+  quadrants,
+  rings,
+  positionedBlips,
+  hoveredBlipId,
+  onHover,
+  onBlipClick,
+}: RadarLegendProps) {
+  const ringNameById = useMemo(() => {
+    const map: Record<string, string> = {};
+    rings.forEach((r) => {
+      map[r.id] = r.name;
+    });
+    return map;
+  }, [rings]);
+
+  return (
+    <div
+      className={`
+        grid grid-cols-1 gap-4
+        sm:grid-cols-2
+        lg:grid-cols-4
+      `}
+    >
+      {quadrants.map((q, idx) => {
+        const color = QUADRANT_PALETTE[idx % QUADRANT_PALETTE.length];
+        const items = positionedBlips.filter(
+          pb => pb.blip.quadrantId === q.id,
+        );
+        return (
+          <div
+            key={q.id}
+            className="flex flex-col gap-1"
+          >
+            <h4
+              className="text-sm font-semibold uppercase"
+              style={{
+                color,
+              }}
+            >
+              {q.name}
+            </h4>
+            {items.length === 0 && (
+              <p className="text-xs text-muted-foreground italic">
+                No blips yet.
+              </p>
+            )}
+            <ul className="flex flex-col gap-0.5">
+              {items.map(({
+                blip, index,
+              }) => (
+                <li
+                  key={blip.id}
+                  onMouseEnter={() => onHover(blip.id)}
+                  onMouseLeave={() => onHover(null)}
+                  onClick={() => onBlipClick?.(blip)}
+                  className={`
+                    cursor-pointer rounded-sm px-1 py-0.5 text-sm
+                    ${hoveredBlipId === blip.id ? "bg-gray-200" : ""}
+                  `}
+                >
+                  <span
+                    className="mr-1 inline-block font-mono text-xs"
+                    style={{
+                      color,
+                    }}
+                  >
+                    {index}.
+                  </span>
+                  <span className="font-medium">{blip.name}</span>
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    (
+                    {ringNameById[blip.ringId]}
+                    )
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -34,9 +34,12 @@ import { Route as DailiesIdIndexRouteImport } from './routes/dailies.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
 import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
+import { Route as DomainsIdRadarRouteImport } from './routes/domains.$id.radar'
 import { Route as DomainsIdEditRouteImport } from './routes/domains.$id.edit'
 import { Route as DailiesIdEditRouteImport } from './routes/dailies.$id.edit'
 import { Route as CoursesIdEditRouteImport } from './routes/courses.$id.edit'
+import { Route as DomainsIdRadarIndexRouteImport } from './routes/domains.$id.radar.index'
+import { Route as DomainsIdRadarEditRouteImport } from './routes/domains.$id.radar.edit'
 
 const TopicsRoute = TopicsRouteImport.update({
   id: '/topics',
@@ -163,6 +166,11 @@ const ProvidersIdEditRoute = ProvidersIdEditRouteImport.update({
   path: '/edit',
   getParentRoute: () => ProvidersIdRoute,
 } as any)
+const DomainsIdRadarRoute = DomainsIdRadarRouteImport.update({
+  id: '/radar',
+  path: '/radar',
+  getParentRoute: () => DomainsIdRoute,
+} as any)
 const DomainsIdEditRoute = DomainsIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -177,6 +185,16 @@ const CoursesIdEditRoute = CoursesIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
   getParentRoute: () => CoursesIdRoute,
+} as any)
+const DomainsIdRadarIndexRoute = DomainsIdRadarIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DomainsIdRadarRoute,
+} as any)
+const DomainsIdRadarEditRoute = DomainsIdRadarEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => DomainsIdRadarRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -201,6 +219,7 @@ export interface FileRoutesByFullPath {
   '/courses/$id/edit': typeof CoursesIdEditRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
+  '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
@@ -208,6 +227,8 @@ export interface FileRoutesByFullPath {
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
+  '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
+  '/domains/$id/radar/': typeof DomainsIdRadarIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -228,6 +249,8 @@ export interface FileRoutesByTo {
   '/domains/$id': typeof DomainsIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
+  '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
+  '/domains/$id/radar': typeof DomainsIdRadarIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -252,6 +275,7 @@ export interface FileRoutesById {
   '/courses/$id/edit': typeof CoursesIdEditRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
+  '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
@@ -259,6 +283,8 @@ export interface FileRoutesById {
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
+  '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
+  '/domains/$id/radar/': typeof DomainsIdRadarIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -284,6 +310,7 @@ export interface FileRouteTypes {
     | '/courses/$id/edit'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
+    | '/domains/$id/radar'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
@@ -291,6 +318,8 @@ export interface FileRouteTypes {
     | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
+    | '/domains/$id/radar/edit'
+    | '/domains/$id/radar/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -311,6 +340,8 @@ export interface FileRouteTypes {
     | '/domains/$id'
     | '/providers/$id'
     | '/topics/$id'
+    | '/domains/$id/radar/edit'
+    | '/domains/$id/radar'
   id:
     | '__root__'
     | '/'
@@ -334,6 +365,7 @@ export interface FileRouteTypes {
     | '/courses/$id/edit'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
+    | '/domains/$id/radar'
     | '/providers/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
@@ -341,6 +373,8 @@ export interface FileRouteTypes {
     | '/domains/$id/'
     | '/providers/$id/'
     | '/topics/$id/'
+    | '/domains/$id/radar/edit'
+    | '/domains/$id/radar/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -531,6 +565,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersIdEditRouteImport
       parentRoute: typeof ProvidersIdRoute
     }
+    '/domains/$id/radar': {
+      id: '/domains/$id/radar'
+      path: '/radar'
+      fullPath: '/domains/$id/radar'
+      preLoaderRoute: typeof DomainsIdRadarRouteImport
+      parentRoute: typeof DomainsIdRoute
+    }
     '/domains/$id/edit': {
       id: '/domains/$id/edit'
       path: '/edit'
@@ -551,6 +592,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/courses/$id/edit'
       preLoaderRoute: typeof CoursesIdEditRouteImport
       parentRoute: typeof CoursesIdRoute
+    }
+    '/domains/$id/radar/': {
+      id: '/domains/$id/radar/'
+      path: '/'
+      fullPath: '/domains/$id/radar/'
+      preLoaderRoute: typeof DomainsIdRadarIndexRouteImport
+      parentRoute: typeof DomainsIdRadarRoute
+    }
+    '/domains/$id/radar/edit': {
+      id: '/domains/$id/radar/edit'
+      path: '/edit'
+      fullPath: '/domains/$id/radar/edit'
+      preLoaderRoute: typeof DomainsIdRadarEditRouteImport
+      parentRoute: typeof DomainsIdRadarRoute
     }
   }
 }
@@ -609,13 +664,29 @@ const DailiesRouteChildren: DailiesRouteChildren = {
 const DailiesRouteWithChildren =
   DailiesRoute._addFileChildren(DailiesRouteChildren)
 
+interface DomainsIdRadarRouteChildren {
+  DomainsIdRadarEditRoute: typeof DomainsIdRadarEditRoute
+  DomainsIdRadarIndexRoute: typeof DomainsIdRadarIndexRoute
+}
+
+const DomainsIdRadarRouteChildren: DomainsIdRadarRouteChildren = {
+  DomainsIdRadarEditRoute: DomainsIdRadarEditRoute,
+  DomainsIdRadarIndexRoute: DomainsIdRadarIndexRoute,
+}
+
+const DomainsIdRadarRouteWithChildren = DomainsIdRadarRoute._addFileChildren(
+  DomainsIdRadarRouteChildren,
+)
+
 interface DomainsIdRouteChildren {
   DomainsIdEditRoute: typeof DomainsIdEditRoute
+  DomainsIdRadarRoute: typeof DomainsIdRadarRouteWithChildren
   DomainsIdIndexRoute: typeof DomainsIdIndexRoute
 }
 
 const DomainsIdRouteChildren: DomainsIdRouteChildren = {
   DomainsIdEditRoute: DomainsIdEditRoute,
+  DomainsIdRadarRoute: DomainsIdRadarRouteWithChildren,
   DomainsIdIndexRoute: DomainsIdIndexRoute,
 }
 

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -275,7 +275,8 @@ function Dailies() {
                                   left={day.status}
                                   right={currentStatus}
                                   className="
-                                    absolute top-5 left-[calc(50%+12px)] z-0 w-3
+                                    absolute top-5 -right-2
+                                    left-[calc(50%+12px)] z-0 w-auto
                                     -translate-y-1/2
                                   "
                                 />

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -231,8 +231,8 @@ export function DashboardDailies() {
                               left={day.status}
                               right={currentStatus}
                               className="
-                                absolute top-5 left-[calc(50%+12px)] z-0 w-3
-                                -translate-y-1/2
+                                absolute top-5 -right-2 left-[calc(50%+12px)]
+                                z-0 w-auto -translate-y-1/2
                               "
                             />
                           )}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon } from "lucide-react";
+import { EditIcon, RadarIcon } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
 import { InfoArea } from "@/components/layout/InfoArea";
@@ -66,6 +66,20 @@ function SingleDomain() {
         pageSection="domains"
       >
         <div className="flex flex-row gap-2">
+          {data?.hasRadar && (
+            <Link
+              to="/domains/$id/radar"
+              params={{
+                id: data?.id + "",
+              }}
+            >
+              <Button>
+                View Radar
+                {" "}
+                <RadarIcon />
+              </Button>
+            </Link>
+          )}
           <Link
             to="/domains/$id/edit"
             params={{

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -1,0 +1,664 @@
+import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types/src";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ArrowLeftIcon, EyeIcon, Loader2, PlusIcon, TrashIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/forms/input";
+import { Textarea } from "@/components/forms/textarea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createRadarBlip,
+  deleteRadarBlip,
+  fetchRadar,
+  upsertRadarBlip,
+  upsertRadarConfig,
+} from "@/utils";
+
+export const Route = createFileRoute("/domains/$id/radar/edit")({
+  component: RadarEdit,
+});
+
+interface QuadrantDraft {
+  id?: string;
+  name: string;
+  position: number;
+  localKey: string;
+}
+
+interface RingDraft {
+  id?: string;
+  name: string;
+  position: number;
+  localKey: string;
+}
+
+interface BlipDraft {
+  id?: string;
+  name: string;
+  description: string;
+  quadrantId: string;
+  ringId: string;
+  localKey: string;
+}
+
+const DEFAULT_QUADRANTS = [
+  "Languages & Frameworks",
+  "Tools",
+  "Platforms",
+  "Techniques",
+];
+
+const DEFAULT_RINGS = ["Adopt", "Trial", "Assess", "Hold"];
+
+let localKeyCounter = 0;
+function nextLocalKey() {
+  localKeyCounter += 1;
+  return `local-${localKeyCounter}`;
+}
+
+function quadrantsFromServer(items: RadarQuadrant[]): QuadrantDraft[] {
+  return items
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map(q => ({
+      id: q.id,
+      name: q.name,
+      position: q.position,
+      localKey: q.id,
+    }));
+}
+
+function ringsFromServer(items: RadarRing[]): RingDraft[] {
+  return items
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map(r => ({
+      id: r.id,
+      name: r.name,
+      position: r.position,
+      localKey: r.id,
+    }));
+}
+
+function defaultQuadrants(): QuadrantDraft[] {
+  return DEFAULT_QUADRANTS.map((name, idx) => ({
+    name,
+    position: idx,
+    localKey: nextLocalKey(),
+  }));
+}
+
+function defaultRings(): RingDraft[] {
+  return DEFAULT_RINGS.map((name, idx) => ({
+    name,
+    position: idx,
+    localKey: nextLocalKey(),
+  }));
+}
+
+function blipsFromServer(items: RadarBlip[]): BlipDraft[] {
+  return items.map(b => ({
+    id: b.id,
+    name: b.name,
+    description: b.description ?? "",
+    quadrantId: b.quadrantId,
+    ringId: b.ringId,
+    localKey: b.id,
+  }));
+}
+
+function RadarEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const {
+    data, isPending,
+  } = useQuery({
+    queryKey: ["radar", id],
+    queryFn: () => fetchRadar(id),
+  });
+
+  const [quadrants, setQuadrants] = useState<QuadrantDraft[]>([]);
+  const [rings, setRings] = useState<RingDraft[]>([]);
+  const [blips, setBlips] = useState<BlipDraft[]>([]);
+  const [isSavingConfig, setIsSavingConfig] = useState(false);
+  const [pendingBlipKey, setPendingBlipKey] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (!data || hydrated) {
+      return;
+    }
+    setQuadrants(
+      data.quadrants.length > 0
+        ? quadrantsFromServer(data.quadrants)
+        : defaultQuadrants(),
+    );
+    setRings(
+      data.rings.length > 0 ? ringsFromServer(data.rings) : defaultRings(),
+    );
+    setBlips(blipsFromServer(data.blips));
+    setHydrated(true);
+  }, [data, hydrated]);
+
+  const persistedQuadrantIds = useMemo(
+    () => new Set((data?.quadrants ?? []).map(q => q.id)),
+    [data],
+  );
+  const persistedRingIds = useMemo(
+    () => new Set((data?.rings ?? []).map(r => r.id)),
+    [data],
+  );
+  const allConfigPersisted
+    = quadrants.every(q => q.id && persistedQuadrantIds.has(q.id))
+      && rings.every(r => r.id && persistedRingIds.has(r.id));
+
+  function addQuadrant() {
+    setQuadrants(prev => [
+      ...prev,
+      {
+        name: "",
+        position: prev.length,
+        localKey: nextLocalKey(),
+      },
+    ]);
+  }
+
+  function removeQuadrant(localKey: string) {
+    setQuadrants(prev =>
+      prev
+        .filter(q => q.localKey !== localKey)
+        .map((q, idx) => ({
+          ...q,
+          position: idx,
+        })));
+  }
+
+  function addRing() {
+    setRings(prev => [
+      ...prev,
+      {
+        name: "",
+        position: prev.length,
+        localKey: nextLocalKey(),
+      },
+    ]);
+  }
+
+  function removeRing(localKey: string) {
+    setRings(prev =>
+      prev
+        .filter(r => r.localKey !== localKey)
+        .map((r, idx) => ({
+          ...r,
+          position: idx,
+        })));
+  }
+
+  async function saveConfig() {
+    if (quadrants.some(q => !q.name.trim())) {
+      toast.error("Every quadrant needs a name.");
+      return;
+    }
+    if (rings.some(r => !r.name.trim())) {
+      toast.error("Every ring needs a name.");
+      return;
+    }
+    setIsSavingConfig(true);
+    try {
+      await upsertRadarConfig(id, {
+        quadrants: quadrants.map(q => ({
+          id: q.id,
+          name: q.name.trim(),
+          position: q.position,
+        })),
+        rings: rings.map(r => ({
+          id: r.id,
+          name: r.name.trim(),
+          position: r.position,
+        })),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["radar", id],
+      });
+      setHydrated(false);
+      toast.success("Radar configuration saved.");
+    }
+    catch {
+      toast.error("Failed to save radar configuration.");
+    }
+    finally {
+      setIsSavingConfig(false);
+    }
+  }
+
+  function addBlipDraft() {
+    if (quadrants.length === 0 || rings.length === 0) {
+      toast.error("Add at least one quadrant and ring first.");
+      return;
+    }
+    if (!allConfigPersisted) {
+      toast.error("Save your quadrants and rings before adding blips.");
+      return;
+    }
+    setBlips(prev => [
+      ...prev,
+      {
+        name: "",
+        description: "",
+        quadrantId: quadrants[0].id ?? "",
+        ringId: rings[0].id ?? "",
+        localKey: nextLocalKey(),
+      },
+    ]);
+  }
+
+  async function saveBlip(blip: BlipDraft) {
+    if (!blip.name.trim()) {
+      toast.error("Blip needs a name.");
+      return;
+    }
+    if (!blip.quadrantId || !blip.ringId) {
+      toast.error("Pick a quadrant and ring.");
+      return;
+    }
+    setPendingBlipKey(blip.localKey);
+    try {
+      const payload = {
+        name: blip.name.trim(),
+        description: blip.description.trim() || null,
+        quadrantId: blip.quadrantId,
+        ringId: blip.ringId,
+      };
+      if (blip.id) {
+        await upsertRadarBlip(id, blip.id, payload);
+      }
+      else {
+        const result = await createRadarBlip(id, payload);
+        setBlips(prev =>
+          prev.map(b =>
+            b.localKey === blip.localKey
+              ? {
+                ...b,
+                id: result.id,
+              }
+              : b));
+      }
+      await queryClient.invalidateQueries({
+        queryKey: ["radar", id],
+      });
+      toast.success("Blip saved.");
+    }
+    catch {
+      toast.error("Failed to save blip.");
+    }
+    finally {
+      setPendingBlipKey(null);
+    }
+  }
+
+  async function removeBlip(blip: BlipDraft) {
+    if (blip.id) {
+      setPendingBlipKey(blip.localKey);
+      try {
+        await deleteRadarBlip(id, blip.id);
+        await queryClient.invalidateQueries({
+          queryKey: ["radar", id],
+        });
+      }
+      catch {
+        toast.error("Failed to delete blip.");
+        setPendingBlipKey(null);
+        return;
+      }
+      setPendingBlipKey(null);
+    }
+    setBlips(prev => prev.filter(b => b.localKey !== blip.localKey));
+  }
+
+  if (isPending) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">Loading radar...</h1>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Edit Radar"
+        pageSection="domains"
+      >
+        <div className="flex flex-row gap-2">
+          <Link
+            to="/domains/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="outline">
+              <ArrowLeftIcon />
+              {" "}
+              Back to Domain
+            </Button>
+          </Link>
+          <Link
+            to="/domains/$id/radar"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Radar
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        </div>
+      </PageHeader>
+      <div className="container flex flex-col gap-12">
+        <section className="flex flex-col gap-4">
+          <h2 className="text-2xl">Quadrants</h2>
+          <p className="text-sm text-muted-foreground">
+            Quadrants are the categories on your radar. They are listed
+            clockwise starting from the top.
+          </p>
+          <ul className="flex flex-col gap-2">
+            {quadrants.map((q, idx) => (
+              <li
+                key={q.localKey}
+                className="flex flex-row items-center gap-2"
+              >
+                <span className="w-6 text-sm text-muted-foreground">
+                  {idx + 1}
+                  .
+                </span>
+                <Input
+                  value={q.name}
+                  onChange={e =>
+                    setQuadrants(prev =>
+                      prev.map(item =>
+                        item.localKey === q.localKey
+                          ? {
+                            ...item,
+                            name: e.target.value,
+                          }
+                          : item))}
+                  placeholder="Quadrant name"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeQuadrant(q.localKey)}
+                  aria-label="Remove quadrant"
+                >
+                  <TrashIcon />
+                </Button>
+              </li>
+            ))}
+          </ul>
+          <div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addQuadrant}
+            >
+              <PlusIcon />
+              {" "}
+              Add Quadrant
+            </Button>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <h2 className="text-2xl">Rings</h2>
+          <p className="text-sm text-muted-foreground">
+            Rings represent levels — listed innermost first.
+          </p>
+          <ul className="flex flex-col gap-2">
+            {rings.map((r, idx) => (
+              <li
+                key={r.localKey}
+                className="flex flex-row items-center gap-2"
+              >
+                <span className="w-6 text-sm text-muted-foreground">
+                  {idx + 1}
+                  .
+                </span>
+                <Input
+                  value={r.name}
+                  onChange={e =>
+                    setRings(prev =>
+                      prev.map(item =>
+                        item.localKey === r.localKey
+                          ? {
+                            ...item,
+                            name: e.target.value,
+                          }
+                          : item))}
+                  placeholder="Ring name"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeRing(r.localKey)}
+                  aria-label="Remove ring"
+                >
+                  <TrashIcon />
+                </Button>
+              </li>
+            ))}
+          </ul>
+          <div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addRing}
+            >
+              <PlusIcon />
+              {" "}
+              Add Ring
+            </Button>
+          </div>
+          <div>
+            <Button
+              type="button"
+              onClick={saveConfig}
+              disabled={isSavingConfig}
+            >
+              {isSavingConfig && <Loader2 className="animate-spin" />}
+              Save Configuration
+            </Button>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <h2 className="text-2xl">Blips</h2>
+          {!allConfigPersisted && (
+            <p className="text-sm text-amber-700">
+              Save your quadrants and rings before adding blips.
+            </p>
+          )}
+          <ul className="flex flex-col gap-4">
+            {blips.map(blip => (
+              <li
+                key={blip.localKey}
+                className="flex flex-col gap-2 rounded-sm border p-4"
+              >
+                <div
+                  className={`
+                    grid grid-cols-1 gap-2
+                    sm:grid-cols-2
+                  `}
+                >
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase">Name</label>
+                    <Input
+                      value={blip.name}
+                      onChange={e =>
+                        setBlips(prev =>
+                          prev.map(b =>
+                            b.localKey === blip.localKey
+                              ? {
+                                ...b,
+                                name: e.target.value,
+                              }
+                              : b))}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase">Quadrant</label>
+                    <Select
+                      value={blip.quadrantId}
+                      onValueChange={value =>
+                        setBlips(prev =>
+                          prev.map(b =>
+                            b.localKey === blip.localKey
+                              ? {
+                                ...b,
+                                quadrantId: value,
+                              }
+                              : b))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choose quadrant" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {quadrants
+                          .filter((q): q is QuadrantDraft & { id: string } =>
+                            Boolean(q.id))
+                          .map(q => (
+                            <SelectItem
+                              key={q.id}
+                              value={q.id}
+                            >
+                              {q.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase">Ring</label>
+                    <Select
+                      value={blip.ringId}
+                      onValueChange={value =>
+                        setBlips(prev =>
+                          prev.map(b =>
+                            b.localKey === blip.localKey
+                              ? {
+                                ...b,
+                                ringId: value,
+                              }
+                              : b))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Choose ring" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {rings
+                          .filter((r): r is RingDraft & { id: string } =>
+                            Boolean(r.id))
+                          .map(r => (
+                            <SelectItem
+                              key={r.id}
+                              value={r.id}
+                            >
+                              {r.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs uppercase">Description</label>
+                    <Textarea
+                      value={blip.description}
+                      onChange={e =>
+                        setBlips(prev =>
+                          prev.map(b =>
+                            b.localKey === blip.localKey
+                              ? {
+                                ...b,
+                                description: e.target.value,
+                              }
+                              : b))}
+                    />
+                  </div>
+                </div>
+                <div className="flex flex-row gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => saveBlip(blip)}
+                    disabled={pendingBlipKey === blip.localKey}
+                  >
+                    {pendingBlipKey === blip.localKey && (
+                      <Loader2 className="animate-spin" />
+                    )}
+                    {blip.id ? "Update Blip" : "Save Blip"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => removeBlip(blip)}
+                    disabled={pendingBlipKey === blip.localKey}
+                  >
+                    <TrashIcon />
+                    {" "}
+                    Remove
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addBlipDraft}
+              disabled={!allConfigPersisted}
+            >
+              <PlusIcon />
+              {" "}
+              Add Blip
+            </Button>
+          </div>
+        </section>
+
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              navigate({
+                to: "/domains/$id/radar",
+                params: {
+                  id,
+                },
+              })}
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.$id.radar.index.tsx
+++ b/packages/client/src/routes/domains.$id.radar.index.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, EditIcon } from "lucide-react";
+
+import { InfoArea } from "@/components/layout/InfoArea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { RadarChart } from "@/components/radar/RadarChart";
+import { Button } from "@/components/ui/button";
+import { fetchRadar } from "@/utils";
+
+export const Route = createFileRoute("/domains/$id/radar/")({
+  component: RadarView,
+});
+
+function RadarView() {
+  const {
+    id,
+  } = Route.useParams();
+
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["radar", id],
+    queryFn: () => fetchRadar(id),
+  });
+
+  if (isPending) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">Loading radar...</h1>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">There was an error loading the radar.</h1>
+      </div>
+    );
+  }
+
+  const isEmpty
+    = !data || data.quadrants.length === 0 || data.rings.length === 0;
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={data ? `${data.domainTitle} Radar` : "Radar"}
+        pageSection="domains"
+      >
+        <div className="flex flex-row gap-2">
+          <Link
+            to="/domains/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="outline">
+              <ArrowLeftIcon />
+              {" "}
+              Back to Domain
+            </Button>
+          </Link>
+          <Link
+            to="/domains/$id/radar/edit"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              Edit Radar
+              {" "}
+              <EditIcon />
+            </Button>
+          </Link>
+        </div>
+      </PageHeader>
+      <div className="container flex flex-col gap-8">
+        {isEmpty
+          ? (
+            <InfoArea header="Get Started">
+              <div className="flex flex-col gap-4 py-4">
+                <p>
+                  This radar has not been configured yet. Define quadrants and
+                  rings before adding blips.
+                </p>
+                <Link
+                  to="/domains/$id/radar/edit"
+                  params={{
+                    id,
+                  }}
+                >
+                  <Button>Configure Radar</Button>
+                </Link>
+              </div>
+            </InfoArea>
+          )
+          : (
+            <RadarChart
+              quadrants={data.quadrants}
+              rings={data.rings}
+              blips={data.blips}
+            />
+          )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.$id.radar.tsx
+++ b/packages/client/src/routes/domains.$id.radar.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/domains/$id/radar")({
+  component: RadarLayout,
+});
+
+function RadarLayout() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -7,6 +7,7 @@ import type {
   CourseProvider,
   Domain,
   Daily,
+  Radar,
 } from "@emstack/types/src/index.js";
 import type { OnboardData } from "@emstack/types/src/OnboardData";
 import type { Topic } from "@emstack/types/src/Topic";
@@ -272,4 +273,100 @@ export async function deleteSingleDaily(
   return await fetch(`/api/dailies/${id}`, {
     method: "DELETE",
   }).then(res => res.json());
+}
+
+export async function fetchRadar(domainId: string): Promise<Radar> {
+  const response = await fetch(`/api/domains/${domainId}/radar`);
+  if (!response.ok) {
+    throw new Error(`Failed to load radar: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+interface RadarConfigPayload {
+  quadrants: { id?: string;
+    name: string;
+    position: number; }[];
+  rings: { id?: string;
+    name: string;
+    position: number; }[];
+}
+
+export async function upsertRadarConfig(
+  domainId: string,
+  data: RadarConfigPayload,
+): Promise<SuccessObj> {
+  const response = await fetch(`/api/domains/${domainId}/radar`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to save radar config: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+interface BlipPayload {
+  name: string;
+  description?: string | null;
+  quadrantId: string;
+  ringId: string;
+}
+
+export async function createRadarBlip(
+  domainId: string,
+  data: BlipPayload,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(`/api/domains/${domainId}/radar/blips`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create blip: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function upsertRadarBlip(
+  domainId: string,
+  blipId: string,
+  data: BlipPayload,
+): Promise<SuccessObj> {
+  const response = await fetch(
+    `/api/domains/${domainId}/radar/blips/${blipId}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to update blip: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function deleteRadarBlip(
+  domainId: string,
+  blipId: string,
+): Promise<SuccessObj> {
+  const response = await fetch(
+    `/api/domains/${domainId}/radar/blips/${blipId}`,
+    {
+      method: "DELETE",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to delete blip: ${response.statusText}`);
+  }
+  return await response.json();
 }

--- a/packages/gateway/server.js
+++ b/packages/gateway/server.js
@@ -16,6 +16,29 @@ const MIDDLEWARE_DIR = path.resolve(__dirname, "../middleware");
 
 let middlewareChild = null;
 
+// --- Schema push ---
+
+function pushSchema() {
+  return new Promise((resolve, reject) => {
+    console.log("[gateway] pushing database schema with drizzle-kit...");
+    const proc = spawn("pnpm", ["exec", "drizzle-kit", "push"], {
+      cwd: MIDDLEWARE_DIR,
+      stdio: "inherit",
+      env: process.env,
+    });
+    proc.on("error", reject);
+    proc.on("exit", (code) => {
+      if (code === 0) {
+        console.log("[gateway] schema push complete");
+        resolve();
+      }
+      else {
+        reject(new Error(`drizzle-kit push exited with code ${code}`));
+      }
+    });
+  });
+}
+
 // --- Child process management ---
 
 function startMiddleware() {
@@ -125,6 +148,8 @@ process.on("SIGINT", shutdown);
 // --- Start ---
 
 async function main() {
+  await pushSchema();
+
   startMiddleware();
 
   await waitForService("middleware (fastify)", MIDDLEWARE_PORT);

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -10,6 +10,7 @@
     "@neondatabase/serverless": "1.0.2",
     "dotenv": "17.2.3",
     "dotenv-cli": "11.0.0",
+    "drizzle-kit": "0.31.10",
     "drizzle-orm": "0.45.2",
     "fastify": "5.8.5",
     "pg": "8.16.3",
@@ -20,7 +21,6 @@
     "@fastify/type-provider-json-schema-to-ts": "5.0.0",
     "@types/node": "24.10.1",
     "@types/pg": "8.15.6",
-    "drizzle-kit": "0.31.10",
     "eslint": "9.39.4",
     "globals": "17.4.0",
     "nodemon": "3.1.14",
@@ -42,6 +42,7 @@
     "push:prod": "dotenv -e .env.production -- drizzle-kit push",
     "push:dev": "dotenv -e .env -- drizzle-kit push",
     "push": "pnpm run push:prod && pnpm run push:dev",
+    "db:push": "drizzle-kit push",
     "studio": "pnpm drizzle-kit studio"
   },
   "type": "module"

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -128,6 +128,9 @@ export const domainsRelations = relations(domains, ({
   many,
 }) => ({
   topicsToDomains: many(topicsToDomains),
+  radarQuadrants: many(radarQuadrants),
+  radarRings: many(radarRings),
+  radarBlips: many(radarBlips),
 }));
 
 export const topicsToDomains = pgTable(
@@ -186,5 +189,81 @@ export const topicsToCoursesRelation = relations(topicsToCourses, ({
   course: one(courses, {
     fields: [topicsToCourses.courseId],
     references: [courses.id],
+  }),
+}));
+
+export const radarQuadrants = pgTable("radar_quadrants", {
+  id: varchar().primaryKey(),
+  domainId: varchar("domain_id")
+    .notNull()
+    .references(() => domains.id),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  position: integer().notNull(),
+});
+
+export const radarRings = pgTable("radar_rings", {
+  id: varchar().primaryKey(),
+  domainId: varchar("domain_id")
+    .notNull()
+    .references(() => domains.id),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  position: integer().notNull(),
+});
+
+export const radarBlips = pgTable("radar_blips", {
+  id: varchar().primaryKey(),
+  domainId: varchar("domain_id")
+    .notNull()
+    .references(() => domains.id),
+  quadrantId: varchar("quadrant_id")
+    .notNull()
+    .references(() => radarQuadrants.id),
+  ringId: varchar("ring_id")
+    .notNull()
+    .references(() => radarRings.id),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  description: varchar(),
+});
+
+export const radarQuadrantsRelations = relations(radarQuadrants, ({
+  one, many,
+}) => ({
+  domain: one(domains, {
+    fields: [radarQuadrants.domainId],
+    references: [domains.id],
+  }),
+  blips: many(radarBlips),
+}));
+
+export const radarRingsRelations = relations(radarRings, ({
+  one, many,
+}) => ({
+  domain: one(domains, {
+    fields: [radarRings.domainId],
+    references: [domains.id],
+  }),
+  blips: many(radarBlips),
+}));
+
+export const radarBlipsRelations = relations(radarBlips, ({
+  one,
+}) => ({
+  domain: one(domains, {
+    fields: [radarBlips.domainId],
+    references: [domains.id],
+  }),
+  quadrant: one(radarQuadrants, {
+    fields: [radarBlips.quadrantId],
+    references: [radarQuadrants.id],
+  }),
+  ring: one(radarRings, {
+    fields: [radarBlips.ringId],
+    references: [radarRings.id],
   }),
 }));

--- a/packages/middleware/src/routes/api/radar/createBlip.ts
+++ b/packages/middleware/src/routes/api/radar/createBlip.ts
@@ -1,0 +1,67 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { radarBlips } from "@/db/schema";
+import { nullableString } from "@/utils/schemas";
+
+const createBlipSchema = {
+  schema: {
+    description: "Create a new blip on a domain's radar",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+      },
+      required: ["domainId"],
+    },
+    body: {
+      type: "object",
+      required: ["name", "quadrantId", "ringId"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        quadrantId: {
+          type: "string",
+        },
+        ringId: {
+          type: "string",
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:domainId/radar/blips",
+    createBlipSchema,
+    async function (request) {
+      const {
+        domainId,
+      } = request.params;
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(radarBlips).values({
+        id,
+        domainId,
+        quadrantId: body.quadrantId,
+        ringId: body.ringId,
+        name: body.name,
+        description: body.description ?? null,
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/radar/deleteBlip.ts
+++ b/packages/middleware/src/routes/api/radar/deleteBlip.ts
@@ -1,0 +1,43 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { radarBlips } from "@/db/schema";
+
+const deleteBlipSchema = {
+  schema: {
+    description: "Delete a blip from a domain's radar",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+        blipId: {
+          type: "string",
+        },
+      },
+      required: ["domainId", "blipId"],
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete(
+    "/:domainId/radar/blips/:blipId",
+    deleteBlipSchema,
+    async function (request) {
+      const {
+        blipId,
+      } = request.params;
+
+      await db.delete(radarBlips).where(eq(radarBlips.id, blipId));
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/radar/getRadar.ts
+++ b/packages/middleware/src/routes/api/radar/getRadar.ts
@@ -1,0 +1,72 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import type { Radar } from "@emstack/types/src";
+
+const getRadarSchema = {
+  schema: {
+    description: "Get the radar (quadrants, rings, blips) for a domain",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+      },
+      required: ["domainId"],
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:domainId/radar",
+    getRadarSchema,
+    async function (request, reply) {
+      const {
+        domainId,
+      } = request.params;
+
+      const domain = await db.query.domains.findFirst({
+        where: (domains, {
+          eq,
+        }) => eq(domains.id, domainId),
+        with: {
+          radarQuadrants: true,
+          radarRings: true,
+          radarBlips: true,
+        },
+      });
+
+      if (!domain) {
+        reply.status(404);
+        return {
+          error: "Domain not found",
+        };
+      }
+
+      const radar: Radar = {
+        domainId: domain.id,
+        domainTitle: domain.title,
+        quadrants: [...(domain.radarQuadrants ?? [])].sort(
+          (a, b) => a.position - b.position,
+        ),
+        rings: [...(domain.radarRings ?? [])].sort(
+          (a, b) => a.position - b.position,
+        ),
+        blips: (domain.radarBlips ?? []).map(b => ({
+          id: b.id,
+          domainId: b.domainId,
+          quadrantId: b.quadrantId,
+          ringId: b.ringId,
+          name: b.name,
+          description: b.description,
+        })),
+      };
+
+      return radar;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/radar/routes.ts
+++ b/packages/middleware/src/routes/api/radar/routes.ts
@@ -1,0 +1,18 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import getRadar from "./getRadar";
+import upsertRadarConfig from "./upsertRadarConfig";
+import createBlip from "./createBlip";
+import upsertBlip from "./upsertBlip";
+import deleteBlip from "./deleteBlip";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(getRadar);
+  fastify.register(upsertRadarConfig);
+  fastify.register(createBlip);
+  fastify.register(upsertBlip);
+  fastify.register(deleteBlip);
+}

--- a/packages/middleware/src/routes/api/radar/upsertBlip.ts
+++ b/packages/middleware/src/routes/api/radar/upsertBlip.ts
@@ -1,0 +1,78 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { radarBlips } from "@/db/schema";
+import { nullableString } from "@/utils/schemas";
+
+const upsertBlipSchema = {
+  schema: {
+    description: "Create or update a blip on a domain's radar",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+        blipId: {
+          type: "string",
+        },
+      },
+      required: ["domainId", "blipId"],
+    },
+    body: {
+      type: "object",
+      required: ["name", "quadrantId", "ringId"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        quadrantId: {
+          type: "string",
+        },
+        ringId: {
+          type: "string",
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:domainId/radar/blips/:blipId",
+    upsertBlipSchema,
+    async function (request) {
+      const {
+        domainId, blipId,
+      } = request.params;
+      const body = request.body;
+
+      await db
+        .insert(radarBlips)
+        .values({
+          id: blipId,
+          domainId,
+          quadrantId: body.quadrantId,
+          ringId: body.ringId,
+          name: body.name,
+          description: body.description ?? null,
+        })
+        .onConflictDoUpdate({
+          target: radarBlips.id,
+          set: {
+            quadrantId: body.quadrantId,
+            ringId: body.ringId,
+            name: body.name,
+            description: body.description ?? null,
+          },
+        });
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/radar/upsertRadarConfig.ts
+++ b/packages/middleware/src/routes/api/radar/upsertRadarConfig.ts
@@ -1,0 +1,165 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { inArray } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { radarBlips, radarQuadrants, radarRings } from "@/db/schema";
+
+const upsertConfigSchema = {
+  schema: {
+    description:
+      "Replace the radar configuration (quadrants and rings) for a domain. Blips referencing removed quadrants/rings are deleted.",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+      },
+      required: ["domainId"],
+    },
+    body: {
+      type: "object",
+      required: ["quadrants", "rings"],
+      properties: {
+        quadrants: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["name", "position"],
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              position: {
+                type: "integer",
+              },
+            },
+          },
+        },
+        rings: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["name", "position"],
+            properties: {
+              id: {
+                type: "string",
+              },
+              name: {
+                type: "string",
+              },
+              position: {
+                type: "integer",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:domainId/radar",
+    upsertConfigSchema,
+    async function (request) {
+      const {
+        domainId,
+      } = request.params;
+      const {
+        quadrants, rings,
+      } = request.body;
+
+      const incomingQuadrantIds = quadrants
+        .map(q => q.id)
+        .filter((id): id is string => Boolean(id));
+      const incomingRingIds = rings
+        .map(r => r.id)
+        .filter((id): id is string => Boolean(id));
+
+      const existingQuadrants = await db.query.radarQuadrants.findMany({
+        where: (q, {
+          eq,
+        }) => eq(q.domainId, domainId),
+      });
+      const existingRings = await db.query.radarRings.findMany({
+        where: (r, {
+          eq,
+        }) => eq(r.domainId, domainId),
+      });
+
+      const removedQuadrantIds = existingQuadrants
+        .map(q => q.id)
+        .filter(id => !incomingQuadrantIds.includes(id));
+      const removedRingIds = existingRings
+        .map(r => r.id)
+        .filter(id => !incomingRingIds.includes(id));
+
+      if (removedQuadrantIds.length > 0) {
+        await db
+          .delete(radarBlips)
+          .where(inArray(radarBlips.quadrantId, removedQuadrantIds));
+        await db
+          .delete(radarQuadrants)
+          .where(inArray(radarQuadrants.id, removedQuadrantIds));
+      }
+      if (removedRingIds.length > 0) {
+        await db
+          .delete(radarBlips)
+          .where(inArray(radarBlips.ringId, removedRingIds));
+        await db
+          .delete(radarRings)
+          .where(inArray(radarRings.id, removedRingIds));
+      }
+
+      for (const q of quadrants) {
+        const id = q.id ?? uuidv4();
+        await db
+          .insert(radarQuadrants)
+          .values({
+            id,
+            domainId,
+            name: q.name,
+            position: q.position,
+          })
+          .onConflictDoUpdate({
+            target: radarQuadrants.id,
+            set: {
+              name: q.name,
+              position: q.position,
+            },
+          });
+      }
+
+      for (const r of rings) {
+        const id = r.id ?? uuidv4();
+        await db
+          .insert(radarRings)
+          .values({
+            id,
+            domainId,
+            name: r.name,
+            position: r.position,
+          })
+          .onConflictDoUpdate({
+            target: radarRings.id,
+            set: {
+              name: r.name,
+              position: r.position,
+            },
+          });
+      }
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -12,6 +12,7 @@ import topics from "./topics/routes";
 import providers from "./providers/routes";
 import domains from "./domains/routes";
 import dailies from "./dailies/routes";
+import radar from "./radar/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -32,6 +33,9 @@ export default async function (server: FastifyInstance) {
     prefix: "/providers",
   });
   fastify.register(domains, {
+    prefix: "/domains",
+  });
+  fastify.register(radar, {
     prefix: "/domains",
   });
   fastify.register(dailies, {

--- a/packages/types/src/Radar.ts
+++ b/packages/types/src/Radar.ts
@@ -1,0 +1,30 @@
+export interface RadarQuadrant {
+  id: string;
+  domainId: string;
+  name: string;
+  position: number;
+}
+
+export interface RadarRing {
+  id: string;
+  domainId: string;
+  name: string;
+  position: number;
+}
+
+export interface RadarBlip {
+  id: string;
+  domainId: string;
+  quadrantId: string;
+  ringId: string;
+  name: string;
+  description?: string | null;
+}
+
+export interface Radar {
+  domainId: string;
+  domainTitle: string;
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  blips: RadarBlip[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,3 +14,4 @@ export * from "./TopicsToCourses";
 export * from "./Domain";
 export * from "./TopicsToDomains";
 export * from "./Daily";
+export * from "./Radar";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       dotenv-cli:
         specifier: 11.0.0
         version: 11.0.0
+      drizzle-kit:
+        specifier: 0.31.10
+        version: 0.31.10
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(pg@8.16.3)
@@ -298,9 +301,6 @@ importers:
       '@types/pg':
         specifier: 8.15.6
         version: 8.15.6
-      drizzle-kit:
-        specifier: 0.31.10
-        version: 0.31.10
       eslint:
         specifier: 9.39.4
         version: 9.39.4(jiti@2.6.1)


### PR DESCRIPTION
## Summary
This PR introduces a complete technology radar feature that allows users to create and manage technology radars within domains. A radar consists of quadrants (categories), rings (maturity levels), and blips (individual technologies/items positioned within the radar).

## Key Changes

### Database Schema
- Added three new tables to support radar functionality:
  - `radar_quadrants`: Categories on the radar (e.g., "Languages & Frameworks")
  - `radar_rings`: Maturity levels (e.g., "Adopt", "Trial", "Assess", "Hold")
  - `radar_blips`: Individual items positioned at quadrant/ring intersections
- Added relationships between domains and radar entities

### Backend API Routes
- `GET /:domainId/radar`: Fetch complete radar data (quadrants, rings, blips)
- `PUT /:domainId/radar`: Upsert radar configuration (quadrants and rings); automatically deletes blips referencing removed quadrants/rings
- `POST /:domainId/radar/blips`: Create a new blip
- `PUT /:domainId/radar/blips/:blipId`: Update an existing blip
- `DELETE /:domainId/radar/blips/:blipId`: Delete a blip

### Frontend Components
- **RadarChart**: SVG-based visualization component that renders:
  - Concentric rings representing maturity levels
  - Quadrants divided by radial lines
  - Positioned blips with deterministic placement using hash-based pseudo-random positioning
  - Interactive legend grouped by quadrant
  - Hover effects and click handlers
  
- **Radar Edit Page** (`domains.$id.radar.edit`): Full-featured editor for:
  - Adding/removing/editing quadrants and rings with default templates
  - Managing blips with name, description, quadrant, and ring selection
  - Save/delete operations with optimistic UI updates
  - Validation ensuring configuration is saved before adding blips

- **Radar View Page** (`domains.$id.radar.index`): Read-only visualization with navigation to edit mode

### Client Utilities
- Added fetch functions for all radar API operations
- Integrated with React Query for data fetching and caching

### UI/UX Features
- Default quadrants: "Languages & Frameworks", "Tools", "Platforms", "Techniques"
- Default rings: "Adopt", "Trial", "Assess", "Hold"
- Local state management with unique keys for unsaved items
- Toast notifications for user feedback
- Responsive grid layout for legend display
- Color-coded quadrants using a consistent palette

### Infrastructure
- Added `drizzle-kit` to middleware dependencies for schema management
- Integrated schema push into gateway startup process
- Updated route tree generation for new radar routes

https://claude.ai/code/session_012nsD1h5UihP5S63XZzadpZ