### PR TITLE
Add domain learning log and richer Radar LLM context

### DIFF
--- a/packages/client/src/components/domains/DomainLearningLog.tsx
+++ b/packages/client/src/components/domains/DomainLearningLog.tsx
@@ -1,0 +1,537 @@
+import type { LearningLogEntry } from "@emstack/types/src";
+
+import { useMemo, useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import {
+  ExternalLinkIcon,
+  Loader2,
+  PencilIcon,
+  PlusIcon,
+  TrashIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
+import { Input } from "@/components/forms/input";
+import { Textarea } from "@/components/forms/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  createDomainLearningLogEntry,
+  deleteDomainLearningLogEntry,
+  isHttpUrl,
+  updateDomainLearningLogEntry,
+} from "@/utils";
+
+interface DomainLearningLogProps {
+  domainId: string;
+  entries: LearningLogEntry[];
+}
+
+interface DraftEntry {
+  date: string;
+  description: string;
+  link: string;
+}
+
+const EMPTY_DRAFT: DraftEntry = {
+  date: "",
+  description: "",
+  link: "",
+};
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function entryKey(entry: LearningLogEntry): string {
+  return `${entry.source}:${entry.id}`;
+}
+
+function formatDate(date: string): string {
+  if (!date) {
+    return "(no date)";
+  }
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function DomainLearningLog({
+  domainId, entries,
+}: DomainLearningLogProps) {
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState<DraftEntry | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<DraftEntry>(EMPTY_DRAFT);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [isSavingNew, setIsSavingNew] = useState(false);
+
+  const sortedEntries = useMemo(() => entries, [entries]);
+
+  async function invalidate() {
+    await queryClient.invalidateQueries({
+      queryKey: ["domain", domainId],
+    });
+  }
+
+  function startAdd() {
+    setDraft({
+      ...EMPTY_DRAFT,
+      date: todayKey(),
+    });
+  }
+
+  function cancelAdd() {
+    setDraft(null);
+  }
+
+  async function saveNew() {
+    if (!draft) {
+      return;
+    }
+    if (!draft.date.trim() || !draft.description.trim()) {
+      toast.error("Date and description are required.");
+      return;
+    }
+    if (draft.link.trim() && !isHttpUrl(draft.link.trim())) {
+      toast.error("Link must be a valid URL (http or https).");
+      return;
+    }
+    setIsSavingNew(true);
+    try {
+      await createDomainLearningLogEntry(domainId, {
+        date: draft.date,
+        description: draft.description.trim(),
+        link: draft.link.trim() || null,
+      });
+      await invalidate();
+      setDraft(null);
+      toast.success("Entry added.");
+    }
+    catch {
+      toast.error("Failed to add entry.");
+    }
+    finally {
+      setIsSavingNew(false);
+    }
+  }
+
+  function startEdit(entry: LearningLogEntry) {
+    setEditingId(entry.id);
+    setEditDraft({
+      date: entry.date,
+      description: entry.description,
+      link: entry.link ?? "",
+    });
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditDraft(EMPTY_DRAFT);
+  }
+
+  async function saveEdit(entryId: string) {
+    if (!editDraft.date.trim() || !editDraft.description.trim()) {
+      toast.error("Date and description are required.");
+      return;
+    }
+    if (editDraft.link.trim() && !isHttpUrl(editDraft.link.trim())) {
+      toast.error("Link must be a valid URL (http or https).");
+      return;
+    }
+    setBusyId(entryId);
+    try {
+      await updateDomainLearningLogEntry(domainId, entryId, {
+        date: editDraft.date,
+        description: editDraft.description.trim(),
+        link: editDraft.link.trim() || null,
+      });
+      await invalidate();
+      cancelEdit();
+      toast.success("Entry updated.");
+    }
+    catch {
+      toast.error("Failed to update entry.");
+    }
+    finally {
+      setBusyId(null);
+    }
+  }
+
+  async function removeEntry(entryId: string) {
+    setBusyId(entryId);
+    try {
+      await deleteDomainLearningLogEntry(domainId, entryId);
+      await invalidate();
+      toast.success("Entry removed.");
+    }
+    catch {
+      toast.error("Failed to delete entry.");
+    }
+    finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex flex-row items-center justify-between gap-2">
+        <h2 className="text-2xl">Learning Log</h2>
+        {!draft && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={startAdd}
+          >
+            <PlusIcon />
+            {" "}
+            Add Entry
+          </Button>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Auto-imports activity from your dailies for courses or topics linked to
+        this domain. You can also add manual notes with a date, description,
+        and optional link.
+      </p>
+
+      {draft && (
+        <div className="flex flex-col gap-2 rounded-sm border p-3">
+          <div
+            className={`
+              grid grid-cols-1 gap-2
+              sm:grid-cols-[180px_minmax(0,1fr)]
+            `}
+          >
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-muted-foreground uppercase">
+                Date
+              </label>
+              <Input
+                type="date"
+                value={draft.date}
+                onChange={e =>
+                  setDraft(prev =>
+                    prev
+                      ? {
+                        ...prev,
+                        date: e.target.value,
+                      }
+                      : prev)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-muted-foreground uppercase">
+                Link (optional)
+              </label>
+              <Input
+                type="url"
+                value={draft.link}
+                onChange={e =>
+                  setDraft(prev =>
+                    prev
+                      ? {
+                        ...prev,
+                        link: e.target.value,
+                      }
+                      : prev)}
+                placeholder="https://..."
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-muted-foreground uppercase">
+              Description
+            </label>
+            <Textarea
+              value={draft.description}
+              onChange={e =>
+                setDraft(prev =>
+                  prev
+                    ? {
+                      ...prev,
+                      description: e.target.value,
+                    }
+                    : prev)}
+              placeholder="What did you learn or do?"
+            />
+          </div>
+          <div className="flex flex-row gap-2">
+            <Button
+              type="button"
+              onClick={saveNew}
+              disabled={isSavingNew}
+            >
+              {isSavingNew && <Loader2 className="animate-spin" />}
+              Save Entry
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={cancelAdd}
+              disabled={isSavingNew}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {sortedEntries.length === 0
+        ? (
+          <p className="text-sm text-muted-foreground italic">
+            No learning log entries yet.
+          </p>
+        )
+        : (
+          <ul className="flex flex-col gap-2">
+            {sortedEntries.map((entry) => {
+              const key = entryKey(entry);
+              const isManual = entry.source === "manual";
+              const isEditing = isManual && editingId === entry.id;
+              const statusOption = entry.status
+                ? getDailyStatusOption(entry.status)
+                : null;
+              return (
+                <li
+                  key={key}
+                  className={`
+                    flex flex-col gap-2 rounded-sm border p-3
+                    ${isManual
+                  ? "bg-white"
+                  : "bg-muted/30"}
+                  `}
+                >
+                  {isEditing
+                    ? (
+                      <div className="flex flex-col gap-2">
+                        <div
+                          className={`
+                            grid grid-cols-1 gap-2
+                            sm:grid-cols-[180px_minmax(0,1fr)]
+                          `}
+                        >
+                          <div className="flex flex-col gap-1">
+                            <label
+                              className={`
+                                text-xs text-muted-foreground uppercase
+                              `}
+                            >
+                              Date
+                            </label>
+                            <Input
+                              type="date"
+                              value={editDraft.date}
+                              onChange={e =>
+                                setEditDraft(prev => ({
+                                  ...prev,
+                                  date: e.target.value,
+                                }))}
+                            />
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <label
+                              className={`
+                                text-xs text-muted-foreground uppercase
+                              `}
+                            >
+                              Link (optional)
+                            </label>
+                            <Input
+                              type="url"
+                              value={editDraft.link}
+                              onChange={e =>
+                                setEditDraft(prev => ({
+                                  ...prev,
+                                  link: e.target.value,
+                                }))}
+                            />
+                          </div>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <label
+                            className="text-xs text-muted-foreground uppercase"
+                          >
+                            Description
+                          </label>
+                          <Textarea
+                            value={editDraft.description}
+                            onChange={e =>
+                              setEditDraft(prev => ({
+                                ...prev,
+                                description: e.target.value,
+                              }))}
+                          />
+                        </div>
+                        <div className="flex flex-row gap-2">
+                          <Button
+                            type="button"
+                            onClick={() => saveEdit(entry.id)}
+                            disabled={busyId === entry.id}
+                          >
+                            {busyId === entry.id && (
+                              <Loader2 className="animate-spin" />
+                            )}
+                            Save
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={cancelEdit}
+                            disabled={busyId === entry.id}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )
+                    : (
+                      <div className="flex flex-row items-start gap-3">
+                        <div
+                          className={`
+                            flex w-28 shrink-0 flex-col gap-1 text-xs
+                            text-muted-foreground
+                          `}
+                        >
+                          <div className="font-mono">
+                            {formatDate(entry.date)}
+                          </div>
+                          <div
+                            className={`
+                              rounded-sm px-1.5 py-0.5 text-center font-medium
+                              ${isManual
+                        ? "bg-blue-100 text-blue-800"
+                        : "bg-emerald-100 text-emerald-800"}
+                            `}
+                          >
+                            {isManual ? "Manual" : "Daily"}
+                          </div>
+                          {statusOption && (
+                            <div
+                              className={`
+                                rounded-sm border px-1.5 py-0.5 text-center
+                                ${statusOption.pillClass}
+                              `}
+                            >
+                              {statusOption.label}
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex flex-1 flex-col gap-1">
+                          <p className="text-sm">{entry.description}</p>
+                          <div
+                            className={`
+                              flex flex-row flex-wrap gap-x-3 gap-y-1 text-xs
+                              text-muted-foreground
+                            `}
+                          >
+                            {entry.link && (
+                              <a
+                                href={entry.link}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={`
+                                  inline-flex items-center gap-1 text-blue-700
+                                  hover:text-blue-500
+                                `}
+                              >
+                                <ExternalLinkIcon className="size-3" />
+                                {" "}
+                                Link
+                              </a>
+                            )}
+                            {entry.courseId && entry.courseName && (
+                              <Link
+                                to="/courses/$id"
+                                params={{
+                                  id: entry.courseId,
+                                }}
+                                className={`
+                                  text-blue-700
+                                  hover:text-blue-500
+                                `}
+                              >
+                                Course:
+                                {" "}
+                                {entry.courseName}
+                              </Link>
+                            )}
+                            {entry.dailyId && entry.dailyName && (
+                              <Link
+                                to="/dailies/$id"
+                                params={{
+                                  id: entry.dailyId,
+                                }}
+                                className={`
+                                  text-blue-700
+                                  hover:text-blue-500
+                                `}
+                              >
+                                Daily:
+                                {" "}
+                                {entry.dailyName}
+                              </Link>
+                            )}
+                          </div>
+                        </div>
+                        {isManual && (
+                          <div className="flex flex-row gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => startEdit(entry)}
+                              disabled={busyId === entry.id}
+                              aria-label="Edit entry"
+                            >
+                              <PencilIcon />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeEntry(entry.id)}
+                              disabled={busyId === entry.id}
+                              aria-label="Delete entry"
+                            >
+                              {busyId === entry.id
+                                ? (
+                                  <Loader2 className="animate-spin" />
+                                )
+                                : (
+                                  <TrashIcon />
+                                )}
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      {draft === null && sortedEntries.length === 0 && (
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={startAdd}
+          >
+            <PlusIcon />
+            {" "}
+            Add First Entry
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -1,5 +1,8 @@
 import type { BulkBlipEntry } from "@/utils";
 import type {
+  DomainExcludedTopic,
+  DomainTopic,
+  LearningLogEntry,
   RadarBlip,
   RadarQuadrant,
   RadarRing,
@@ -28,6 +31,10 @@ import {
 interface BlipLlmAssistProps {
   domainId: string;
   domainTitle: string;
+  domainDescription?: string | null;
+  domainTopics?: DomainTopic[];
+  excludedTopics?: DomainExcludedTopic[];
+  learningLog?: LearningLogEntry[];
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   topics: TopicForTopicsPage[];
@@ -61,11 +68,17 @@ interface ResolvedLlmEntry {
   problems: string[];
 }
 
-function computeProblems(entry: Pick<ResolvedLlmEntry,
-  "topicName" | "quadrantInput" | "quadrantId" | "ringInput" | "ringId">): string[] {
+function computeProblems(
+  entry: Pick<ResolvedLlmEntry,
+    "topicName" | "quadrantInput" | "quadrantId" | "ringInput" | "ringId">,
+  excludedNames?: Set<string>,
+): string[] {
   const problems: string[] = [];
   if (!entry.topicName) {
     problems.push("missing topic");
+  }
+  else if (excludedNames?.has(entry.topicName.toLowerCase())) {
+    problems.push("topic is excluded from this radar");
   }
   if (!entry.quadrantId) {
     problems.push(
@@ -82,25 +95,120 @@ function computeProblems(entry: Pick<ResolvedLlmEntry,
   return problems;
 }
 
-function buildLlmPrompt(
-  domainTitle: string,
-  quadrants: RadarQuadrant[],
-  rings: RadarRing[],
+function describeProgress(course: {
+  progressCurrent?: number | null;
+  progressTotal?: number | null;
+  status?: string | null;
+}): string {
+  const parts: string[] = [];
+  const current = course.progressCurrent ?? 0;
+  const total = course.progressTotal ?? 0;
+  if (total > 0) {
+    const pct = Math.round((current / total) * 100);
+    parts.push(`${current}/${total} (${pct}%)`);
+  }
+  else if (current > 0) {
+    parts.push(`${current} done`);
+  }
+  if (course.status) {
+    parts.push(course.status);
+  }
+  return parts.length > 0 ? ` — ${parts.join(", ")}` : "";
+}
+
+function formatTopicsWithCourses(domainTopics: DomainTopic[]): string {
+  if (!domainTopics || domainTopics.length === 0) {
+    return "- (no topics linked to this domain yet)";
+  }
+  return domainTopics
+    .map((topic) => {
+      const lines: string[] = [];
+      lines.push(`- ${topic.name}`);
+      const courses = topic.courses ?? [];
+      if (courses.length === 0) {
+        lines.push("  - (no courses)");
+      }
+      else {
+        for (const course of courses) {
+          lines.push(`  - ${course.name}${describeProgress(course)}`);
+        }
+      }
+      return lines.join("\n");
+    })
+    .join("\n");
+}
+
+function formatExcludedTopics(excluded: DomainExcludedTopic[]): string {
+  if (!excluded || excluded.length === 0) {
+    return "- (none)";
+  }
+  return excluded
+    .map((row) => {
+      const reason = row.reason?.trim();
+      return reason ? `- ${row.name} — ${reason}` : `- ${row.name}`;
+    })
+    .join("\n");
+}
+
+const MAX_LEARNING_LOG_ENTRIES = 20;
+
+function formatLearningLog(entries: LearningLogEntry[]): string {
+  if (!entries || entries.length === 0) {
+    return "- (no learning log entries yet)";
+  }
+  return entries
+    .slice(0, MAX_LEARNING_LOG_ENTRIES)
+    .map((entry) => {
+      const tag = entry.source === "manual" ? "manual" : "daily";
+      const courseSuffix = entry.courseName ? ` [${entry.courseName}]` : "";
+      return `- ${entry.date} (${tag}): ${entry.description}${courseSuffix}`;
+    })
+    .join("\n");
+}
+
+interface BuildPromptArgs {
+  domainTitle: string;
+  domainDescription?: string | null;
+  domainTopics: DomainTopic[];
+  excludedTopics: DomainExcludedTopic[];
+  learningLog: LearningLogEntry[];
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
   existingBlips: { topicName: string;
-    description?: string | null; }[],
-): string {
+    description?: string | null; }[];
+}
+
+function buildLlmPrompt(args: BuildPromptArgs): string {
+  const {
+    domainTitle,
+    domainDescription,
+    domainTopics,
+    excludedTopics,
+    learningLog,
+    quadrants,
+    rings,
+    existingBlips,
+  } = args;
+
   const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
   const ringList = rings.map(r => `- ${r.name}`).join("\n");
   const domainLabel = domainTitle.trim() || "(unnamed domain)";
+  const descriptionBlock = domainDescription?.trim()
+    ? domainDescription.trim()
+    : "(no description provided)";
   const existingList = existingBlips.length > 0
     ? existingBlips
-        .map((b) => {
-          const desc = b.description?.trim();
-          return desc ? `- ${b.topicName}: ${desc}` : `- ${b.topicName}`;
-        })
-        .join("\n")
+      .map((b) => {
+        const desc = b.description?.trim();
+        return desc ? `- ${b.topicName}: ${desc}` : `- ${b.topicName}`;
+      })
+      .join("\n")
     : "- (none yet)";
+
   return `I'm placing topics on a tech-radar style chart for the "${domainLabel}" domain.
+
+Domain description:
+${descriptionBlock}
 
 The radar has these quadrants:
 ${quadrantList || "- (none defined)"}
@@ -108,8 +216,21 @@ ${quadrantList || "- (none defined)"}
 And these rings (innermost first):
 ${ringList || "- (none defined)"}
 
+Topics already linked to this domain, with the courses I'm taking and current
+progress for each (use this to gauge what I've actually been investing time in):
+${formatTopicsWithCourses(domainTopics)}
+
+Recent learning-log activity for this domain (manual notes plus auto-imported
+daily completions, most recent first):
+${formatLearningLog(learningLog)}
+
 Topics already on the radar (with current descriptions, if any):
 ${existingList}
+
+Topics I have explicitly EXCLUDED from this radar — do NOT suggest these,
+even with a different description or placement. The reason for each is in
+parentheses; treat the reasons as binding context for what I don't want:
+${formatExcludedTopics(excludedTopics)}
 
 Please suggest topics relevant to the "${domainLabel}" domain and return ONLY a
 JSON array of entries, using this exact shape (no other keys, no commentary):
@@ -125,13 +246,18 @@ JSON array of entries, using this exact shape (no other keys, no commentary):
 
 You may include topics already on the radar to suggest a better description or
 a different placement for them. The reviewer will choose whether to overwrite,
-update only the description, or skip each one.
+update only the description, or skip each one. Do not include any topic from
+the excluded list above.
 `;
 }
 
 export function BlipLlmAssist({
   domainId,
   domainTitle,
+  domainDescription = null,
+  domainTopics = [],
+  excludedTopics = [],
+  learningLog = [],
   quadrants,
   rings,
   topics,
@@ -140,16 +266,29 @@ export function BlipLlmAssist({
 }: BlipLlmAssistProps) {
   const prompt = useMemo(
     () =>
-      buildLlmPrompt(
+      buildLlmPrompt({
         domainTitle,
+        domainDescription,
+        domainTopics,
+        excludedTopics,
+        learningLog,
         quadrants,
         rings,
-        existingBlips.map(b => ({
+        existingBlips: existingBlips.map(b => ({
           topicName: b.topicName,
           description: b.description,
         })),
-      ),
-    [domainTitle, quadrants, rings, existingBlips],
+      }),
+    [
+      domainTitle,
+      domainDescription,
+      domainTopics,
+      excludedTopics,
+      learningLog,
+      quadrants,
+      rings,
+      existingBlips,
+    ],
   );
 
   const [jsonText, setJsonText] = useState("");
@@ -200,6 +339,16 @@ export function BlipLlmAssist({
     rings.forEach(r => map.set(r.id, r));
     return map;
   }, [rings]);
+
+  const excludedNamesLower = useMemo(() => {
+    const set = new Set<string>();
+    excludedTopics.forEach((t) => {
+      if (t.name) {
+        set.add(t.name.toLowerCase());
+      }
+    });
+    return set;
+  }, [excludedTopics]);
 
   async function copyPrompt() {
     if (navigator.clipboard?.writeText) {
@@ -287,6 +436,7 @@ export function BlipLlmAssist({
         ringId: ringMatch?.id ?? null,
       };
 
+      const isExcluded = excludedNamesLower.has(topicName.toLowerCase());
       return {
         ...partial,
         matchedTopicId: topicMatch?.id ?? null,
@@ -296,8 +446,12 @@ export function BlipLlmAssist({
         existingQuadrantId: existingBlip?.quadrantId ?? null,
         existingRingId: existingBlip?.ringId ?? null,
         existingDescription: existingBlip?.description ?? null,
-        resolution: existingBlip ? "overwrite" : "create",
-        problems: computeProblems(partial),
+        resolution: isExcluded
+          ? "skip"
+          : existingBlip
+            ? "overwrite"
+            : "create",
+        problems: computeProblems(partial, excludedNamesLower),
       };
     });
     setResolved(out);
@@ -318,7 +472,7 @@ export function BlipLlmAssist({
         };
         return {
           ...next,
-          problems: computeProblems(next),
+          problems: computeProblems(next, excludedNamesLower),
         };
       });
     });
@@ -536,12 +690,12 @@ export function BlipLlmAssist({
                   className={`
                     flex flex-col gap-2 rounded-sm border px-3 py-2
                     ${isSkipped
-                      ? "border-muted bg-muted/30 opacity-70"
-                      : hasProblems
-                        ? "border-red-200 bg-red-50"
-                        : conflicts
-                          ? "border-amber-300 bg-amber-50"
-                          : "bg-white"}
+                  ? "border-muted bg-muted/30 opacity-70"
+                  : hasProblems
+                    ? "border-red-200 bg-red-50"
+                    : conflicts
+                      ? "border-amber-300 bg-amber-50"
+                      : "bg-white"}
                   `}
                 >
                   <div className="flex flex-row flex-wrap items-center gap-2">
@@ -613,12 +767,14 @@ export function BlipLlmAssist({
                     `}
                   >
                     <div className="flex flex-col gap-1">
-                      <label className="text-xs uppercase text-muted-foreground">
+                      <label className="text-xs text-muted-foreground uppercase">
                         Quadrant
                         {r.quadrantInput && (
                           <>
                             {" "}
-                            <span className="normal-case text-muted-foreground/70">
+                            <span
+                              className="text-muted-foreground/70 normal-case"
+                            >
                               (LLM:
                               {" "}
                               {r.quadrantInput}
@@ -651,12 +807,14 @@ export function BlipLlmAssist({
                       </Select>
                     </div>
                     <div className="flex flex-col gap-1">
-                      <label className="text-xs uppercase text-muted-foreground">
+                      <label className="text-xs text-muted-foreground uppercase">
                         Ring
                         {r.ringInput && (
                           <>
                             {" "}
-                            <span className="normal-case text-muted-foreground/70">
+                            <span
+                              className="text-muted-foreground/70 normal-case"
+                            >
                               (LLM:
                               {" "}
                               {r.ringInput}
@@ -689,7 +847,7 @@ export function BlipLlmAssist({
                       </Select>
                     </div>
                     <div className="flex flex-col gap-1">
-                      <label className="text-xs uppercase text-muted-foreground">
+                      <label className="text-xs text-muted-foreground uppercase">
                         Action
                       </label>
                       <Select
@@ -705,24 +863,24 @@ export function BlipLlmAssist({
                         <SelectContent>
                           {conflicts
                             ? (
-                                <>
-                                  <SelectItem value="overwrite">
-                                    Overwrite existing
-                                  </SelectItem>
-                                  <SelectItem value="updateDescription">
-                                    Update description only
-                                  </SelectItem>
-                                  <SelectItem value="skip">
-                                    Skip (keep existing)
-                                  </SelectItem>
-                                </>
-                              )
+                              <>
+                                <SelectItem value="overwrite">
+                                  Overwrite existing
+                                </SelectItem>
+                                <SelectItem value="updateDescription">
+                                  Update description only
+                                </SelectItem>
+                                <SelectItem value="skip">
+                                  Skip (keep existing)
+                                </SelectItem>
+                              </>
+                            )
                             : (
-                                <>
-                                  <SelectItem value="create">Add</SelectItem>
-                                  <SelectItem value="skip">Skip</SelectItem>
-                                </>
-                              )}
+                              <>
+                                <SelectItem value="create">Add</SelectItem>
+                                <SelectItem value="skip">Skip</SelectItem>
+                              </>
+                            )}
                         </SelectContent>
                       </Select>
                     </div>

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -1,15 +1,23 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EyeIcon, Loader2 } from "lucide-react";
+import { EyeIcon, Loader2, PlusIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
+import { Textarea } from "@/components/forms/textarea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createDomain,
@@ -25,10 +33,22 @@ export const Route = createFileRoute("/domains/$id/edit")({
 
 const formSchema = z.object({
   title: z.string().min(1, "Title is required").max(255),
-  description: z.string().max(500),
+  description: z.string().max(1000),
   hasRadar: z.string(),
   topicIds: z.array(z.string()),
 });
+
+interface ExcludedTopicRow {
+  topicId: string;
+  reason: string;
+  localKey: string;
+}
+
+let exclusionKeyCounter = 0;
+function nextExclusionKey() {
+  exclusionKeyCounter += 1;
+  return `exclusion-${exclusionKeyCounter}`;
+}
 
 function SingleDomainEdit() {
   const {
@@ -74,6 +94,29 @@ function SingleDomainEdit() {
     [data],
   );
 
+  const startingExcluded = useMemo<ExcludedTopicRow[]>(
+    () =>
+      (data?.excludedTopics ?? []).map(et => ({
+        topicId: et.id,
+        reason: et.reason ?? "",
+        localKey: nextExclusionKey(),
+      })),
+    [data],
+  );
+
+  const [excludedRows, setExcludedRows] = useState<ExcludedTopicRow[]>([]);
+  const excludedHydrated = useRef(false);
+
+  useEffect(() => {
+    if (excludedHydrated.current) {
+      return;
+    }
+    if (isNew || data) {
+      setExcludedRows(startingExcluded);
+      excludedHydrated.current = true;
+    }
+  }, [data, isNew, startingExcluded]);
+
   const form = useAppForm({
     defaultValues: startingValues,
     validators: {
@@ -82,11 +125,28 @@ function SingleDomainEdit() {
     onSubmit: async ({
       value,
     }) => {
+      const cleanedExcluded = excludedRows
+        .filter(r => r.topicId)
+        .map(r => ({
+          topicId: r.topicId,
+          reason: r.reason.trim() || null,
+        }));
+
+      const seen = new Set<string>();
+      const dedupedExcluded = cleanedExcluded.filter((r) => {
+        if (seen.has(r.topicId)) {
+          return false;
+        }
+        seen.add(r.topicId);
+        return true;
+      });
+
       const domainData = {
         title: value.title,
         description: value.description || null,
         hasRadar: value.hasRadar === "true",
         topicIds: value.topicIds,
+        excludedTopics: dedupedExcluded,
       };
 
       try {
@@ -128,7 +188,49 @@ function SingleDomainEdit() {
     ...state.values,
   }));
   const isSubmitting = useStore(form.store, state => state.isSubmitting);
-  const hasChanges = formHasChanges(currentValues, startingValues);
+  const formHasFieldChanges = formHasChanges(currentValues, startingValues);
+  const exclusionsHaveChanges = useMemo(() => {
+    if (excludedRows.length !== startingExcluded.length) {
+      return true;
+    }
+    const startingMap = new Map(
+      startingExcluded.map(r => [r.topicId, r.reason]),
+    );
+    return excludedRows.some(r =>
+      !startingMap.has(r.topicId) || startingMap.get(r.topicId) !== r.reason);
+  }, [excludedRows, startingExcluded]);
+  const hasChanges = formHasFieldChanges || exclusionsHaveChanges;
+
+  function addExclusion() {
+    setExcludedRows(prev => [
+      ...prev,
+      {
+        topicId: "",
+        reason: "",
+        localKey: nextExclusionKey(),
+      },
+    ]);
+  }
+
+  function removeExclusion(localKey: string) {
+    setExcludedRows(prev => prev.filter(r => r.localKey !== localKey));
+  }
+
+  function updateExclusion(localKey: string, patch: Partial<ExcludedTopicRow>) {
+    setExcludedRows(prev =>
+      prev.map(r =>
+        r.localKey === localKey
+          ? {
+            ...r,
+            ...patch,
+          }
+          : r));
+  }
+
+  const usedExclusionTopicIds = useMemo(
+    () => new Set(excludedRows.map(r => r.topicId).filter(Boolean)),
+    [excludedRows],
+  );
 
   return (
     <div>
@@ -200,6 +302,99 @@ function SingleDomainEdit() {
               />
             )}
           </form.AppField>
+
+          <section className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <h3 className="text-2xl">Topics excluded from Radar</h3>
+              <p className="text-sm text-muted-foreground">
+                Topics listed here will not be considered by the Radar LLM
+                assistant. Each one can include a reason explaining why.
+              </p>
+            </div>
+            <ul className="flex flex-col gap-3">
+              {excludedRows.map(row => (
+                <li
+                  key={row.localKey}
+                  className="flex flex-col gap-2 rounded-sm border p-3"
+                >
+                  <div
+                    className={`
+                      grid grid-cols-1 gap-2
+                      sm:grid-cols-[minmax(0,1fr)_auto]
+                    `}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs text-muted-foreground uppercase">
+                        Topic
+                      </label>
+                      <Select
+                        value={row.topicId}
+                        onValueChange={value =>
+                          updateExclusion(row.localKey, {
+                            topicId: value,
+                          })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Choose topic" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(topicsData ?? [])
+                            .filter(
+                              t =>
+                                t.id === row.topicId
+                                || !usedExclusionTopicIds.has(t.id),
+                            )
+                            .map(t => (
+                              <SelectItem
+                                key={t.id}
+                                value={t.id}
+                              >
+                                {t.name}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex flex-row items-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeExclusion(row.localKey)}
+                        aria-label="Remove excluded topic"
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs text-muted-foreground uppercase">
+                      Reason (optional)
+                    </label>
+                    <Textarea
+                      value={row.reason}
+                      onChange={e =>
+                        updateExclusion(row.localKey, {
+                          reason: e.target.value,
+                        })}
+                      placeholder="Why should the radar ignore this topic?"
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={addExclusion}
+              >
+                <PlusIcon />
+                {" "}
+                Add Excluded Topic
+              </Button>
+            </div>
+          </section>
 
           <div className="flex flex-row gap-4">
             <Button

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, RadarIcon } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
+import { DomainLearningLog } from "@/components/domains/DomainLearningLog";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -58,6 +59,9 @@ function SingleDomain() {
       to: "/domains",
     });
   }
+
+  const excludedTopics = data?.excludedTopics ?? [];
+  const learningLog = data?.learningLog ?? [];
 
   return (
     <div>
@@ -125,11 +129,56 @@ function SingleDomain() {
                     >
                       {topic.name}
                     </Link>
+                    {topic.courses && topic.courses.length > 0 && (
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        (
+                        {topic.courses.length}
+                        {" course"}
+                        {topic.courses.length === 1 ? "" : "s"}
+                        )
+                      </span>
+                    )}
                   </li>
                 ))}
             </ul>
           </InfoArea>
         </div>
+        <InfoArea
+          header="Topics excluded from Radar"
+          condition={excludedTopics.length > 0}
+        >
+          <ul className="ml-5 flex list-disc flex-col gap-1">
+            {excludedTopics.map(topic => (
+              <li key={topic.id}>
+                <Link
+                  to="/topics/$id"
+                  params={{
+                    id: topic.id,
+                  }}
+                  className={`
+                    font-bold text-blue-800
+                    hover:text-blue-600
+                  `}
+                >
+                  {topic.name}
+                </Link>
+                {topic.reason && (
+                  <span className="ml-2 text-sm text-muted-foreground">
+                    —
+                    {" "}
+                    {topic.reason}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </InfoArea>
+        {data && (
+          <DomainLearningLog
+            domainId={data.id}
+            entries={learningLog}
+          />
+        )}
         <div>
           <DeleteButton onClick={handleDelete}>Delete Domain</DeleteButton>
         </div>

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -31,6 +31,7 @@ import {
   createRadarBlip,
   deleteRadarBlip,
   fetchRadar,
+  fetchSingleDomain,
   fetchTopics,
   upsertRadarBlip,
   upsertRadarConfig,
@@ -153,6 +154,13 @@ function RadarEdit() {
   } = useQuery({
     queryKey: ["topics"],
     queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: domainDetail,
+  } = useQuery({
+    queryKey: ["domain", id],
+    queryFn: () => fetchSingleDomain(id),
   });
 
   const [quadrants, setQuadrants] = useState<QuadrantDraft[]>([]);
@@ -800,6 +808,10 @@ function RadarEdit() {
             <BlipLlmAssist
               domainId={id}
               domainTitle={data?.domainTitle ?? ""}
+              domainDescription={domainDetail?.description ?? null}
+              domainTopics={domainDetail?.topics ?? []}
+              excludedTopics={domainDetail?.excludedTopics ?? []}
+              learningLog={domainDetail?.learningLog ?? []}
               quadrants={persistedQuadrants}
               rings={persistedRings}
               topics={topics ?? []}

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -244,6 +244,70 @@ export async function upsertDomain(
   return await response.json();
 }
 
+interface LearningLogEntryPayload {
+  date: string;
+  description: string;
+  link?: string | null;
+}
+
+export async function createDomainLearningLogEntry(
+  domainId: string,
+  data: LearningLogEntryPayload,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(
+    `/api/domains/${domainId}/learning-log`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to create learning log entry: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function updateDomainLearningLogEntry(
+  domainId: string,
+  entryId: string,
+  data: LearningLogEntryPayload,
+): Promise<SuccessObj> {
+  const response = await fetch(
+    `/api/domains/${domainId}/learning-log/${entryId}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to update learning log entry: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function deleteDomainLearningLogEntry(
+  domainId: string,
+  entryId: string,
+): Promise<SuccessObj> {
+  const response = await fetch(
+    `/api/domains/${domainId}/learning-log/${entryId}`,
+    {
+      method: "DELETE",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to delete learning log entry: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
 export async function fetchDailies(): Promise<Daily[]> {
   return await fetch("/api/dailies").then(res => res.json());
 }

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -120,6 +120,7 @@ export const topicsRelations = relations(topics, ({
   topicsToCourses: many(topicsToCourses),
   topicsToDomains: many(topicsToDomains),
   radarBlips: many(radarBlips),
+  domainExclusions: many(domainExcludedTopics),
 }));
 
 export const domains = pgTable("domains", {
@@ -138,7 +139,65 @@ export const domainsRelations = relations(domains, ({
   radarQuadrants: many(radarQuadrants),
   radarRings: many(radarRings),
   radarBlips: many(radarBlips),
+  excludedTopics: many(domainExcludedTopics),
+  learningLogEntries: many(domainLearningLogEntries),
 }));
+
+export const domainLearningLogEntries = pgTable("domain_learning_log_entries", {
+  id: varchar().primaryKey(),
+  domainId: varchar("domain_id")
+    .notNull()
+    .references(() => domains.id),
+  date: date().notNull(),
+  description: varchar().notNull(),
+  link: varchar(),
+});
+
+export const domainLearningLogEntriesRelations = relations(
+  domainLearningLogEntries,
+  ({
+    one,
+  }) => ({
+    domain: one(domains, {
+      fields: [domainLearningLogEntries.domainId],
+      references: [domains.id],
+    }),
+  }),
+);
+
+export const domainExcludedTopics = pgTable(
+  "domain_excluded_topics",
+  {
+    topicId: varchar("topic_id")
+      .notNull()
+      .references(() => topics.id),
+    domainId: varchar("domain_id")
+      .notNull()
+      .references(() => domains.id),
+    reason: varchar(),
+  },
+  t => [
+    primaryKey({
+      columns: [t.topicId, t.domainId],
+    }),
+  ],
+);
+
+export const domainExcludedTopicsRelations = relations(
+  domainExcludedTopics,
+  ({
+    one,
+  }) => ({
+    topic: one(topics, {
+      fields: [domainExcludedTopics.topicId],
+      references: [topics.id],
+    }),
+    domain: one(domains, {
+      fields: [domainExcludedTopics.domainId],
+      references: [domains.id],
+    }),
+  }),
+);
 
 export const topicsToDomains = pgTable(
   "topics_to_domains",

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { domains, topicsToDomains } from "@/db/schema";
+import { domainExcludedTopics, domains, topicsToDomains } from "@/db/schema";
 import { nullableBoolean, nullableString } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -21,6 +21,19 @@ const createSchema = {
           type: "array",
           items: {
             type: "string",
+          },
+        },
+        excludedTopics: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["topicId"],
+            properties: {
+              topicId: {
+                type: "string",
+              },
+              reason: nullableString,
+            },
           },
         },
       },
@@ -50,6 +63,16 @@ export default async function (server: FastifyInstance) {
           body.topicIds.map(topicId => ({
             topicId,
             domainId: id,
+          })),
+        );
+      }
+
+      if (body.excludedTopics && body.excludedTopics.length > 0) {
+        await db.insert(domainExcludedTopics).values(
+          body.excludedTopics.map(entry => ({
+            topicId: entry.topicId,
+            domainId: id,
+            reason: entry.reason ?? null,
           })),
         );
       }

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -1,12 +1,43 @@
-import { domains, topicsToDomains } from "@/db/schema";
-import { createDeleteHandler } from "@/utils/createDeleteHandler";
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  domainExcludedTopics,
+  domainLearningLogEntries,
+  domains,
+  topicsToDomains,
+} from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
 
-export default createDeleteHandler({
-  description: "Delete a domain by ID",
-  table: domains,
-  idColumn: domains.id,
-  junction: {
-    table: topicsToDomains,
-    foreignKey: topicsToDomains.domainId,
+const deleteSchema = {
+  schema: {
+    description: "Delete a domain by ID",
+    params: idParamSchema,
   },
-});
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete("/:id", deleteSchema, async function (request) {
+    const {
+      id,
+    } = request.params;
+
+    await db
+      .delete(topicsToDomains)
+      .where(eq(topicsToDomains.domainId, id));
+    await db
+      .delete(domainExcludedTopics)
+      .where(eq(domainExcludedTopics.domainId, id));
+    await db
+      .delete(domainLearningLogEntries)
+      .where(eq(domainLearningLogEntries.domainId, id));
+    await db.delete(domains).where(eq(domains.id, id));
+
+    return {
+      status: "ok",
+    };
+  });
+}

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -1,7 +1,9 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
+import type { DailyCompletion, Domain, LearningLogEntry } from "@emstack/types/src";
 import { idParamSchema } from "@/utils/schemas";
+import { buildDomainLearningLog } from "@/utils/learningLog";
 
 const getDomainSchema = {
   schema: {
@@ -27,31 +29,129 @@ export default async function (server: FastifyInstance) {
         with: {
           topicsToDomains: {
             with: {
-              topic: true,
+              topic: {
+                with: {
+                  topicsToCourses: {
+                    with: {
+                      course: {
+                        columns: {
+                          id: true,
+                          name: true,
+                          progressCurrent: true,
+                          progressTotal: true,
+                          status: true,
+                        },
+                        with: {
+                          dailies: {
+                            columns: {
+                              id: true,
+                              name: true,
+                              completions: true,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
+          excludedTopics: {
+            with: {
+              topic: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+          },
+          learningLogEntries: true,
         },
       });
 
-      if (domain) {
-        const topics = domain.topicsToDomains.map((ttd) => {
-          if (ttd.topic) {
-            return {
-              name: ttd.topic.name,
-              id: ttd.topic.id,
-            };
-          }
-        }).filter(Boolean);
-
+      if (!domain) {
+        reply.status(404);
         return {
-          id: domain.id,
-          title: domain.title,
-          description: domain.description,
-          hasRadar: domain.hasRadar,
-          topicCount: topics.length,
-          topics: topics,
+          error: "Domain not found",
         };
       }
+
+      const topics = domain.topicsToDomains
+        .map((ttd) => {
+          if (!ttd.topic) {
+            return null;
+          }
+          const courses = (ttd.topic.topicsToCourses ?? [])
+            .map(ttc => ttc.course)
+            .filter((c): c is NonNullable<typeof c> => Boolean(c))
+            .map(c => ({
+              id: c.id,
+              name: c.name,
+              progressCurrent: c.progressCurrent ?? null,
+              progressTotal: c.progressTotal ?? null,
+              status: c.status ?? null,
+            }));
+          return {
+            id: ttd.topic.id,
+            name: ttd.topic.name,
+            description: ttd.topic.description ?? null,
+            reason: ttd.topic.reason ?? null,
+            courses,
+          };
+        })
+        .filter((t): t is NonNullable<typeof t> => Boolean(t));
+
+      const excludedTopics = (domain.excludedTopics ?? [])
+        .map((row) => {
+          if (!row.topic) {
+            return null;
+          }
+          return {
+            id: row.topic.id,
+            name: row.topic.name,
+            reason: row.reason ?? null,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => Boolean(row));
+
+      const dailySource = domain.topicsToDomains.flatMap((ttd) => {
+        if (!ttd.topic) {
+          return [];
+        }
+        return (ttd.topic.topicsToCourses ?? []).flatMap((ttc) => {
+          const course = ttc.course;
+          if (!course) {
+            return [];
+          }
+          return (course.dailies ?? []).map(d => ({
+            id: d.id,
+            name: d.name,
+            completions: (d.completions ?? []) as DailyCompletion[],
+            courseId: course.id,
+            courseName: course.name,
+          }));
+        });
+      });
+
+      const learningLog: LearningLogEntry[] = buildDomainLearningLog(
+        domain.learningLogEntries ?? [],
+        dailySource,
+      );
+
+      const result: Domain = {
+        id: domain.id,
+        title: domain.title,
+        description: domain.description,
+        hasRadar: domain.hasRadar,
+        topicCount: topics.length,
+        topics,
+        excludedTopics,
+        learningLog,
+      };
+
+      return result;
     },
   );
 }

--- a/packages/middleware/src/routes/api/domains/learningLogEntries.ts
+++ b/packages/middleware/src/routes/api/domains/learningLogEntries.ts
@@ -1,0 +1,169 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { and, eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+import { db } from "@/db";
+import { domainLearningLogEntries } from "@/db/schema";
+import { nullableString } from "@/utils/schemas";
+
+const createSchema = {
+  schema: {
+    description: "Create a manual learning-log entry for a domain",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+      },
+      required: ["domainId"],
+    },
+    body: {
+      type: "object",
+      required: ["date", "description"],
+      properties: {
+        date: {
+          type: "string",
+        },
+        description: {
+          type: "string",
+        },
+        link: nullableString,
+      },
+    },
+  },
+} as const;
+
+const updateSchema = {
+  schema: {
+    description: "Update a manual learning-log entry",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+        entryId: {
+          type: "string",
+        },
+      },
+      required: ["domainId", "entryId"],
+    },
+    body: {
+      type: "object",
+      required: ["date", "description"],
+      properties: {
+        date: {
+          type: "string",
+        },
+        description: {
+          type: "string",
+        },
+        link: nullableString,
+      },
+    },
+  },
+} as const;
+
+const deleteSchema = {
+  schema: {
+    description: "Delete a manual learning-log entry",
+    params: {
+      type: "object",
+      properties: {
+        domainId: {
+          type: "string",
+        },
+        entryId: {
+          type: "string",
+        },
+      },
+      required: ["domainId", "entryId"],
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:domainId/learning-log",
+    createSchema,
+    async function (request) {
+      const {
+        domainId,
+      } = request.params;
+      const body = request.body;
+      const id = uuidv4();
+      await db.insert(domainLearningLogEntries).values({
+        id,
+        domainId,
+        date: body.date,
+        description: body.description,
+        link: body.link ?? null,
+      });
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+
+  fastify.put(
+    "/:domainId/learning-log/:entryId",
+    updateSchema,
+    async function (request, reply) {
+      const {
+        domainId, entryId,
+      } = request.params;
+      const body = request.body;
+      const result = await db
+        .update(domainLearningLogEntries)
+        .set({
+          date: body.date,
+          description: body.description,
+          link: body.link ?? null,
+        })
+        .where(
+          and(
+            eq(domainLearningLogEntries.id, entryId),
+            eq(domainLearningLogEntries.domainId, domainId),
+          ),
+        )
+        .returning({
+          id: domainLearningLogEntries.id,
+        });
+      if (result.length === 0) {
+        reply.status(404);
+        return {
+          error: "Entry not found",
+        };
+      }
+      return {
+        status: "ok",
+      };
+    },
+  );
+
+  fastify.delete(
+    "/:domainId/learning-log/:entryId",
+    deleteSchema,
+    async function (request) {
+      const {
+        domainId, entryId,
+      } = request.params;
+      await db
+        .delete(domainLearningLogEntries)
+        .where(
+          and(
+            eq(domainLearningLogEntries.id, entryId),
+            eq(domainLearningLogEntries.domainId, domainId),
+          ),
+        );
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/routes.ts
+++ b/packages/middleware/src/routes/api/domains/routes.ts
@@ -6,6 +6,7 @@ import getDomain from "./getDomain";
 import createDomain from "./createDomain";
 import upsertDomain from "./upsertDomain";
 import deleteDomain from "./deleteDomain";
+import learningLogEntries from "./learningLogEntries";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -15,4 +16,5 @@ export default async function (server: FastifyInstance) {
   fastify.register(createDomain);
   fastify.register(upsertDomain);
   fastify.register(deleteDomain);
+  fastify.register(learningLogEntries);
 }

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { domains, topicsToDomains } from "@/db/schema";
+import { domainExcludedTopics, domains, topicsToDomains } from "@/db/schema";
 import { idParamSchema, nullableBoolean, nullableString } from "@/utils/schemas";
 import { syncJunctionTable } from "@/utils/syncJunctionTable";
 
@@ -22,6 +22,19 @@ const upsertSchema = {
           type: "array",
           items: {
             type: "string",
+          },
+        },
+        excludedTopics: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["topicId"],
+            properties: {
+              topicId: {
+                type: "string",
+              },
+              reason: nullableString,
+            },
           },
         },
       },
@@ -67,6 +80,23 @@ export default async function (server: FastifyInstance) {
         (body.topicIds ?? []).map(topicId => ({
           topicId,
           domainId: id,
+        })),
+      );
+
+      const dedupedExclusions = new Map<string, string | null>();
+      for (const entry of body.excludedTopics ?? []) {
+        if (!dedupedExclusions.has(entry.topicId)) {
+          dedupedExclusions.set(entry.topicId, entry.reason ?? null);
+        }
+      }
+      await syncJunctionTable(
+        domainExcludedTopics,
+        domainExcludedTopics.domainId,
+        id,
+        Array.from(dedupedExclusions.entries()).map(([topicId, reason]) => ({
+          topicId,
+          domainId: id,
+          reason,
         })),
       );
 

--- a/packages/middleware/src/utils/learningLog.ts
+++ b/packages/middleware/src/utils/learningLog.ts
@@ -1,0 +1,100 @@
+import type { DailyCompletion, DailyCompletionStatus, LearningLogEntry } from "@emstack/types/src";
+
+interface ManualEntryRow {
+  id: string;
+  date: string | Date | null;
+  description: string;
+  link: string | null;
+}
+
+interface DailySource {
+  id: string;
+  name: string;
+  completions: DailyCompletion[];
+  courseId: string;
+  courseName: string;
+}
+
+function dateString(value: string | Date | null): string {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === "string" && value.length >= 10) {
+    return value.slice(0, 10);
+  }
+  return "";
+}
+
+function isMeaningfulCompletion(c: DailyCompletion): boolean {
+  if (c.status && c.status !== "incomplete") {
+    return true;
+  }
+  if (c.note && c.note.trim()) {
+    return true;
+  }
+  return false;
+}
+
+function describeCompletion(daily: DailySource, c: DailyCompletion): string {
+  const note = c.note?.trim();
+  if (note) {
+    return `${daily.name} — ${note}`;
+  }
+  return daily.name;
+}
+
+export function buildDomainLearningLog(
+  manualEntries: ManualEntryRow[],
+  dailySources: DailySource[],
+): LearningLogEntry[] {
+  const manual: LearningLogEntry[] = manualEntries.map(entry => ({
+    id: entry.id,
+    source: "manual" as const,
+    date: dateString(entry.date),
+    description: entry.description,
+    link: entry.link ?? null,
+  }));
+
+  const seenDailyKeys = new Set<string>();
+  const fromDailies: LearningLogEntry[] = [];
+  for (const daily of dailySources) {
+    for (const completion of daily.completions ?? []) {
+      if (!isMeaningfulCompletion(completion)) {
+        continue;
+      }
+      const date = dateString(completion.date);
+      if (!date) {
+        continue;
+      }
+      const dedupeKey = `${daily.id}:${date}`;
+      if (seenDailyKeys.has(dedupeKey)) {
+        continue;
+      }
+      seenDailyKeys.add(dedupeKey);
+      fromDailies.push({
+        id: dedupeKey,
+        source: "daily",
+        date,
+        description: describeCompletion(daily, completion),
+        link: null,
+        dailyId: daily.id,
+        dailyName: daily.name,
+        courseId: daily.courseId,
+        courseName: daily.courseName,
+        status: (completion.status ?? null) as DailyCompletionStatus | null,
+      });
+    }
+  }
+
+  const combined = [...manual, ...fromDailies];
+  combined.sort((a, b) => {
+    if (a.date === b.date) {
+      if (a.source === b.source) {
+        return 0;
+      }
+      return a.source === "manual" ? -1 : 1;
+    }
+    return a.date < b.date ? 1 : -1;
+  });
+  return combined;
+}

--- a/packages/types/src/Domain.ts
+++ b/packages/types/src/Domain.ts
@@ -1,11 +1,12 @@
+import { DomainExcludedTopic, DomainTopic, LearningLogEntry } from "@/LearningLog";
+
 export interface Domain {
   id: string;
   title: string;
   description?: string | null;
   hasRadar?: boolean | null;
   topicCount?: number;
-  topics?: {
-    id: string;
-    name: string;
-  }[];
+  topics?: DomainTopic[];
+  excludedTopics?: DomainExcludedTopic[];
+  learningLog?: LearningLogEntry[];
 }

--- a/packages/types/src/LearningLog.ts
+++ b/packages/types/src/LearningLog.ts
@@ -1,0 +1,38 @@
+import { DailyCompletionStatus } from "@/Daily";
+
+export type LearningLogEntrySource = "manual" | "daily";
+
+export interface LearningLogEntry {
+  id: string;
+  source: LearningLogEntrySource;
+  date: string;
+  description: string;
+  link?: string | null;
+  dailyId?: string | null;
+  dailyName?: string | null;
+  courseId?: string | null;
+  courseName?: string | null;
+  status?: DailyCompletionStatus | null;
+}
+
+export interface DomainExcludedTopic {
+  id: string;
+  name: string;
+  reason?: string | null;
+}
+
+export interface DomainTopicCourse {
+  id: string;
+  name: string;
+  progressCurrent?: number | null;
+  progressTotal?: number | null;
+  status?: string | null;
+}
+
+export interface DomainTopic {
+  id: string;
+  name: string;
+  description?: string | null;
+  reason?: string | null;
+  courses?: DomainTopicCourse[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,7 @@ export * from "./TopicsFromServer";
 export * from "./TopicForTopicsPage";
 export * from "./TopicsToCourses";
 export * from "./Domain";
+export * from "./LearningLog";
 export * from "./TopicsToDomains";
 export * from "./Daily";
 export * from "./Radar";


### PR DESCRIPTION
Introduces a Learning Log on each Domain that combines manual entries
(date, description, optional link) with an auto-imported chronological
feed of daily completions for courses or topics linked to the domain.
Adds a per-domain excluded-topics list with reasons that the Radar
should not consider, and extends the Radar LLM prompt to include the
domain description, topics with their courses and progress, recent
learning-log activity, and the excluded topics — so suggestions are
informed by what's actually being worked on and which topics are
explicitly off-limits.

Note: requires running drizzle-kit push to create the new
domain_learning_log_entries and domain_excluded_topics tables.