### PR TITLE
Add search, filtering, and sorting to topics page

### DIFF
--- a/packages/client/src/components/boxes/TopicBox.tsx
+++ b/packages/client/src/components/boxes/TopicBox.tsx
@@ -20,6 +20,7 @@ export function TopicBox({
   name,
   description,
   courseCount,
+  domains,
 }: TopicForTopicsPage) {
   return (
     <ContentBox>
@@ -36,6 +37,21 @@ export function TopicBox({
         </ContentBoxTitle>
       </ContentBoxHeader>
       <ContentBoxBody>
+        {domains && domains.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-1">
+            {domains.map(domain => (
+              <span
+                key={domain.id}
+                className="
+                  rounded-sm bg-gray-100 px-2 py-0.5 text-xs
+                  text-gray-700
+                "
+              >
+                {domain.title}
+              </span>
+            ))}
+          </div>
+        )}
         <Description description={description} />
       </ContentBoxBody>
       <ContentBoxFooter>

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -1,14 +1,30 @@
 import type { TopicForTopicsPage } from "@emstack/types/src";
 
+import { useMemo, useState } from "react";
+
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRightIcon, PlusIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  PlusIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { fetchTopics } from "@/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { fetchDomains, fetchTopics } from "@/utils";
+
+type SortOption = "alpha-asc" | "alpha-desc" | "resources";
 
 export const Route = createFileRoute("/topics/")({
   component: Topics,
@@ -42,7 +58,27 @@ function TopicsError() {
   );
 }
 
+function sortTopics(
+  topics: TopicForTopicsPage[],
+  sortBy: SortOption,
+): TopicForTopicsPage[] {
+  return [...topics].sort((a, b) => {
+    switch (sortBy) {
+      case "alpha-asc":
+        return a.name.localeCompare(b.name);
+      case "alpha-desc":
+        return b.name.localeCompare(a.name);
+      case "resources":
+        return (b.courseCount ?? 0) - (a.courseCount ?? 0);
+    }
+  });
+}
+
 function Topics() {
+  const [search, setSearch] = useState("");
+  const [filterDomain, setFilterDomain] = useState<string | undefined>();
+  const [sortBy, setSortBy] = useState<SortOption>("alpha-asc");
+
   const {
     data,
   } = useQuery({
@@ -50,13 +86,134 @@ function Topics() {
     queryFn: () => fetchTopics(),
   });
 
+  const {
+    data: domains,
+  } = useQuery({
+    queryKey: ["domains"],
+    queryFn: () => fetchDomains(),
+  });
+
+  const filteredAndSorted = useMemo(() => {
+    if (!data) return [];
+
+    let result = data.filter(t => t.name !== "");
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter((t) => {
+        const nameMatch = t.name.toLowerCase().includes(q);
+        const domainMatch = t.domains?.some(d =>
+          d.title.toLowerCase().includes(q));
+        return nameMatch || domainMatch;
+      });
+    }
+
+    if (filterDomain === "none") {
+      result = result.filter(t => !t.domains || t.domains.length === 0);
+    }
+    else if (filterDomain) {
+      result = result.filter(t =>
+        t.domains?.some(d => d.id === filterDomain));
+    }
+
+    return sortTopics(result, sortBy);
+  }, [data, search, filterDomain, sortBy]);
+
+  const hasActiveFilters = filterDomain;
+
   return (
     <div>
       <PageHeader
         pageTitle="Topics"
         pageSection=""
       />
-      <div className="container">
+      <div className="container flex flex-col gap-4">
+        <div>
+          {data && data.length > 0 && (
+            <div
+              className="mb-4 flex flex-wrap items-center justify-between gap-3"
+            >
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="relative">
+                  <SearchIcon
+                    className="
+                      absolute top-1/2 left-2.5 size-4 -translate-y-1/2
+                      text-muted-foreground
+                    "
+                  />
+                  <input
+                    type="text"
+                    placeholder="Search topics..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    className="
+                      h-9 rounded-md border border-input bg-transparent pr-3
+                      pl-8 text-sm shadow-xs transition-[color,box-shadow]
+                      outline-none
+                      placeholder:text-muted-foreground
+                      focus-visible:border-ring focus-visible:ring-[3px]
+                      focus-visible:ring-ring/50
+                    "
+                  />
+                </div>
+
+                <Select
+                  value={filterDomain ?? "all"}
+                  onValueChange={v =>
+                    setFilterDomain(v === "all" ? undefined : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Domain" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Domains</SelectItem>
+                    <SelectItem value="none">No Domain</SelectItem>
+                    {domains?.map(d => (
+                      <SelectItem
+                        key={d.id}
+                        value={d.id}
+                      >
+                        {d.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                {hasActiveFilters && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setFilterDomain(undefined);
+                    }}
+                  >
+                    <XIcon className="size-4" />
+                    Clear filters
+                  </Button>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Sort</span>
+                <Select
+                  value={sortBy}
+                  onValueChange={v => setSortBy(v as SortOption)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort by" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="alpha-asc">A-Z</SelectItem>
+                    <SelectItem value="alpha-desc">Z-A</SelectItem>
+                    <SelectItem value="resources">
+                      Number of linked resources
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+        </div>
         <div className="card-grid">
           {(!data || data.length === 0) && (
             <div className="flex flex-col gap-6">
@@ -75,12 +232,8 @@ function Topics() {
             </div>
           )}
 
-          {data
-            && data.length > 0
-            && data.map((topic: TopicForTopicsPage) => {
-              if (topic.name === "") {
-                return;
-              }
+          {filteredAndSorted.length > 0
+            && filteredAndSorted.map((topic: TopicForTopicsPage) => {
               return (
                 <TopicBox
                   {...topic}
@@ -88,6 +241,12 @@ function Topics() {
                 />
               );
             })}
+
+          {data && data.length > 0 && filteredAndSorted.length === 0 && (
+            <div className="text-muted-foreground">
+              <i>No topics match your filters.</i>
+            </div>
+          )}
 
           <Link
             to="/topics/$id/edit"

--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -21,11 +21,31 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          topicsToDomains: {
+            with: {
+              domain: {
+                columns: {
+                  id: true,
+                  title: true,
+                },
+              },
+            },
+          },
         },
       });
 
       const processedData: TopicForTopicsPage[] = rawData.map((topic: TopicsFromServer) => {
         const courseCount = topic.topicsToCourses?.length ?? 0;
+
+        const domainsById = new Map<string, { id: string; title: string }>();
+        for (const ttd of topic.topicsToDomains ?? []) {
+          if (ttd.domain?.id && ttd.domain.title && !domainsById.has(ttd.domain.id)) {
+            domainsById.set(ttd.domain.id, {
+              id: ttd.domain.id,
+              title: ttd.domain.title,
+            });
+          }
+        }
 
         return {
           id: topic.id,
@@ -33,6 +53,7 @@ export default async function (server: FastifyInstance) {
           description: topic.description,
           reason: topic.reason,
           courseCount: courseCount,
+          domains: Array.from(domainsById.values()),
         };
       });
 

--- a/packages/types/src/TopicForTopicsPage.ts
+++ b/packages/types/src/TopicForTopicsPage.ts
@@ -1,6 +1,12 @@
+export interface TopicForTopicsPageDomain {
+  id: string;
+  title: string;
+}
+
 export interface TopicForTopicsPage {
   id: string;
   name: string;
   description?: string | null;
   courseCount?: number;
+  domains?: TopicForTopicsPageDomain[];
 }

--- a/packages/types/src/TopicsFromServer.ts
+++ b/packages/types/src/TopicsFromServer.ts
@@ -1,4 +1,5 @@
 import { TopicsToCourses } from "@/TopicsToCourses";
+import { TopicsToDomains } from "@/TopicsToDomains";
 
 export interface TopicsFromServer {
   id: string;
@@ -6,4 +7,5 @@ export interface TopicsFromServer {
   description?: string | null;
   reason?: string | null;
   topicsToCourses?: TopicsToCourses[] | null;
+  topicsToDomains?: TopicsToDomains[] | null;
 }


### PR DESCRIPTION
## Summary
Enhanced the topics page with comprehensive search, filtering, and sorting capabilities. Users can now search topics by name or domain, filter by domain assignment, and sort results alphabetically or by resource count.

## Key Changes
- **Search functionality**: Added search input that filters topics by name or associated domain titles
- **Domain filtering**: Implemented dropdown to filter topics by domain or show unassigned topics
- **Sorting options**: Added sort dropdown with three options:
  - Alphabetical ascending (A-Z)
  - Alphabetical descending (Z-A)
  - By number of linked resources
- **Clear filters button**: Added button to reset active filters
- **Domain display**: Topics now display their associated domains as badges in the topic cards
- **Empty state messaging**: Added message when filters result in no matching topics
- **Backend enhancement**: Updated topics API endpoint to include domain relationships with domain metadata (id and title)
- **Type updates**: Extended `TopicForTopicsPage` type to include domains array

## Implementation Details
- Used `useMemo` to efficiently compute filtered and sorted results based on search, domain filter, and sort option
- Filtering logic handles three cases: search query matching, domain-specific filtering, and unassigned topics
- Domain data is fetched separately via `fetchDomains()` query
- UI layout updated to accommodate new filter/sort controls with responsive flex layout
- Domains are deduplicated on the backend using a Map before returning to client

https://claude.ai/code/session_01RQZ6CGkb3h12MgfwDymYqy