### PR TITLE
Add error handling to fetchSingleDomain

### DIFF
--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -199,7 +199,11 @@ export async function fetchDomains(): Promise<Domain[]> {
 }
 
 export async function fetchSingleDomain(id: string): Promise<Domain> {
-  return await fetch(`/api/domains/${id}`).then(res => res.json());
+  const res = await fetch(`/api/domains/${id}`);
+  if (!res.ok) {
+    throw new Error(`Failed to load domain: ${res.statusText}`);
+  }
+  return await res.json();
 }
 
 export async function deleteSingleDomain(


### PR DESCRIPTION
## Summary
Enhanced the `fetchSingleDomain` function with proper error handling to catch and report failed API requests.

## Changes
- Added response status validation before parsing JSON
- Throws a descriptive error when the API request fails (non-2xx status codes)
- Improves debugging by including the HTTP status text in the error message

## Implementation Details
The function now checks `res.ok` before attempting to parse the response body. If the request fails, it throws an error with a clear message indicating the failure and the server's status text, rather than silently failing or throwing a JSON parsing error.

https://claude.ai/code/session_01PakDYHGuKMyBvAcKdsX2n4