### PR TITLE
Allow editing daily completions when status is active

### DIFF
--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -242,7 +242,7 @@ function SingleDaily() {
         >
           <DailyCompletionsManager
             daily={data}
-            readOnly
+            readOnly={data.status !== "active"}
           />
         </InfoArea>
       </div>


### PR DESCRIPTION
## Summary
Modified the `DailyCompletionsManager` component to conditionally enable editing based on the daily's status, rather than always being read-only.

## Changes
- Updated the `readOnly` prop binding to be dynamic: `readOnly={data.status !== "active"}` instead of a static `readOnly` boolean
- This allows users to edit daily completions when the daily item has an "active" status
- Daily completions remain read-only for all other statuses

## Implementation Details
The change enables a more flexible workflow where active daily items can be modified, while completed or inactive items are protected from accidental changes.

https://claude.ai/code/session_01826vgf33MJz3S1mTVSQNM6