### PR TITLE
Add duplicate functionality and radar blips support

### DIFF
--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { CopyIcon } from "lucide-react";
+import { toast } from "sonner";
 
 import { TopicList } from "@/components/boxElements/TopicList";
 import { DailyRecentDaysStrip } from "@/components/dailies";
@@ -17,9 +19,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { DeleteButton } from "@/components/ui/DeleteButton";
 import {
   deleteSingleCourse,
+  duplicateCourse,
   fetchSingleCourse,
   getCurrentChain,
   getTotalCompletedDays,
@@ -45,6 +49,7 @@ function SingleCourse() {
   } = Route.useParams();
   const search = Route.useSearch();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const [dailyPromptOpen, setDailyPromptOpen] = useState<boolean>(
     search.promptDaily === 1,
@@ -64,6 +69,24 @@ function SingleCourse() {
     enabled: false,
     queryFn: () => deleteSingleCourse(id),
   });
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateCourse(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["courses"],
+      });
+      await navigate({
+        to: "/courses/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate course. Please try again.");
+    }
+  }
 
   const percentComplete = makePercentageComplete(
     data?.progressCurrent,
@@ -212,7 +235,15 @@ function SingleCourse() {
           </InfoArea>
         </div>
       </InfoRow>
-      <div>
+      <div className="flex flex-row gap-2">
+        <Button
+          variant="secondary"
+          onClick={handleDuplicate}
+        >
+          Duplicate Course
+          {" "}
+          <CopyIcon />
+        </Button>
         <DeleteButton onClick={handleDelete}>Delete Course</DeleteButton>
       </div>
       <AlertDialog open={dailyPromptOpen}>

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,6 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, ExternalLink, FlameIcon, LaughIcon } from "lucide-react";
+import {
+  CopyIcon,
+  EditIcon,
+  ExternalLink,
+  FlameIcon,
+  LaughIcon,
+} from "lucide-react";
+import { toast } from "sonner";
 
 import {
   DailyCompletionsManager,
@@ -12,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { DeleteButton } from "@/components/ui/DeleteButton";
 import {
   deleteSingleDaily,
+  duplicateDaily,
   fetchSingleDaily,
   getCurrentChain,
   getTotalCompletedDays,
@@ -43,6 +51,7 @@ function SingleDaily() {
     id,
   } = Route.useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const {
     isPending, error, data,
@@ -58,6 +67,24 @@ function SingleDaily() {
     enabled: false,
     queryFn: () => deleteSingleDaily(id),
   });
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateDaily(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
+      });
+      await navigate({
+        to: "/dailies/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate daily. Please try again.");
+    }
+  }
 
   if (isPending) {
     return <DailyPending />;
@@ -97,6 +124,14 @@ function SingleDaily() {
               </Button>
             </a>
           )}
+          <Button
+            variant="secondary"
+            onClick={handleDuplicate}
+          >
+            Duplicate
+            {" "}
+            <CopyIcon />
+          </Button>
           <Link
             to="/dailies/$id/edit"
             params={{

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, RadarIcon } from "lucide-react";
+import { CopyIcon, EditIcon, RadarIcon } from "lucide-react";
+import { toast } from "sonner";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
 import { DomainLearningLog } from "@/components/domains/DomainLearningLog";
@@ -8,7 +9,11 @@ import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { DeleteButton } from "@/components/ui/DeleteButton";
-import { deleteSingleDomain, fetchSingleDomain } from "@/utils";
+import {
+  deleteSingleDomain,
+  duplicateDomain,
+  fetchSingleDomain,
+} from "@/utils";
 
 export const Route = createFileRoute("/domains/$id/")({
   component: SingleDomain,
@@ -19,6 +24,7 @@ function SingleDomain() {
     id,
   } = Route.useParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const {
     isPending, error, data,
@@ -34,6 +40,24 @@ function SingleDomain() {
     enabled: false,
     queryFn: () => deleteSingleDomain(id),
   });
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateDomain(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["domains"],
+      });
+      await navigate({
+        to: "/domains/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate domain. Please try again.");
+    }
+  }
 
   if (isPending) {
     return (
@@ -66,7 +90,7 @@ function SingleDomain() {
   return (
     <div>
       <PageHeader
-        pageTitle={data?.title}
+        pageTitle={data?.title || "(Untitled Domain)"}
         pageSection="domains"
       >
         <div className="flex flex-row gap-2">
@@ -84,6 +108,14 @@ function SingleDomain() {
               </Button>
             </Link>
           )}
+          <Button
+            variant="secondary"
+            onClick={handleDuplicate}
+          >
+            Duplicate
+            {" "}
+            <CopyIcon />
+          </Button>
           <Link
             to="/domains/$id/edit"
             params={{

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createTopic,
+  fetchDomains,
   fetchSingleTopic,
   formHasChanges,
   upsertTopic,
@@ -26,6 +27,7 @@ const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   description: z.string().max(500),
   reason: z.string().max(500),
+  domainIds: z.array(z.string()),
 });
 
 function SingleTopicEdit() {
@@ -46,11 +48,30 @@ function SingleTopicEdit() {
     enabled: !isNew,
   });
 
+  const {
+    data: domainsData,
+  } = useQuery({
+    queryKey: ["domains"],
+    queryFn: () => fetchDomains(),
+  });
+
+  const domainOptions = useMemo(
+    () =>
+      (domainsData ?? [])
+        .filter(d => d.title)
+        .map(d => ({
+          value: d.id,
+          label: d.title,
+        })),
+    [domainsData],
+  );
+
   const startingValues = useMemo(
     () => ({
       name: data?.name ?? "",
       description: data?.description ?? "",
       reason: data?.reason ?? "",
+      domainIds: data?.domains?.map(d => d.id) ?? [],
     }),
     [data],
   );
@@ -67,6 +88,7 @@ function SingleTopicEdit() {
         name: value.name,
         description: value.description || null,
         reason: value.reason || null,
+        domainIds: value.domainIds,
       };
 
       try {
@@ -85,6 +107,9 @@ function SingleTopicEdit() {
 
         await queryClient.invalidateQueries({
           queryKey: ["topics"],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ["domains"],
         });
         skipBlocker.current = true;
         await navigate({
@@ -157,6 +182,16 @@ function SingleTopicEdit() {
               <field.TextareaField
                 label="Reason"
                 placeholder="Why are you learning this?"
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="domainIds">
+            {field => (
+              <field.MultiComboboxField
+                label="Domains"
+                options={domainOptions}
+                placeholder="Search domains..."
               />
             )}
           </form.AppField>

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -108,6 +108,32 @@ function SingleTopic() {
         </InfoArea>
         <div>
           <InfoArea
+            header="Domains"
+            condition={!!data?.domains && data.domains.length > 0}
+          >
+            <ul className="ml-5 list-disc">
+              {data?.domains
+                && data.domains.map(domain => (
+                  <li key={domain.id}>
+                    <Link
+                      to="/domains/$id"
+                      params={{
+                        id: domain.id + "",
+                      }}
+                      className={`
+                        font-bold text-blue-800
+                        hover:text-blue-600
+                      `}
+                    >
+                      {domain.title}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </InfoArea>
+        </div>
+        <div>
+          <InfoArea
             header="Courses"
             condition={!!data?.courseCount && data.courseCount > 0}
           >

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -359,6 +359,45 @@ export async function deleteSingleDaily(
   }).then(res => res.json());
 }
 
+export async function duplicateDomain(
+  id: string,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(`/api/domains/${id}/duplicate`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to duplicate domain: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function duplicateCourse(
+  id: string,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(`/api/courses/${id}/duplicate`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to duplicate course: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function duplicateDaily(
+  id: string,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch(`/api/dailies/${id}/duplicate`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to duplicate daily: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
 export async function fetchRadar(domainId: string): Promise<Radar> {
   const response = await fetch(`/api/domains/${domainId}/radar`);
   if (!response.ok) {

--- a/packages/middleware/src/routes/api/courses/duplicateCourse.ts
+++ b/packages/middleware/src/routes/api/courses/duplicateCourse.ts
@@ -1,0 +1,73 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { courses, topicsToCourses } from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const duplicateSchema = {
+  schema: {
+    description: "Duplicate a course by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:id/duplicate",
+    duplicateSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const source = await db.query.courses.findFirst({
+        where: (c, {
+          eq,
+        }) => eq(c.id, id),
+        with: {
+          topicsToCourses: true,
+        },
+      });
+
+      if (!source) {
+        reply.status(404);
+        return {
+          error: "Course not found",
+        };
+      }
+
+      const newId = uuidv4();
+      await db.insert(courses).values({
+        id: newId,
+        name: `${source.name} (Copy)`,
+        description: source.description ?? null,
+        url: null,
+        isCostFromPlatform: source.isCostFromPlatform ?? false,
+        progressCurrent: 0,
+        progressTotal: source.progressTotal ?? null,
+        dateExpires: source.dateExpires ?? null,
+        isExpires: source.isExpires ?? null,
+        cost: source.cost ?? null,
+        status: source.status ?? undefined,
+        minutesLength: source.minutesLength ?? null,
+        courseProviderId: source.courseProviderId ?? null,
+      });
+
+      const topicLinks = (source.topicsToCourses ?? []).map(t => ({
+        topicId: t.topicId,
+        courseId: newId,
+      }));
+      if (topicLinks.length > 0) {
+        await db.insert(topicsToCourses).values(topicLinks);
+      }
+
+      return {
+        status: "ok",
+        id: newId,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/courses/routes.ts
+++ b/packages/middleware/src/routes/api/courses/routes.ts
@@ -5,6 +5,7 @@ import courseRoot from "./root";
 import getCourse from "./getCourse";
 import deleteCourse from "./deleteCourse";
 import upsertCourse from "./upsertCourse";
+import duplicateCourse from "./duplicateCourse";
 import incrementCourseProgress from "./incrementCourseProgress";
 
 export default async function (server: FastifyInstance) {
@@ -14,5 +15,6 @@ export default async function (server: FastifyInstance) {
   fastify.register(getCourse);
   fastify.register(deleteCourse);
   fastify.register(upsertCourse);
+  fastify.register(duplicateCourse);
   fastify.register(incrementCourseProgress);
 }

--- a/packages/middleware/src/routes/api/dailies/duplicateDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/duplicateDaily.ts
@@ -1,0 +1,56 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { dailies } from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const duplicateSchema = {
+  schema: {
+    description: "Duplicate a daily by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:id/duplicate",
+    duplicateSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const source = await db.query.dailies.findFirst({
+        where: (d, {
+          eq,
+        }) => eq(d.id, id),
+      });
+
+      if (!source) {
+        reply.status(404);
+        return {
+          error: "Daily not found",
+        };
+      }
+
+      const newId = uuidv4();
+      await db.insert(dailies).values({
+        id: newId,
+        name: `${source.name} (Copy)`,
+        location: source.location ?? null,
+        description: source.description ?? null,
+        completions: [],
+        courseProviderId: source.courseProviderId ?? null,
+        courseId: source.courseId ?? null,
+      });
+
+      return {
+        status: "ok",
+        id: newId,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/dailies/routes.ts
+++ b/packages/middleware/src/routes/api/dailies/routes.ts
@@ -6,6 +6,7 @@ import getDaily from "./getDaily";
 import createDaily from "./createDaily";
 import upsertDaily from "./upsertDaily";
 import deleteDaily from "./deleteDaily";
+import duplicateDaily from "./duplicateDaily";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -15,4 +16,5 @@ export default async function (server: FastifyInstance) {
   fastify.register(createDaily);
   fastify.register(upsertDaily);
   fastify.register(deleteDaily);
+  fastify.register(duplicateDaily);
 }

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -14,6 +14,7 @@ const createSchema = {
       properties: {
         title: {
           type: "string",
+          minLength: 1,
         },
         description: nullableString,
         hasRadar: nullableBoolean,
@@ -49,30 +50,44 @@ export default async function (server: FastifyInstance) {
     createSchema,
     async function (request, reply) {
       const body = request.body;
+      const title = body.title.trim();
+      if (!title) {
+        reply.status(400);
+        return {
+          error: "Title is required",
+        };
+      }
       const id = uuidv4();
 
       await db.insert(domains).values({
         id,
-        title: body.title,
+        title,
         description: body.description ?? null,
         hasRadar: body.hasRadar ?? null,
       });
 
-      if (body.topicIds && body.topicIds.length > 0) {
+      const uniqueTopicIds = Array.from(new Set(body.topicIds ?? []));
+      if (uniqueTopicIds.length > 0) {
         await db.insert(topicsToDomains).values(
-          body.topicIds.map(topicId => ({
+          uniqueTopicIds.map(topicId => ({
             topicId,
             domainId: id,
           })),
         );
       }
 
-      if (body.excludedTopics && body.excludedTopics.length > 0) {
+      const dedupedExcluded = new Map<string, string | null>();
+      for (const entry of body.excludedTopics ?? []) {
+        if (!dedupedExcluded.has(entry.topicId)) {
+          dedupedExcluded.set(entry.topicId, entry.reason ?? null);
+        }
+      }
+      if (dedupedExcluded.size > 0) {
         await db.insert(domainExcludedTopics).values(
-          body.excludedTopics.map(entry => ({
-            topicId: entry.topicId,
+          Array.from(dedupedExcluded.entries()).map(([topicId, reason]) => ({
+            topicId,
             domainId: id,
-            reason: entry.reason ?? null,
+            reason,
           })),
         );
       }

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -6,6 +6,9 @@ import {
   domainExcludedTopics,
   domainLearningLogEntries,
   domains,
+  radarBlips,
+  radarQuadrants,
+  radarRings,
   topicsToDomains,
 } from "@/db/schema";
 import { idParamSchema } from "@/utils/schemas";
@@ -25,6 +28,9 @@ export default async function (server: FastifyInstance) {
       id,
     } = request.params;
 
+    await db.delete(radarBlips).where(eq(radarBlips.domainId, id));
+    await db.delete(radarQuadrants).where(eq(radarQuadrants.domainId, id));
+    await db.delete(radarRings).where(eq(radarRings.domainId, id));
     await db
       .delete(topicsToDomains)
       .where(eq(topicsToDomains.domainId, id));

--- a/packages/middleware/src/routes/api/domains/duplicateDomain.ts
+++ b/packages/middleware/src/routes/api/domains/duplicateDomain.ts
@@ -1,0 +1,78 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import {
+  domainExcludedTopics,
+  domains,
+  topicsToDomains,
+} from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const duplicateSchema = {
+  schema: {
+    description: "Duplicate a domain by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:id/duplicate",
+    duplicateSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const source = await db.query.domains.findFirst({
+        where: (d, {
+          eq,
+        }) => eq(d.id, id),
+        with: {
+          topicsToDomains: true,
+          excludedTopics: true,
+        },
+      });
+
+      if (!source) {
+        reply.status(404);
+        return {
+          error: "Domain not found",
+        };
+      }
+
+      const newId = uuidv4();
+      await db.insert(domains).values({
+        id: newId,
+        title: `${source.title} (Copy)`,
+        description: source.description ?? null,
+        hasRadar: source.hasRadar ?? null,
+      });
+
+      const topicLinks = (source.topicsToDomains ?? []).map(t => ({
+        topicId: t.topicId,
+        domainId: newId,
+      }));
+      if (topicLinks.length > 0) {
+        await db.insert(topicsToDomains).values(topicLinks);
+      }
+
+      const exclusions = (source.excludedTopics ?? []).map(e => ({
+        topicId: e.topicId,
+        domainId: newId,
+        reason: e.reason ?? null,
+      }));
+      if (exclusions.length > 0) {
+        await db.insert(domainExcludedTopics).values(exclusions);
+      }
+
+      return {
+        status: "ok",
+        id: newId,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -57,6 +57,36 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          radarBlips: {
+            with: {
+              topic: {
+                with: {
+                  topicsToCourses: {
+                    with: {
+                      course: {
+                        columns: {
+                          id: true,
+                          name: true,
+                          progressCurrent: true,
+                          progressTotal: true,
+                          status: true,
+                        },
+                        with: {
+                          dailies: {
+                            columns: {
+                              id: true,
+                              name: true,
+                              completions: true,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
           excludedTopics: {
             with: {
               topic: {
@@ -78,30 +108,63 @@ export default async function (server: FastifyInstance) {
         };
       }
 
-      const topics = domain.topicsToDomains
-        .map((ttd) => {
-          if (!ttd.topic) {
-            return null;
-          }
-          const courses = (ttd.topic.topicsToCourses ?? [])
-            .map(ttc => ttc.course)
-            .filter((c): c is NonNullable<typeof c> => Boolean(c))
-            .map(c => ({
-              id: c.id,
-              name: c.name,
-              progressCurrent: c.progressCurrent ?? null,
-              progressTotal: c.progressTotal ?? null,
-              status: c.status ?? null,
-            }));
-          return {
-            id: ttd.topic.id,
-            name: ttd.topic.name,
-            description: ttd.topic.description ?? null,
-            reason: ttd.topic.reason ?? null,
-            courses,
-          };
-        })
-        .filter((t): t is NonNullable<typeof t> => Boolean(t));
+      const topicsById = new Map<string, {
+        id: string;
+        name: string;
+        description: string | null;
+        reason: string | null;
+        courses: {
+          id: string;
+          name: string;
+          progressCurrent: number | null;
+          progressTotal: number | null;
+          status: string | null;
+        }[];
+      }>();
+
+      function addTopic(topic: {
+        id: string;
+        name: string;
+        description?: string | null;
+        reason?: string | null;
+        topicsToCourses?: { course: {
+          id: string;
+          name: string;
+          progressCurrent: number | null;
+          progressTotal: number | null;
+          status: string | null;
+        } | null; }[];
+      } | null | undefined) {
+        if (!topic || topicsById.has(topic.id)) {
+          return;
+        }
+        const courses = (topic.topicsToCourses ?? [])
+          .map(ttc => ttc.course)
+          .filter((c): c is NonNullable<typeof c> => Boolean(c))
+          .map(c => ({
+            id: c.id,
+            name: c.name,
+            progressCurrent: c.progressCurrent ?? null,
+            progressTotal: c.progressTotal ?? null,
+            status: c.status ?? null,
+          }));
+        topicsById.set(topic.id, {
+          id: topic.id,
+          name: topic.name,
+          description: topic.description ?? null,
+          reason: topic.reason ?? null,
+          courses,
+        });
+      }
+
+      for (const ttd of domain.topicsToDomains) {
+        addTopic(ttd.topic);
+      }
+      for (const blip of domain.radarBlips ?? []) {
+        addTopic(blip.topic);
+      }
+
+      const topics = Array.from(topicsById.values());
 
       const excludedTopics = (domain.excludedTopics ?? [])
         .map((row) => {
@@ -116,24 +179,50 @@ export default async function (server: FastifyInstance) {
         })
         .filter((row): row is NonNullable<typeof row> => Boolean(row));
 
-      const dailySource = domain.topicsToDomains.flatMap((ttd) => {
-        if (!ttd.topic) {
-          return [];
-        }
-        return (ttd.topic.topicsToCourses ?? []).flatMap((ttc) => {
+      const dailySourceMap = new Map<string, {
+        id: string;
+        name: string;
+        completions: DailyCompletion[];
+        courseId: string;
+        courseName: string;
+      }>();
+
+      function addDailiesFromTopic(topic: {
+        topicsToCourses?: { course: {
+          id: string;
+          name: string;
+          dailies?: {
+            id: string;
+            name: string;
+            completions?: DailyCompletion[] | null;
+          }[];
+        } | null; }[];
+      } | null | undefined) {
+        if (!topic) return;
+        for (const ttc of topic.topicsToCourses ?? []) {
           const course = ttc.course;
-          if (!course) {
-            return [];
+          if (!course) continue;
+          for (const d of course.dailies ?? []) {
+            if (dailySourceMap.has(d.id)) continue;
+            dailySourceMap.set(d.id, {
+              id: d.id,
+              name: d.name,
+              completions: (d.completions ?? []) as DailyCompletion[],
+              courseId: course.id,
+              courseName: course.name,
+            });
           }
-          return (course.dailies ?? []).map(d => ({
-            id: d.id,
-            name: d.name,
-            completions: (d.completions ?? []) as DailyCompletion[],
-            courseId: course.id,
-            courseName: course.name,
-          }));
-        });
-      });
+        }
+      }
+
+      for (const ttd of domain.topicsToDomains) {
+        addDailiesFromTopic(ttd.topic);
+      }
+      for (const blip of domain.radarBlips ?? []) {
+        addDailiesFromTopic(blip.topic);
+      }
+
+      const dailySource = Array.from(dailySourceMap.values());
 
       const learningLog: LearningLogEntry[] = buildDomainLearningLog(
         domain.learningLogEntries ?? [],

--- a/packages/middleware/src/routes/api/domains/root.ts
+++ b/packages/middleware/src/routes/api/domains/root.ts
@@ -16,18 +16,29 @@ export default async function (server: FastifyInstance) {
               topicId: true,
             },
           },
+          radarBlips: {
+            columns: {
+              topicId: true,
+            },
+          },
         },
       });
 
       const processedData: Partial<Domain>[] = rawData.map((domain) => {
-        const topicCount = domain.topicsToDomains?.length ?? 0;
+        const topicIds = new Set<string>();
+        for (const ttd of domain.topicsToDomains ?? []) {
+          topicIds.add(ttd.topicId);
+        }
+        for (const blip of domain.radarBlips ?? []) {
+          topicIds.add(blip.topicId);
+        }
 
         return {
           id: domain.id,
           title: domain.title,
           description: domain.description,
           hasRadar: domain.hasRadar,
-          topicCount: topicCount,
+          topicCount: topicIds.size,
         };
       });
 

--- a/packages/middleware/src/routes/api/domains/routes.ts
+++ b/packages/middleware/src/routes/api/domains/routes.ts
@@ -6,6 +6,7 @@ import getDomain from "./getDomain";
 import createDomain from "./createDomain";
 import upsertDomain from "./upsertDomain";
 import deleteDomain from "./deleteDomain";
+import duplicateDomain from "./duplicateDomain";
 import learningLogEntries from "./learningLogEntries";
 
 export default async function (server: FastifyInstance) {
@@ -16,5 +17,6 @@ export default async function (server: FastifyInstance) {
   fastify.register(createDomain);
   fastify.register(upsertDomain);
   fastify.register(deleteDomain);
+  fastify.register(duplicateDomain);
   fastify.register(learningLogEntries);
 }

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -15,6 +15,7 @@ const upsertSchema = {
       properties: {
         title: {
           type: "string",
+          minLength: 1,
         },
         description: nullableString,
         hasRadar: nullableBoolean,
@@ -54,9 +55,17 @@ export default async function (server: FastifyInstance) {
       } = request.params;
       const body = request.body;
 
+      const title = body.title.trim();
+      if (!title) {
+        reply.status(400);
+        return {
+          error: "Title is required",
+        };
+      }
+
       const domainData = {
         id,
-        title: body.title,
+        title,
         description: body.description ?? null,
         hasRadar: body.hasRadar ?? null,
       };

--- a/packages/middleware/src/routes/api/topics/createTopic.ts
+++ b/packages/middleware/src/routes/api/topics/createTopic.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { topics } from "@/db/schema";
+import { topics, topicsToDomains } from "@/db/schema";
 import { nullableString } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -14,9 +14,16 @@ const createSchema = {
       properties: {
         name: {
           type: "string",
+          minLength: 1,
         },
         description: nullableString,
         reason: nullableString,
+        domainIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
       },
     },
   },
@@ -38,6 +45,16 @@ export default async function (server: FastifyInstance) {
         description: body.description ?? null,
         reason: body.reason ?? null,
       });
+
+      const uniqueDomainIds = Array.from(new Set(body.domainIds ?? []));
+      if (uniqueDomainIds.length > 0) {
+        await db.insert(topicsToDomains).values(
+          uniqueDomainIds.map(domainId => ({
+            topicId: id,
+            domainId,
+          })),
+        );
+      }
 
       return {
         status: "ok",

--- a/packages/middleware/src/routes/api/topics/deleteTopic.ts
+++ b/packages/middleware/src/routes/api/topics/deleteTopic.ts
@@ -1,12 +1,45 @@
-import { topics, topicsToCourses } from "@/db/schema";
-import { createDeleteHandler } from "@/utils/createDeleteHandler";
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import {
+  domainExcludedTopics,
+  radarBlips,
+  topics,
+  topicsToCourses,
+  topicsToDomains,
+} from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
 
-export default createDeleteHandler({
-  description: "Delete a topic by ID",
-  table: topics,
-  idColumn: topics.id,
-  junction: {
-    table: topicsToCourses,
-    foreignKey: topicsToCourses.topicId,
+const deleteSchema = {
+  schema: {
+    description: "Delete a topic by ID",
+    params: idParamSchema,
   },
-});
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete("/:id", deleteSchema, async function (request) {
+    const {
+      id,
+    } = request.params;
+
+    await db.delete(radarBlips).where(eq(radarBlips.topicId, id));
+    await db
+      .delete(topicsToCourses)
+      .where(eq(topicsToCourses.topicId, id));
+    await db
+      .delete(topicsToDomains)
+      .where(eq(topicsToDomains.topicId, id));
+    await db
+      .delete(domainExcludedTopics)
+      .where(eq(domainExcludedTopics.topicId, id));
+    await db.delete(topics).where(eq(topics.id, id));
+
+    return {
+      status: "ok",
+    };
+  });
+}

--- a/packages/middleware/src/routes/api/topics/getTopic.ts
+++ b/packages/middleware/src/routes/api/topics/getTopic.ts
@@ -1,7 +1,6 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { TopicsFromServer } from "@emstack/types/src/TopicsFromServer";
 import { processCourses } from "@/utils/processCourses";
 import { idParamSchema } from "@/utils/schemas";
 
@@ -22,10 +21,10 @@ export default async function (server: FastifyInstance) {
       const {
         id,
       } = request.params;
-      const topic: TopicsFromServer | undefined = await db.query.topics.findFirst({
-        where: (courses, {
+      const topic = await db.query.topics.findFirst({
+        where: (topics, {
           eq,
-        }) => (eq(courses.id, id)),
+        }) => (eq(topics.id, id)),
         with: {
           topicsToCourses: {
             with: {
@@ -37,12 +36,59 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          topicsToDomains: {
+            with: {
+              domain: {
+                columns: {
+                  id: true,
+                  title: true,
+                  hasRadar: true,
+                },
+              },
+            },
+          },
+          radarBlips: {
+            with: {
+              domain: {
+                columns: {
+                  id: true,
+                  title: true,
+                  hasRadar: true,
+                },
+              },
+            },
+          },
         },
       });
 
       if (topic) {
         const courseCount = topic.topicsToCourses?.length ?? 0;
         const courses = processCourses(topic.topicsToCourses);
+
+        const domainsById = new Map<string, {
+          id: string;
+          title: string;
+          hasRadar: boolean | null;
+        }>();
+        for (const ttd of topic.topicsToDomains ?? []) {
+          if (ttd.domain && !domainsById.has(ttd.domain.id)) {
+            domainsById.set(ttd.domain.id, {
+              id: ttd.domain.id,
+              title: ttd.domain.title,
+              hasRadar: ttd.domain.hasRadar ?? null,
+            });
+          }
+        }
+        for (const blip of topic.radarBlips ?? []) {
+          if (blip.domain && !domainsById.has(blip.domain.id)) {
+            domainsById.set(blip.domain.id, {
+              id: blip.domain.id,
+              title: blip.domain.title,
+              hasRadar: blip.domain.hasRadar ?? null,
+            });
+          }
+        }
+        const domains = Array.from(domainsById.values());
 
         return {
           id: topic.id,
@@ -51,6 +97,7 @@ export default async function (server: FastifyInstance) {
           reason: topic.reason,
           courseCount: courseCount,
           courses: courses,
+          domains,
         };
       }
     },

--- a/packages/middleware/src/routes/api/topics/upsertTopic.ts
+++ b/packages/middleware/src/routes/api/topics/upsertTopic.ts
@@ -1,8 +1,9 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { topics } from "@/db/schema";
+import { topics, topicsToDomains } from "@/db/schema";
 import { idParamSchema, nullableString } from "@/utils/schemas";
+import { syncJunctionTable } from "@/utils/syncJunctionTable";
 
 const upsertSchema = {
   schema: {
@@ -14,9 +15,16 @@ const upsertSchema = {
       properties: {
         name: {
           type: "string",
+          minLength: 1,
         },
         description: nullableString,
         reason: nullableString,
+        domainIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
       },
     },
   },
@@ -52,6 +60,19 @@ export default async function (server: FastifyInstance) {
             reason: topicData.reason,
           },
         });
+
+      if (body.domainIds !== undefined) {
+        const uniqueDomainIds = Array.from(new Set(body.domainIds));
+        await syncJunctionTable(
+          topicsToDomains,
+          topicsToDomains.topicId,
+          id,
+          uniqueDomainIds.map(domainId => ({
+            topicId: id,
+            domainId,
+          })),
+        );
+      }
 
       return {
         status: "ok",

--- a/packages/types/src/Topic.ts
+++ b/packages/types/src/Topic.ts
@@ -1,5 +1,11 @@
 import { Course } from "@/Course";
 
+export interface TopicDomain {
+  id: string;
+  title: string;
+  hasRadar?: boolean | null;
+}
+
 export interface Topic {
   id: string;
   name: string;
@@ -7,4 +13,5 @@ export interface Topic {
   reason?: string | null;
   courseCount?: number;
   courses?: Course[];
+  domains?: TopicDomain[];
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to duplicate domains, courses, and dailies, and introduces support for radar blips as an alternative way to associate topics with domains. It also improves topic management by allowing topics to be linked to domains during creation/editing.

## Key Changes

### Duplicate Functionality
- Added `POST /:id/duplicate` endpoints for domains, courses, and dailies
- Duplicates copy all relevant data and relationships (e.g., topic associations, excluded topics)
- New duplicated items are appended with "(Copy)" suffix
- Client-side UI buttons added to domain, course, and daily detail pages with success/error handling

### Radar Blips Support
- Extended domain queries to include `radarBlips` relationship alongside `topicsToDomains`
- Topics can now be associated with domains through either `topicsToDomains` or `radarBlips` tables
- Updated `getDomain` endpoint to deduplicate topics from both sources
- Updated `deleteTopic` to cascade delete radar blips when a topic is deleted
- Modified domain listing to count unique topics from both associations

### Topic-Domain Linking
- Topics can now be directly linked to domains during creation and editing
- Added `domainIds` field to topic create/upsert endpoints
- Updated `getTopic` endpoint to return associated domains (from both `topicsToDomains` and `radarBlips`)
- Added domains display section to topic detail page

### Data Validation & Deduplication
- Added `minLength: 1` validation for domain and topic titles
- Implemented deduplication logic for topic and excluded topic arrays in domain creation
- Added trim() validation for domain titles to prevent whitespace-only entries
- Refactored daily and topic processing to use Map-based deduplication to prevent duplicates from multiple sources

### Type Updates
- Extended `Topic` type to include optional `domains` array with `TopicDomain` interface
- Updated `TopicsFromServer` type usage in getTopic endpoint

### Code Refactoring
- Extracted topic and daily processing into reusable helper functions (`addTopic`, `addDailiesFromTopic`)
- Improved query efficiency by using Maps for deduplication instead of filtering arrays

https://claude.ai/code/session_018NdtbKWbVwEAMmh8b3fyT1