### PR TITLE
Add mobile nav, radar preview, edit-page footer; refine domain log

### DIFF
--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -76,8 +76,8 @@ export function TodayStatusCell({
     <div className="flex w-36 flex-row items-center gap-1">
       <span
         className={cn(`
-          inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs
-          font-medium
+          inline-flex items-center gap-1 rounded-full border-2 px-2 py-0.5
+          text-xs font-medium
         `, option?.pillClass)}
       >
         {option?.icon}

--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -54,9 +54,9 @@ export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
     value: "freeze",
     label: "Freeze",
     icon: <SnowflakeIcon className="size-4" />,
-    circleClass: "bg-sky-50 text-sky-800 border-sky-300 dark:bg-sky-900/30 dark:text-sky-200",
-    pillClass: "bg-sky-50 text-sky-800 border-sky-300 dark:bg-sky-900/30 dark:text-sky-200",
-    borderColor: "#7dd3fc",
+    circleClass: "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
+    pillClass: "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
+    borderColor: "#bae6fd",
   },
 ];
 

--- a/packages/client/src/components/domains/DomainLearningLog.tsx
+++ b/packages/client/src/components/domains/DomainLearningLog.tsx
@@ -198,9 +198,9 @@ export function DomainLearningLog({
         )}
       </div>
       <p className="text-sm text-muted-foreground">
