### PR TITLE
Show meaningful day-entry info in domain learning log

### DIFF
--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { DailyCompletion, Domain, LearningLogEntry } from "@emstack/types/src";
+import type { DailyCompletion, DailyCriteria, Domain, LearningLogEntry } from "@emstack/types/src";
 import { idParamSchema } from "@/utils/schemas";
 import { buildDomainLearningLog } from "@/utils/learningLog";
 
@@ -47,6 +47,7 @@ export default async function (server: FastifyInstance) {
                               id: true,
                               name: true,
                               completions: true,
+                              criteria: true,
                             },
                           },
                         },
@@ -64,6 +65,7 @@ export default async function (server: FastifyInstance) {
                           id: true,
                           name: true,
                           completions: true,
+                          criteria: true,
                         },
                       },
                     },
@@ -92,6 +94,7 @@ export default async function (server: FastifyInstance) {
                               id: true,
                               name: true,
                               completions: true,
+                              criteria: true,
                             },
                           },
                         },
@@ -109,6 +112,7 @@ export default async function (server: FastifyInstance) {
                           id: true,
                           name: true,
                           completions: true,
+                          criteria: true,
                         },
                       },
                     },
@@ -213,6 +217,7 @@ export default async function (server: FastifyInstance) {
         id: string;
         name: string;
         completions: DailyCompletion[];
+        criteria?: DailyCriteria | null;
         courseId?: string | null;
         courseName?: string | null;
         taskId?: string | null;
@@ -227,6 +232,7 @@ export default async function (server: FastifyInstance) {
             id: string;
             name: string;
             completions?: DailyCompletion[] | null;
+            criteria?: DailyCriteria | null;
           }[];
         } | null; }[];
         tasks?: {
@@ -236,6 +242,7 @@ export default async function (server: FastifyInstance) {
             id: string;
             name: string;
             completions?: DailyCompletion[] | null;
+            criteria?: DailyCriteria | null;
           } | null;
         }[];
       } | null | undefined) {
@@ -244,11 +251,19 @@ export default async function (server: FastifyInstance) {
           const course = ttc.course;
           if (!course) continue;
           for (const d of course.dailies ?? []) {
-            if (dailySourceMap.has(d.id)) continue;
+            const existing = dailySourceMap.get(d.id);
+            if (existing) {
+              if (!existing.courseId) {
+                existing.courseId = course.id;
+                existing.courseName = course.name;
+              }
+              continue;
+            }
             dailySourceMap.set(d.id, {
               id: d.id,
               name: d.name,
               completions: (d.completions ?? []) as DailyCompletion[],
+              criteria: (d.criteria ?? null) as DailyCriteria | null,
               courseId: course.id,
               courseName: course.name,
             });
@@ -257,11 +272,19 @@ export default async function (server: FastifyInstance) {
         for (const task of topic.tasks ?? []) {
           const d = task.daily;
           if (!d) continue;
-          if (dailySourceMap.has(d.id)) continue;
+          const existing = dailySourceMap.get(d.id);
+          if (existing) {
+            if (!existing.taskId) {
+              existing.taskId = task.id;
+              existing.taskName = task.name;
+            }
+            continue;
+          }
           dailySourceMap.set(d.id, {
             id: d.id,
             name: d.name,
             completions: (d.completions ?? []) as DailyCompletion[],
+            criteria: (d.criteria ?? null) as DailyCriteria | null,
             taskId: task.id,
             taskName: task.name,
           });

--- a/packages/middleware/src/utils/learningLog.ts
+++ b/packages/middleware/src/utils/learningLog.ts
@@ -1,4 +1,4 @@
-import type { DailyCompletion, DailyCompletionStatus, LearningLogEntry } from "@emstack/types/src";
+import type { DailyCompletion, DailyCompletionStatus, DailyCriteria, LearningLogEntry } from "@emstack/types/src";
 
 interface ManualEntryRow {
   id: string;
@@ -11,6 +11,7 @@ interface DailySource {
   id: string;
   name: string;
   completions: DailyCompletion[];
+  criteria?: DailyCriteria | null;
   courseId?: string | null;
   courseName?: string | null;
   taskId?: string | null;
@@ -37,10 +38,25 @@ function isMeaningfulCompletion(c: DailyCompletion): boolean {
   return false;
 }
 
+function criteriaTextForStatus(
+  criteria: DailyCriteria | null | undefined,
+  status: DailyCompletionStatus | undefined,
+): string | null {
+  if (!criteria || !status) {
+    return null;
+  }
+  const text = criteria[status]?.trim();
+  return text ? text : null;
+}
+
 function describeCompletion(daily: DailySource, c: DailyCompletion): string {
   const note = c.note?.trim();
   if (note) {
     return `${daily.name} — ${note}`;
+  }
+  const criteriaText = criteriaTextForStatus(daily.criteria, c.status);
+  if (criteriaText) {
+    return `${daily.name} — ${criteriaText}`;
   }
   return daily.name;
 }


### PR DESCRIPTION
When a daily completion has only a status (no note), the description
fell back to just the daily's name — which duplicates the linked
course/task and tells the reader nothing about what the entry
represents. Use the daily's criteria text for the active status as a
secondary fallback so e.g. a "touched" entry surfaces what "touched"
means for that daily.

Also merge course and task info when the same daily is reachable via
both the topic→course and topic→task paths, instead of using only the
first path encountered, so dual-linked dailies show both navigation
links in the log.