### PR TITLE
Move Menu items into a dedicated Settings page

### DIFF
--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TopicsRouteImport } from './routes/topics'
 import { Route as TasksRouteImport } from './routes/tasks'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
 import { Route as DomainsRouteImport } from './routes/domains'
@@ -54,6 +55,11 @@ const TopicsRoute = TopicsRouteImport.update({
 const TasksRoute = TasksRouteImport.update({
   id: '/tasks',
   path: '/tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProvidersRoute = ProvidersRouteImport.update({
@@ -235,6 +241,7 @@ export interface FileRoutesByFullPath {
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
@@ -269,6 +276,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
   '/onboard': typeof OnboardRoute
+  '/settings': typeof SettingsRoute
   '/courses': typeof CoursesIndexRoute
   '/dailies': typeof DailiesIndexRoute
   '/domains': typeof DomainsIndexRoute
@@ -299,6 +307,7 @@ export interface FileRoutesById {
   '/domains': typeof DomainsRouteWithChildren
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
   '/courses/$id': typeof CoursesIdRouteWithChildren
@@ -339,6 +348,7 @@ export interface FileRouteTypes {
     | '/domains'
     | '/onboard'
     | '/providers'
+    | '/settings'
     | '/tasks'
     | '/topics'
     | '/courses/$id'
@@ -373,6 +383,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/onboard'
+    | '/settings'
     | '/courses'
     | '/dailies'
     | '/domains'
@@ -402,6 +413,7 @@ export interface FileRouteTypes {
     | '/domains'
     | '/onboard'
     | '/providers'
+    | '/settings'
     | '/tasks'
     | '/topics'
     | '/courses/$id'
@@ -441,6 +453,7 @@ export interface RootRouteChildren {
   DomainsRoute: typeof DomainsRouteWithChildren
   OnboardRoute: typeof OnboardRoute
   ProvidersRoute: typeof ProvidersRouteWithChildren
+  SettingsRoute: typeof SettingsRoute
   TasksRoute: typeof TasksRouteWithChildren
   TopicsRoute: typeof TopicsRouteWithChildren
 }
@@ -459,6 +472,13 @@ declare module '@tanstack/react-router' {
       path: '/tasks'
       fullPath: '/tasks'
       preLoaderRoute: typeof TasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/providers': {
@@ -887,6 +907,7 @@ const rootRouteChildren: RootRouteChildren = {
   DomainsRoute: DomainsRouteWithChildren,
   OnboardRoute: OnboardRoute,
   ProvidersRoute: ProvidersRouteWithChildren,
+  SettingsRoute: SettingsRoute,
   TasksRoute: TasksRouteWithChildren,
   TopicsRoute: TopicsRouteWithChildren,
 }

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -5,9 +5,8 @@ import {
   createRootRoute,
   Link,
   Outlet,
-  useNavigate,
 } from "@tanstack/react-router";
-import { EraserIcon, MenuIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
+import { MenuIcon } from "lucide-react";
 
 import { NavDropdown } from "@/components/layout/NavDropdown";
 import { Toaster } from "@/components/sonner";
@@ -17,47 +16,16 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuItemInteractive,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useTheme } from "@/hooks/useTheme.ts";
 import {
-  fetchClear,
   fetchCourses,
   fetchDomains,
   fetchProviders,
-  fetchSeed,
   fetchTopics,
 } from "@/utils";
 
 const RootComponent: React.FunctionComponent = () => {
-  const navigate = useNavigate();
-  const {
-    theme, setTheme,
-  } = useTheme();
-
-  const {
-    isFetching: isSeedFetching,
-    error: seedError,
-    refetch: seedRefetch,
-  } = useQuery({
-    enabled: false,
-    queryKey: ["seed"],
-    queryFn: () => fetchSeed(),
-  });
-
-  const {
-    isFetching: isClearFetching,
-    error: clearError,
-    refetch: clearRefetch,
-  } = useQuery({
-    enabled: false,
-    queryKey: ["clear"],
-    queryFn: () => fetchClear(),
-  });
-
   const {
     data: coursesData,
   } = useQuery({
@@ -97,27 +65,6 @@ const RootComponent: React.FunctionComponent = () => {
         && !topicsData?.length
         && !providersData?.length
         && !domainsData?.length);
-
-  async function handleClearLocal() {
-    const clearRefetchResult = await clearRefetch();
-
-    if (clearRefetchResult.status === "success") {
-      navigate({
-        to: "/courses",
-        reloadDocument: true,
-      });
-    }
-  }
-
-  async function handleClearSeedLocal() {
-    const seedRefetchResult = await seedRefetch();
-    if (seedRefetchResult.status === "success") {
-      navigate({
-        to: "/courses",
-        reloadDocument: true,
-      });
-    }
-  }
 
   const navLinkClass = `
     underline-offset-2
@@ -188,7 +135,12 @@ const RootComponent: React.FunctionComponent = () => {
             Tasks
           </Link>
         </div>
-        <div className="md:hidden">
+        <div
+          className={`
+            ml-auto flex flex-row gap-2
+            md:hidden
+          `}
+        >
           <DropdownMenu>
             <DropdownMenuTrigger asChild={true}>
               <Button
@@ -199,7 +151,7 @@ const RootComponent: React.FunctionComponent = () => {
                 <MenuIcon />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
+            <DropdownMenuContent align="end">
               <DropdownMenuGroup>
                 <DropdownMenuItem
                   asChild
@@ -251,62 +203,28 @@ const RootComponent: React.FunctionComponent = () => {
                 >
                   <Link to="/tasks">Tasks</Link>
                 </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/settings">Settings</Link>
+                </DropdownMenuItem>
               </DropdownMenuGroup>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-        <div className="flex flex-row gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild={true}>
-              <Button>Menu</Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>Data Tools</DropdownMenuLabel>
-              <DropdownMenuGroup>
-                <DropdownMenuItemInteractive
-                  onClick={() => handleClearLocal()}
-                  isLoading={isClearFetching}
-                  isError={clearError}
-                >
-                  <EraserIcon />
-                  Clear Data
-                </DropdownMenuItemInteractive>
-                <DropdownMenuItemInteractive
-                  onClick={() => handleClearSeedLocal()}
-                  isLoading={isSeedFetching}
-                  isError={seedError}
-                >
-                  <SproutIcon />
-                  Clear & Seed Data
-                </DropdownMenuItemInteractive>
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Settings</DropdownMenuLabel>
-              <DropdownMenuGroup>
-                {theme === "dark"
-                  ? (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setTheme("light");
-                      }}
-                    >
-                      <SunIcon />
-                      Set to Light Mode
-                    </DropdownMenuItem>
-                  )
-                  : (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setTheme("dark");
-                      }}
-                    >
-                      <MoonIcon />
-                      Set to Dark Mode
-                    </DropdownMenuItem>
-                  )}
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+        <div
+          className={`
+            hidden flex-row gap-2
+            md:flex
+          `}
+        >
+          <Link
+            to="/settings"
+            className={navLinkClass}
+          >
+            Settings
+          </Link>
         </div>
       </div>
       <hr />

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -1,0 +1,116 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { EraserIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/hooks/useTheme.ts";
+import { fetchClear, fetchSeed } from "@/utils";
+
+export const Route = createFileRoute("/settings")({
+  component: Settings,
+});
+
+function Settings() {
+  const navigate = useNavigate();
+  const {
+    theme, setTheme,
+  } = useTheme();
+
+  const {
+    isFetching: isSeedFetching,
+    refetch: seedRefetch,
+  } = useQuery({
+    enabled: false,
+    queryKey: ["seed"],
+    queryFn: () => fetchSeed(),
+  });
+
+  const {
+    isFetching: isClearFetching,
+    refetch: clearRefetch,
+  } = useQuery({
+    enabled: false,
+    queryKey: ["clear"],
+    queryFn: () => fetchClear(),
+  });
+
+  async function handleClearLocal() {
+    const clearRefetchResult = await clearRefetch();
+
+    if (clearRefetchResult.status === "success") {
+      navigate({
+        to: "/courses",
+        reloadDocument: true,
+      });
+    }
+  }
+
+  async function handleClearSeedLocal() {
+    const seedRefetchResult = await seedRefetch();
+    if (seedRefetchResult.status === "success") {
+      navigate({
+        to: "/courses",
+        reloadDocument: true,
+      });
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader pageTitle="Settings" />
+      <div className="container flex flex-col gap-8">
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Data Tools</h2>
+          <div className="flex flex-col items-start gap-2">
+            <Button
+              variant="outline"
+              onClick={() => handleClearLocal()}
+              disabled={isClearFetching}
+            >
+              <EraserIcon />
+              Clear Data
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleClearSeedLocal()}
+              disabled={isSeedFetching}
+            >
+              <SproutIcon />
+              Clear & Seed Data
+            </Button>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Appearance</h2>
+          <div className="flex flex-col items-start gap-2">
+            {theme === "dark"
+              ? (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setTheme("light");
+                  }}
+                >
+                  <SunIcon />
+                  Set to Light Mode
+                </Button>
+              )
+              : (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setTheme("dark");
+                  }}
+                >
+                  <MoonIcon />
+                  Set to Dark Mode
+                </Button>
+              )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add /settings route housing Clear Data, Clear & Seed Data, and theme toggle
- Replace the right-side Menu dropdown with a Settings link on desktop
- Add Settings entry to the mobile nav and shift that menu to the right

https://claude.ai/code/session_01BCbMGHCGWU6QrvzRiEvQ44