### PR TITLE
Use direct drizzle-kit binary path instead of pnpm exec

### DIFF
--- a/packages/gateway/server.js
+++ b/packages/gateway/server.js
@@ -21,7 +21,13 @@ let middlewareChild = null;
 function pushSchema() {
   return new Promise((resolve, reject) => {
     console.log("[gateway] pushing database schema with drizzle-kit...");
-    const proc = spawn("pnpm", ["exec", "drizzle-kit", "push"], {
+    const drizzleKitBin = path.join(
+      MIDDLEWARE_DIR,
+      "node_modules",
+      ".bin",
+      "drizzle-kit",
+    );
+    const proc = spawn(drizzleKitBin, ["push"], {
       cwd: MIDDLEWARE_DIR,
       stdio: "inherit",
       env: process.env,


### PR DESCRIPTION
## Summary
Updated the `pushSchema()` function in the gateway server to invoke drizzle-kit directly via its binary path instead of using `pnpm exec`.

## Key Changes
- Replaced `spawn("pnpm", ["exec", "drizzle-kit", "push"])` with direct binary invocation
- Construct the drizzle-kit binary path by joining `MIDDLEWARE_DIR`, `node_modules/.bin/`, and `drizzle-kit`
- Pass only `["push"]` as arguments to the spawned process instead of `["exec", "drizzle-kit", "push"]`

## Implementation Details
This change eliminates the dependency on pnpm's exec command and directly executes the drizzle-kit binary from the middleware directory's node_modules. This approach is more direct and may improve performance by avoiding the pnpm wrapper layer.

https://claude.ai/code/session_01KEbFT6SKSCi2jPTYLpxCtN