### PR TITLE
Include drizzle.config.ts in middleware Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=build /app/packages/types/dist/ ./packages/types/dist/
 COPY --from=build /app/packages/types/src/ ./packages/types/src/
 COPY --from=build /app/packages/middleware/dist/ ./packages/middleware/dist/
 COPY --from=build /app/packages/middleware/src/ ./packages/middleware/src/
+COPY --from=build /app/packages/middleware/drizzle.config.ts ./packages/middleware/drizzle.config.ts
 COPY --from=build /app/packages/client/dist/ ./packages/client/dist/
 COPY --from=build /app/packages/gateway/server.js ./packages/gateway/server.js
 


### PR DESCRIPTION
## Summary
Added the `drizzle.config.ts` configuration file to the Docker image build for the middleware package, ensuring database migration configuration is available at runtime.

## Changes
- Copy `packages/middleware/drizzle.config.ts` from the build stage to the final Docker image alongside other middleware source files

## Details
The drizzle.config.ts file is required for Drizzle ORM database operations and migrations. By including it in the Docker image, the middleware service will have access to the necessary database configuration at runtime, preventing potential "file not found" errors during deployment.

https://claude.ai/code/session_01Jxt82vAj1B26wABcfGzQTz