-        Auto-imports activity from your dailies for courses or topics linked to
-        this domain. You can also add manual notes with a date, description,
-        and optional link.
+        Auto-imports activity from your dailies for courses, topics, or tasks
+        linked to this domain. You can also add manual notes with a date,
+        description, and optional link.
       </p>
 
       {draft && (
@@ -462,6 +462,22 @@ export function DomainLearningLog({
                                 Course:
                                 {" "}
                                 {entry.courseName}
+                              </Link>
+                            )}
+                            {entry.taskId && entry.taskName && (
+                              <Link
+                                to="/tasks/$id"
+                                params={{
+                                  id: entry.taskId,
+                                }}
+                                className={`
+                                  text-blue-700
+                                  hover:text-blue-500
+                                `}
+                              >
+                                Task:
+                                {" "}
+                                {entry.taskName}
                               </Link>
                             )}
                             {entry.dailyId && entry.dailyName && (

--- a/packages/client/src/components/layout/EditPageFooter.tsx
+++ b/packages/client/src/components/layout/EditPageFooter.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+
+import { CopyIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DeleteButton } from "@/components/ui/DeleteButton";
+
+interface EditPageFooterProps {
+  isNew: boolean;
+  onDelete?: () => void | Promise<void>;
+  deleteLabel?: string;
+  onDuplicate?: () => void | Promise<void>;
+  duplicateLabel?: string;
+  children: ReactNode;
+}
+
+export function EditPageFooter({
+  isNew,
+  onDelete,
+  deleteLabel,
+  onDuplicate,
+  duplicateLabel,
+  children,
+}: EditPageFooterProps) {
+  const showDestructive = !isNew && (onDelete || onDuplicate);
+
+  return (
+    <div
+      className={`
+        mt-4 flex flex-col gap-3 rounded-md border bg-card p-4
+        sm:flex-row sm:items-center sm:justify-between
+      `}
+    >
+      <div className="flex flex-row gap-2">{children}</div>
+      {showDestructive && (
+        <div
+          className="
+            flex flex-row gap-2
+            sm:justify-end
+          "
+        >
+          {onDuplicate && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onDuplicate}
+            >
+              {duplicateLabel ?? "Duplicate"}
+              {" "}
+              <CopyIcon />
+            </Button>
+          )}
+          {onDelete && (
+            <DeleteButton onClick={onDelete}>
+              {deleteLabel ?? "Delete"}
+            </DeleteButton>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -282,97 +282,103 @@ export function RadarChart({
                 </text>
               );
             })}
-            {positionedBlips.map(({
-              blip, x, y, index,
-            }) => {
-              const quadrantIndex = sortedQuadrants.findIndex(
-                q => q.id === blip.quadrantId,
-              );
-              const color
-                = QUADRANT_PALETTE[quadrantIndex % QUADRANT_PALETTE.length];
-              const isActive = activeBlipId === blip.id;
-              const isSelected = selectedBlipId === blip.id;
-              return (
-                <Tooltip
-                  key={blip.id}
-                  open={isActive || undefined}
-                >
-                  <TooltipTrigger asChild>
-                    <g
-                      onMouseEnter={() => setHoveredBlipId(blip.id)}
-                      onMouseLeave={() => setHoveredBlipId(null)}
-                      onFocus={() => setHoveredBlipId(blip.id)}
-                      onBlur={() => setHoveredBlipId(null)}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleBlipClick(blip);
-                      }}
-                      style={{
-                        cursor: "pointer",
-                      }}
-                      tabIndex={0}
-                    >
-                      {isActive && (
+            {[...positionedBlips]
+              .sort((a, b) => {
+                const aActive = activeBlipId === a.blip.id ? 1 : 0;
+                const bActive = activeBlipId === b.blip.id ? 1 : 0;
+                return aActive - bActive;
+              })
+              .map(({
+                blip, x, y, index,
+              }) => {
+                const quadrantIndex = sortedQuadrants.findIndex(
+                  q => q.id === blip.quadrantId,
+                );
+                const color
+                  = QUADRANT_PALETTE[quadrantIndex % QUADRANT_PALETTE.length];
+                const isActive = activeBlipId === blip.id;
+                const isSelected = selectedBlipId === blip.id;
+                return (
+                  <Tooltip
+                    key={blip.id}
+                    open={isActive || undefined}
+                  >
+                    <TooltipTrigger asChild>
+                      <g
+                        onMouseEnter={() => setHoveredBlipId(blip.id)}
+                        onMouseLeave={() => setHoveredBlipId(null)}
+                        onFocus={() => setHoveredBlipId(blip.id)}
+                        onBlur={() => setHoveredBlipId(null)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleBlipClick(blip);
+                        }}
+                        style={{
+                          cursor: "pointer",
+                        }}
+                        tabIndex={0}
+                      >
+                        {isActive && (
+                          <circle
+                            cx={x}
+                            cy={y}
+                            r={16}
+                            fill="none"
+                            stroke={color}
+                            strokeWidth={isSelected ? 3 : 2}
+                            strokeOpacity={isSelected ? 0.8 : 0.5}
+                          />
+                        )}
                         <circle
                           cx={x}
                           cy={y}
-                          r={16}
-                          fill="none"
-                          stroke={color}
-                          strokeWidth={isSelected ? 3 : 2}
-                          strokeOpacity={isSelected ? 0.8 : 0.5}
+                          r={isActive ? 12 : 10}
+                          fill={color}
+                          stroke="white"
+                          strokeWidth={2}
                         />
-                      )}
-                      <circle
-                        cx={x}
-                        cy={y}
-                        r={isActive ? 12 : 10}
-                        fill={color}
-                        stroke="white"
-                        strokeWidth={2}
-                      />
-                      <text
-                        x={x}
-                        y={y}
-                        textAnchor="middle"
-                        dominantBaseline="central"
-                        fontSize={10}
-                        fontWeight="700"
-                        fill="white"
-                        style={{
-                          pointerEvents: "none",
-                        }}
-                      >
-                        {index}
-                      </text>
-                    </g>
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="top"
-                    className="max-w-xs"
-                  >
-                    <div className="flex flex-col gap-0.5 text-left">
-                      <div className="font-semibold">
-                        {index}
-                        .
-                        {" "}
-                        {blip.topicName}
-                      </div>
-                      <div className="text-[11px] opacity-80">
-                        {sortedQuadrants[quadrantIndex]?.name}
-                        {" · "}
-                        {ringNameById[blip.ringId]}
-                      </div>
-                      {blip.description && (
-                        <div className="text-[11px] opacity-90">
-                          {blip.description}
+                        <text
+                          x={x}
+                          y={y}
+                          textAnchor="middle"
+                          dominantBaseline="central"
+                          fontSize={10}
+                          fontWeight="700"
+                          fill="white"
+                          style={{
+                            pointerEvents: "none",
+                          }}
+                        >
+                          {index}
+                        </text>
+                      </g>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="top"
+                      className="max-w-xs"
+                    >
+                      <div className="flex flex-col gap-0.5 text-left">
+                        <div className="font-semibold">
+                          {index}
+                          .
+                          {" "}
+                          {blip.topicName}
                         </div>
-                      )}
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
+                        <div className="text-[11px] opacity-80">
+                          {sortedQuadrants[quadrantIndex]?.name}
+                          {" · "}
+                          {ringNameById[blip.ringId]}
+                        </div>
+                        {blip.description && (
+                          <div className="text-[11px] opacity-90">
+                            {blip.description}
+                          </div>
+                        )}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
           </svg>
         </div>
         <RadarLegend

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
   Outlet,
   useNavigate,
 } from "@tanstack/react-router";
-import { EraserIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
+import { EraserIcon, MenuIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
 
 import { NavDropdown } from "@/components/layout/NavDropdown";
 import { Toaster } from "@/components/sonner";
@@ -119,17 +119,24 @@ const RootComponent: React.FunctionComponent = () => {
     }
   }
 
+  const navLinkClass = `
+    underline-offset-2
+    hover:underline
+    [&.active]:font-bold
+  `;
+
   return (
     <>
       <div className="container items-center justify-between gap-2 py-2">
-        <div className="flex gap-4">
+        <div
+          className={`
+            hidden gap-4
+            md:flex
+          `}
+        >
           <Link
             to="/dashboard"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
+            className={navLinkClass}
           >
             Dashboard
           </Link>
@@ -137,11 +144,7 @@ const RootComponent: React.FunctionComponent = () => {
           {showOnboard && (
             <Link
               to="/onboard"
-              className={`
-                underline-offset-2
-                hover:underline
-                [&.active]:font-bold
-              `}
+              className={navLinkClass}
             >
               Onboard
             </Link>
@@ -173,25 +176,84 @@ const RootComponent: React.FunctionComponent = () => {
 
           <Link
             to="/dailies"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
+            className={navLinkClass}
           >
             Dailies
           </Link>
 
           <Link
             to="/tasks"
-            className={`
-              underline-offset-2
-              hover:underline
-              [&.active]:font-bold
-            `}
+            className={navLinkClass}
           >
             Tasks
           </Link>
+        </div>
+        <div className="md:hidden">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild={true}>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Open navigation menu"
+              >
+                <MenuIcon />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuGroup>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/dashboard">Dashboard</Link>
+                </DropdownMenuItem>
+                {showOnboard && (
+                  <DropdownMenuItem
+                    asChild
+                    className="cursor-pointer"
+                  >
+                    <Link to="/onboard">Onboard</Link>
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/courses">Courses</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/providers">Providers</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/topics">Topics</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/domains">Domains</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/dailies">Dailies</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/tasks">Tasks</Link>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         <div className="flex flex-row gap-2">
           <DropdownMenu>

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -10,9 +10,12 @@ import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
+  deleteSingleCourse,
+  duplicateCourse,
   fetchProviders,
   fetchSingleCourse,
   fetchTopics,
@@ -186,6 +189,41 @@ function SingleCourseEdit() {
     }
   }
 
+  async function handleDelete() {
+    try {
+      await deleteSingleCourse(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["courses"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/courses",
+      });
+    }
+    catch {
+      toast.error("Failed to delete course. Please try again.");
+    }
+  }
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateCourse(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["courses"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/courses/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate course. Please try again.");
+    }
+  }
+
   return (
     <div className="container flex-col">
       <h2 className="mb-6 text-2xl">{isNew ? "New Course" : "Edit Course"}</h2>
@@ -309,7 +347,13 @@ function SingleCourseEdit() {
           {field => <field.DatePickerField label="Expiry Date" />}
         </form.AppField>
 
-        <div className="flex flex-row gap-4">
+        <EditPageFooter
+          isNew={isNew}
+          onDelete={handleDelete}
+          deleteLabel="Delete Course"
+          onDuplicate={handleDuplicate}
+          duplicateLabel="Duplicate Course"
+        >
           <Button
             type="submit"
             disabled={isSubmitting}
@@ -338,7 +382,7 @@ function SingleCourseEdit() {
           >
             Cancel
           </Button>
-        </div>
+        </EditPageFooter>
       </form>
       <UnsavedChangesDialog
         shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { CopyIcon } from "lucide-react";
-import { toast } from "sonner";
 
 import { TopicList } from "@/components/boxElements/TopicList";
 import { DailyRecentDaysStrip } from "@/components/dailies";
@@ -19,11 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
 import {
-  deleteSingleCourse,
-  duplicateCourse,
   fetchSingleCourse,
   getCurrentChain,
   getTotalCompletedDays,
@@ -49,7 +43,6 @@ function SingleCourse() {
   } = Route.useParams();
   const search = Route.useSearch();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const [dailyPromptOpen, setDailyPromptOpen] = useState<boolean>(
     search.promptDaily === 1,
@@ -62,32 +55,6 @@ function SingleCourse() {
     queryFn: () => fetchSingleCourse(id),
   });
 
-  const {
-    refetch: deleteCourse,
-  } = useQuery({
-    queryKey: ["course", id],
-    enabled: false,
-    queryFn: () => deleteSingleCourse(id),
-  });
-
-  async function handleDuplicate() {
-    try {
-      const result = await duplicateCourse(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["courses"],
-      });
-      await navigate({
-        to: "/courses/$id",
-        params: {
-          id: result.id,
-        },
-      });
-    }
-    catch {
-      toast.error("Failed to duplicate course. Please try again.");
-    }
-  }
-
   const percentComplete = makePercentageComplete(
     data?.progressCurrent,
     data?.progressTotal,
@@ -95,13 +62,6 @@ function SingleCourse() {
 
   const topics = data?.topics ?? null;
   const dailies = data?.dailies ?? [];
-
-  async function handleDelete() {
-    await deleteCourse();
-    await navigate({
-      to: "/courses",
-    });
-  }
 
   return (
     <div className="container flex-col gap-12">
@@ -235,17 +195,6 @@ function SingleCourse() {
           </InfoArea>
         </div>
       </InfoRow>
-      <div className="flex flex-row gap-2">
-        <Button
-          variant="secondary"
-          onClick={handleDuplicate}
-        >
-          Duplicate Course
-          {" "}
-          <CopyIcon />
-        </Button>
-        <DeleteButton onClick={handleDelete}>Delete Course</DeleteButton>
-      </div>
       <AlertDialog open={dailyPromptOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -18,11 +18,14 @@ import {
   ComboboxList,
 } from "@/components/combobox";
 import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createDaily,
+  deleteSingleDaily,
+  duplicateDaily,
   fetchCourses,
   fetchProviders,
   fetchSingleDaily,
@@ -286,6 +289,41 @@ function SingleDailyEdit() {
     }
   }, [selectedTask, currentValues.name, form]);
 
+  async function handleDelete() {
+    try {
+      await deleteSingleDaily(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/dailies",
+      });
+    }
+    catch {
+      toast.error("Failed to delete daily. Please try again.");
+    }
+  }
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateDaily(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/dailies/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate daily. Please try again.");
+    }
+  }
+
   return (
     <div>
       <PageHeader
@@ -478,7 +516,13 @@ function SingleDailyEdit() {
             </form.AppField>
           </div>
 
-          <div className="flex flex-row gap-4">
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Daily"
+            onDuplicate={handleDuplicate}
+            duplicateLabel="Duplicate Daily"
+          >
             <Button
               type="submit"
               disabled={isSubmitting}
@@ -507,7 +551,7 @@ function SingleDailyEdit() {
             >
               Cancel
             </Button>
-          </div>
+          </EditPageFooter>
         </form>
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -1,14 +1,12 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ChevronRightIcon,
-  CopyIcon,
   EditIcon,
   ExternalLink,
   FlameIcon,
   LaughIcon,
 } from "lucide-react";
-import { toast } from "sonner";
 
 import {
   DailyCompletionsManager,
@@ -18,10 +16,7 @@ import {
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
 import {
-  deleteSingleDaily,
-  duplicateDaily,
   fetchSingleDaily,
   getCurrentChain,
   getTotalCompletedDays,
@@ -52,8 +47,6 @@ function SingleDaily() {
   const {
     id,
   } = Route.useParams();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const {
     isPending, error, data,
@@ -62,45 +55,12 @@ function SingleDaily() {
     queryFn: () => fetchSingleDaily(id),
   });
 
-  const {
-    refetch: deleteDaily,
-  } = useQuery({
-    queryKey: ["dailies", "delete", id],
-    enabled: false,
-    queryFn: () => deleteSingleDaily(id),
-  });
-
-  async function handleDuplicate() {
-    try {
-      const result = await duplicateDaily(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["dailies"],
-      });
-      await navigate({
-        to: "/dailies/$id",
-        params: {
-          id: result.id,
-        },
-      });
-    }
-    catch {
-      toast.error("Failed to duplicate daily. Please try again.");
-    }
-  }
-
   if (isPending) {
     return <DailyPending />;
   }
 
   if (error || !data) {
     return <DailyError />;
-  }
-
-  async function handleDelete() {
-    await deleteDaily();
-    await navigate({
-      to: "/dailies",
-    });
   }
 
   const total = getTotalCompletedDays(data);
@@ -164,14 +124,6 @@ function SingleDaily() {
               </Button>
             </a>
           )}
-          <Button
-            variant="secondary"
-            onClick={handleDuplicate}
-          >
-            Duplicate
-            {" "}
-            <CopyIcon />
-          </Button>
           <Link
             to="/dailies/$id/edit"
             params={{
@@ -275,9 +227,6 @@ function SingleDaily() {
             readOnly
           />
         </InfoArea>
-        <div>
-          <DeleteButton onClick={handleDelete}>Delete Daily</DeleteButton>
-        </div>
       </div>
     </div>
   );

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -9,6 +9,7 @@ import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
 import { Textarea } from "@/components/forms/textarea";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +22,8 @@ import {
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createDomain,
+  deleteSingleDomain,
+  duplicateDomain,
   fetchSingleDomain,
   fetchTopics,
   formHasChanges,
@@ -232,6 +235,41 @@ function SingleDomainEdit() {
     [excludedRows],
   );
 
+  async function handleDelete() {
+    try {
+      await deleteSingleDomain(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["domains"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/domains",
+      });
+    }
+    catch {
+      toast.error("Failed to delete domain. Please try again.");
+    }
+  }
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateDomain(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["domains"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/domains/$id",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate domain. Please try again.");
+    }
+  }
+
   return (
     <div>
       <PageHeader
@@ -396,7 +434,13 @@ function SingleDomainEdit() {
             </div>
           </section>
 
-          <div className="flex flex-row gap-4">
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Domain"
+            onDuplicate={handleDuplicate}
+            duplicateLabel="Duplicate Domain"
+          >
             <Button
               type="submit"
               disabled={isSubmitting}
@@ -425,7 +469,7 @@ function SingleDomainEdit() {
             >
               Cancel
             </Button>
-          </div>
+          </EditPageFooter>
         </form>
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -1,19 +1,14 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { CopyIcon, EditIcon, RadarIcon } from "lucide-react";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { EditIcon, RadarIcon } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
 import { DomainLearningLog } from "@/components/domains/DomainLearningLog";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { RadarChart } from "@/components/radar/RadarChart";
 import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
-import {
-  deleteSingleDomain,
-  duplicateDomain,
-  fetchSingleDomain,
-} from "@/utils";
+import { fetchRadar, fetchSingleDomain } from "@/utils";
 
 export const Route = createFileRoute("/domains/$id/")({
   component: SingleDomain,
@@ -23,8 +18,6 @@ function SingleDomain() {
   const {
     id,
   } = Route.useParams();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const {
     isPending, error, data,
@@ -34,30 +27,12 @@ function SingleDomain() {
   });
 
   const {
-    refetch: deleteDomain,
+    data: radarData,
   } = useQuery({
-    queryKey: ["domain", "delete", id],
-    enabled: false,
-    queryFn: () => deleteSingleDomain(id),
+    queryKey: ["radar", id],
+    queryFn: () => fetchRadar(id),
+    enabled: !!data?.hasRadar,
   });
-
-  async function handleDuplicate() {
-    try {
-      const result = await duplicateDomain(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["domains"],
-      });
-      await navigate({
-        to: "/domains/$id",
-        params: {
-          id: result.id,
-        },
-      });
-    }
-    catch {
-      toast.error("Failed to duplicate domain. Please try again.");
-    }
-  }
 
   if (isPending) {
     return (
@@ -77,15 +52,13 @@ function SingleDomain() {
     );
   }
 
-  async function handleDelete() {
-    await deleteDomain();
-    await navigate({
-      to: "/domains",
-    });
-  }
-
   const excludedTopics = data?.excludedTopics ?? [];
   const learningLog = data?.learningLog ?? [];
+  const radarReady
+    = !!data?.hasRadar
+      && !!radarData
+      && radarData.quadrants.length > 0
+      && radarData.rings.length > 0;
 
   return (
     <div>
@@ -108,14 +81,6 @@ function SingleDomain() {
               </Button>
             </Link>
           )}
-          <Button
-            variant="secondary"
-            onClick={handleDuplicate}
-          >
-            Duplicate
-            {" "}
-            <CopyIcon />
-          </Button>
           <Link
             to="/domains/$id/edit"
             params={{
@@ -140,6 +105,16 @@ function SingleDomain() {
         <InfoArea header="Has Radar?">
           <YesNoDisplay value={!!data?.hasRadar} />
         </InfoArea>
+        {radarReady && radarData && (
+          <InfoArea header="Radar Preview">
+            <RadarChart
+              quadrants={radarData.quadrants}
+              rings={radarData.rings}
+              blips={radarData.blips}
+              size={400}
+            />
+          </InfoArea>
+        )}
         <div>
           <InfoArea
             header="Topics"
@@ -211,9 +186,6 @@ function SingleDomain() {
             entries={learningLog}
           />
         )}
-        <div>
-          <DeleteButton onClick={handleDelete}>Delete Domain</DeleteButton>
-        </div>
       </div>
     </div>
   );

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -8,11 +8,13 @@ import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createProvider,
+  deleteSinglePlatform,
   fetchSingleProvider,
   formHasChanges,
   upsertProvider,
@@ -135,6 +137,22 @@ function SingleProviderEdit() {
     form.store,
     state => state.values.isRecurring === "true",
   );
+
+  async function handleDelete() {
+    try {
+      await deleteSinglePlatform(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["providers"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/providers",
+      });
+    }
+    catch {
+      toast.error("Failed to delete provider. Please try again.");
+    }
+  }
 
   return (
     <div>
@@ -270,7 +288,11 @@ function SingleProviderEdit() {
             </>
           )}
 
-          <div className="flex flex-row gap-4">
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Provider"
+          >
             <Button
               type="submit"
               disabled={isSubmitting}
@@ -299,7 +321,7 @@ function SingleProviderEdit() {
             >
               Cancel
             </Button>
-          </div>
+          </EditPageFooter>
         </form>
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/providers.$id.index.tsx
+++ b/packages/client/src/routes/providers.$id.index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon, ExternalLink } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
@@ -7,8 +7,7 @@ import { InfoArea } from "@/components/layout/InfoArea";
 import { InfoRow } from "@/components/layout/InfoRow";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
-import { deleteSinglePlatform, fetchSingleProvider } from "@/utils";
+import { fetchSingleProvider } from "@/utils";
 
 export const Route = createFileRoute("/providers/$id/")({
   component: SingleProviders,
@@ -42,7 +41,6 @@ function SingleProviders() {
   const {
     id,
   } = Route.useParams();
-  const navigate = useNavigate();
 
   const {
     isPending, error, data,
@@ -51,27 +49,12 @@ function SingleProviders() {
     queryFn: () => fetchSingleProvider(id),
   });
 
-  const {
-    refetch: deletePlatform,
-  } = useQuery({
-    queryKey: ["provider", "delete", id],
-    enabled: false,
-    queryFn: () => deleteSinglePlatform(id),
-  });
-
   if (isPending) {
     <TopicPending />;
   }
 
   if (error) {
     <TopicError />;
-  }
-
-  async function handleDelete() {
-    await deletePlatform();
-    await navigate({
-      to: "/providers",
-    });
   }
 
   return (
@@ -167,9 +150,6 @@ function SingleProviders() {
                 ))}
             </ul>
           </InfoArea>
-        </div>
-        <div>
-          <DeleteButton onClick={handleDelete}>Delete Platform</DeleteButton>
         </div>
       </div>
     </div>

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -10,12 +10,14 @@ import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ResourcesEditor } from "@/components/tasks/ResourcesEditor";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createTask,
+  deleteSingleTask,
   fetchSingleTask,
   fetchTopics,
   formHasChanges,
@@ -157,6 +159,22 @@ function SingleTaskEdit() {
     = JSON.stringify(resources) !== JSON.stringify(initialResources);
   const hasChanges = formHasFieldChanges || resourcesChanged;
 
+  async function handleDelete() {
+    try {
+      await deleteSingleTask(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["tasks"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/tasks",
+      });
+    }
+    catch {
+      toast.error("Failed to delete task. Please try again.");
+    }
+  }
+
   return (
     <div>
       <PageHeader
@@ -220,7 +238,11 @@ function SingleTaskEdit() {
             />
           </div>
 
-          <div className="flex flex-row gap-4">
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Task"
+          >
             <Button
               type="submit"
               disabled={isSubmitting}
@@ -249,7 +271,7 @@ function SingleTaskEdit() {
             >
               Cancel
             </Button>
-          </div>
+          </EditPageFooter>
         </form>
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -1,5 +1,5 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon, ExternalLinkIcon } from "lucide-react";
 
 import { DailyRecentDaysStrip } from "@/components/dailies";
@@ -7,8 +7,7 @@ import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ResourcesTable } from "@/components/tasks/ResourcesTable";
 import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
-import { deleteSingleTask, fetchSingleTask } from "@/utils";
+import { fetchSingleTask } from "@/utils";
 
 export const Route = createFileRoute("/tasks/$id/")({
   component: SingleTask,
@@ -34,8 +33,6 @@ function SingleTask() {
   const {
     id,
   } = Route.useParams();
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const {
     isPending, error, data,
@@ -50,16 +47,6 @@ function SingleTask() {
 
   if (error || !data) {
     return <TaskError />;
-  }
-
-  async function handleDelete() {
-    await deleteSingleTask(id);
-    await queryClient.invalidateQueries({
-      queryKey: ["tasks"],
-    });
-    await navigate({
-      to: "/tasks",
-    });
   }
 
   const linkedDaily = data.daily;
@@ -152,9 +139,6 @@ function SingleTask() {
         >
           <ResourcesTable task={data} />
         </InfoArea>
-        <div>
-          <DeleteButton onClick={handleDelete}>Delete Task</DeleteButton>
-        </div>
       </div>
     </div>
   );

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -8,11 +8,13 @@ import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createTopic,
+  deleteSingleTopic,
   fetchDomains,
   fetchSingleTopic,
   formHasChanges,
@@ -135,6 +137,22 @@ function SingleTopicEdit() {
   const isSubmitting = useStore(form.store, state => state.isSubmitting);
   const hasChanges = formHasChanges(currentValues, startingValues);
 
+  async function handleDelete() {
+    try {
+      await deleteSingleTopic(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["topics"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/topics",
+      });
+    }
+    catch {
+      toast.error("Failed to delete topic. Please try again.");
+    }
+  }
+
   return (
     <div>
       <PageHeader
@@ -196,7 +214,11 @@ function SingleTopicEdit() {
             )}
           </form.AppField>
 
-          <div className="flex flex-row gap-4">
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Topic"
+          >
             <Button
               type="submit"
               disabled={isSubmitting}
@@ -225,7 +247,7 @@ function SingleTopicEdit() {
             >
               Cancel
             </Button>
-          </div>
+          </EditPageFooter>
         </form>
         <UnsavedChangesDialog
           shouldBlockFn={() => hasChanges && !skipBlocker.current}

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -1,12 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon } from "lucide-react";
 
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { DeleteButton } from "@/components/ui/DeleteButton";
-import { deleteSingleTopic, fetchSingleTopic } from "@/utils";
+import { fetchSingleTopic } from "@/utils";
 
 export const Route = createFileRoute("/topics/$id/")({
   component: SingleTopic,
@@ -40,7 +39,6 @@ function SingleTopic() {
   const {
     id,
   } = Route.useParams();
-  const navigate = useNavigate();
 
   const {
     isPending, error, data,
@@ -49,27 +47,12 @@ function SingleTopic() {
     queryFn: () => fetchSingleTopic(id),
   });
 
-  const {
-    refetch: deleteTopic,
-  } = useQuery({
-    queryKey: ["topics", "delete", id],
-    enabled: false,
-    queryFn: () => deleteSingleTopic(id),
-  });
-
   if (isPending) {
     <TopicPending />;
   }
 
   if (error) {
     <TopicError />;
-  }
-
-  async function handleDelete() {
-    await deleteTopic();
-    await navigate({
-      to: "/topics",
-    });
   }
 
   return (
@@ -158,9 +141,6 @@ function SingleTopic() {
                 ))}
             </ul>
           </InfoArea>
-        </div>
-        <div>
-          <DeleteButton onClick={handleDelete}>Delete Topic</DeleteButton>
         </div>
       </div>
     </div>

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -53,6 +53,21 @@ export default async function (server: FastifyInstance) {
                       },
                     },
                   },
+                  tasks: {
+                    columns: {
+                      id: true,
+                      name: true,
+                    },
+                    with: {
+                      daily: {
+                        columns: {
+                          id: true,
+                          name: true,
+                          completions: true,
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -79,6 +94,21 @@ export default async function (server: FastifyInstance) {
                               completions: true,
                             },
                           },
+                        },
+                      },
+                    },
+                  },
+                  tasks: {
+                    columns: {
+                      id: true,
+                      name: true,
+                    },
+                    with: {
+                      daily: {
+                        columns: {
+                          id: true,
+                          name: true,
+                          completions: true,
                         },
                       },
                     },
@@ -183,8 +213,10 @@ export default async function (server: FastifyInstance) {
         id: string;
         name: string;
         completions: DailyCompletion[];
-        courseId: string;
-        courseName: string;
+        courseId?: string | null;
+        courseName?: string | null;
+        taskId?: string | null;
+        taskName?: string | null;
       }>();
 
       function addDailiesFromTopic(topic: {
@@ -197,6 +229,15 @@ export default async function (server: FastifyInstance) {
             completions?: DailyCompletion[] | null;
           }[];
         } | null; }[];
+        tasks?: {
+          id: string;
+          name: string;
+          daily?: {
+            id: string;
+            name: string;
+            completions?: DailyCompletion[] | null;
+          } | null;
+        }[];
       } | null | undefined) {
         if (!topic) return;
         for (const ttc of topic.topicsToCourses ?? []) {
@@ -212,6 +253,18 @@ export default async function (server: FastifyInstance) {
               courseName: course.name,
             });
           }
+        }
+        for (const task of topic.tasks ?? []) {
+          const d = task.daily;
+          if (!d) continue;
+          if (dailySourceMap.has(d.id)) continue;
+          dailySourceMap.set(d.id, {
+            id: d.id,
+            name: d.name,
+            completions: (d.completions ?? []) as DailyCompletion[],
+            taskId: task.id,
+            taskName: task.name,
+          });
         }
       }
 

--- a/packages/middleware/src/utils/learningLog.ts
+++ b/packages/middleware/src/utils/learningLog.ts
@@ -11,8 +11,10 @@ interface DailySource {
   id: string;
   name: string;
   completions: DailyCompletion[];
-  courseId: string;
-  courseName: string;
+  courseId?: string | null;
+  courseName?: string | null;
+  taskId?: string | null;
+  taskName?: string | null;
 }
 
 function dateString(value: string | Date | null): string {
@@ -79,8 +81,10 @@ export function buildDomainLearningLog(
         link: null,
         dailyId: daily.id,
         dailyName: daily.name,
-        courseId: daily.courseId,
-        courseName: daily.courseName,
+        courseId: daily.courseId ?? null,
+        courseName: daily.courseName ?? null,
+        taskId: daily.taskId ?? null,
+        taskName: daily.taskName ?? null,
         status: (completion.status ?? null) as DailyCompletionStatus | null,
       });
     }

--- a/packages/types/src/LearningLog.ts
+++ b/packages/types/src/LearningLog.ts
@@ -12,6 +12,8 @@ export interface LearningLogEntry {
   dailyName?: string | null;
   courseId?: string | null;
   courseName?: string | null;
+  taskId?: string | null;
+  taskName?: string | null;
   status?: DailyCompletionStatus | null;
 }
 


### PR DESCRIPTION
- Mobile hamburger menu with all nav links
- Domain learning log picks up dailies from tasks via topic association
- Domain page shows a small radar preview when radar is configured
- Selected radar blip renders on top of other blips
- Today's status pill uses border-2 to match status icon circles
- Freeze status more deemphasized (lighter shades, partial opacity)
- Delete and Duplicate buttons moved into shared EditPageFooter on
  edit pages; removed from view pages