### PR TITLE
Fix daily status connector and comment popover visibility

### DIFF
--- a/packages/client/src/components/dailies/DailyStatusConnector.tsx
+++ b/packages/client/src/components/dailies/DailyStatusConnector.tsx
@@ -40,6 +40,24 @@ export function DailyStatusConnector({
   const leftColor = getDailyStatusOption(left).borderColor;
   const rightColor = getDailyStatusOption(right).borderColor;
 
+  if (left === "freeze" || right === "freeze") {
+    const dashColor = left === "freeze" ? rightColor : leftColor;
+    return (
+      <div
+        aria-hidden
+        className={cn(
+          isVertical
+            ? "h-3 w-0 border-l-2 border-dashed"
+            : "h-0 w-3 border-t-2 border-dashed",
+          className,
+        )}
+        style={{
+          borderColor: dashColor,
+        }}
+      />
+    );
+  }
+
   return (
     <div
       aria-hidden

--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -103,7 +103,7 @@ export function TodayStatusCell({
             </span>
           </div>
         )}
-      <DailyCommentPopover daily={daily} />
+      {currentStatus !== null && <DailyCommentPopover daily={daily} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR fixes two issues in the daily status components: improves the visual connector between daily statuses when one is "freeze", and prevents the comment popover from appearing when there is no current status.

## Key Changes
- **DailyStatusConnector**: Added special handling for "freeze" status to render a dashed border connector instead of the default solid connector. When either side is "freeze", the connector uses the non-freeze side's color.
- **TodayStatusCell**: Conditionally render the `DailyCommentPopover` only when `currentStatus` is not null, preventing UI issues when there's no active status.

## Implementation Details
- The freeze status check is performed early in the connector component, returning a dashed border variant before the default solid border logic
- The dashed connector maintains the same directional styling (vertical/horizontal) as the standard connector
- The comment popover guard ensures the component is only mounted when there's a valid current status to reference

https://claude.ai/code/session_01JUwRgZnQoFHJhij13DeMQp