### PR TITLE
Add Tasks page and extend Dailies with status, criteria, and task link

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -23,6 +23,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
+  getReferenceDateKey,
   getTodayKey,
   shiftDateKey,
   upsertDaily,
@@ -118,7 +119,10 @@ export function DailyCompletionsManager({
   readOnly = false,
 }: DailyCompletionsManagerProps) {
   const queryClient = useQueryClient();
-  const todayKey = getTodayKey();
+  const isComplete = daily.status === "complete";
+  const effectiveReadOnly = readOnly || isComplete;
+  const todayKey = getReferenceDateKey(daily);
+  const realToday = getTodayKey();
   const currentMonth = getMonthFromKey(todayKey);
 
   const [viewMonth, setViewMonth] = useState<ViewMonth>(currentMonth);
@@ -217,7 +221,7 @@ export function DailyCompletionsManager({
               >
                 <CalendarIcon className="mr-2 size-4" />
                 {isCurrentMonth
-                  ? "Last 30 days"
+                  ? (isComplete ? "Last 30 days (final)" : "Last 30 days")
                   : formatMonthLabel(viewMonth.year, viewMonth.month)}
               </Button>
             </PopoverTrigger>
@@ -263,9 +267,9 @@ export function DailyCompletionsManager({
             const status = entry?.status ?? null;
             const note = entry?.note ?? null;
             const hasStatusEntry = status !== null;
-            const isFuture = dateKey > todayKey;
-            const isToday = dateKey === todayKey;
-            const isEditable = !readOnly || isToday;
+            const isFuture = dateKey > realToday;
+            const isToday = dateKey === realToday;
+            const isEditable = !effectiveReadOnly && (!readOnly || isToday);
             const hasActions = isEditable && !isFuture;
             const isExpanded = expandedDateKey === dateKey;
             const nextDateKey = visibleDateKeys[i + 1];

--- a/packages/client/src/components/dailies/DailyLocationCell.tsx
+++ b/packages/client/src/components/dailies/DailyLocationCell.tsx
@@ -1,14 +1,39 @@
+import { Link } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
 
 import { isHttpUrl } from "@/utils/isHttpUrl";
 
 interface DailyLocationCellProps {
   location?: string | null;
+  taskId?: string | null;
 }
+
+const goButtonClasses = `
+  inline-flex items-center gap-1 rounded-md border border-input
+  bg-background px-2 py-1 text-xs font-medium text-foreground
+  hover:bg-accent hover:text-accent-foreground
+`;
 
 export function DailyLocationCell({
   location,
+  taskId,
 }: DailyLocationCellProps) {
+  if (taskId) {
+    return (
+      <Link
+        to="/tasks/$id"
+        params={{
+          id: taskId,
+        }}
+        className={goButtonClasses}
+        title="Go to linked task"
+      >
+        Go
+        <ChevronRightIcon className="size-3.5" />
+      </Link>
+    );
+  }
+
   if (!location) {
     return null;
   }
@@ -19,11 +44,7 @@ export function DailyLocationCell({
         href={location}
         target="_blank"
         rel="noreferrer"
-        className="
-          inline-flex items-center gap-1 rounded-md border border-input
-          bg-background px-2 py-1 text-xs font-medium text-foreground
-          hover:bg-accent hover:text-accent-foreground
-        "
+        className={goButtonClasses}
       >
         Go
         <ChevronRightIcon className="size-3.5" />

--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -7,7 +7,7 @@ import { DailyStatusCircle } from "./DailyStatusCircle";
 import { DailyStatusConnector } from "./DailyStatusConnector";
 
 import { cn } from "@/lib/utils";
-import { getRecentDays, getTodayKey } from "@/utils/dailyHelpers";
+import { getReferenceDateKey, getRecentDays } from "@/utils/dailyHelpers";
 
 interface DailyRecentDaysStripProps {
   daily: Daily;
@@ -36,7 +36,7 @@ export function DailyRecentDaysStrip({
   size = "lg",
   showLabels = true,
 }: DailyRecentDaysStripProps) {
-  const days = getRecentDays(daily, count, getTodayKey(), labelFormat);
+  const days = getRecentDays(daily, count, getReferenceDateKey(daily), labelFormat);
 
   return (
     <div

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   pageTitle?: string;
-  pageSection?: "" | "courses" | "topics" | "providers" | "domains" | "dailies";
+  pageSection?: "" | "courses" | "topics" | "providers" | "domains" | "dailies" | "tasks";
   children?: React.ReactNode;
   progressCurrent?: number;
   progressTotal?: number;
@@ -71,6 +71,14 @@ export function PageHeader({
                   className="text-sm uppercase"
                 >
                   Dailies
+                </Link>
+              )}
+              {pageSection === "tasks" && (
+                <Link
+                  to="/tasks"
+                  className="text-sm uppercase"
+                >
+                  Tasks
                 </Link>
               )}
             </div>

--- a/packages/client/src/components/tasks/ResourcesEditor.tsx
+++ b/packages/client/src/components/tasks/ResourcesEditor.tsx
@@ -1,0 +1,252 @@
+import type { Resource, ResourceLevel } from "@emstack/types/src";
+
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { RESOURCE_LEVEL_OPTIONS } from "./resourceMeta";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { uuidv4 } from "@/utils/uuid";
+
+export type DraftResource = Pick<
+  Resource,
+  | "id"
+  | "name"
+  | "url"
+  | "easeOfStarting"
+  | "timeNeeded"
+  | "interactivity"
+  | "usedYet"
+>;
+
+interface ResourcesEditorProps {
+  resources: DraftResource[];
+  onChange: (resources: DraftResource[]) => void;
+}
+
+const NONE_VALUE = "__none";
+
+function emptyResource(): DraftResource {
+  return {
+    id: uuidv4(),
+    name: "",
+    url: "",
+    easeOfStarting: null,
+    timeNeeded: null,
+    interactivity: null,
+    usedYet: false,
+  };
+}
+
+function LevelSelect({
+  value,
+  onValueChange,
+  ariaLabel,
+}: {
+  value: ResourceLevel | null | undefined;
+  onValueChange: (next: ResourceLevel | null) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <Select
+      value={value ?? NONE_VALUE}
+      onValueChange={(v) => {
+        onValueChange(v === NONE_VALUE ? null : (v as ResourceLevel));
+      }}
+    >
+      <SelectTrigger
+        size="sm"
+        aria-label={ariaLabel}
+        className="w-full"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={NONE_VALUE}>—</SelectItem>
+        {RESOURCE_LEVEL_OPTIONS.map(opt => (
+          <SelectItem
+            key={opt.value}
+            value={opt.value}
+          >
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function ResourcesEditor({
+  resources,
+  onChange,
+}: ResourcesEditorProps) {
+  function update(index: number, patch: Partial<DraftResource>) {
+    const next = resources.map((r, i) => (i === index
+      ? {
+        ...r,
+        ...patch,
+      }
+      : r));
+    onChange(next);
+  }
+
+  function remove(index: number) {
+    onChange(resources.filter((_, i) => i !== index));
+  }
+
+  function add() {
+    onChange([...resources, emptyResource()]);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {resources.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          <i>No resources yet. Add one below.</i>
+        </p>
+      )}
+      {resources.map((r, i) => (
+        <div
+          key={r.id}
+          className="flex flex-col gap-2 rounded-md border bg-card p-3"
+        >
+          <div
+            className="
+              grid grid-cols-1 gap-2
+              md:grid-cols-2
+            "
+          >
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor={`resource-name-${r.id}`}
+              >
+                Name
+              </label>
+              <input
+                id={`resource-name-${r.id}`}
+                type="text"
+                value={r.name}
+                onChange={e => update(i, {
+                  name: e.target.value,
+                })}
+                className="
+                  rounded-md border border-input bg-background px-2 py-1 text-sm
+                  shadow-xs
+                  focus-visible:border-ring focus-visible:ring-[3px]
+                  focus-visible:ring-ring/50 focus-visible:outline-none
+                "
+                placeholder="Resource name"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor={`resource-url-${r.id}`}
+              >
+                URL (optional)
+              </label>
+              <input
+                id={`resource-url-${r.id}`}
+                type="url"
+                value={r.url ?? ""}
+                onChange={e => update(i, {
+                  url: e.target.value,
+                })}
+                className="
+                  rounded-md border border-input bg-background px-2 py-1 text-sm
+                  shadow-xs
+                  focus-visible:border-ring focus-visible:ring-[3px]
+                  focus-visible:ring-ring/50 focus-visible:outline-none
+                "
+                placeholder="https://..."
+              />
+            </div>
+          </div>
+          <div
+            className="
+              grid grid-cols-1 gap-2
+              md:grid-cols-3
+            "
+          >
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                Ease of Starting
+              </label>
+              <LevelSelect
+                value={r.easeOfStarting}
+                onValueChange={v => update(i, {
+                  easeOfStarting: v,
+                })}
+                ariaLabel={`Ease of starting for ${r.name || "resource"}`}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                Time Needed
+              </label>
+              <LevelSelect
+                value={r.timeNeeded}
+                onValueChange={v => update(i, {
+                  timeNeeded: v,
+                })}
+                ariaLabel={`Time needed for ${r.name || "resource"}`}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                Interactivity
+              </label>
+              <LevelSelect
+                value={r.interactivity}
+                onValueChange={v => update(i, {
+                  interactivity: v,
+                })}
+                ariaLabel={`Interactivity for ${r.name || "resource"}`}
+              />
+            </div>
+          </div>
+          <div className="flex flex-row items-center justify-between gap-2">
+            <label className="inline-flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={r.usedYet}
+                onChange={e => update(i, {
+                  usedYet: e.target.checked,
+                })}
+                className="size-4"
+              />
+              <span>Used yet?</span>
+            </label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => remove(i)}
+              className="text-destructive"
+            >
+              <Trash2Icon className="size-4" />
+              Remove
+            </Button>
+          </div>
+        </div>
+      ))}
+      <div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={add}
+        >
+          <PlusIcon className="size-4" />
+          Add Resource
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/tasks/ResourcesTable.tsx
+++ b/packages/client/src/components/tasks/ResourcesTable.tsx
@@ -1,0 +1,161 @@
+import type { Resource, Task } from "@emstack/types/src";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ExternalLinkIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { getResourceLevelClass, getResourceLevelLabel } from "./resourceMeta";
+
+import { cn } from "@/lib/utils";
+import { isHttpUrl, upsertTask } from "@/utils";
+
+interface ResourcesTableProps {
+  task: Task;
+}
+
+function LevelBadge({
+  level,
+}: {
+  level: Resource["easeOfStarting"];
+}) {
+  return (
+    <span
+      className={cn(
+        `
+          inline-flex items-center rounded-full border px-2 py-0.5 text-xs
+          font-medium
+        `,
+        getResourceLevelClass(level),
+      )}
+    >
+      {getResourceLevelLabel(level)}
+    </span>
+  );
+}
+
+export function ResourcesTable({
+  task,
+}: ResourcesTableProps) {
+  const queryClient = useQueryClient();
+  const resources = task.resources ?? [];
+
+  const mutation = useMutation({
+    mutationFn: (next: Resource[]) =>
+      upsertTask(task.id, {
+        name: task.name,
+        description: task.description ?? null,
+        topicId: task.topicId ?? null,
+        resources: next.map(r => ({
+          id: r.id,
+          name: r.name,
+          url: r.url ?? null,
+          easeOfStarting: r.easeOfStarting ?? null,
+          timeNeeded: r.timeNeeded ?? null,
+          interactivity: r.interactivity ?? null,
+          usedYet: r.usedYet,
+        })),
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["task", task.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["tasks"],
+        }),
+      ]);
+    },
+    onError: () => {
+      toast.error("Failed to update resource.");
+    },
+  });
+
+  function handleToggleUsed(resourceId: string, nextUsed: boolean) {
+    const next = resources.map(r =>
+      r.id === resourceId
+        ? {
+          ...r,
+          usedYet: nextUsed,
+        }
+        : r);
+    mutation.mutate(next);
+  }
+
+  if (resources.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        <i>No resources yet. Add some when you edit this task.</i>
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="text-left text-xs text-muted-foreground">
+            <th className="p-2 font-medium">Name</th>
+            <th className="p-2 font-medium whitespace-nowrap">Ease of Starting</th>
+            <th className="p-2 font-medium whitespace-nowrap">Time Needed</th>
+            <th className="p-2 font-medium">Interactivity</th>
+            <th className="p-2 font-medium whitespace-nowrap">Used yet?</th>
+          </tr>
+        </thead>
+        <tbody>
+          {resources.map(r => (
+            <tr
+              key={r.id}
+              className="border-t"
+            >
+              <td className="p-2 align-top">
+                {r.url && isHttpUrl(r.url)
+                  ? (
+                    <a
+                      href={r.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="
+                        inline-flex items-center gap-1 font-medium text-blue-700
+                        hover:text-blue-500
+                        dark:text-blue-300
+                      "
+                    >
+                      {r.name}
+                      <ExternalLinkIcon className="size-3.5" />
+                    </a>
+                  )
+                  : (
+                    <span className="font-medium">{r.name}</span>
+                  )}
+              </td>
+              <td className="p-2 align-top">
+                <LevelBadge level={r.easeOfStarting} />
+              </td>
+              <td className="p-2 align-top">
+                <LevelBadge level={r.timeNeeded} />
+              </td>
+              <td className="p-2 align-top">
+                <LevelBadge level={r.interactivity} />
+              </td>
+              <td className="p-2 align-top">
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={r.usedYet}
+                    disabled={mutation.isPending}
+                    onChange={e => handleToggleUsed(r.id, e.target.checked)}
+                    className="size-4"
+                    aria-label={`Mark ${r.name} as used`}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    {r.usedYet ? "Used" : "Not yet"}
+                  </span>
+                </label>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/client/src/components/tasks/resourceMeta.ts
+++ b/packages/client/src/components/tasks/resourceMeta.ts
@@ -1,0 +1,41 @@
+import type { ResourceLevel } from "@emstack/types/src";
+
+export const RESOURCE_LEVEL_OPTIONS: { value: ResourceLevel;
+  label: string; }[] = [
+  {
+    value: "low",
+    label: "Low",
+  },
+  {
+    value: "medium",
+    label: "Medium",
+  },
+  {
+    value: "high",
+    label: "High",
+  },
+];
+
+export function getResourceLevelLabel(
+  level: ResourceLevel | null | undefined,
+): string {
+  if (!level) {
+    return "—";
+  }
+  return RESOURCE_LEVEL_OPTIONS.find(o => o.value === level)?.label ?? level;
+}
+
+export function getResourceLevelClass(
+  level: ResourceLevel | null | undefined,
+): string {
+  switch (level) {
+    case "low":
+      return "bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-900/40 dark:text-emerald-200";
+    case "medium":
+      return "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/40 dark:text-amber-200";
+    case "high":
+      return "bg-rose-100 text-rose-800 border-rose-300 dark:bg-rose-900/40 dark:text-rose-200";
+    default:
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+  }
+}

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TopicsRouteImport } from './routes/topics'
+import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
 import { Route as DomainsRouteImport } from './routes/domains'
@@ -18,21 +19,25 @@ import { Route as DailiesRouteImport } from './routes/dailies'
 import { Route as CoursesRouteImport } from './routes/courses'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
+import { Route as TasksIndexRouteImport } from './routes/tasks.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as DomainsIndexRouteImport } from './routes/domains.index'
 import { Route as DailiesIndexRouteImport } from './routes/dailies.index'
 import { Route as CoursesIndexRouteImport } from './routes/courses.index'
 import { Route as TopicsIdRouteImport } from './routes/topics.$id'
+import { Route as TasksIdRouteImport } from './routes/tasks.$id'
 import { Route as ProvidersIdRouteImport } from './routes/providers.$id'
 import { Route as DomainsIdRouteImport } from './routes/domains.$id'
 import { Route as DailiesIdRouteImport } from './routes/dailies.$id'
 import { Route as CoursesIdRouteImport } from './routes/courses.$id'
 import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
+import { Route as TasksIdIndexRouteImport } from './routes/tasks.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
 import { Route as DomainsIdIndexRouteImport } from './routes/domains.$id.index'
 import { Route as DailiesIdIndexRouteImport } from './routes/dailies.$id.index'
 import { Route as CoursesIdIndexRouteImport } from './routes/courses.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
+import { Route as TasksIdEditRouteImport } from './routes/tasks.$id.edit'
 import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
 import { Route as DomainsIdRadarRouteImport } from './routes/domains.$id.radar'
 import { Route as DomainsIdEditRouteImport } from './routes/domains.$id.edit'
@@ -44,6 +49,11 @@ import { Route as DomainsIdRadarEditRouteImport } from './routes/domains.$id.rad
 const TopicsRoute = TopicsRouteImport.update({
   id: '/topics',
   path: '/topics',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TasksRoute = TasksRouteImport.update({
+  id: '/tasks',
+  path: '/tasks',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProvidersRoute = ProvidersRouteImport.update({
@@ -86,6 +96,11 @@ const TopicsIndexRoute = TopicsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => TopicsRoute,
 } as any)
+const TasksIndexRoute = TasksIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => TasksRoute,
+} as any)
 const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -110,6 +125,11 @@ const TopicsIdRoute = TopicsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => TopicsRoute,
+} as any)
+const TasksIdRoute = TasksIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => TasksRoute,
 } as any)
 const ProvidersIdRoute = ProvidersIdRouteImport.update({
   id: '/$id',
@@ -136,6 +156,11 @@ const TopicsIdIndexRoute = TopicsIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => TopicsIdRoute,
 } as any)
+const TasksIdIndexRoute = TasksIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => TasksIdRoute,
+} as any)
 const ProvidersIdIndexRoute = ProvidersIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -160,6 +185,11 @@ const TopicsIdEditRoute = TopicsIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
   getParentRoute: () => TopicsIdRoute,
+} as any)
+const TasksIdEditRoute = TasksIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => TasksIdRoute,
 } as any)
 const ProvidersIdEditRoute = ProvidersIdEditRouteImport.update({
   id: '/edit',
@@ -205,27 +235,32 @@ export interface FileRoutesByFullPath {
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
+  '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
   '/dailies/$id': typeof DailiesIdRouteWithChildren
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
+  '/tasks/$id': typeof TasksIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
   '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/tasks/': typeof TasksIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
+  '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
+  '/tasks/$id/': typeof TasksIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
   '/domains/$id/radar/': typeof DomainsIdRadarIndexRoute
@@ -238,16 +273,19 @@ export interface FileRoutesByTo {
   '/dailies': typeof DailiesIndexRoute
   '/domains': typeof DomainsIndexRoute
   '/providers': typeof ProvidersIndexRoute
+  '/tasks': typeof TasksIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
+  '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id': typeof CoursesIdIndexRoute
   '/dailies/$id': typeof DailiesIdIndexRoute
   '/domains/$id': typeof DomainsIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
+  '/tasks/$id': typeof TasksIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
   '/domains/$id/radar': typeof DomainsIdRadarIndexRoute
@@ -261,27 +299,32 @@ export interface FileRoutesById {
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
+  '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
   '/dailies/$id': typeof DailiesIdRouteWithChildren
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
+  '/tasks/$id': typeof TasksIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/courses/': typeof CoursesIndexRoute
   '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
+  '/tasks/': typeof TasksIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/courses/$id/edit': typeof CoursesIdEditRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
+  '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/courses/$id/': typeof CoursesIdIndexRoute
   '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
+  '/tasks/$id/': typeof TasksIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
   '/domains/$id/radar/': typeof DomainsIdRadarIndexRoute
@@ -296,27 +339,32 @@ export interface FileRouteTypes {
     | '/domains'
     | '/onboard'
     | '/providers'
+    | '/tasks'
     | '/topics'
     | '/courses/$id'
     | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
+    | '/tasks/$id'
     | '/topics/$id'
     | '/courses/'
     | '/dailies/'
     | '/domains/'
     | '/providers/'
+    | '/tasks/'
     | '/topics/'
     | '/courses/$id/edit'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/domains/$id/radar'
     | '/providers/$id/edit'
+    | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
     | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
+    | '/tasks/$id/'
     | '/topics/$id/'
     | '/domains/$id/radar/edit'
     | '/domains/$id/radar/'
@@ -329,16 +377,19 @@ export interface FileRouteTypes {
     | '/dailies'
     | '/domains'
     | '/providers'
+    | '/tasks'
     | '/topics'
     | '/courses/$id/edit'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/providers/$id/edit'
+    | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id'
     | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
+    | '/tasks/$id'
     | '/topics/$id'
     | '/domains/$id/radar/edit'
     | '/domains/$id/radar'
@@ -351,27 +402,32 @@ export interface FileRouteTypes {
     | '/domains'
     | '/onboard'
     | '/providers'
+    | '/tasks'
     | '/topics'
     | '/courses/$id'
     | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
+    | '/tasks/$id'
     | '/topics/$id'
     | '/courses/'
     | '/dailies/'
     | '/domains/'
     | '/providers/'
+    | '/tasks/'
     | '/topics/'
     | '/courses/$id/edit'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/domains/$id/radar'
     | '/providers/$id/edit'
+    | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/courses/$id/'
     | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
+    | '/tasks/$id/'
     | '/topics/$id/'
     | '/domains/$id/radar/edit'
     | '/domains/$id/radar/'
@@ -385,6 +441,7 @@ export interface RootRouteChildren {
   DomainsRoute: typeof DomainsRouteWithChildren
   OnboardRoute: typeof OnboardRoute
   ProvidersRoute: typeof ProvidersRouteWithChildren
+  TasksRoute: typeof TasksRouteWithChildren
   TopicsRoute: typeof TopicsRouteWithChildren
 }
 
@@ -395,6 +452,13 @@ declare module '@tanstack/react-router' {
       path: '/topics'
       fullPath: '/topics'
       preLoaderRoute: typeof TopicsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tasks': {
+      id: '/tasks'
+      path: '/tasks'
+      fullPath: '/tasks'
+      preLoaderRoute: typeof TasksRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/providers': {
@@ -453,6 +517,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicsIndexRouteImport
       parentRoute: typeof TopicsRoute
     }
+    '/tasks/': {
+      id: '/tasks/'
+      path: '/'
+      fullPath: '/tasks/'
+      preLoaderRoute: typeof TasksIndexRouteImport
+      parentRoute: typeof TasksRoute
+    }
     '/providers/': {
       id: '/providers/'
       path: '/'
@@ -487,6 +558,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/topics/$id'
       preLoaderRoute: typeof TopicsIdRouteImport
       parentRoute: typeof TopicsRoute
+    }
+    '/tasks/$id': {
+      id: '/tasks/$id'
+      path: '/$id'
+      fullPath: '/tasks/$id'
+      preLoaderRoute: typeof TasksIdRouteImport
+      parentRoute: typeof TasksRoute
     }
     '/providers/$id': {
       id: '/providers/$id'
@@ -523,6 +601,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicsIdIndexRouteImport
       parentRoute: typeof TopicsIdRoute
     }
+    '/tasks/$id/': {
+      id: '/tasks/$id/'
+      path: '/'
+      fullPath: '/tasks/$id/'
+      preLoaderRoute: typeof TasksIdIndexRouteImport
+      parentRoute: typeof TasksIdRoute
+    }
     '/providers/$id/': {
       id: '/providers/$id/'
       path: '/'
@@ -557,6 +642,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/topics/$id/edit'
       preLoaderRoute: typeof TopicsIdEditRouteImport
       parentRoute: typeof TopicsIdRoute
+    }
+    '/tasks/$id/edit': {
+      id: '/tasks/$id/edit'
+      path: '/edit'
+      fullPath: '/tasks/$id/edit'
+      preLoaderRoute: typeof TasksIdEditRouteImport
+      parentRoute: typeof TasksIdRoute
     }
     '/providers/$id/edit': {
       id: '/providers/$id/edit'
@@ -735,6 +827,31 @@ const ProvidersRouteWithChildren = ProvidersRoute._addFileChildren(
   ProvidersRouteChildren,
 )
 
+interface TasksIdRouteChildren {
+  TasksIdEditRoute: typeof TasksIdEditRoute
+  TasksIdIndexRoute: typeof TasksIdIndexRoute
+}
+
+const TasksIdRouteChildren: TasksIdRouteChildren = {
+  TasksIdEditRoute: TasksIdEditRoute,
+  TasksIdIndexRoute: TasksIdIndexRoute,
+}
+
+const TasksIdRouteWithChildren =
+  TasksIdRoute._addFileChildren(TasksIdRouteChildren)
+
+interface TasksRouteChildren {
+  TasksIdRoute: typeof TasksIdRouteWithChildren
+  TasksIndexRoute: typeof TasksIndexRoute
+}
+
+const TasksRouteChildren: TasksRouteChildren = {
+  TasksIdRoute: TasksIdRouteWithChildren,
+  TasksIndexRoute: TasksIndexRoute,
+}
+
+const TasksRouteWithChildren = TasksRoute._addFileChildren(TasksRouteChildren)
+
 interface TopicsIdRouteChildren {
   TopicsIdEditRoute: typeof TopicsIdEditRoute
   TopicsIdIndexRoute: typeof TopicsIdIndexRoute
@@ -770,6 +887,7 @@ const rootRouteChildren: RootRouteChildren = {
   DomainsRoute: DomainsRouteWithChildren,
   OnboardRoute: OnboardRoute,
   ProvidersRoute: ProvidersRouteWithChildren,
+  TasksRoute: TasksRouteWithChildren,
   TopicsRoute: TopicsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -181,6 +181,17 @@ const RootComponent: React.FunctionComponent = () => {
           >
             Dailies
           </Link>
+
+          <Link
+            to="/tasks"
+            className={`
+              underline-offset-2
+              hover:underline
+              [&.active]:font-bold
+            `}
+          >
+            Tasks
+          </Link>
         </div>
         <div className="flex flex-row gap-2">
           <DropdownMenu>

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -17,6 +17,7 @@ import {
   fetchCourses,
   fetchProviders,
   fetchSingleDaily,
+  fetchTasks,
   formHasChanges,
   upsertDaily,
 } from "@/utils";
@@ -41,6 +42,12 @@ const formSchema = z.object({
   description: z.string().max(500),
   courseProviderId: z.string(),
   courseId: z.string(),
+  taskId: z.string(),
+  isComplete: z.boolean(),
+  criteriaIncomplete: z.string().max(500),
+  criteriaTouched: z.string().max(500),
+  criteriaGoal: z.string().max(500),
+  criteriaExceeded: z.string().max(500),
 });
 
 function SingleDailyEdit() {
@@ -76,6 +83,13 @@ function SingleDailyEdit() {
     queryFn: () => fetchCourses(),
   });
 
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
   const providerOptions = (providers ?? []).map(p => ({
     value: p.id,
     label: p.name,
@@ -84,6 +98,11 @@ function SingleDailyEdit() {
   const courseOptions = (courses ?? []).map(c => ({
     value: c.id,
     label: c.name,
+  }));
+
+  const taskOptions = (tasks ?? []).map(t => ({
+    value: t.id,
+    label: t.name,
   }));
 
   const startingValues = useMemo(
@@ -95,6 +114,12 @@ function SingleDailyEdit() {
       courseId: data?.course?.id ?? (isNew && search.newCourseId
         ? search.newCourseId
         : ""),
+      taskId: data?.taskId ?? data?.task?.id ?? "",
+      isComplete: data?.status === "complete",
+      criteriaIncomplete: data?.criteria?.incomplete ?? "",
+      criteriaTouched: data?.criteria?.touched ?? "",
+      criteriaGoal: data?.criteria?.goal ?? "",
+      criteriaExceeded: data?.criteria?.exceeded ?? "",
     }),
     [data, isNew, search.newCourseId],
   );
@@ -111,6 +136,20 @@ function SingleDailyEdit() {
     onSubmit: async ({
       value,
     }) => {
+      const criteria: Record<string, string> = {};
+      if (value.criteriaIncomplete) {
+        criteria.incomplete = value.criteriaIncomplete;
+      }
+      if (value.criteriaTouched) {
+        criteria.touched = value.criteriaTouched;
+      }
+      if (value.criteriaGoal) {
+        criteria.goal = value.criteriaGoal;
+      }
+      if (value.criteriaExceeded) {
+        criteria.exceeded = value.criteriaExceeded;
+      }
+
       const dailyData = {
         name: value.name,
         location: value.location || null,
@@ -118,6 +157,9 @@ function SingleDailyEdit() {
         completions: data?.completions ?? [],
         courseProviderId: value.courseProviderId || null,
         courseId: value.courseId || null,
+        taskId: value.taskId || null,
+        status: value.isComplete ? "complete" : "active",
+        criteria,
       };
 
       try {
@@ -293,6 +335,74 @@ function SingleDailyEdit() {
               />
             )}
           </form.AppField>
+
+          <form.AppField name="taskId">
+            {field => (
+              <field.ComboboxField
+                label="Linked Task"
+                options={taskOptions}
+                placeholder="Search tasks..."
+              />
+            )}
+          </form.AppField>
+
+          {!isNew && (
+            <form.AppField name="isComplete">
+              {field => (
+                <label className="flex flex-row items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={field.state.value}
+                    onChange={e => field.handleChange(e.target.checked)}
+                    className="size-4"
+                  />
+                  <span>Mark as completed (locks log editing)</span>
+                </label>
+              )}
+            </form.AppField>
+          )}
+
+          <div className="flex flex-col gap-4 rounded-md border bg-card p-4">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-2xl">Status Criteria</h2>
+              <p className="text-sm text-muted-foreground">
+                Optional notes describing what each status means for this
+                daily.
+              </p>
+            </div>
+            <form.AppField name="criteriaIncomplete">
+              {field => (
+                <field.TextareaField
+                  label="Incomplete"
+                  placeholder="What does &quot;Incomplete&quot; mean here?"
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="criteriaTouched">
+              {field => (
+                <field.TextareaField
+                  label="Touched"
+                  placeholder="What does &quot;Touched&quot; mean here?"
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="criteriaGoal">
+              {field => (
+                <field.TextareaField
+                  label="Completed (Goal)"
+                  placeholder="What does &quot;Completed&quot; (goal) mean here?"
+                />
+              )}
+            </form.AppField>
+            <form.AppField name="criteriaExceeded">
+              {field => (
+                <field.TextareaField
+                  label="Exceeded"
+                  placeholder="What does &quot;Exceeded&quot; mean here?"
+                />
+              )}
+            </form.AppField>
+          </div>
 
           <div className="flex flex-row gap-4">
             <Button

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,10 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, ExternalLink, FlameIcon, LaughIcon } from "lucide-react";
+import {
+  ChevronRightIcon,
+  EditIcon,
+  ExternalLink,
+  FlameIcon,
+  LaughIcon,
+} from "lucide-react";
 
 import {
   DailyCompletionsManager,
   DailyRecentDaysStrip,
+  DAILY_STATUS_OPTIONS,
 } from "@/components/dailies";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -77,6 +84,31 @@ function SingleDaily() {
   const total = getTotalCompletedDays(data);
   const chain = getCurrentChain(data);
   const locationIsUrl = !!data.location && isHttpUrl(data.location);
+  const isComplete = data.status === "complete";
+  const criteria = data.criteria ?? {};
+  const criteriaLabels: { key: keyof typeof criteria;
+    label: string; }[] = [
+    {
+      key: "incomplete",
+      label: DAILY_STATUS_OPTIONS.find(o => o.value === "incomplete")?.label
+        ?? "Incomplete",
+    },
+    {
+      key: "touched",
+      label: DAILY_STATUS_OPTIONS.find(o => o.value === "touched")?.label
+        ?? "Touched",
+    },
+    {
+      key: "goal",
+      label: "Completed",
+    },
+    {
+      key: "exceeded",
+      label: DAILY_STATUS_OPTIONS.find(o => o.value === "exceeded")?.label
+        ?? "Exceeded",
+    },
+  ];
+  const visibleCriteria = criteriaLabels.filter(c => !!criteria[c.key]);
 
   return (
     <div>
@@ -85,7 +117,20 @@ function SingleDaily() {
         pageSection="dailies"
       >
         <div className="flex flex-row gap-2">
-          {locationIsUrl && data.location && (
+          {data.task && (
+            <Link
+              to="/tasks/$id"
+              params={{
+                id: data.task.id,
+              }}
+            >
+              <Button>
+                Go to Task
+                <ChevronRightIcon />
+              </Button>
+            </Link>
+          )}
+          {locationIsUrl && data.location && !data.task && (
             <a
               href={data.location}
               target="_blank"
@@ -167,8 +212,32 @@ function SingleDaily() {
             </span>
           </div>
         </InfoArea>
+        {visibleCriteria.length > 0 && (
+          <InfoArea
+            header="Status Criteria"
+            condition={true}
+          >
+            <dl className="flex flex-col gap-2">
+              {visibleCriteria.map(c => (
+                <div
+                  key={c.key}
+                  className="flex flex-col gap-0.5"
+                >
+                  <dt className="text-sm font-bold">{c.label}</dt>
+                  <dd
+                    className="
+                      text-sm whitespace-pre-wrap text-muted-foreground
+                    "
+                  >
+                    {criteria[c.key]}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </InfoArea>
+        )}
         <InfoArea
-          header="Day entries"
+          header={isComplete ? "Day entries (completed)" : "Day entries"}
           condition={true}
         >
           <DailyCompletionsManager

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -9,6 +9,7 @@ import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
   DailyCourseIndicator,
   DailyLocationCell,
+  DailyRecentDaysStrip,
   DailyStatusCircle,
   DailyStatusConnector,
   TodayStatusCell,
@@ -99,9 +100,12 @@ function Dailies() {
       }))
     : undefined;
 
-  const dayHeaders = sortedDailies && sortedDailies.length > 0
+  const activeDailies = sortedDailies?.filter(d => d.status !== "complete") ?? [];
+  const completedDailies = sortedDailies?.filter(d => d.status === "complete") ?? [];
+
+  const dayHeaders = activeDailies.length > 0
     ? getRecentDays(
-      sortedDailies[0],
+      activeDailies[0],
       RECENT_DAYS_COUNT + 1,
       todayKey,
       "mmdd",
@@ -141,8 +145,8 @@ function Dailies() {
           </p>
         )}
 
-        {sortedDailies && sortedDailies.length > 0 && (
-          <DashboardCard title="All Dailies">
+        {activeDailies.length > 0 && (
+          <DashboardCard title="Active Dailies">
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
@@ -169,7 +173,7 @@ function Dailies() {
                   </tr>
                 </thead>
                 <tbody>
-                  {sortedDailies.map((daily) => {
+                  {activeDailies.map((daily) => {
                     const currentStatus = findStatusForDate(daily, todayKey);
                     const chain = getCurrentChain(daily, todayKey);
                     const total = getTotalCompletedDays(daily);
@@ -310,7 +314,10 @@ function Dailies() {
                           />
                         </td>
                         <td className="p-2 align-top whitespace-nowrap">
-                          <DailyLocationCell location={daily.location} />
+                          <DailyLocationCell
+                            location={daily.location}
+                            taskId={daily.taskId ?? daily.task?.id ?? null}
+                          />
                         </td>
                       </tr>
                     );
@@ -318,6 +325,59 @@ function Dailies() {
                 </tbody>
               </table>
             </div>
+          </DashboardCard>
+        )}
+
+        {completedDailies.length > 0 && (
+          <DashboardCard title="Completed Dailies">
+            <ul className="flex flex-col divide-y">
+              {completedDailies.map(daily => (
+                <li
+                  key={daily.id}
+                  className="flex flex-col gap-1 py-2 opacity-80"
+                >
+                  <div
+                    className="
+                      flex flex-row flex-wrap items-center justify-between gap-2
+                    "
+                  >
+                    <span className="inline-flex items-center gap-1.5">
+                      <Link
+                        to="/dailies/$id"
+                        from="/dailies"
+                        params={{
+                          id: daily.id,
+                        }}
+                        className="
+                          font-medium
+                          hover:text-blue-600
+                        "
+                      >
+                        {daily.name}
+                      </Link>
+                      <DailyCourseIndicator daily={daily} />
+                    </span>
+                    <span
+                      className="
+                        inline-flex items-center gap-1 text-xs
+                        text-muted-foreground
+                      "
+                      title={`${getTotalCompletedDays(daily)} total days completed`}
+                    >
+                      <LaughIcon className="size-3.5" />
+                      {getTotalCompletedDays(daily)}
+                    </span>
+                  </div>
+                  <DailyRecentDaysStrip
+                    daily={daily}
+                    count={RECENT_DAYS_COUNT + 1}
+                    labelFormat="mmdd"
+                    size="sm"
+                    showLabels={false}
+                  />
+                </li>
+              ))}
+            </ul>
           </DashboardCard>
         )}
       </div>

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -1,0 +1,260 @@
+import type { DraftResource } from "@/components/tasks/ResourcesEditor";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { ResourcesEditor } from "@/components/tasks/ResourcesEditor";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createTask,
+  fetchSingleTask,
+  fetchTopics,
+  formHasChanges,
+  upsertTask,
+} from "@/utils";
+
+export const Route = createFileRoute("/tasks/$id/edit")({
+  component: SingleTaskEdit,
+});
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(2000),
+  topicId: z.string(),
+});
+
+function SingleTaskEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["task", id],
+    queryFn: () => fetchSingleTask(id),
+    enabled: !isNew,
+  });
+
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const topicOptions = (topics ?? []).map(t => ({
+    value: t.id,
+    label: t.name,
+  }));
+
+  const startingValues = useMemo(
+    () => ({
+      name: data?.name ?? "",
+      description: data?.description ?? "",
+      topicId: data?.topicId ?? "",
+    }),
+    [data],
+  );
+
+  const initialResources = useMemo<DraftResource[]>(
+    () =>
+      (data?.resources ?? []).map(r => ({
+        id: r.id,
+        name: r.name,
+        url: r.url ?? "",
+        easeOfStarting: r.easeOfStarting ?? null,
+        timeNeeded: r.timeNeeded ?? null,
+        interactivity: r.interactivity ?? null,
+        usedYet: r.usedYet,
+      })),
+    [data],
+  );
+
+  const [resources, setResources] = useState<DraftResource[]>(initialResources);
+
+  useEffect(() => {
+    setResources(initialResources);
+  }, [initialResources]);
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const taskData = {
+        name: value.name,
+        description: value.description || null,
+        topicId: value.topicId || null,
+        resources: resources.map(r => ({
+          id: r.id,
+          name: r.name,
+          url: r.url || null,
+          easeOfStarting: r.easeOfStarting ?? null,
+          timeNeeded: r.timeNeeded ?? null,
+          interactivity: r.interactivity ?? null,
+          usedYet: r.usedYet,
+        })),
+      };
+
+      try {
+        let taskId: string;
+        if (isNew) {
+          const result = await createTask(taskData);
+          taskId = result.id;
+        }
+        else {
+          await upsertTask(id, taskData);
+          taskId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["task", id],
+          });
+        }
+        await queryClient.invalidateQueries({
+          queryKey: ["tasks"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/tasks/$id",
+          params: {
+            id: taskId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create task. Please try again."
+            : "Failed to save task. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const formHasFieldChanges = formHasChanges(currentValues, startingValues);
+  const resourcesChanged
+    = JSON.stringify(resources) !== JSON.stringify(initialResources);
+  const hasChanges = formHasFieldChanges || resourcesChanged;
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Task" : "Edit Task"}
+        pageSection="tasks"
+      >
+        {!isNew && (
+          <Link
+            to="/tasks/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Task
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="container flex-col">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-3xl flex-col gap-8"
+        >
+          <form.AppField name="name">
+            {field => <field.InputField label="Task Name" />}
+          </form.AppField>
+
+          <form.AppField name="topicId">
+            {field => (
+              <field.ComboboxField
+                label="Topic"
+                options={topicOptions}
+                placeholder="Search topics..."
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What is this task about?"
+              />
+            )}
+          </form.AppField>
+
+          <div className="flex flex-col gap-3">
+            <h2 className="text-2xl">Resources</h2>
+            <p className="text-sm text-muted-foreground">
+              Connect resources you might use to study this task.
+            </p>
+            <ResourcesEditor
+              resources={resources}
+              onChange={setResources}
+            />
+          </div>
+
+          <div className="flex flex-row gap-4">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Task" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/tasks",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/tasks/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -1,0 +1,161 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EditIcon, ExternalLinkIcon } from "lucide-react";
+
+import { DailyRecentDaysStrip } from "@/components/dailies";
+import { InfoArea } from "@/components/layout/InfoArea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { ResourcesTable } from "@/components/tasks/ResourcesTable";
+import { Button } from "@/components/ui/button";
+import { DeleteButton } from "@/components/ui/DeleteButton";
+import { deleteSingleTask, fetchSingleTask } from "@/utils";
+
+export const Route = createFileRoute("/tasks/$id/")({
+  component: SingleTask,
+});
+
+function TaskPending() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">Hold on, loading your task...</h1>
+    </div>
+  );
+}
+
+function TaskError() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">There was an error loading this task.</h1>
+    </div>
+  );
+}
+
+function SingleTask() {
+  const {
+    id,
+  } = Route.useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["task", id],
+    queryFn: () => fetchSingleTask(id),
+  });
+
+  if (isPending) {
+    return <TaskPending />;
+  }
+
+  if (error || !data) {
+    return <TaskError />;
+  }
+
+  async function handleDelete() {
+    await deleteSingleTask(id);
+    await queryClient.invalidateQueries({
+      queryKey: ["tasks"],
+    });
+    await navigate({
+      to: "/tasks",
+    });
+  }
+
+  const linkedDaily = data.daily;
+  const dailyForStrip = linkedDaily
+    ? {
+      id: linkedDaily.id,
+      name: linkedDaily.name,
+      completions: linkedDaily.completions ?? [],
+      status: linkedDaily.status ?? "active",
+    }
+    : null;
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={data.name}
+        pageSection="tasks"
+      >
+        <div className="flex flex-row gap-2">
+          <Link
+            to="/tasks/$id/edit"
+            params={{
+              id: data.id,
+            }}
+          >
+            <Button variant="secondary">
+              Edit Task
+              {" "}
+              <EditIcon />
+            </Button>
+          </Link>
+        </div>
+      </PageHeader>
+      <div className="container flex flex-col gap-12">
+        {dailyForStrip && linkedDaily && (
+          <InfoArea
+            header={`Daily: ${linkedDaily.name}${linkedDaily.status === "complete" ? " (completed)" : ""}`}
+            condition={true}
+          >
+            <div className="flex flex-col gap-2">
+              <DailyRecentDaysStrip
+                daily={dailyForStrip}
+                count={14}
+                labelFormat="mmdd"
+              />
+              <Link
+                to="/dailies/$id"
+                params={{
+                  id: linkedDaily.id,
+                }}
+                className="
+                  inline-flex w-fit items-center gap-1 text-xs text-blue-700
+                  hover:text-blue-500
+                  dark:text-blue-300
+                "
+              >
+                Open Daily
+                <ExternalLinkIcon className="size-3.5" />
+              </Link>
+            </div>
+          </InfoArea>
+        )}
+        <InfoArea
+          header="Topic"
+          condition={!!data.topic}
+        >
+          <Link
+            to="/topics/$id"
+            params={{
+              id: data.topic?.id ?? "",
+            }}
+            className={`
+              font-bold text-blue-800
+              hover:text-blue-600
+              dark:text-blue-300
+            `}
+          >
+            {data.topic?.name}
+          </Link>
+        </InfoArea>
+        <InfoArea
+          header="Description"
+          condition={!!data.description}
+        >
+          <p>{data.description}</p>
+        </InfoArea>
+        <InfoArea
+          header="Resources"
+          condition={true}
+        >
+          <ResourcesTable task={data} />
+        </InfoArea>
+        <div>
+          <DeleteButton onClick={handleDelete}>Delete Task</DeleteButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/tasks.$id.tsx
+++ b/packages/client/src/routes/tasks.$id.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/tasks/$id")({
+  component: SingleTaskIndex,
+});
+
+function SingleTaskIndex() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -1,0 +1,135 @@
+import type { Task } from "@emstack/types/src";
+
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CheckSquareIcon, PlusIcon } from "lucide-react";
+
+import { ContentBox } from "@/components/boxes/ContentBox";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { fetchTasks } from "@/utils";
+
+export const Route = createFileRoute("/tasks/")({
+  component: Tasks,
+  errorComponent: TasksError,
+  pendingComponent: TasksPending,
+});
+
+function TasksPending() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">Hold on, loading your tasks...</h1>
+    </div>
+  );
+}
+
+function TasksError() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">There was an error loading your tasks.</h1>
+    </div>
+  );
+}
+
+function TaskBox({
+  task,
+}: { task: Task }) {
+  const totalResources = task.resources?.length ?? 0;
+  const usedResources
+    = task.resources?.filter(r => r.usedYet).length ?? 0;
+
+  return (
+    <Link
+      to="/tasks/$id"
+      params={{
+        id: task.id,
+      }}
+      className="block"
+    >
+      <ContentBox
+        className="
+          h-full transition-colors
+          hover:bg-accent
+        "
+      >
+        <div className="flex flex-col gap-2 p-4">
+          <h3 className="text-xl font-semibold">{task.name}</h3>
+          {task.topic && (
+            <span className="text-xs text-muted-foreground">
+              Topic:
+              {" "}
+              {task.topic.name}
+            </span>
+          )}
+          {task.description && (
+            <p className="line-clamp-3 text-sm text-muted-foreground">
+              {task.description}
+            </p>
+          )}
+          <div
+            className="
+              mt-2 flex flex-row items-center gap-2 text-xs
+              text-muted-foreground
+            "
+          >
+            <CheckSquareIcon className="size-4" />
+            <span>
+              {usedResources}
+              {" / "}
+              {totalResources}
+              {" resources used"}
+            </span>
+          </div>
+        </div>
+      </ContentBox>
+    </Link>
+  );
+}
+
+function Tasks() {
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Tasks"
+        pageSection=""
+      />
+      <div className="container">
+        <div className="mb-4 flex justify-end">
+          <Link
+            to="/tasks/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <Button variant="outline">
+              <PlusIcon className="size-4" />
+              New Task
+            </Button>
+          </Link>
+        </div>
+        {(!data || data.length === 0) && (
+          <p className="text-sm text-muted-foreground">
+            <i>No tasks yet!</i>
+          </p>
+        )}
+        {data && data.length > 0 && (
+          <div className="card-grid">
+            {data.map(task => (
+              <TaskBox
+                key={task.id}
+                task={task}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/tasks.tsx
+++ b/packages/client/src/routes/tasks.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/tasks")({
+  component: Tasks,
+});
+
+export function Tasks() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -53,6 +53,22 @@ export function getTotalCompletedDays(daily: Daily): number {
   ).length;
 }
 
+export function getReferenceDateKey(
+  daily: Daily,
+  todayKey: string = getTodayKey(),
+): string {
+  if (daily.status !== "complete") {
+    return todayKey;
+  }
+  let latest: string | null = null;
+  for (const c of daily.completions) {
+    if (!latest || c.date > latest) {
+      latest = c.date;
+    }
+  }
+  return latest ?? todayKey;
+}
+
 const SHORT_DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export type DayLabelFormat = "dow" | "mmdd";

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -8,6 +8,7 @@ import type {
   Domain,
   Daily,
   Radar,
+  Task,
 } from "@emstack/types/src/index.js";
 import type { OnboardData } from "@emstack/types/src/OnboardData";
 import type { Topic } from "@emstack/types/src/Topic";
@@ -355,6 +356,56 @@ export async function deleteSingleDaily(
   id: string,
 ): Promise<{ status: string }> {
   return await fetch(`/api/dailies/${id}`, {
+    method: "DELETE",
+  }).then(res => res.json());
+}
+
+export async function fetchTasks(): Promise<Task[]> {
+  return await fetch("/api/tasks").then(res => res.json());
+}
+
+export async function fetchSingleTask(id: string): Promise<Task> {
+  return await fetch(`/api/tasks/${id}`).then(res => res.json());
+}
+
+export async function createTask(
+  data: Record<string, unknown>,
+): Promise<{ status: string;
+  id: string; }> {
+  const response = await fetch("/api/tasks", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to create task: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function upsertTask(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<SuccessObj> {
+  const response = await fetch(`/api/tasks/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update task: ${response.statusText}`);
+  }
+  return await response.json();
+}
+
+export async function deleteSingleTask(
+  id: string,
+): Promise<SuccessObj> {
+  return await fetch(`/api/tasks/${id}`, {
     method: "DELETE",
   }).then(res => res.json());
 }

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -9,6 +9,13 @@ export interface DailyCompletion {
   note?: string;
 }
 
+export interface DailyCriteria {
+  incomplete?: string;
+  touched?: string;
+  goal?: string;
+  exceeded?: string;
+}
+
 export const usersTable = pgTable("users", {
   id: varchar().primaryKey(),
   name: varchar({
@@ -24,6 +31,7 @@ export const usersTable = pgTable("users", {
 export const recurPeriodUnitEnum = pgEnum("recurPeriodUnit", ["days", "months", "years"]);
 export const statusEnum = pgEnum("status", ["active", "inactive", "complete"]);
 export const dailyCompletionStatusEnum = pgEnum("dailyCompletionStatus", ["incomplete", "touched", "goal", "exceeded", "freeze"]);
+export const resourceLevelEnum = pgEnum("resourceLevel", ["low", "medium", "high"]);
 
 export const topics = pgTable("topics", {
   id: varchar().primaryKey(),
@@ -81,7 +89,56 @@ export const dailies = pgTable("dailies", {
   completions: jsonb().$type<DailyCompletion[]>().default([]).notNull(),
   courseProviderId: varchar("course_provider_id"),
   courseId: varchar("course_id"),
+  taskId: varchar("task_id").unique(),
+  status: statusEnum().default("active"),
+  criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
 });
+
+export const tasks = pgTable("tasks", {
+  id: varchar().primaryKey(),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  description: varchar(),
+  topicId: varchar("topic_id"),
+});
+
+export const resources = pgTable("resources", {
+  id: varchar().primaryKey(),
+  taskId: varchar("task_id").notNull(),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  url: varchar(),
+  easeOfStarting: resourceLevelEnum("ease_of_starting"),
+  timeNeeded: resourceLevelEnum("time_needed"),
+  interactivity: resourceLevelEnum(),
+  usedYet: boolean("used_yet").default(false).notNull(),
+  position: integer(),
+});
+
+export const tasksRelations = relations(tasks, ({
+  one, many,
+}) => ({
+  topic: one(topics, {
+    fields: [tasks.topicId],
+    references: [topics.id],
+  }),
+  resources: many(resources),
+  daily: one(dailies, {
+    fields: [tasks.id],
+    references: [dailies.taskId],
+  }),
+}));
+
+export const resourcesRelations = relations(resources, ({
+  one,
+}) => ({
+  task: one(tasks, {
+    fields: [resources.taskId],
+    references: [tasks.id],
+  }),
+}));
 
 export const courseProviderRelations = relations(courseProviders, ({
   many,
@@ -100,6 +157,10 @@ export const dailiesRelations = relations(dailies, ({
   course: one(courses, {
     fields: [dailies.courseId],
     references: [courses.id],
+  }),
+  task: one(tasks, {
+    fields: [dailies.taskId],
+    references: [tasks.id],
   }),
 }));
 
@@ -121,6 +182,7 @@ export const topicsRelations = relations(topics, ({
   topicsToDomains: many(topicsToDomains),
   radarBlips: many(radarBlips),
   domainExclusions: many(domainExcludedTopics),
+  tasks: many(tasks),
 }));
 
 export const domains = pgTable("domains", {

--- a/packages/middleware/src/routes/api/dailies/createDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/createDaily.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { dailies } from "@/db/schema";
-import type { DailyCompletion } from "@emstack/types/src";
+import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
 import { v4 as uuidv4 } from "uuid";
 
 const completionSchema = {
@@ -17,6 +17,24 @@ const completionSchema = {
       enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],
     },
     note: {
+      type: "string",
+    },
+  },
+} as const;
+
+const criteriaSchema = {
+  type: "object",
+  properties: {
+    incomplete: {
+      type: "string",
+    },
+    touched: {
+      type: "string",
+    },
+    goal: {
+      type: "string",
+    },
+    exceeded: {
       type: "string",
     },
   },
@@ -48,6 +66,14 @@ const createSchema = {
         courseId: {
           type: ["string", "null"],
         },
+        taskId: {
+          type: ["string", "null"],
+        },
+        status: {
+          type: ["string", "null"],
+          enum: ["active", "complete", null],
+        },
+        criteria: criteriaSchema,
       },
     },
   },
@@ -59,7 +85,7 @@ export default async function (server: FastifyInstance) {
   fastify.post(
     "/",
     createSchema,
-    async function (request, reply) {
+    async function (request) {
       const body = request.body;
       const id = uuidv4();
 
@@ -71,6 +97,9 @@ export default async function (server: FastifyInstance) {
         completions: (body.completions ?? []) as DailyCompletion[],
         courseProviderId: body.courseProviderId ?? null,
         courseId: body.courseId ?? null,
+        taskId: body.taskId || null,
+        status: body.status ?? "active",
+        criteria: (body.criteria ?? {}) as DailyCriteria,
       });
 
       return {

--- a/packages/middleware/src/routes/api/dailies/getDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/getDaily.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Daily, DailyCompletion } from "@emstack/types/src";
+import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types/src";
 
 const getSchema = {
   schema: {
@@ -24,7 +24,7 @@ export default async function (server: FastifyInstance) {
   fastify.get(
     "/:id",
     getSchema,
-    async function (request, reply) {
+    async function (request) {
       const {
         id,
       } = request.params;
@@ -47,6 +47,12 @@ export default async function (server: FastifyInstance) {
               progressTotal: true,
             },
           },
+          task: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
         },
       });
 
@@ -57,6 +63,15 @@ export default async function (server: FastifyInstance) {
           location: daily.location,
           description: daily.description,
           completions: (daily.completions ?? []) as DailyCompletion[],
+          status: daily.status ?? "active",
+          criteria: (daily.criteria ?? {}) as DailyCriteria,
+          taskId: daily.taskId ?? null,
+          task: daily.task
+            ? {
+              id: daily.task.id,
+              name: daily.task.name,
+            }
+            : null,
           provider:
             daily.courseProvider?.name && daily.courseProvider?.id
               ? {

--- a/packages/middleware/src/routes/api/dailies/root.ts
+++ b/packages/middleware/src/routes/api/dailies/root.ts
@@ -1,12 +1,12 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Daily, DailyCompletion } from "@emstack/types/src";
+import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types/src";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
 
-  fastify.get("/", async (request, reply) => {
+  fastify.get("/", async () => {
     const rawData = await db.query.dailies.findMany({
       with: {
         courseProvider: {
@@ -23,6 +23,12 @@ export default async function (server: FastifyInstance) {
             progressTotal: true,
           },
         },
+        task: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
       },
     });
 
@@ -32,6 +38,15 @@ export default async function (server: FastifyInstance) {
       location: daily.location,
       description: daily.description,
       completions: (daily.completions ?? []) as DailyCompletion[],
+      status: daily.status ?? "active",
+      criteria: (daily.criteria ?? {}) as DailyCriteria,
+      taskId: daily.taskId ?? null,
+      task: daily.task
+        ? {
+          id: daily.task.id,
+          name: daily.task.name,
+        }
+        : null,
       provider:
         daily.courseProvider?.name && daily.courseProvider?.id
           ? {

--- a/packages/middleware/src/routes/api/dailies/upsertDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/upsertDaily.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { dailies } from "@/db/schema";
-import type { DailyCompletion } from "@emstack/types/src";
+import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
 import { v4 as uuidv4 } from "uuid";
 
 const completionSchema = {
@@ -17,6 +17,24 @@ const completionSchema = {
       enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],
     },
     note: {
+      type: "string",
+    },
+  },
+} as const;
+
+const criteriaSchema = {
+  type: "object",
+  properties: {
+    incomplete: {
+      type: "string",
+    },
+    touched: {
+      type: "string",
+    },
+    goal: {
+      type: "string",
+    },
+    exceeded: {
       type: "string",
     },
   },
@@ -57,6 +75,14 @@ const upsertSchema = {
         courseId: {
           type: ["string", "null"],
         },
+        taskId: {
+          type: ["string", "null"],
+        },
+        status: {
+          type: ["string", "null"],
+          enum: ["active", "complete", null],
+        },
+        criteria: criteriaSchema,
       },
     },
   },
@@ -68,7 +94,7 @@ export default async function (server: FastifyInstance) {
   fastify.put(
     "/:id",
     upsertSchema,
-    async function (request, reply) {
+    async function (request) {
       const {
         id,
       } = request.params;
@@ -82,6 +108,9 @@ export default async function (server: FastifyInstance) {
         completions: (body.completions ?? []) as DailyCompletion[],
         courseProviderId: body.courseProviderId ?? null,
         courseId: body.courseId ?? null,
+        taskId: body.taskId || null,
+        status: body.status ?? "active",
+        criteria: (body.criteria ?? {}) as DailyCriteria,
       };
 
       await db
@@ -96,6 +125,9 @@ export default async function (server: FastifyInstance) {
             completions: dailyData.completions,
             courseProviderId: dailyData.courseProviderId,
             courseId: dailyData.courseId,
+            taskId: dailyData.taskId,
+            status: dailyData.status,
+            criteria: dailyData.criteria,
           },
         });
 

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -13,6 +13,7 @@ import providers from "./providers/routes";
 import domains from "./domains/routes";
 import dailies from "./dailies/routes";
 import radar from "./radar/routes";
+import tasks from "./tasks/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -40,5 +41,8 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(dailies, {
     prefix: "/dailies",
+  });
+  fastify.register(tasks, {
+    prefix: "/tasks",
   });
 }

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -1,0 +1,94 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { resources, tasks } from "@/db/schema";
+import { nullableString } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const resourceLevel = {
+  type: ["string", "null"],
+  enum: ["low", "medium", "high", null],
+} as const;
+
+const resourceSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    url: nullableString,
+    easeOfStarting: resourceLevel,
+    timeNeeded: resourceLevel,
+    interactivity: resourceLevel,
+    usedYet: {
+      type: "boolean",
+    },
+  },
+} as const;
+
+const createSchema = {
+  schema: {
+    description: "Create a new task",
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        topicId: nullableString,
+        resources: {
+          type: "array",
+          items: resourceSchema,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(tasks).values({
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        topicId: body.topicId || null,
+      });
+
+      const incoming = body.resources ?? [];
+      if (incoming.length > 0) {
+        await db.insert(resources).values(
+          incoming.map((r, index) => ({
+            id: r.id || uuidv4(),
+            taskId: id,
+            name: r.name,
+            url: r.url ?? null,
+            easeOfStarting: r.easeOfStarting ?? null,
+            timeNeeded: r.timeNeeded ?? null,
+            interactivity: r.interactivity ?? null,
+            usedYet: r.usedYet ?? false,
+            position: index,
+          })),
+        );
+      }
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/tasks/deleteTask.ts
+++ b/packages/middleware/src/routes/api/tasks/deleteTask.ts
@@ -1,0 +1,12 @@
+import { resources, tasks } from "@/db/schema";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
+
+export default createDeleteHandler({
+  description: "Delete a task by ID",
+  table: tasks,
+  idColumn: tasks.id,
+  junction: {
+    table: resources,
+    foreignKey: resources.taskId,
+  },
+});

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -1,0 +1,90 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import type { Task } from "@emstack/types/src";
+import { idParamSchema } from "@/utils/schemas";
+
+const getSchema = {
+  schema: {
+    description: "Get a single task by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id",
+    getSchema,
+    async function (request) {
+      const {
+        id,
+      } = request.params;
+
+      const task = await db.query.tasks.findFirst({
+        where: (tasks, {
+          eq,
+        }) => eq(tasks.id, id),
+        with: {
+          topic: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+          resources: true,
+          daily: {
+            columns: {
+              id: true,
+              name: true,
+              status: true,
+              completions: true,
+            },
+          },
+        },
+      });
+
+      if (!task) {
+        return null;
+      }
+
+      const result: Task = {
+        id: task.id,
+        name: task.name,
+        description: task.description,
+        topicId: task.topicId ?? null,
+        topic: task.topic
+          ? {
+            id: task.topic.id,
+            name: task.topic.name,
+          }
+          : null,
+        resources: (task.resources ?? [])
+          .slice()
+          .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+          .map(r => ({
+            id: r.id,
+            taskId: r.taskId,
+            name: r.name,
+            url: r.url,
+            easeOfStarting: r.easeOfStarting,
+            timeNeeded: r.timeNeeded,
+            interactivity: r.interactivity,
+            usedYet: r.usedYet,
+            position: r.position,
+          })),
+        daily: task.daily
+          ? {
+            id: task.daily.id,
+            name: task.daily.name,
+            status: task.daily.status ?? null,
+            completions: task.daily.completions ?? [],
+          }
+          : null,
+      };
+
+      return result;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -1,0 +1,67 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import type { Task } from "@emstack/types/src";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get("/", async () => {
+    const rawData = await db.query.tasks.findMany({
+      with: {
+        topic: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
+        resources: true,
+        daily: {
+          columns: {
+            id: true,
+            name: true,
+            status: true,
+            completions: true,
+          },
+        },
+      },
+    });
+
+    const processedData: Task[] = rawData.map(task => ({
+      id: task.id,
+      name: task.name,
+      description: task.description,
+      topicId: task.topicId ?? null,
+      topic: task.topic
+        ? {
+          id: task.topic.id,
+          name: task.topic.name,
+        }
+        : null,
+      resources: (task.resources ?? [])
+        .slice()
+        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+        .map(r => ({
+          id: r.id,
+          taskId: r.taskId,
+          name: r.name,
+          url: r.url,
+          easeOfStarting: r.easeOfStarting,
+          timeNeeded: r.timeNeeded,
+          interactivity: r.interactivity,
+          usedYet: r.usedYet,
+          position: r.position,
+        })),
+      daily: task.daily
+        ? {
+          id: task.daily.id,
+          name: task.daily.name,
+          status: task.daily.status ?? null,
+          completions: task.daily.completions ?? [],
+        }
+        : null,
+    }));
+
+    return processedData;
+  });
+}

--- a/packages/middleware/src/routes/api/tasks/routes.ts
+++ b/packages/middleware/src/routes/api/tasks/routes.ts
@@ -1,0 +1,18 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import tasksRoot from "./root";
+import getTask from "./getTask";
+import createTask from "./createTask";
+import upsertTask from "./upsertTask";
+import deleteTask from "./deleteTask";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(tasksRoot);
+  fastify.register(getTask);
+  fastify.register(createTask);
+  fastify.register(upsertTask);
+  fastify.register(deleteTask);
+}

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -1,0 +1,111 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { resources, tasks } from "@/db/schema";
+import { idParamSchema, nullableString } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const resourceLevel = {
+  type: ["string", "null"],
+  enum: ["low", "medium", "high", null],
+} as const;
+
+const resourceSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    url: nullableString,
+    easeOfStarting: resourceLevel,
+    timeNeeded: resourceLevel,
+    interactivity: resourceLevel,
+    usedYet: {
+      type: "boolean",
+    },
+  },
+} as const;
+
+const upsertSchema = {
+  schema: {
+    description: "Update a task and its resources",
+    params: idParamSchema,
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        topicId: nullableString,
+        resources: {
+          type: "array",
+          items: resourceSchema,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:id",
+    upsertSchema,
+    async function (request) {
+      const {
+        id,
+      } = request.params;
+      const body = request.body;
+
+      const taskData = {
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        topicId: body.topicId || null,
+      };
+
+      await db
+        .insert(tasks)
+        .values(taskData)
+        .onConflictDoUpdate({
+          target: tasks.id,
+          set: {
+            name: taskData.name,
+            description: taskData.description,
+            topicId: taskData.topicId,
+          },
+        });
+
+      if (body.resources !== undefined) {
+        await db.delete(resources).where(eq(resources.taskId, id));
+        if (body.resources.length > 0) {
+          await db.insert(resources).values(
+            body.resources.map((r, index) => ({
+              id: r.id || uuidv4(),
+              taskId: id,
+              name: r.name,
+              url: r.url ?? null,
+              easeOfStarting: r.easeOfStarting ?? null,
+              timeNeeded: r.timeNeeded ?? null,
+              interactivity: r.interactivity ?? null,
+              usedYet: r.usedYet ?? false,
+              position: index,
+            })),
+          );
+        }
+      }
+
+      return {
+        status: "ok",
+      };
+    },
+  );
+}

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -6,12 +6,28 @@ export interface DailyCompletion {
   note?: string;
 }
 
+export interface DailyCriteria {
+  incomplete?: string;
+  touched?: string;
+  goal?: string;
+  exceeded?: string;
+}
+
+export type DailyStatus = "active" | "inactive" | "complete";
+
 export interface Daily {
   id: string;
   name: string;
   location?: string | null;
   description?: string | null;
   completions: DailyCompletion[];
+  status?: DailyStatus | null;
+  criteria?: DailyCriteria | null;
+  taskId?: string | null;
+  task?: {
+    id: string;
+    name: string;
+  } | null;
   provider?: {
     name: string;
     id: string;

--- a/packages/types/src/Resource.ts
+++ b/packages/types/src/Resource.ts
@@ -1,0 +1,13 @@
+export type ResourceLevel = "low" | "medium" | "high";
+
+export interface Resource {
+  id: string;
+  taskId: string;
+  name: string;
+  url?: string | null;
+  easeOfStarting?: ResourceLevel | null;
+  timeNeeded?: ResourceLevel | null;
+  interactivity?: ResourceLevel | null;
+  usedYet: boolean;
+  position?: number | null;
+}

--- a/packages/types/src/Task.ts
+++ b/packages/types/src/Task.ts
@@ -1,0 +1,20 @@
+import type { DailyCompletion, DailyStatus } from "./Daily";
+import type { Resource } from "./Resource";
+
+export interface TaskLinkedDaily {
+  id: string;
+  name: string;
+  status?: DailyStatus | null;
+  completions: DailyCompletion[];
+}
+
+export interface Task {
+  id: string;
+  name: string;
+  description?: string | null;
+  topicId?: string | null;
+  topic?: { id: string;
+    name: string; } | null;
+  resources?: Resource[];
+  daily?: TaskLinkedDaily | null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,3 +16,5 @@ export * from "./LearningLog";
 export * from "./TopicsToDomains";
 export * from "./Daily";
 export * from "./Radar";
+export * from "./Resource";
+export * from "./Task";


### PR DESCRIPTION
Introduces a new Tasks feature so users can capture study items per Topic,
attach a description, and track Resources (Ease of Starting, Time Needed,
Interactivity, Used Yet) in a table. A Daily can be linked 1:1 to a Task;
when linked, the Daily's status icons render at the top of the Task page
and its Go button on the dailies list navigates to the Task.

Dailies now have a status (active/complete) and per-status criteria
descriptions (Incomplete, Touched, Completed/goal, Exceeded). Completed
Dailies are read-only, listed below the active list, and their 30-day log
window anchors at the last log entry instead of today.

https://claude.ai/code/session_01GcrTba8Rxu6Z6aRiShzQbb