### PR TITLE
Add task to-dos, daily progress, paused status, and link sync

### DIFF
--- a/packages/client/src/components/dailies/DailyCourseIndicator.tsx
+++ b/packages/client/src/components/dailies/DailyCourseIndicator.tsx
@@ -1,6 +1,7 @@
 import type { Daily } from "@emstack/types/src";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { GraduationCapIcon, PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 
@@ -46,19 +47,25 @@ export function DailyCourseIndicator({
     return null;
   }
 
-  const tooltipText = course.progressTotal > 0
-    ? `${course.name} (${course.progressCurrent}/${course.progressTotal})`
-    : course.name;
-
   return (
     <span className="inline-flex items-center gap-1">
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="inline-flex items-center text-muted-foreground">
+          <Link
+            to="/courses/$id"
+            params={{
+              id: course.id,
+            }}
+            aria-label={`Go to course ${course.name}`}
+            className="
+              inline-flex items-center text-muted-foreground
+              hover:text-foreground
+            "
+          >
             <GraduationCapIcon className="size-4" />
-          </span>
+          </Link>
         </TooltipTrigger>
-        <TooltipContent>{tooltipText}</TooltipContent>
+        <TooltipContent>{course.name}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>

--- a/packages/client/src/components/dailies/DailyProgressCell.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.tsx
@@ -1,0 +1,138 @@
+import type { Daily } from "@emstack/types/src";
+
+import { InfinityIcon } from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
+import { RadialProgress } from "@/components/ui/RadialProgress";
+
+interface DailyProgressCellProps {
+  daily: Daily;
+}
+
+export function DailyProgressCell({
+  daily,
+}: DailyProgressCellProps) {
+  const course = daily.course;
+  const taskProgress = daily.task?.progress;
+
+  if (course) {
+    const progressTotal = course.progressTotal ?? 0;
+    const progressCurrent = course.progressCurrent ?? 0;
+    const percent = progressTotal > 0
+      ? Math.round((progressCurrent / progressTotal) * 100)
+      : 0;
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="
+              inline-flex items-center justify-center rounded-sm
+              hover:bg-muted
+              focus-visible:ring-2 focus-visible:ring-ring
+              focus-visible:outline-none
+            "
+            aria-label={`Course progress ${percent}%`}
+          >
+            <RadialProgress
+              current={progressCurrent}
+              total={progressTotal > 0 ? progressTotal : 1}
+              size={20}
+              strokeWidth={3}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-auto p-3"
+          align="center"
+        >
+          <div className="flex flex-col gap-1 text-sm">
+            <div className="font-medium">{course.name}</div>
+            <div className="text-muted-foreground">
+              {progressTotal > 0
+                ? `${progressCurrent} / ${progressTotal} (${percent}%)`
+                : `${progressCurrent} completed`}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  if (taskProgress) {
+    const total = taskProgress.todosTotal + taskProgress.resourcesTotal;
+    const done = taskProgress.todosComplete + taskProgress.resourcesUsed;
+    const percent = total > 0 ? Math.round((done / total) * 100) : 0;
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="
+              inline-flex items-center justify-center rounded-sm
+              hover:bg-muted
+              focus-visible:ring-2 focus-visible:ring-ring
+              focus-visible:outline-none
+            "
+            aria-label={`Task progress ${percent}%`}
+          >
+            <RadialProgress
+              current={done}
+              total={total > 0 ? total : 1}
+              size={20}
+              strokeWidth={3}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-auto p-3"
+          align="center"
+        >
+          <div className="flex flex-col gap-1 text-sm">
+            <div className="font-medium">
+              {daily.task?.name ?? "Task progress"}
+            </div>
+            <div className="text-muted-foreground">
+              {total > 0
+                ? `${done} / ${total} (${percent}%)`
+                : "No to-dos or resources yet"}
+            </div>
+            <div className="mt-1 flex flex-col gap-0.5 text-xs">
+              <span>
+                ToDo&apos;s:
+                {" "}
+                <strong>
+                  {taskProgress.todosComplete}
+                  {" "}
+                  /
+                  {" "}
+                  {taskProgress.todosTotal}
+                </strong>
+              </span>
+              <span>
+                Resources used:
+                {" "}
+                <strong>
+                  {taskProgress.resourcesUsed}
+                  {" "}
+                  /
+                  {" "}
+                  {taskProgress.resourcesTotal}
+                </strong>
+              </span>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex text-muted-foreground"
+      title="No linked progress"
+    >
+      <InfinityIcon className="size-5" />
+    </span>
+  );
+}

--- a/packages/client/src/components/dailies/DailyTaskIndicator.tsx
+++ b/packages/client/src/components/dailies/DailyTaskIndicator.tsx
@@ -1,0 +1,40 @@
+import type { Daily } from "@emstack/types/src";
+
+import { Link } from "@tanstack/react-router";
+import { CheckSquareIcon } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface DailyTaskIndicatorProps {
+  daily: Daily;
+}
+
+export function DailyTaskIndicator({
+  daily,
+}: DailyTaskIndicatorProps) {
+  const task = daily.task;
+  if (!task) {
+    return null;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          to="/tasks/$id"
+          params={{
+            id: task.id,
+          }}
+          aria-label={`Go to task ${task.name}`}
+          className="
+            inline-flex items-center text-muted-foreground
+            hover:text-foreground
+          "
+        >
+          <CheckSquareIcon className="size-4" />
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>{task.name}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -1,6 +1,8 @@
 export { DailyCompletionsManager } from "./DailyCompletionsManager";
 export { DailyCourseIndicator } from "./DailyCourseIndicator";
 export { DailyLocationCell } from "./DailyLocationCell";
+export { DailyProgressCell } from "./DailyProgressCell";
+export { DailyTaskIndicator } from "./DailyTaskIndicator";
 export { DailyRecentDaysStrip } from "./DailyRecentDaysStrip";
 export { DailyStatusButtons } from "./DailyStatusButtons";
 export { DailyStatusCircle } from "./DailyStatusCircle";

--- a/packages/client/src/components/tasks/ResourcesTable.tsx
+++ b/packages/client/src/components/tasks/ResourcesTable.tsx
@@ -170,6 +170,11 @@ export function ResourcesTable({
           interactivity: r.interactivity ?? null,
           usedYet: r.usedYet,
         })),
+        todos: (task.todos ?? []).map(t => ({
+          id: t.id,
+          name: t.name,
+          isComplete: t.isComplete,
+        })),
       }),
     onSuccess: async () => {
       await Promise.all([
@@ -178,6 +183,9 @@ export function ResourcesTable({
         }),
         queryClient.invalidateQueries({
           queryKey: ["tasks"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["dailies"],
         }),
       ]);
     },

--- a/packages/client/src/components/tasks/TodosChecklist.tsx
+++ b/packages/client/src/components/tasks/TodosChecklist.tsx
@@ -1,0 +1,182 @@
+import type { Task, TaskTodo } from "@emstack/types/src";
+
+import { useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { upsertTask } from "@/utils";
+import { uuidv4 } from "@/utils/uuid";
+
+interface TodosChecklistProps {
+  task: Task;
+}
+
+export function TodosChecklist({
+  task,
+}: TodosChecklistProps) {
+  const queryClient = useQueryClient();
+  const todos = task.todos ?? [];
+  const [draft, setDraft] = useState("");
+
+  const buildPayload = (nextTodos: TaskTodo[]) => ({
+    name: task.name,
+    description: task.description ?? null,
+    topicId: task.topicId ?? null,
+    resources: (task.resources ?? []).map(r => ({
+      id: r.id,
+      name: r.name,
+      url: r.url ?? null,
+      easeOfStarting: r.easeOfStarting ?? null,
+      timeNeeded: r.timeNeeded ?? null,
+      interactivity: r.interactivity ?? null,
+      usedYet: r.usedYet,
+    })),
+    todos: nextTodos.map(t => ({
+      id: t.id,
+      name: t.name,
+      isComplete: t.isComplete,
+    })),
+  });
+
+  const mutation = useMutation({
+    mutationFn: (next: TaskTodo[]) => upsertTask(task.id, buildPayload(next)),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["task", task.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["tasks"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["dailies"],
+        }),
+      ]);
+    },
+    onError: () => {
+      toast.error("Failed to update todos.");
+    },
+  });
+
+  function handleToggle(todoId: string, nextValue: boolean) {
+    const next = todos.map(t =>
+      t.id === todoId
+        ? {
+          ...t,
+          isComplete: nextValue,
+        }
+        : t);
+    mutation.mutate(next);
+  }
+
+  function handleDelete(todoId: string) {
+    const next = todos.filter(t => t.id !== todoId);
+    mutation.mutate(next);
+  }
+
+  function handleAdd() {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    const next: TaskTodo[] = [
+      ...todos,
+      {
+        id: uuidv4(),
+        taskId: task.id,
+        name: trimmed,
+        isComplete: false,
+        position: todos.length,
+      },
+    ];
+    mutation.mutate(next, {
+      onSuccess: () => {
+        setDraft("");
+      },
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {todos.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          <i>No to-dos yet.</i>
+        </p>
+      )}
+      {todos.length > 0 && (
+        <ul className="flex flex-col divide-y rounded-md border">
+          {todos.map(todo => (
+            <li
+              key={todo.id}
+              className="
+                group flex flex-row items-center gap-2 p-2
+                hover:bg-muted/40
+              "
+            >
+              <input
+                type="checkbox"
+                checked={todo.isComplete}
+                disabled={mutation.isPending}
+                onChange={e => handleToggle(todo.id, e.target.checked)}
+                className="size-4"
+                aria-label={`Mark ${todo.name} as complete`}
+              />
+              <span
+                className={cn(
+                  "flex-1 text-sm",
+                  todo.isComplete
+                  && "text-muted-foreground line-through",
+                )}
+              >
+                {todo.name}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => handleDelete(todo.id)}
+                disabled={mutation.isPending}
+                aria-label={`Delete ${todo.name}`}
+                title="Delete to-do"
+                className="
+                  text-destructive opacity-0 transition
+                  group-hover:opacity-100
+                  focus-visible:opacity-100
+                "
+              >
+                <Trash2Icon className="size-3.5" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleAdd();
+        }}
+        className="flex flex-row items-center gap-2"
+      >
+        <Input
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          placeholder="Add a to-do..."
+          maxLength={500}
+          disabled={mutation.isPending}
+        />
+        <Button
+          type="submit"
+          variant="outline"
+          size="sm"
+          disabled={mutation.isPending || !draft.trim()}
+        >
+          <PlusIcon className="size-4" />
+          Add
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -225,7 +225,7 @@ function SingleCourseEdit() {
   }
 
   return (
-    <div className="container flex-col">
+    <div className="m-auto w-full max-w-[1200px] px-4">
       <h2 className="mb-6 text-2xl">{isNew ? "New Course" : "Edit Course"}</h2>
       <form
         onSubmit={(e) => {

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -3,7 +3,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EyeIcon, Loader2, WandSparklesIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  EyeIcon,
+  Loader2,
+  WandSparklesIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
@@ -24,6 +30,7 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { useSettings } from "@/hooks/useSettings";
+import { cn } from "@/lib/utils";
 import {
   createDaily,
   deleteSingleDaily,
@@ -58,7 +65,8 @@ const formSchema = z.object({
   courseProviderId: z.string(),
   courseId: z.string(),
   taskId: z.string(),
-  isComplete: z.boolean(),
+  status: z.enum(["active", "paused", "complete"]),
+  syncValues: z.boolean(),
   criteriaIncomplete: z.string().max(500),
   criteriaTouched: z.string().max(500),
   criteriaGoal: z.string().max(500),
@@ -118,7 +126,9 @@ function SingleDailyEdit() {
   });
 
   const activeDailiesCount
-    = existingDailies?.filter(d => d.status !== "complete").length ?? 0;
+    = existingDailies?.filter(
+      d => d.status !== "complete" && d.status !== "paused",
+    ).length ?? 0;
   const projectedActiveCount = activeDailiesCount + 1;
   const showLimitWarning
     = isNew && projectedActiveCount >= settings.maxActiveDailies;
@@ -139,6 +149,13 @@ function SingleDailyEdit() {
     return m;
   }, [courses, tasks]);
 
+  const initialLinked = !!(
+    data?.course?.id
+    || data?.taskId
+    || data?.task?.id
+    || (isNew && search.newCourseId)
+  );
+
   const startingValues = useMemo(
     () => ({
       name: data?.name ?? "",
@@ -149,17 +166,22 @@ function SingleDailyEdit() {
         ? search.newCourseId
         : ""),
       taskId: data?.taskId ?? data?.task?.id ?? "",
-      isComplete: data?.status === "complete",
+      status: (data?.status === "complete"
+        ? "complete"
+        : data?.status === "paused"
+          ? "paused"
+          : "active") as "active" | "paused" | "complete",
+      syncValues: initialLinked,
       criteriaIncomplete: data?.criteria?.incomplete ?? "",
       criteriaTouched: data?.criteria?.touched ?? "",
       criteriaGoal: data?.criteria?.goal ?? "",
       criteriaExceeded: data?.criteria?.exceeded ?? "",
       criteriaFreeze: data?.criteria?.freeze ?? "",
     }),
-    [data, isNew, search.newCourseId],
+    [data, isNew, search.newCourseId, initialLinked],
   );
 
-  const [hideLinkBox, setHideLinkBox] = useState(false);
+  const [linkBoxCollapsed, setLinkBoxCollapsed] = useState(false);
 
   const form = useAppForm({
     defaultValues: startingValues,
@@ -194,7 +216,7 @@ function SingleDailyEdit() {
         courseProviderId: value.courseProviderId || null,
         courseId: value.courseId || null,
         taskId: value.taskId || null,
-        status: value.isComplete ? "complete" : "active",
+        status: value.status,
         criteria,
       };
 
@@ -256,6 +278,7 @@ function SingleDailyEdit() {
   );
 
   const isLinked = !!(currentValues.courseId || currentValues.taskId);
+  const syncValues = currentValues.syncValues && isLinked;
 
   const linkedValue = currentValues.courseId
     ? `course:${currentValues.courseId}`
@@ -267,6 +290,7 @@ function SingleDailyEdit() {
     if (!val) {
       form.setFieldValue("courseId", "");
       form.setFieldValue("taskId", "");
+      form.setFieldValue("syncValues", false);
       return;
     }
     if (val.startsWith("course:")) {
@@ -279,10 +303,10 @@ function SingleDailyEdit() {
     }
   };
 
-  // When a course is linked, mirror its name/url/provider into the daily
-  // fields so the (now-disabled) inputs stay in sync with the source.
+  // When a course is linked AND sync is on, mirror its name/url/provider into
+  // the daily fields so the (hidden) inputs stay in sync with the source.
   useEffect(() => {
-    if (!selectedCourse) {
+    if (!syncValues || !selectedCourse) {
       return;
     }
     if (currentValues.name !== selectedCourse.name) {
@@ -297,6 +321,7 @@ function SingleDailyEdit() {
       form.setFieldValue("courseProviderId", courseProviderId);
     }
   }, [
+    syncValues,
     selectedCourse,
     currentValues.name,
     currentValues.location,
@@ -304,15 +329,15 @@ function SingleDailyEdit() {
     form,
   ]);
 
-  // When a task is linked, mirror its name into the daily name field.
+  // When a task is linked AND sync is on, mirror its name into the daily name.
   useEffect(() => {
-    if (!selectedTask) {
+    if (!syncValues || !selectedTask) {
       return;
     }
     if (currentValues.name !== selectedTask.name) {
       form.setFieldValue("name", selectedTask.name);
     }
-  }, [selectedTask, currentValues.name, form]);
+  }, [syncValues, selectedTask, currentValues.name, form]);
 
   async function handleDelete() {
     try {
@@ -376,7 +401,7 @@ function SingleDailyEdit() {
           </Link>
         )}
       </PageHeader>
-      <div className="container flex-col">
+      <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -384,15 +409,34 @@ function SingleDailyEdit() {
           }}
           className="flex max-w-2xl flex-col gap-8"
         >
-          {!hideLinkBox && (
-            <div
-              className="
-                flex flex-row items-start justify-between gap-4 rounded-md
-                border bg-card p-4
-              "
-            >
-              <div className="flex min-w-0 flex-1 flex-col gap-3">
-                <h2 className="text-2xl">Link this Daily</h2>
+          <div
+            className="flex flex-col gap-3 rounded-md border bg-card p-4"
+          >
+            <div className="flex flex-row items-center justify-between gap-2">
+              <h2 className="text-2xl">Link this Daily</h2>
+              <div className="flex shrink-0 flex-row items-center gap-2">
+                <WandSparklesIcon
+                  className="size-6 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={linkBoxCollapsed ? "Expand" : "Collapse"}
+                  title={linkBoxCollapsed
+                    ? "Show link options"
+                    : "Hide link options"}
+                  onClick={() => setLinkBoxCollapsed(prev => !prev)}
+                >
+                  {linkBoxCollapsed
+                    ? <ChevronDownIcon className="size-4" />
+                    : <ChevronUpIcon className="size-4" />}
+                </Button>
+              </div>
+            </div>
+            {!linkBoxCollapsed && (
+              <div className="flex flex-col gap-3">
                 <Combobox
                   value={linkedValue || null}
                   onValueChange={val => setLinkedValue(val ?? null)}
@@ -434,40 +478,49 @@ function SingleDailyEdit() {
                     </ComboboxList>
                   </ComboboxContent>
                 </Combobox>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="w-fit"
-                  onClick={() => setHideLinkBox(true)}
-                >
-                  Hide This
-                </Button>
+                <form.AppField name="syncValues">
+                  {field => (
+                    <label
+                      className="flex flex-row items-center gap-2 text-sm"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={field.state.value}
+                        onChange={e => field.handleChange(e.target.checked)}
+                        className="size-4"
+                        disabled={!isLinked}
+                      />
+                      <span>
+                        Sync Values
+                        {" "}
+                        <span className="text-muted-foreground">
+                          (mirror Title, Location, and Provider from the linked
+                          item)
+                        </span>
+                      </span>
+                    </label>
+                  )}
+                </form.AppField>
               </div>
-              <WandSparklesIcon
-                className="size-8 shrink-0 text-muted-foreground"
-                aria-hidden="true"
-              />
-            </div>
+            )}
+          </div>
+
+          {!syncValues && (
+            <form.AppField name="name">
+              {field => <field.InputField label="Daily Name" />}
+            </form.AppField>
           )}
 
-          <form.AppField name="name">
-            {field => (
-              <field.InputField
-                label="Daily Name"
-                disabled={isLinked}
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="location">
-            {field => (
-              <field.InputField
-                label="Location"
-                placeholder="e.g. Spanish app, gym, journal"
-                disabled={isLinked}
-              />
-            )}
-          </form.AppField>
+          {!syncValues && (
+            <form.AppField name="location">
+              {field => (
+                <field.InputField
+                  label="Location"
+                  placeholder="e.g. Spanish app, gym, journal"
+                />
+              )}
+            </form.AppField>
+          )}
 
           <form.AppField name="description">
             {field => (
@@ -478,29 +531,58 @@ function SingleDailyEdit() {
             )}
           </form.AppField>
 
-          <form.AppField name="courseProviderId">
-            {field => (
-              <field.ComboboxField
-                label="Provider"
-                options={providerOptions}
-                placeholder="Search providers..."
-                disabled={isLinked}
-              />
-            )}
-          </form.AppField>
+          {!syncValues && (
+            <form.AppField name="courseProviderId">
+              {field => (
+                <field.ComboboxField
+                  label="Provider"
+                  options={providerOptions}
+                  placeholder="Search providers..."
+                />
+              )}
+            </form.AppField>
+          )}
 
           {!isNew && (
-            <form.AppField name="isComplete">
+            <form.AppField name="status">
               {field => (
-                <label className="flex flex-row items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={field.state.value}
-                    onChange={e => field.handleChange(e.target.checked)}
-                    className="size-4"
-                  />
-                  <span>Mark as completed (locks log editing)</span>
-                </label>
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm font-medium">Status</span>
+                  <div className="flex flex-row flex-wrap gap-2">
+                    {(["active", "paused", "complete"] as const).map(opt => (
+                      <label
+                        key={opt}
+                        className={cn(
+                          `
+                            inline-flex cursor-pointer items-center gap-2
+                            rounded-md border px-3 py-1.5 text-sm
+                          `,
+                          field.state.value === opt
+                            ? "border-primary bg-primary/10"
+                            : `
+                              border-input bg-background
+                              hover:bg-muted
+                            `,
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          name="dailyStatus"
+                          value={opt}
+                          checked={field.state.value === opt}
+                          onChange={() => field.handleChange(opt)}
+                          className="size-3.5"
+                        />
+                        <span className="capitalize">{opt}</span>
+                      </label>
+                    ))}
+                  </div>
+                  {field.state.value === "complete" && (
+                    <p className="text-xs text-muted-foreground">
+                      Marking complete locks log editing.
+                    </p>
+                  )}
+                </div>
               )}
             </form.AppField>
           )}

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -2,7 +2,12 @@ import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { FlameIcon, LaughIcon, PencilIcon, PlusIcon } from "lucide-react";
+import {
+  FlameIcon,
+  LaughIcon,
+  MessageSquareIcon,
+  PlusIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
@@ -10,8 +15,10 @@ import {
   DailiesLimitSetting,
   DailyCourseIndicator,
   DailyLocationCell,
+  DailyProgressCell,
   DailyStatusCircle,
   DailyStatusConnector,
+  DailyTaskIndicator,
   TodayStatusCell,
   TooManyDailiesWarning,
 } from "@/components/dailies";
@@ -108,8 +115,12 @@ function Dailies() {
       }))
     : undefined;
 
-  const activeDailies = sortedDailies?.filter(d => d.status !== "complete") ?? [];
-  const completedDailies = sortedDailies?.filter(d => d.status === "complete") ?? [];
+  const activeDailies = sortedDailies?.filter(
+    d => d.status !== "complete" && d.status !== "paused",
+  ) ?? [];
+  const pausedDailies = sortedDailies?.filter(d => d.status === "paused") ?? [];
+  const completedDailies = sortedDailies?.filter(d => d.status === "complete")
+    ?? [];
 
   const dayHeaders = activeDailies.length > 0
     ? getRecentDays(
@@ -172,6 +183,7 @@ function Dailies() {
                 <thead>
                   <tr className="text-left text-xs text-muted-foreground">
                     <th className="p-2 font-medium">Title</th>
+                    <th className="p-2 font-medium">Progress</th>
                     <th className="p-2 font-medium">Description</th>
                     <th className="p-2 font-medium">Streak</th>
                     <th className="p-2 font-medium">Total</th>
@@ -228,7 +240,11 @@ function Dailies() {
                               {daily.name}
                             </Link>
                             <DailyCourseIndicator daily={daily} />
+                            <DailyTaskIndicator daily={daily} />
                           </span>
+                        </td>
+                        <td className="p-2">
+                          <DailyProgressCell daily={daily} />
                         </td>
                         <td className="max-w-xs p-2">
                           {daily.description
@@ -342,23 +358,79 @@ function Dailies() {
                         </td>
                         <td className="p-2">
                           <Link
-                            to="/dailies/$id/edit"
+                            to="/dailies/$id"
                             params={{
                               id: daily.id,
                             }}
-                            aria-label={`Edit ${daily.name}`}
-                            title="Edit daily"
+                            aria-label={`View comments for ${daily.name}`}
+                            title="View daily comments"
                             className="
                               inline-flex items-center justify-center rounded-md
-                              p-1 text-muted-foreground opacity-0 transition
-                              group-hover:opacity-100
+                              p-1 text-muted-foreground transition
                               hover:bg-muted hover:text-foreground
-                              focus-visible:opacity-100
                             "
                           >
-                            <PencilIcon className="size-3.5" />
+                            <MessageSquareIcon className="size-3.5" />
                           </Link>
                         </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </DashboardCard>
+        )}
+
+        {pausedDailies.length > 0 && (
+          <DashboardCard title="Paused Dailies">
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-muted-foreground">
+                    <th className="p-2 font-medium">Name</th>
+                    <th className="p-2 font-medium whitespace-nowrap">
+                      Last Entry
+                    </th>
+                    <th className="p-2 font-medium whitespace-nowrap">
+                      Days Completed
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pausedDailies.map((daily) => {
+                    const lastEntry = getLastEntryDate(daily);
+                    const totalDays = getTotalCompletedDays(daily);
+                    return (
+                      <tr
+                        key={daily.id}
+                        className="border-t align-middle opacity-90"
+                      >
+                        <td className="p-2">
+                          <span className="inline-flex items-center gap-1.5">
+                            <Link
+                              to="/dailies/$id"
+                              from="/dailies"
+                              params={{
+                                id: daily.id,
+                              }}
+                              className="
+                                font-medium
+                                hover:text-blue-600
+                              "
+                            >
+                              {daily.name}
+                            </Link>
+                            <DailyCourseIndicator daily={daily} />
+                            <DailyTaskIndicator daily={daily} />
+                          </span>
+                        </td>
+                        <td className="p-2 whitespace-nowrap">
+                          {lastEntry ?? (
+                            <span className="text-muted-foreground/70">—</span>
+                          )}
+                        </td>
+                        <td className="p-2 whitespace-nowrap">{totalDays}</td>
                       </tr>
                     );
                   })}
@@ -416,6 +488,7 @@ function Dailies() {
                               {daily.name}
                             </Link>
                             <DailyCourseIndicator daily={daily} />
+                            <DailyTaskIndicator daily={daily} />
                           </span>
                         </td>
                         <td className="p-2 whitespace-nowrap">

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -2,15 +2,17 @@ import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { FlameIcon, LaughIcon } from "lucide-react";
+import { FlameIcon, LaughIcon, MessageSquareIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
   DailyCourseIndicator,
   DailyLocationCell,
+  DailyProgressCell,
   DailyStatusCircle,
   DailyStatusConnector,
+  DailyTaskIndicator,
   TodayStatusCell,
   TooManyDailiesWarning,
 } from "@/components/dailies";
@@ -75,7 +77,7 @@ export function DashboardDailies() {
 
   const sortedDailies = dailies
     ? [...dailies]
-      .filter(d => d.status !== "complete")
+      .filter(d => d.status !== "complete" && d.status !== "paused")
       .sort((a, b) =>
         a.name.localeCompare(b.name, undefined, {
           sensitivity: "base",
@@ -139,6 +141,7 @@ export function DashboardDailies() {
             <thead>
               <tr className="text-left text-xs text-muted-foreground">
                 <th className="p-2 font-medium">Title</th>
+                <th className="p-2 font-medium">Progress</th>
                 <th className="p-2 font-medium">Streak</th>
                 <th className="p-2 font-medium">Total</th>
                 {dayHeaders.map(d => (
@@ -154,6 +157,7 @@ export function DashboardDailies() {
                 ))}
                 <th className="p-2 font-medium">Today&apos;s Status</th>
                 <th className="p-2 font-medium whitespace-nowrap">Location</th>
+                <th className="w-8 p-2" />
               </tr>
             </thead>
             <tbody>
@@ -190,7 +194,11 @@ export function DashboardDailies() {
                           {daily.name}
                         </Link>
                         <DailyCourseIndicator daily={daily} />
+                        <DailyTaskIndicator daily={daily} />
                       </span>
+                    </td>
+                    <td className="p-2">
+                      <DailyProgressCell daily={daily} />
                     </td>
                     <td className="p-2">
                       <span
@@ -281,6 +289,23 @@ export function DashboardDailies() {
                     </td>
                     <td className="p-2 whitespace-nowrap">
                       <DailyLocationCell location={daily.location} />
+                    </td>
+                    <td className="p-2">
+                      <Link
+                        to="/dailies/$id"
+                        params={{
+                          id: daily.id,
+                        }}
+                        aria-label={`View comments for ${daily.name}`}
+                        title="View daily comments"
+                        className="
+                          inline-flex items-center justify-center rounded-md p-1
+                          text-muted-foreground transition
+                          hover:bg-muted hover:text-foreground
+                        "
+                      >
+                        <MessageSquareIcon className="size-3.5" />
+                      </Link>
                     </td>
                   </tr>
                 );

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -291,7 +291,7 @@ function SingleDomainEdit() {
           </Link>
         )}
       </PageHeader>
-      <div className="container flex-col">
+      <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -175,7 +175,7 @@ function SingleProviderEdit() {
           </Link>
         )}
       </PageHeader>
-      <div className="container flex-col">
+      <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -88,11 +88,18 @@ function SingleTaskEdit() {
         usedYet: r.usedYet,
       }));
 
+      const existingTodos = (data?.todos ?? []).map(t => ({
+        id: t.id,
+        name: t.name,
+        isComplete: t.isComplete,
+      }));
+
       const taskData = {
         name: value.name,
         description: value.description || null,
         topicId: value.topicId || null,
         resources: existingResources,
+        todos: existingTodos,
       };
 
       try {
@@ -172,7 +179,7 @@ function SingleTaskEdit() {
           </Link>
         )}
       </PageHeader>
-      <div className="container flex-col">
+      <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -6,6 +6,7 @@ import { DailyRecentDaysStrip } from "@/components/dailies";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ResourcesTable } from "@/components/tasks/ResourcesTable";
+import { TodosChecklist } from "@/components/tasks/TodosChecklist";
 import { Button } from "@/components/ui/button";
 import { fetchSingleTask } from "@/utils";
 
@@ -135,6 +136,12 @@ function SingleTask() {
           condition={!!data.description}
         >
           <p>{data.description}</p>
+        </InfoArea>
+        <InfoArea
+          header="ToDo's"
+          condition={true}
+        >
+          <TodosChecklist task={data} />
         </InfoArea>
         <InfoArea
           header="Resources"

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -174,7 +174,7 @@ function SingleTopicEdit() {
           </Link>
         )}
       </PageHeader>
-      <div className="container flex-col">
+      <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -29,7 +29,7 @@ export const usersTable = pgTable("users", {
 });
 
 export const recurPeriodUnitEnum = pgEnum("recurPeriodUnit", ["days", "months", "years"]);
-export const statusEnum = pgEnum("status", ["active", "inactive", "complete"]);
+export const statusEnum = pgEnum("status", ["active", "inactive", "complete", "paused"]);
 export const dailyCompletionStatusEnum = pgEnum("dailyCompletionStatus", ["incomplete", "touched", "goal", "exceeded", "freeze"]);
 export const resourceLevelEnum = pgEnum("resourceLevel", ["low", "medium", "high"]);
 
@@ -117,6 +117,16 @@ export const resources = pgTable("resources", {
   position: integer(),
 });
 
+export const taskTodos = pgTable("task_todos", {
+  id: varchar().primaryKey(),
+  taskId: varchar("task_id").notNull(),
+  name: varchar({
+    length: 500,
+  }).notNull(),
+  isComplete: boolean("is_complete").default(false).notNull(),
+  position: integer(),
+});
+
 export const tasksRelations = relations(tasks, ({
   one, many,
 }) => ({
@@ -125,6 +135,7 @@ export const tasksRelations = relations(tasks, ({
     references: [topics.id],
   }),
   resources: many(resources),
+  todos: many(taskTodos),
   daily: one(dailies, {
     fields: [tasks.id],
     references: [dailies.taskId],
@@ -136,6 +147,15 @@ export const resourcesRelations = relations(resources, ({
 }) => ({
   task: one(tasks, {
     fields: [resources.taskId],
+    references: [tasks.id],
+  }),
+}));
+
+export const taskTodosRelations = relations(taskTodos, ({
+  one,
+}) => ({
+  task: one(tasks, {
+    fields: [taskTodos.taskId],
     references: [tasks.id],
   }),
 }));

--- a/packages/middleware/src/routes/api/dailies/createDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/createDaily.ts
@@ -71,7 +71,7 @@ const createSchema = {
         },
         status: {
           type: ["string", "null"],
-          enum: ["active", "complete", null],
+          enum: ["active", "complete", "paused", null],
         },
         criteria: criteriaSchema,
       },

--- a/packages/middleware/src/routes/api/dailies/getDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/getDaily.ts
@@ -52,11 +52,41 @@ export default async function (server: FastifyInstance) {
               id: true,
               name: true,
             },
+            with: {
+              resources: {
+                columns: {
+                  id: true,
+                  usedYet: true,
+                },
+              },
+              todos: {
+                columns: {
+                  id: true,
+                  isComplete: true,
+                },
+              },
+            },
           },
         },
       });
 
       if (daily) {
+        const taskRecord = daily.task;
+        const taskBlock = taskRecord
+          ? {
+            id: taskRecord.id,
+            name: taskRecord.name,
+            progress: {
+              todosTotal: taskRecord.todos?.length ?? 0,
+              todosComplete:
+                taskRecord.todos?.filter(t => t.isComplete).length ?? 0,
+              resourcesTotal: taskRecord.resources?.length ?? 0,
+              resourcesUsed:
+                taskRecord.resources?.filter(r => r.usedYet).length ?? 0,
+            },
+          }
+          : null;
+
         const result: Daily = {
           id: daily.id,
           name: daily.name,
@@ -66,12 +96,7 @@ export default async function (server: FastifyInstance) {
           status: daily.status ?? "active",
           criteria: (daily.criteria ?? {}) as DailyCriteria,
           taskId: daily.taskId ?? null,
-          task: daily.task
-            ? {
-              id: daily.task.id,
-              name: daily.task.name,
-            }
-            : null,
+          task: taskBlock,
           provider:
             daily.courseProvider?.name && daily.courseProvider?.id
               ? {

--- a/packages/middleware/src/routes/api/dailies/root.ts
+++ b/packages/middleware/src/routes/api/dailies/root.ts
@@ -28,42 +28,69 @@ export default async function (server: FastifyInstance) {
             id: true,
             name: true,
           },
+          with: {
+            resources: {
+              columns: {
+                id: true,
+                usedYet: true,
+              },
+            },
+            todos: {
+              columns: {
+                id: true,
+                isComplete: true,
+              },
+            },
+          },
         },
       },
     });
 
-    const processedData: Daily[] = rawData.map(daily => ({
-      id: daily.id,
-      name: daily.name,
-      location: daily.location,
-      description: daily.description,
-      completions: (daily.completions ?? []) as DailyCompletion[],
-      status: daily.status ?? "active",
-      criteria: (daily.criteria ?? {}) as DailyCriteria,
-      taskId: daily.taskId ?? null,
-      task: daily.task
+    const processedData: Daily[] = rawData.map((daily) => {
+      const taskRecord = daily.task;
+      const taskBlock = taskRecord
         ? {
-          id: daily.task.id,
-          name: daily.task.name,
+          id: taskRecord.id,
+          name: taskRecord.name,
+          progress: {
+            todosTotal: taskRecord.todos?.length ?? 0,
+            todosComplete:
+              taskRecord.todos?.filter(t => t.isComplete).length ?? 0,
+            resourcesTotal: taskRecord.resources?.length ?? 0,
+            resourcesUsed:
+              taskRecord.resources?.filter(r => r.usedYet).length ?? 0,
+          },
         }
-        : null,
-      provider:
-        daily.courseProvider?.name && daily.courseProvider?.id
-          ? {
-            name: daily.courseProvider.name,
-            id: daily.courseProvider.id,
-          }
-          : undefined,
-      course:
-        daily.course?.id && daily.course?.name
-          ? {
-            id: daily.course.id,
-            name: daily.course.name,
-            progressCurrent: daily.course.progressCurrent ?? 0,
-            progressTotal: daily.course.progressTotal ?? 0,
-          }
-          : undefined,
-    }));
+        : null;
+
+      return {
+        id: daily.id,
+        name: daily.name,
+        location: daily.location,
+        description: daily.description,
+        completions: (daily.completions ?? []) as DailyCompletion[],
+        status: daily.status ?? "active",
+        criteria: (daily.criteria ?? {}) as DailyCriteria,
+        taskId: daily.taskId ?? null,
+        task: taskBlock,
+        provider:
+          daily.courseProvider?.name && daily.courseProvider?.id
+            ? {
+              name: daily.courseProvider.name,
+              id: daily.courseProvider.id,
+            }
+            : undefined,
+        course:
+          daily.course?.id && daily.course?.name
+            ? {
+              id: daily.course.id,
+              name: daily.course.name,
+              progressCurrent: daily.course.progressCurrent ?? 0,
+              progressTotal: daily.course.progressTotal ?? 0,
+            }
+            : undefined,
+      };
+    });
 
     return processedData;
   });

--- a/packages/middleware/src/routes/api/dailies/upsertDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/upsertDaily.ts
@@ -83,7 +83,7 @@ const upsertSchema = {
         },
         status: {
           type: ["string", "null"],
-          enum: ["active", "complete", null],
+          enum: ["active", "complete", "paused", null],
         },
         criteria: criteriaSchema,
       },

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { resources, tasks } from "@/db/schema";
+import { resources, taskTodos, tasks } from "@/db/schema";
 import { nullableString } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -30,6 +30,22 @@ const resourceSchema = {
   },
 } as const;
 
+const todoSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    isComplete: {
+      type: "boolean",
+    },
+  },
+} as const;
+
 const createSchema = {
   schema: {
     description: "Create a new task",
@@ -45,6 +61,10 @@ const createSchema = {
         resources: {
           type: "array",
           items: resourceSchema,
+        },
+        todos: {
+          type: "array",
+          items: todoSchema,
         },
       },
     },
@@ -80,6 +100,19 @@ export default async function (server: FastifyInstance) {
             timeNeeded: r.timeNeeded ?? null,
             interactivity: r.interactivity ?? null,
             usedYet: r.usedYet ?? false,
+            position: index,
+          })),
+        );
+      }
+
+      const incomingTodos = body.todos ?? [];
+      if (incomingTodos.length > 0) {
+        await db.insert(taskTodos).values(
+          incomingTodos.map((t, index) => ({
+            id: t.id || uuidv4(),
+            taskId: id,
+            name: t.name,
+            isComplete: t.isComplete ?? false,
             position: index,
           })),
         );

--- a/packages/middleware/src/routes/api/tasks/deleteTask.ts
+++ b/packages/middleware/src/routes/api/tasks/deleteTask.ts
@@ -1,12 +1,31 @@
-import { resources, tasks } from "@/db/schema";
-import { createDeleteHandler } from "@/utils/createDeleteHandler";
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { resources, taskTodos, tasks } from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
 
-export default createDeleteHandler({
-  description: "Delete a task by ID",
-  table: tasks,
-  idColumn: tasks.id,
-  junction: {
-    table: resources,
-    foreignKey: resources.taskId,
+const deleteSchema = {
+  schema: {
+    description: "Delete a task by ID",
+    params: idParamSchema,
   },
-});
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete("/:id", deleteSchema, async function (request) {
+    const {
+      id,
+    } = request.params;
+
+    await db.delete(resources).where(eq(resources.taskId, id));
+    await db.delete(taskTodos).where(eq(taskTodos.taskId, id));
+    await db.delete(tasks).where(eq(tasks.id, id));
+
+    return {
+      status: "ok",
+    };
+  });
+}

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -34,6 +34,7 @@ export default async function (server: FastifyInstance) {
             },
           },
           resources: true,
+          todos: true,
           daily: {
             columns: {
               id: true,
@@ -73,6 +74,16 @@ export default async function (server: FastifyInstance) {
             interactivity: r.interactivity,
             usedYet: r.usedYet,
             position: r.position,
+          })),
+        todos: (task.todos ?? [])
+          .slice()
+          .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+          .map(t => ({
+            id: t.id,
+            taskId: t.taskId,
+            name: t.name,
+            isComplete: t.isComplete,
+            position: t.position,
           })),
         daily: task.daily
           ? {

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -16,6 +16,7 @@ export default async function (server: FastifyInstance) {
           },
         },
         resources: true,
+        todos: true,
         daily: {
           columns: {
             id: true,
@@ -51,6 +52,16 @@ export default async function (server: FastifyInstance) {
           interactivity: r.interactivity,
           usedYet: r.usedYet,
           position: r.position,
+        })),
+      todos: (task.todos ?? [])
+        .slice()
+        .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+        .map(t => ({
+          id: t.id,
+          taskId: t.taskId,
+          name: t.name,
+          isComplete: t.isComplete,
+          position: t.position,
         })),
       daily: task.daily
         ? {

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { resources, tasks } from "@/db/schema";
+import { resources, taskTodos, tasks } from "@/db/schema";
 import { idParamSchema, nullableString } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -31,6 +31,22 @@ const resourceSchema = {
   },
 } as const;
 
+const todoSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    isComplete: {
+      type: "boolean",
+    },
+  },
+} as const;
+
 const upsertSchema = {
   schema: {
     description: "Update a task and its resources",
@@ -47,6 +63,10 @@ const upsertSchema = {
         resources: {
           type: "array",
           items: resourceSchema,
+        },
+        todos: {
+          type: "array",
+          items: todoSchema,
         },
       },
     },
@@ -97,6 +117,21 @@ export default async function (server: FastifyInstance) {
               timeNeeded: r.timeNeeded ?? null,
               interactivity: r.interactivity ?? null,
               usedYet: r.usedYet ?? false,
+              position: index,
+            })),
+          );
+        }
+      }
+
+      if (body.todos !== undefined) {
+        await db.delete(taskTodos).where(eq(taskTodos.taskId, id));
+        if (body.todos.length > 0) {
+          await db.insert(taskTodos).values(
+            body.todos.map((t, index) => ({
+              id: t.id || uuidv4(),
+              taskId: id,
+              name: t.name,
+              isComplete: t.isComplete ?? false,
               position: index,
             })),
           );

--- a/packages/types/src/Course.ts
+++ b/packages/types/src/Course.ts
@@ -4,7 +4,7 @@ import { Daily } from "@/Daily";
 import { MinimalTopic } from "@/MinimalTopic";
 import { Topic } from "@/Topic";
 
-export type CourseStatus = "active" | "inactive" | "complete";
+export type CourseStatus = "active" | "inactive" | "complete" | "paused";
 
 export interface Course {
   id: string;

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -14,7 +14,14 @@ export interface DailyCriteria {
   freeze?: string;
 }
 
-export type DailyStatus = "active" | "inactive" | "complete";
+export type DailyStatus = "active" | "inactive" | "complete" | "paused";
+
+export interface DailyTaskProgress {
+  todosTotal: number;
+  todosComplete: number;
+  resourcesTotal: number;
+  resourcesUsed: number;
+}
 
 export interface Daily {
   id: string;
@@ -28,6 +35,7 @@ export interface Daily {
   task?: {
     id: string;
     name: string;
+    progress?: DailyTaskProgress;
   } | null;
   provider?: {
     name: string;

--- a/packages/types/src/Task.ts
+++ b/packages/types/src/Task.ts
@@ -1,5 +1,6 @@
 import type { DailyCompletion, DailyStatus } from "./Daily";
 import type { Resource } from "./Resource";
+import type { TaskTodo } from "./TaskTodo";
 
 export interface TaskLinkedDaily {
   id: string;
@@ -16,5 +17,6 @@ export interface Task {
   topic?: { id: string;
     name: string; } | null;
   resources?: Resource[];
+  todos?: TaskTodo[];
   daily?: TaskLinkedDaily | null;
 }

--- a/packages/types/src/TaskTodo.ts
+++ b/packages/types/src/TaskTodo.ts
@@ -1,0 +1,7 @@
+export interface TaskTodo {
+  id: string;
+  taskId: string;
+  name: string;
+  isComplete: boolean;
+  position?: number | null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,4 @@ export * from "./Daily";
 export * from "./Radar";
 export * from "./Resource";
 export * from "./Task";
+export * from "./TaskTodo";


### PR DESCRIPTION
## Summary
- **Tasks: ToDo's checklist** — new `task_todos` table; checklist UI on the task page lets you add, complete, and delete to-dos
- **Dailies + Dashboard: task icon** — dailies linked to a task now show a check-square icon next to the title (mirrors the existing graduation cap)
- **Dailies + Dashboard: Comment icon** — the trailing pencil/edit button on `/dailies` is replaced with a comment icon that links to the daily detail; the same icon is added after Location on Dashboard Dailies
- **Dailies + Dashboard: Progress column** — new column right of Title with a radial progress bar
  - Course-linked dailies show course progress
  - Task-linked dailies show `(used resources + completed todos) / (total resources + total todos)` with a hover popover that breaks down each
  - Otherwise an infinity icon
- **Graduation cap popover** — now only shows the course name; the icon itself links to the course
- **Link this Daily — Sync Values** — new checkbox that hides Title, Location, and Provider when on (and mirrors them from the linked course/task)
- **Link this Daily — Hide This → collapse** — the button is now a chevron toggle in the header; the box can be re-expanded
- **Dailies status — Paused** — status is now Active / Paused / Complete; Paused dailies render in their own card on the `/dailies` page (Complete still gets its own card)
- **Edit-page scroll fix** — replaced the flex `container flex-col` wrapper on every edit page with a plain block layout so long forms scroll vertically

## Schema changes
- `status` enum gains `"paused"`
- New `task_todos` table (`id`, `task_id`, `name`, `is_complete`, `position`)
- `Task` type gains `todos`; `Daily.task` gains a `progress` block

## Test plan
- [ ] `pnpm push:dev` to apply schema changes
- [ ] `pnpm dev` and verify:
  - [ ] Task page: add / check / delete to-dos
  - [ ] `/dailies` and Dashboard: task icon appears for task-linked dailies; clicking the cap goes to the course
  - [ ] Progress column shows course %, task progress popover with breakdown, or infinity
  - [ ] Comment icon at end of row navigates to the daily
  - [ ] Link this Daily: Sync Values hides/shows fields; chevron collapses/expands; clearing the link clears Sync Values
  - [ ] Edit a daily and set status to Paused — it appears under "Paused Dailies"
  - [ ] `/dailies/:id/edit` scrolls vertically to the bottom of the form

https://claude.ai/code/session_01VYPmrBy2HbJpjB2xAyuZ39

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYPmrBy2HbJpjB2xAyuZ39)_