### PR TITLE
Refactor daily linking UI and remove completions manager

### DIFF
--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -46,8 +46,8 @@ export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
     value: "exceeded",
     label: "Exceeded",
     icon: <SparklesIcon className="size-4" />,
-    circleClass: "bg-violet-100 text-violet-800 border-violet-500 dark:bg-violet-900/40 dark:text-violet-200",
-    pillClass: "bg-violet-100 text-violet-800 border-violet-500 dark:bg-violet-900/40 dark:text-violet-200",
+    circleClass: "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_8px_2px_rgba(139,92,246,0.5)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_8px_2px_rgba(167,139,250,0.55)]",
+    pillClass: "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_6px_1px_rgba(139,92,246,0.45)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_6px_1px_rgba(167,139,250,0.5)]",
     borderColor: "#8b5cf6",
   },
   {

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -3,11 +3,20 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EyeIcon, Loader2 } from "lucide-react";
+import { EyeIcon, Loader2, WandSparklesIcon } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
-import { DailyCompletionsManager } from "@/components/dailies";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+} from "@/components/combobox";
 import { useAppForm } from "@/components/formFields";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -95,15 +104,16 @@ function SingleDailyEdit() {
     label: p.name,
   }));
 
-  const courseOptions = (courses ?? []).map(c => ({
-    value: c.id,
-    label: c.name,
-  }));
-
-  const taskOptions = (tasks ?? []).map(t => ({
-    value: t.id,
-    label: t.name,
-  }));
+  const linkedLabelMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of courses ?? []) {
+      m.set(`course:${c.id}`, c.name);
+    }
+    for (const t of tasks ?? []) {
+      m.set(`task:${t.id}`, t.name);
+    }
+    return m;
+  }, [courses, tasks]);
 
   const startingValues = useMemo(
     () => ({
@@ -124,9 +134,7 @@ function SingleDailyEdit() {
     [data, isNew, search.newCourseId],
   );
 
-  const [informFromCourse, setInformFromCourse] = useState<boolean>(
-    !!(isNew && search.newCourseId),
-  );
+  const [hideLinkBox, setHideLinkBox] = useState(false);
 
   const form = useAppForm({
     defaultValues: startingValues,
@@ -211,11 +219,42 @@ function SingleDailyEdit() {
     [currentValues.courseId, courses],
   );
 
-  // When "Inform data from course" is checked, mirror the chosen course's
-  // name / url / provider into the daily fields. We rerun whenever either
-  // the toggle or the course changes.
+  const selectedTask = useMemo(
+    () =>
+      currentValues.taskId
+        ? (tasks ?? []).find(t => t.id === currentValues.taskId)
+        : undefined,
+    [currentValues.taskId, tasks],
+  );
+
+  const isLinked = !!(currentValues.courseId || currentValues.taskId);
+
+  const linkedValue = currentValues.courseId
+    ? `course:${currentValues.courseId}`
+    : currentValues.taskId
+      ? `task:${currentValues.taskId}`
+      : "";
+
+  const setLinkedValue = (val: string | null) => {
+    if (!val) {
+      form.setFieldValue("courseId", "");
+      form.setFieldValue("taskId", "");
+      return;
+    }
+    if (val.startsWith("course:")) {
+      form.setFieldValue("courseId", val.slice("course:".length));
+      form.setFieldValue("taskId", "");
+    }
+    else if (val.startsWith("task:")) {
+      form.setFieldValue("taskId", val.slice("task:".length));
+      form.setFieldValue("courseId", "");
+    }
+  };
+
+  // When a course is linked, mirror its name/url/provider into the daily
+  // fields so the (now-disabled) inputs stay in sync with the source.
   useEffect(() => {
-    if (!informFromCourse || !selectedCourse) {
+    if (!selectedCourse) {
       return;
     }
     if (currentValues.name !== selectedCourse.name) {
@@ -230,7 +269,6 @@ function SingleDailyEdit() {
       form.setFieldValue("courseProviderId", courseProviderId);
     }
   }, [
-    informFromCourse,
     selectedCourse,
     currentValues.name,
     currentValues.location,
@@ -238,13 +276,15 @@ function SingleDailyEdit() {
     form,
   ]);
 
-  // If the user clears the course while the toggle is on, turn it off so
-  // the disabled fields don't get stuck.
+  // When a task is linked, mirror its name into the daily name field.
   useEffect(() => {
-    if (informFromCourse && !currentValues.courseId) {
-      setInformFromCourse(false);
+    if (!selectedTask) {
+      return;
     }
-  }, [informFromCourse, currentValues.courseId]);
+    if (currentValues.name !== selectedTask.name) {
+      form.setFieldValue("name", selectedTask.name);
+    }
+  }, [selectedTask, currentValues.name, form]);
 
   return (
     <div>
@@ -275,33 +315,77 @@ function SingleDailyEdit() {
           }}
           className="flex max-w-2xl flex-col gap-8"
         >
-          <form.AppField name="courseId">
-            {field => (
-              <field.ComboboxField
-                label="Course"
-                options={courseOptions}
-                placeholder="Search courses..."
+          {!hideLinkBox && (
+            <div
+              className="
+                flex flex-row items-start justify-between gap-4 rounded-md
+                border bg-card p-4
+              "
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-3">
+                <h2 className="text-2xl">Link this Daily</h2>
+                <Combobox
+                  value={linkedValue || null}
+                  onValueChange={val => setLinkedValue(val ?? null)}
+                  itemToStringLabel={val => linkedLabelMap.get(val) ?? ""}
+                >
+                  <ComboboxInput
+                    placeholder="Search courses or tasks..."
+                    showClear
+                  />
+                  <ComboboxContent>
+                    <ComboboxEmpty>No items found.</ComboboxEmpty>
+                    <ComboboxList>
+                      {(courses ?? []).length > 0 && (
+                        <ComboboxGroup>
+                          <ComboboxLabel>Courses</ComboboxLabel>
+                          {(courses ?? []).map(c => (
+                            <ComboboxItem
+                              key={`course:${c.id}`}
+                              value={`course:${c.id}`}
+                            >
+                              {c.name}
+                            </ComboboxItem>
+                          ))}
+                        </ComboboxGroup>
+                      )}
+                      {(tasks ?? []).length > 0 && (
+                        <ComboboxGroup>
+                          <ComboboxLabel>Tasks</ComboboxLabel>
+                          {(tasks ?? []).map(t => (
+                            <ComboboxItem
+                              key={`task:${t.id}`}
+                              value={`task:${t.id}`}
+                            >
+                              {t.name}
+                            </ComboboxItem>
+                          ))}
+                        </ComboboxGroup>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="w-fit"
+                  onClick={() => setHideLinkBox(true)}
+                >
+                  Hide This
+                </Button>
+              </div>
+              <WandSparklesIcon
+                className="size-8 shrink-0 text-muted-foreground"
+                aria-hidden="true"
               />
-            )}
-          </form.AppField>
-
-          {currentValues.courseId && (
-            <label className="flex flex-row items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={informFromCourse}
-                onChange={e => setInformFromCourse(e.target.checked)}
-                className="size-4"
-              />
-              <span>Inform data from course</span>
-            </label>
+            </div>
           )}
 
           <form.AppField name="name">
             {field => (
               <field.InputField
                 label="Daily Name"
-                disabled={informFromCourse}
+                disabled={isLinked}
               />
             )}
           </form.AppField>
@@ -311,7 +395,7 @@ function SingleDailyEdit() {
               <field.InputField
                 label="Location"
                 placeholder="e.g. Spanish app, gym, journal"
-                disabled={informFromCourse}
+                disabled={isLinked}
               />
             )}
           </form.AppField>
@@ -331,17 +415,7 @@ function SingleDailyEdit() {
                 label="Provider"
                 options={providerOptions}
                 placeholder="Search providers..."
-                disabled={informFromCourse}
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="taskId">
-            {field => (
-              <field.ComboboxField
-                label="Linked Task"
-                options={taskOptions}
-                placeholder="Search tasks..."
+                disabled={isLinked}
               />
             )}
           </form.AppField>
@@ -438,15 +512,6 @@ function SingleDailyEdit() {
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}
         />
-        {!isNew && data && (
-          <div className="mt-12 flex max-w-2xl flex-col gap-4 border-t pt-8">
-            <h2 className="text-2xl">Completions</h2>
-            <p className="text-sm text-muted-foreground">
-              Pick a date below to retroactively set or change the status for that day.
-            </p>
-            <DailyCompletionsManager daily={data} />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -2,7 +2,7 @@ import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { FlameIcon, LaughIcon, PlusIcon } from "lucide-react";
+import { FlameIcon, LaughIcon, PencilIcon, PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
@@ -170,6 +170,7 @@ function Dailies() {
                     <th className="p-2 font-medium whitespace-nowrap">
                       Location
                     </th>
+                    <th className="w-8 p-2" />
                   </tr>
                 </thead>
                 <tbody>
@@ -318,6 +319,25 @@ function Dailies() {
                             location={daily.location}
                             taskId={daily.taskId ?? daily.task?.id ?? null}
                           />
+                        </td>
+                        <td className="p-2 align-top">
+                          <Link
+                            to="/dailies/$id/edit"
+                            params={{
+                              id: daily.id,
+                            }}
+                            aria-label={`Edit ${daily.name}`}
+                            title="Edit daily"
+                            className="
+                              inline-flex items-center justify-center rounded-md
+                              p-1 text-muted-foreground opacity-0 transition
+                              group-hover:opacity-100
+                              hover:bg-muted hover:text-foreground
+                              focus-visible:opacity-100
+                            "
+                          >
+                            <PencilIcon className="size-3.5" />
+                          </Link>
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
## Summary
This PR refactors the daily linking interface to use a unified combobox for linking to both courses and tasks, replacing the previous separate course selector with a checkbox toggle. It also removes the completions manager section from the edit page and adds an edit button to the dailies list.

## Key Changes

- **Unified linking interface**: Replaced separate `courseId` and `taskId` form fields with a single combobox that allows selecting either a course or task. The combobox displays both options in grouped sections (Courses and Tasks).

- **Improved UX for linked fields**: 
  - Created `linkedValue` and `setLinkedValue` helpers to manage the combined course/task selection state
  - Built `linkedLabelMap` to efficiently map linked item IDs to their display names
  - Fields (name, location, provider) are now disabled when any item is linked, with automatic syncing of values from the linked source

- **Removed completions manager**: Deleted the `DailyCompletionsManager` component section from the edit page, simplifying the edit view

- **Enhanced dailies list**: Added an edit button (pencil icon) to each daily row in the list view for quick access to editing

- **Visual improvements**: 
  - Added glow/shadow effects to the "exceeded" status indicator for better visual prominence
  - Introduced a collapsible "Link this Daily" card with a wand sparkles icon for better visual hierarchy

- **Simplified state management**: Replaced `informFromCourse` boolean state with `hideLinkBox` to control visibility of the linking interface

## Implementation Details

- The linking logic now uses string prefixes (`course:` and `task:`) to distinguish between linked item types in a single value field
- Task linking mirrors the task name into the daily name field, similar to course linking behavior
- The combobox component is now imported and used directly instead of through form field wrappers

https://claude.ai/code/session_01CBWYeBQtcy77uEHddHKiMU