### PR TITLE
Add table view mode for courses with persistent preference

### DIFF
--- a/packages/client/src/components/boxes/CoursesTable.tsx
+++ b/packages/client/src/components/boxes/CoursesTable.tsx
@@ -1,0 +1,139 @@
+import type { CourseInCourses } from "@emstack/types/src";
+
+import { ExternalLink } from "lucide-react";
+
+import { EntityLink } from "@/components/boxElements/EntityLink";
+import { StatusIndicator } from "@/components/boxElements/StatusIndicator";
+import { TopicList } from "@/components/boxElements/TopicList";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface CoursesTableProps {
+  courses: CourseInCourses[];
+}
+
+function formatProgress(course: CourseInCourses): string {
+  if (!course.progressTotal) return "—";
+  const pct = Math.round(
+    (course.progressCurrent / course.progressTotal) * 100,
+  );
+  return `${course.progressCurrent} / ${course.progressTotal} (${pct}%)`;
+}
+
+function formatCost(course: CourseInCourses): string {
+  const {
+    cost,
+  } = course;
+  if (cost.cost == null) return "—";
+  const value = cost.isCostFromPlatform
+    ? Number(cost.cost) / cost.splitBy
+    : Number(cost.cost);
+  const suffix = cost.isCostFromPlatform ? "*" : "";
+  return `$${value}${suffix}`;
+}
+
+export function CoursesTable({
+  courses,
+}: CoursesTableProps) {
+  return (
+    <div className="w-full rounded-md border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">Status</TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Provider</TableHead>
+            <TableHead>Topics</TableHead>
+            <TableHead>Progress</TableHead>
+            <TableHead>Cost</TableHead>
+            <TableHead>Expires</TableHead>
+            <TableHead className="w-12 text-right">Link</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {courses.map(course => (
+            <TableRow key={course.id}>
+              <TableCell>
+                <StatusIndicator status={course.status} />
+              </TableCell>
+              <TableCell className="font-medium">
+                <EntityLink
+                  entity="courses"
+                  id={course.id}
+                  className="hover:text-blue-600"
+                >
+                  {course.name}
+                </EntityLink>
+              </TableCell>
+              <TableCell>
+                {course.provider
+                  ? (
+                    <EntityLink
+                      entity="providers"
+                      id={course.provider.id}
+                      from="/courses"
+                      className="
+                        text-blue-800
+                        hover:text-blue-600
+                      "
+                    >
+                      {course.provider.name}
+                    </EntityLink>
+                  )
+                  : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+              </TableCell>
+              <TableCell>
+                {course.topics && course.topics.length > 0
+                  ? (
+                    <TopicList
+                      topics={course.topics}
+                      isPills={false}
+                    />
+                  )
+                  : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                {formatProgress(course)}
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                {formatCost(course)}
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                {course.dateExpires || (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </TableCell>
+              <TableCell className="text-right">
+                {course.url
+                  ? (
+                    <a
+                      href={course.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="
+                        inline-flex items-center text-muted-foreground
+                        hover:text-foreground
+                      "
+                    >
+                      <ExternalLink size={16} />
+                    </a>
+                  )
+                  : null}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/packages/client/src/components/ui/table.tsx
+++ b/packages/client/src/components/ui/table.tsx
@@ -1,0 +1,149 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({
+  className,
+  ...props
+}: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({
+  className,
+  ...props
+}: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({
+  className,
+  ...props
+}: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({
+  className,
+  ...props
+}: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        `
+          border-t bg-muted/50 font-medium
+          [&>tr]:last:border-b-0
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({
+  className,
+  ...props
+}: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        `
+          border-b transition-colors
+          hover:bg-muted/50
+          data-[state=selected]:bg-muted
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({
+  className,
+  ...props
+}: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        `
+          h-10 px-3 text-left align-middle text-xs font-semibold
+          text-muted-foreground uppercase
+          [&:has([role=checkbox])]:pr-0
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({
+  className,
+  ...props
+}: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        `
+          p-3 align-middle
+          [&:has([role=checkbox])]:pr-0
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -8,6 +8,8 @@ import {
   ArrowDownAZIcon,
   ArrowRightIcon,
   ArrowUpAZIcon,
+  LayoutGridIcon,
+  ListIcon,
   PlusIcon,
   SearchIcon,
   XIcon,
@@ -15,6 +17,7 @@ import {
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { CourseBox } from "@/components/boxes/CourseBox";
+import { CoursesTable } from "@/components/boxes/CoursesTable";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +30,15 @@ import {
 import { fetchCourses, fetchProviders, fetchTopics } from "@/utils";
 
 type SortOption = "alpha" | "progress" | "provider" | "topic";
+type ViewMode = "grid" | "table";
+
+const VIEW_MODE_STORAGE_KEY = "courses:viewMode";
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === "undefined") return "grid";
+  const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+  return stored === "table" ? "table" : "grid";
+}
 
 export const Route = createFileRoute("/courses/")({
   component: Courses,
@@ -91,6 +103,14 @@ function Courses() {
   const [filterTopic, setFilterTopic] = useState<string | undefined>();
   const [sortBy, setSortBy] = useState<SortOption>("alpha");
   const [sortAsc, setSortAsc] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+
+  const updateViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    }
+  };
 
   const {
     data,
@@ -267,65 +287,118 @@ function Courses() {
                       <ArrowUpAZIcon className="size-4" />
                     )}
                 </Button>
+                <div
+                  className="
+                    ml-2 flex items-center rounded-md border border-input
+                    bg-transparent
+                  "
+                  role="group"
+                  aria-label="View mode"
+                >
+                  <Button
+                    type="button"
+                    variant={viewMode === "grid" ? "secondary" : "ghost"}
+                    size="icon"
+                    aria-label="Grid view"
+                    aria-pressed={viewMode === "grid"}
+                    onClick={() => updateViewMode("grid")}
+                  >
+                    <LayoutGridIcon className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={viewMode === "table" ? "secondary" : "ghost"}
+                    size="icon"
+                    aria-label="Table view"
+                    aria-pressed={viewMode === "table"}
+                    onClick={() => updateViewMode("table")}
+                  >
+                    <ListIcon className="size-4" />
+                  </Button>
+                </div>
               </div>
             </div>
           )}
         </div>
-        <div className="card-grid">
-          {(!data || data.length === 0) && (
-            <div className="flex flex-col gap-6">
-              <i>No courses yet!</i>
+        {(!data || data.length === 0) && (
+          <div className="flex flex-col gap-6">
+            <i>No courses yet!</i>
 
-              <Link
-                to="/onboard"
-                className=""
+            <Link
+              to="/onboard"
+              className=""
+            >
+              <Button>
+                Go to onboarding
+                {" "}
+                <ArrowRightIcon />
+              </Button>
+            </Link>
+          </div>
+        )}
+
+        {data && data.length > 0 && filteredAndSorted.length === 0 && (
+          <div className="text-muted-foreground">
+            <i>No courses match your filters.</i>
+          </div>
+        )}
+
+        {viewMode === "grid" && (
+          <div className="card-grid">
+            {filteredAndSorted.length > 0
+              && filteredAndSorted.map((course: Course) => {
+                if (!course) {
+                  return <></>;
+                }
+                return (
+                  <CourseBox
+                    {...course}
+                    key={course.id}
+                  />
+                );
+              })}
+
+            <Link
+              to="/courses/$id/edit"
+              params={{
+                id: "new",
+              }}
+            >
+              <ContentBox
+                className="
+                  h-full items-center justify-center border-dashed p-8
+                  text-muted-foreground transition-colors
+                  hover:border-solid hover:bg-accent
+                  hover:text-accent-foreground
+                "
               >
-                <Button>
-                  Go to onboarding
-                  {" "}
-                  <ArrowRightIcon />
+                <PlusIcon size={32} />
+                <span className="text-lg font-medium">Add New Course</span>
+              </ContentBox>
+            </Link>
+          </div>
+        )}
+
+        {viewMode === "table" && (
+          <div className="flex flex-col gap-4">
+            {filteredAndSorted.length > 0 && (
+              <CoursesTable courses={filteredAndSorted} />
+            )}
+            <div>
+              <Link
+                to="/courses/$id/edit"
+                params={{
+                  id: "new",
+                }}
+              >
+                <Button variant="outline">
+                  <PlusIcon className="size-4" />
+                  Add New Course
                 </Button>
               </Link>
             </div>
-          )}
-
-          {filteredAndSorted.length > 0
-            && filteredAndSorted.map((course: Course) => {
-              if (!course) {
-                return <></>;
-              }
-              return (
-                <CourseBox
-                  {...course}
-                  key={course.id}
-                />
-              );
-            })}
-
-          {data && data.length > 0 && filteredAndSorted.length === 0 && (
-            <div className="text-muted-foreground">
-              <i>No courses match your filters.</i>
-            </div>
-          )}
-
-          <Link
-            to="/courses/$id/edit"
-            params={{
-              id: "new",
-            }}
-          >
-            <ContentBox
-              className="
-                h-full items-center justify-center border-dashed p-8
-                text-muted-foreground transition-colors
-                hover:border-solid hover:bg-accent hover:text-accent-foreground
-              "
-            >
-              <PlusIcon size={32} />
-              <span className="text-lg font-medium">Add New Course</span>
-            </ContentBox>
-          </Link>
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Added a table view mode for the courses page alongside the existing grid view, with the ability to toggle between them. The user's view preference is persisted to localStorage.

## Key Changes
- **View Mode Toggle**: Added grid/table view switcher in the courses header with `LayoutGridIcon` and `ListIcon` buttons
- **Persistent Preference**: View mode selection is saved to localStorage (`courses:viewMode`) and restored on page load
- **CoursesTable Component**: New table component displaying courses with columns for status, name, provider, topics, progress, cost, expiration date, and external link
- **Table UI Components**: Added reusable table primitives (`Table`, `TableHeader`, `TableBody`, `TableRow`, `TableHead`, `TableCell`, etc.) for consistent styling
- **Conditional Rendering**: Courses display in either grid or table layout based on selected view mode
- **Improved Empty States**: Separated empty state messaging for no courses vs. no matching filters

## Implementation Details
- View mode state is initialized via `getInitialViewMode()` which safely checks localStorage (handles SSR)
- `updateViewMode()` function handles both state update and localStorage persistence
- Table view includes formatted progress (current/total with percentage), cost calculations (accounting for platform splits), and clickable entity links
- View mode buttons use ARIA attributes (`aria-label`, `aria-pressed`) for accessibility
- Table styling includes hover effects and responsive overflow handling

https://claude.ai/code/session_016rMKvQT8gFe6auWkcdbhvk