### PR TITLE
Refactor for better agent experience and deduplication

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm install)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm build)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm typecheck:*)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm lint:fix)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm --filter=*)",
+      "Bash(pnpm -r run *)",
+      "Bash(pnpm exec:*)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff)",
+      "Bash(git diff:*)",
+      "Bash(git log)",
+      "Bash(git log:*)",
+      "Bash(git branch)",
+      "Bash(git branch:*)",
+      "Bash(git show)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(ls)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(curl http://localhost:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Course Tracker ("emstack") — a full-stack TypeScript monorepo for tracking online courses and learning goals. Built with pnpm workspaces.
+Course Tracker ("emstack") — a full-stack TypeScript monorepo for tracking online courses, learning topics, daily habits, and tasks. Built with pnpm workspaces.
 
 ## Tech Stack
 
@@ -33,6 +33,7 @@ pnpm dev              # Start all packages concurrently (client + middleware + t
 pnpm build            # Build all packages
 pnpm start            # Start the gateway (production mode, requires pnpm build first)
 pnpm test             # Run all tests
+pnpm typecheck        # Type-check all buildable packages (no emit)
 pnpm lint             # Lint all files (ESLint flat config)
 pnpm lint:fix         # Auto-fix lint issues
 pnpm storybook        # Run Storybook on port 6006
@@ -43,28 +44,56 @@ pnpm studio           # Drizzle ORM database GUI
 
 ```bash
 # Client
-pnpm --filter=@emstack/client test       # Run client tests
-pnpm --filter=@emstack/client build      # Build client
+pnpm --filter=@emstack/client test            # Run client tests (Vitest)
+pnpm --filter=@emstack/client typecheck       # Type-check only
+pnpm --filter=@emstack/client build           # Build client
 pnpm --filter=@emstack/client run routeTree   # Regenerate TanStack Router route tree
 
 # Middleware
-pnpm --filter=@emstack/middleware test    # Run middleware tests
-pnpm --filter=@emstack/middleware dev     # Run middleware dev server
-pnpm --filter=@emstack/middleware push:dev   # Push DB schema (dev)
-pnpm --filter=@emstack/middleware push:prod  # Push DB schema (prod)
+pnpm --filter=@emstack/middleware test        # Run middleware tests (node --test)
+pnpm --filter=@emstack/middleware typecheck   # Type-check only
+pnpm --filter=@emstack/middleware dev         # Run middleware dev server
+pnpm --filter=@emstack/middleware push:dev    # Push DB schema (dev)
+pnpm --filter=@emstack/middleware push:prod   # Push DB schema (prod)
+```
+
+### Running a single test
+
+```bash
+# Client (Vitest)
+pnpm --filter=@emstack/client exec vitest run path/to/file.test.tsx
+
+# Middleware (Node test runner)
+pnpm --filter=@emstack/middleware exec node --test src/tests/<file>.test.js
 ```
 
 ## Local Development Setup
 
 1. Run `pnpm install`
 2. Start PostgreSQL (pick one):
-   - **Docker Compose:** `docker compose up db` (uses compose defaults)
+   - **Docker Compose (recommended):** `docker compose up --wait db` (uses compose defaults; the `db` service has a healthcheck so `--wait` blocks until it's ready)
    - **Standalone:** `docker run --name course-postgres -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
-3. Copy `packages/middleware/.env.example` to `.env` and adjust if needed
-4. Push DB schema: `cd packages/middleware && pnpm push:dev`
+3. Copy `packages/middleware/.env.example` to `packages/middleware/.env` and adjust if needed
+4. Push DB schema: `pnpm --filter=@emstack/middleware push:dev`
 5. Run `pnpm dev`
 
-Ports: client dev server on 5173 (Vite proxies `/api` to middleware), middleware on 3001
+Ports: client dev server on 5173 (Vite proxies `/api` to middleware), middleware on 3001. **Both must be running** for the app to work in dev — `pnpm dev` starts everything together.
+
+### Database reset / re-seed
+
+The middleware **auto-seeds** an empty database on startup via `packages/middleware/src/db/seed.ts`. To clear and reseed:
+
+```bash
+# Option A: nuke the docker volume and recreate
+docker compose down -v && docker compose up --wait db
+pnpm --filter=@emstack/middleware push:dev
+
+# Option B: hit the dev-only endpoints (server must be running)
+curl http://localhost:3001/api/clearData
+curl http://localhost:3001/api/seed
+```
+
+If you change `packages/middleware/src/db/schema.ts`, run `pnpm --filter=@emstack/middleware push:dev` to push the new schema (this project uses `drizzle-kit push`, not migration files).
 
 ## Architecture Notes
 
@@ -75,24 +104,60 @@ Ports: client dev server on 5173 (Vite proxies `/api` to middleware), middleware
 - shadcn/ui components live in `components/ui/` — add new ones via shadcn CLI
 - Path alias: `@` → `packages/client/src`
 - Theme support via ThemeProvider context (dark/light mode)
-- **Forms:** Uses TanStack Form's `createFormHook` API. The `useAppForm` hook (`hooks/useAppForm.ts`) provides context-based field components (`InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`) via `form.AppField`. Field components live in `components/formFields/` and access form state via `useFieldContext()` from `utils/fieldContext.ts`. To add a new reusable field: create the component, register it in `useAppForm.ts`.
+- **Forms:** Uses TanStack Form's `createFormHook` API. The `useAppForm` hook (`hooks/useAppForm.ts`) provides context-based field components (`InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) via `form.AppField`. Field components live in `components/formFields/` and access form state via `useFieldContext()` from `utils/fieldContext.ts`. To add a new reusable field: create the component, register it in `useAppForm.ts`.
+- **Edit-page boilerplate** (skip-blocker, query invalidation, navigation, delete handler) lives in `hooks/useEditFormPage.ts`. New edit routes should reuse it.
+- **Loading / error placeholders** for routes use `<EntityPending entity="..."/>` and `<EntityError entity="..."/>` from `components/EntityStates.tsx`.
 
 ### Backend
 - Fastify plugin pattern with nested route modules under `src/routes/api/`
-- Resources: courses, topics, providers (each has `routes.ts`, `root.ts`, handler files)
-- Drizzle ORM schema in `src/db/schema.ts` — tables: users, topics, courseProviders, courses
+- **Resources:** `courses`, `topics`, `providers`, `domains`, `dailies`, `tasks`, plus `domains/$id/radar` sub-resource (quadrants, rings, blips)
+- Each resource folder follows the convention: `routes.ts` (registers handlers), `root.ts` (collection-level GET/POST), per-operation handler files (`getX.ts`, `upsertX.ts`, `deleteX.ts`, `duplicateX.ts`, etc.)
+- Drizzle ORM schema in `src/db/schema.ts`
 - JSON Schema type provider (`@fastify/type-provider-json-schema-to-ts`) for type-safe route handlers
 - Swagger/OpenAPI docs auto-generated at `/documentation`
 - Auto-seeds on empty database via `src/db/seed.ts`
+- **Shared handler factories** in `src/utils/`: `createDeleteHandler` (single or multi-junction cascade), `createUpsertHandler` (insert + onConflictDoUpdate + junction sync). Reuse these instead of hand-writing CRUD.
+- **Shared schemas** in `src/utils/schemas.ts`: `idParamSchema`, `nullableString/Boolean/Integer`, `statusEnum`, `resourceLevelEnum`, `dailyStatusEnum`, `resourceSchema`, `todoSchema`, `completionSchema`, `criteriaSchema`.
+- **Error helpers** in `src/utils/errors.ts`: `sendNotFound(reply, resource)`, `sendBadRequest(reply, message)`.
 
 ### Database Schema
-- Key tables: `users`, `courseProviders`, `courses`, `topics`, `topics_to_courses` (junction)
-- Enums: `recurPeriodUnit` (days/months/years), `status` (active/inactive/complete)
+Defined in `packages/middleware/src/db/schema.ts`.
+
+- **Core tables:** `users`, `topics`, `courseProviders`, `courses`, `dailies`, `tasks`, `resources` (task resources), `task_todos`, `domains`
+- **Junction tables:** `topics_to_courses`, `topics_to_domains`, `domain_excluded_topics`
+- **Radar tables:** `radar_quadrants`, `radar_rings`, `radar_blips`
+- **Enums:** `recurPeriodUnit` (days/months/years), `status` (active/inactive/complete/paused), `dailyCompletionStatus` (incomplete/touched/goal/exceeded/freeze), `resourceLevel` (low/medium/high)
 - Uses `drizzle-kit push` (not migration files) — schema changes pushed directly to database
 
 ### Shared Types
-- `@emstack/types` package exports Course, Topic, CourseProvider, etc.
+- `@emstack/types` package exports Course, Topic, CourseProvider, Domain, Daily, Task, Radar, etc.
 - Used by both client and middleware via workspace protocol
+- Add new types as `packages/types/src/MyType.ts` and re-export from `packages/types/src/index.ts`. Run `pnpm --filter=@emstack/types build` (or `pnpm dev` which runs `tsc --watch`) so the dist output picks them up before consumers import them.
+
+## Common Workflows
+
+### Adding a new API endpoint to an existing resource
+
+1. Create a handler file in `packages/middleware/src/routes/api/<resource>/<verb><Thing>.ts`. Define a `schema` with `idParamSchema` for params (if applicable) and shared schemas from `src/utils/schemas.ts` for the body.
+2. For DELETE handlers, prefer `createDeleteHandler` from `src/utils/createDeleteHandler.ts`. For PUT/upsert handlers, prefer `createUpsertHandler` from `src/utils/createUpsertHandler.ts`.
+3. Register the new handler in the resource's `routes.ts` with `fastify.register(...)`.
+4. Add a corresponding fetch function — usually you want to add a method on the entity client in `packages/client/src/utils/fetchFunctions.ts`. The named exports (`upsertCourse`, etc.) are thin re-exports of `coursesApi.upsert`, etc.
+
+### Adding a new resource
+
+1. Add the table(s) and relations to `packages/middleware/src/db/schema.ts` and run `pnpm --filter=@emstack/middleware push:dev`.
+2. Add a shared type at `packages/types/src/<Name>.ts` and re-export from `index.ts`.
+3. Create `packages/middleware/src/routes/api/<name>/` with `routes.ts`, `root.ts`, and per-operation handler files. Reuse `createDeleteHandler` / `createUpsertHandler`.
+4. Register the resource in `packages/middleware/src/routes/api/routes.ts`.
+5. Add an `<name>Api = createEntityClient<...>(...)` in `packages/client/src/utils/fetchFunctions.ts`.
+6. Add routes in `packages/client/src/routes/<name>.*.tsx`. Run `pnpm --filter=@emstack/client run routeTree` to regenerate `routeTree.gen.ts` (or it'll happen automatically when `vite` runs).
+
+### Adding a new page (client)
+
+1. Create the route file in `packages/client/src/routes/`. File naming follows TanStack Router conventions: `foo.tsx` is the layout, `foo.index.tsx` is the index page, `foo.$id.tsx` is the dynamic-segment layout, `foo.$id.edit.tsx` is a child route.
+2. Run `pnpm --filter=@emstack/client run routeTree` to regenerate `routeTree.gen.ts` (the dev server also regenerates it on file save when running).
+3. For edit pages, use the `useEditFormPage` hook from `@/hooks/useEditFormPage` to avoid re-implementing skip-blocker / invalidation / navigation boilerplate.
+4. For loading/error placeholders use `<EntityPending entity="..."/>` and `<EntityError entity="..."/>` from `@/components/EntityStates`.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-App to stop me from buying courses I don't need.
+# Course Tracker (emstack)
 
-# Ideas
+Full-stack TypeScript monorepo for tracking online courses, learning topics, daily habits, and tasks.
+
+## Quick start
+
+See [`CLAUDE.md`](./CLAUDE.md) for full setup, architecture, and contributor workflows. The short version:
+
+```bash
+pnpm install
+docker compose up --wait db
+cp packages/middleware/.env.example packages/middleware/.env
+pnpm --filter=@emstack/middleware push:dev
+pnpm dev
+```
+
+Client runs at http://localhost:5173, middleware at http://localhost:3001, OpenAPI docs at http://localhost:3001/documentation.
+
+## Ideas / Roadmap
+
 - LLM call to take info in and tell you if a course you're considering is worth it or not
 - Need to be able to add a course via a provider
 - "Goals" attachable to courses or providers, which can show up on a dashboard and checked off each day. Should direct link to a place the daily can be done.
@@ -9,9 +26,3 @@ App to stop me from buying courses I don't need.
   - 2 types: "Target" and "Marathon"
     - Marathon being something like just doing tasks daily (Renshuu)
     - Target being "finish a course by X date", or "do course X times a week"
-
-# Local stuff
-## DB
-1. Run command for docker: `docker run --name course-postgres -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
-  - Verify with `docker ps`
-2. Run `npx drizzle-kit push`

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "docker compose up --wait db && pnpm --filter=@emstack/middleware run push:dev && concurrently -n \"models,server,ui\" -c \"yellow,blue,green\" \"pnpm --filter=@emstack/types --stream run dev\" \"pnpm --filter=@emstack/middleware --stream run dev\" \"pnpm --filter=@emstack/client --stream run dev\"",
     "lint": "eslint .",
     "lint:fix": "eslint .. --fix",
+    "typecheck": "pnpm --filter=@emstack/types build && pnpm -r --filter=@emstack/middleware --filter=@emstack/client run typecheck",
     "storybook": "pnpm --filter=@emstack/client run storybook",
     "studio": "pnpm --filter=@emstack/middleware run studio",
     "prepare": "husky"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -75,7 +75,8 @@
     "lint": "eslint ..",
     "lint:fix": "eslint .. --fix",
     "routeTree": "tsr generate",
-    "storybook": "storybook dev -p 6006"
+    "storybook": "storybook dev -p 6006",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "type": "module"
 }

--- a/packages/client/src/components/ConfirmDialog.tsx
+++ b/packages/client/src/components/ConfirmDialog.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void | Promise<void>;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Yes",
+  cancelLabel = "No",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => onCancel()}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={() => onConfirm()}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/client/src/components/EntityStates.tsx
+++ b/packages/client/src/components/EntityStates.tsx
@@ -1,0 +1,47 @@
+import { Link } from "@tanstack/react-router";
+
+interface EntityStateProps {
+  /** Plural noun for the entity, e.g. "courses", "topics", "domains". */
+  entity: string;
+}
+
+export function EntityPending({
+  entity,
+}: EntityStateProps) {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">
+        Hold on, loading your
+        {" "}
+        {entity}
+        ...
+      </h1>
+    </div>
+  );
+}
+
+export function EntityError({
+  entity,
+}: EntityStateProps) {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-3xl">
+        There was an error loading your
+        {" "}
+        {entity}
+        .
+      </h1>
+      <p>
+        Try to use the
+        {" "}
+        <Link to="/onboard">Onboarding Wizard</Link>
+        {" "}
+        again, or load in properly formed
+        {" "}
+        {entity}
+        {" "}
+        data.
+      </p>
+    </div>
+  );
+}

--- a/packages/client/src/components/boxes/CourseBox.tsx
+++ b/packages/client/src/components/boxes/CourseBox.tsx
@@ -1,9 +1,12 @@
-import type { Course } from "@emstack/types/src";
+import type { CourseInCourses } from "@emstack/types/src";
 
+import { Link } from "@tanstack/react-router";
 import {
+  CalendarCheckIcon,
   CheckCheckIcon,
   DollarSignIcon,
   ExternalLink,
+  ExternalLinkIcon,
   TimerIcon,
 } from "lucide-react";
 
@@ -35,13 +38,15 @@ export function CourseBox({
   progressCurrent = 0,
   progressTotal = 0,
   cost,
-}: Course) {
+  dailies,
+}: CourseInCourses) {
   const costValue
     = cost.cost != null
       ? cost.isCostFromPlatform
         ? `${Number(cost.cost) / cost.splitBy}*`
         : Number(cost.cost)
       : null;
+  const linkedDaily = dailies?.[0];
   return (
     <ContentBox>
       <ContentBoxHeader>
@@ -51,21 +56,41 @@ export function CourseBox({
             <TopicList topics={topics} />
           </div>
 
-          {url && (
-            <Button
-              variant="ghost"
-              size="icon-xs"
-            >
-              <a
-                href={url}
-                target="_blank"
-                className="cursor-pointer"
-                rel="noopener noreferrer"
+          <div className="flex flex-row items-center gap-2">
+            {linkedDaily && (
+              <Link
+                to="/dailies/$id"
+                params={{
+                  id: linkedDaily.id,
+                }}
+                title={`Open Daily: ${linkedDaily.name}`}
+                className={`
+                  inline-flex items-center gap-1 text-xs text-blue-700
+                  hover:text-blue-500
+                  dark:text-blue-300
+                `}
               >
-                <ExternalLink />
-              </a>
-            </Button>
-          )}
+                <CalendarCheckIcon className="size-3.5" />
+                <span className="max-w-32 truncate">{linkedDaily.name}</span>
+                <ExternalLinkIcon className="size-3" />
+              </Link>
+            )}
+            {url && (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+              >
+                <a
+                  href={url}
+                  target="_blank"
+                  className="cursor-pointer"
+                  rel="noopener noreferrer"
+                >
+                  <ExternalLink />
+                </a>
+              </Button>
+            )}
+          </div>
         </ContentBoxHeaderBar>
         <ContentBoxTitle>
           <h3 className="text-xl">

--- a/packages/client/src/components/boxes/CoursesTable.tsx
+++ b/packages/client/src/components/boxes/CoursesTable.tsx
@@ -1,6 +1,11 @@
 import type { CourseInCourses } from "@emstack/types/src";
 
-import { ExternalLink } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import {
+  CalendarCheckIcon,
+  ExternalLink,
+  ExternalLinkIcon,
+} from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { StatusIndicator } from "@/components/boxElements/StatusIndicator";
@@ -50,6 +55,7 @@ export function CoursesTable({
             <TableHead>Name</TableHead>
             <TableHead>Provider</TableHead>
             <TableHead>Topics</TableHead>
+            <TableHead>Daily</TableHead>
             <TableHead>Progress</TableHead>
             <TableHead>Cost</TableHead>
             <TableHead>Expires</TableHead>
@@ -97,6 +103,32 @@ export function CoursesTable({
                       topics={course.topics}
                       isPills={false}
                     />
+                  )
+                  : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+              </TableCell>
+              <TableCell>
+                {course.dailies && course.dailies.length > 0
+                  ? (
+                    <Link
+                      to="/dailies/$id"
+                      params={{
+                        id: course.dailies[0].id,
+                      }}
+                      title={`Open Daily: ${course.dailies[0].name}`}
+                      className={`
+                        inline-flex items-center gap-1 text-xs text-blue-700
+                        hover:text-blue-500
+                        dark:text-blue-300
+                      `}
+                    >
+                      <CalendarCheckIcon className="size-3.5" />
+                      <span className="max-w-32 truncate">
+                        {course.dailies[0].name}
+                      </span>
+                      <ExternalLinkIcon className="size-3" />
+                    </Link>
                   )
                   : (
                     <span className="text-muted-foreground">—</span>

--- a/packages/client/src/components/boxes/TopicBox.tsx
+++ b/packages/client/src/components/boxes/TopicBox.tsx
@@ -43,8 +43,7 @@ export function TopicBox({
               <span
                 key={domain.id}
                 className="
-                  rounded-sm bg-gray-100 px-2 py-0.5 text-xs
-                  text-gray-700
+                  rounded-sm bg-gray-100 px-2 py-0.5 text-xs text-gray-700
                 "
               >
                 {domain.title}

--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -269,7 +269,7 @@ export function DailyCompletionsManager({
             const hasStatusEntry = status !== null;
             const isFuture = dateKey > realToday;
             const isToday = dateKey === realToday;
-            const isEditable = !effectiveReadOnly && (!readOnly || isToday);
+            const isEditable = isToday || !effectiveReadOnly;
             const hasActions = isEditable && !isFuture;
             const isExpanded = expandedDateKey === dateKey;
             const nextDateKey = visibleDateKeys[i + 1];
@@ -368,7 +368,12 @@ export function DailyCompletionsManager({
                       `
                         flex-row items-center gap-1
                         max-md:w-full max-md:justify-end
-                        md:flex
+                        md:pointer-events-none md:flex md:opacity-0
+                        md:transition-opacity
+                        md:group-focus-within:pointer-events-auto
+                        md:group-focus-within:opacity-100
+                        md:group-hover:pointer-events-auto
+                        md:group-hover:opacity-100
                       `,
                       isExpanded ? "flex" : "hidden",
                     )}
@@ -404,12 +409,7 @@ export function DailyCompletionsManager({
                             dateKey,
                             status: null,
                           })}
-                          className="
-                            text-destructive
-                            md:opacity-0
-                            md:group-focus-within:opacity-100
-                            md:group-hover:opacity-100
-                          "
+                          className="text-destructive"
                           title="Delete entry"
                           aria-label="Delete entry"
                         >

--- a/packages/client/src/hooks/useEditFormPage.ts
+++ b/packages/client/src/hooks/useEditFormPage.ts
@@ -1,0 +1,98 @@
+import type { QueryKey } from "@tanstack/react-query";
+
+import { useCallback, useRef } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface UseEditFormPageOptions<TData> {
+  id: string;
+  isNew: boolean;
+  queryKey: QueryKey;
+  queryFn: () => Promise<TData>;
+  /** Extra query keys to invalidate after a successful save or delete. */
+  relatedQueryKeys?: QueryKey[];
+}
+
+interface MakeDeleteHandlerOptions {
+  deleteFn: (id: string) => Promise<unknown>;
+  entityLabel: string;
+  navigateToList: () => void | Promise<void>;
+}
+
+/**
+ * Shared boilerplate for entity edit pages:
+ *   - fetches the entity via useQuery (skipped when isNew)
+ *   - manages the "skip unsaved-changes blocker" ref
+ *   - exposes invalidateRelated() to refresh list/detail caches
+ *   - exposes makeDeleteHandler(...) that wires up delete + invalidate + nav
+ *
+ * Navigation stays in the route file so TanStack Router types are preserved.
+ */
+export function useEditFormPage<TData>({
+  id,
+  isNew,
+  queryKey,
+  queryFn,
+  relatedQueryKeys = [],
+}: UseEditFormPageOptions<TData>) {
+  const queryClient = useQueryClient();
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey,
+    queryFn,
+    enabled: !isNew,
+  });
+
+  const invalidateRelated = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey,
+    });
+    for (const key of relatedQueryKeys) {
+      await queryClient.invalidateQueries({
+        queryKey: key,
+      });
+    }
+  }, [queryClient, queryKey, relatedQueryKeys]);
+
+  const skipBlock = useCallback(() => {
+    skipBlocker.current = true;
+  }, []);
+
+  const shouldBlockFn = useCallback(
+    (hasChanges: boolean) => () => hasChanges && !skipBlocker.current,
+    [],
+  );
+
+  const makeDeleteHandler = useCallback(
+    ({
+      deleteFn,
+      entityLabel,
+      navigateToList,
+    }: MakeDeleteHandlerOptions) =>
+      async () => {
+        try {
+          await deleteFn(id);
+          await invalidateRelated();
+          skipBlock();
+          await navigateToList();
+        }
+        catch {
+          toast.error(`Failed to delete ${entityLabel}. Please try again.`);
+        }
+      },
+    [id, invalidateRelated, skipBlock],
+  );
+
+  return {
+    data,
+    queryClient,
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  };
+}

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -1,9 +1,9 @@
 import type { AnyFieldApi } from "@tanstack/react-form";
 
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import { useAppForm } from "@/components/formFields";
 import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   deleteSingleCourse,
   duplicateCourse,
@@ -47,16 +48,19 @@ function SingleCourseEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const skipBlocker = useRef(false);
 
   const {
     data,
-  } = useQuery({
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  } = useEditFormPage({
+    id,
+    isNew,
     queryKey: ["course", id],
     queryFn: () => fetchSingleCourse(id),
-    enabled: !isNew,
+    relatedQueryKeys: [["courses"], ["topics"]],
   });
 
   const {
@@ -132,19 +136,8 @@ function SingleCourseEdit() {
         const courseId = isNew ? uuidv4() : id;
         const previousStatus = data?.status;
         await upsertCourse(courseId, courseData);
-        if (!isNew) {
-          await queryClient.invalidateQueries({
-            queryKey: ["course", id],
-          });
-        }
-
-        await queryClient.invalidateQueries({
-          queryKey: ["courses"],
-        });
-        await queryClient.invalidateQueries({
-          queryKey: ["topics"],
-        });
-        skipBlocker.current = true;
+        await invalidateRelated();
+        skipBlock();
 
         const becameActive
           = value.status === "active"
@@ -189,29 +182,19 @@ function SingleCourseEdit() {
     }
   }
 
-  async function handleDelete() {
-    try {
-      await deleteSingleCourse(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["courses"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/courses",
-      });
-    }
-    catch {
-      toast.error("Failed to delete course. Please try again.");
-    }
-  }
+  const handleDelete = makeDeleteHandler({
+    deleteFn: deleteSingleCourse,
+    entityLabel: "course",
+    navigateToList: () => navigate({
+      to: "/courses",
+    }),
+  });
 
   async function handleDuplicate() {
     try {
       const result = await duplicateCourse(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["courses"],
-      });
-      skipBlocker.current = true;
+      await invalidateRelated();
+      skipBlock();
       await navigate({
         to: "/courses/$id",
         params: {
@@ -385,7 +368,7 @@ function SingleCourseEdit() {
         </EditPageFooter>
       </form>
       <UnsavedChangesDialog
-        shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        shouldBlockFn={shouldBlockFn(hasChanges)}
       />
     </div>
   );

--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -4,19 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 
 import { TopicList } from "@/components/boxElements/TopicList";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { DailyRecentDaysStrip } from "@/components/dailies";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { InfoRow } from "@/components/layout/InfoRow";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import {
   fetchSingleCourse,
   getCurrentChain,
@@ -195,50 +186,36 @@ function SingleCourse() {
           </InfoArea>
         </div>
       </InfoRow>
-      <AlertDialog open={dailyPromptOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Create a Daily for this course?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You marked this course as active. Want to create a Daily that
-              tracks your progress on it?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={async () => {
-                setDailyPromptOpen(false);
-                await navigate({
-                  to: "/courses/$id",
-                  params: {
-                    id,
-                  },
-                  search: {},
-                  replace: true,
-                });
-              }}
-            >
-              No thanks
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={async () => {
-                setDailyPromptOpen(false);
-                await navigate({
-                  to: "/dailies/$id/edit",
-                  params: {
-                    id: "new",
-                  },
-                  search: {
-                    newCourseId: id,
-                  },
-                });
-              }}
-            >
-              Create Daily
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={dailyPromptOpen}
+        title="Create a Daily for this course?"
+        description="You marked this course as active. Want to create a Daily that tracks your progress on it?"
+        cancelLabel="No thanks"
+        confirmLabel="Create Daily"
+        onCancel={async () => {
+          setDailyPromptOpen(false);
+          await navigate({
+            to: "/courses/$id",
+            params: {
+              id,
+            },
+            search: {},
+            replace: true,
+          });
+        }}
+        onConfirm={async () => {
+          setDailyPromptOpen(false);
+          await navigate({
+            to: "/dailies/$id/edit",
+            params: {
+              id: "new",
+            },
+            search: {
+              newCourseId: id,
+            },
+          });
+        }}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes/courses.$id.tsx
+++ b/packages/client/src/routes/courses.$id.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { EditIcon, ExternalLink, EyeIcon } from "lucide-react";
 
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { fetchSingleCourse } from "@/utils";
@@ -49,29 +50,11 @@ function SingleCourseLayout() {
   }
 
   if (isPending || !data) {
-    return (
-      <div className="p-4">
-        <h1 className="mb-4 text-3xl">Hold on, loading your courses...</h1>
-      </div>
-    );
+    return <EntityPending entity="course" />;
   }
 
   if (error) {
-    return (
-      <div className="p-4">
-        <h1 className="mb-4 text-3xl">
-          There was an error loading your courses.
-        </h1>
-        <p>
-          Try to use the
-          {" "}
-          <Link to="/onboard">Onboarding Wizard</Link>
-          {" "}
-          again, or
-          load in properly formed course data.
-        </p>
-      </div>
-    );
+    return <EntityError entity="course" />;
   }
 
   return (

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -18,6 +18,7 @@ import {
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { CourseBox } from "@/components/boxes/CourseBox";
 import { CoursesTable } from "@/components/boxes/CoursesTable";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -47,29 +48,11 @@ export const Route = createFileRoute("/courses/")({
 });
 
 function CoursesPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your courses...</h1>
-    </div>
-  );
+  return <EntityPending entity="courses" />;
 }
 
 function CoursesError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">
-        There was an error loading your courses.
-      </h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed course data.
-      </p>
-    </div>
-  );
+  return <EntityError entity="courses" />;
 }
 
 function getProgressPercent(course: CourseInCourses): number {

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -1,4 +1,4 @@
-import type { Course, CourseInCourses } from "@emstack/types/src";
+import type { CourseInCourses } from "@emstack/types/src";
 
 import { useMemo, useState } from "react";
 
@@ -329,7 +329,7 @@ function Courses() {
         {viewMode === "grid" && (
           <div className="card-grid">
             {filteredAndSorted.length > 0
-              && filteredAndSorted.map((course: Course) => {
+              && filteredAndSorted.map((course: CourseInCourses) => {
                 if (!course) {
                   return <></>;
                 }

--- a/packages/client/src/routes/dailies.$id.index.tsx
+++ b/packages/client/src/routes/dailies.$id.index.tsx
@@ -13,6 +13,7 @@ import {
   DailyRecentDaysStrip,
   DAILY_STATUS_OPTIONS,
 } from "@/components/dailies";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -28,19 +29,11 @@ export const Route = createFileRoute("/dailies/$id/")({
 });
 
 function DailyPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your daily...</h1>
-    </div>
-  );
+  return <EntityPending entity="daily" />;
 }
 
 function DailyError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading this daily.</h1>
-    </div>
-  );
+  return <EntityError entity="daily" />;
 }
 
 function SingleDaily() {

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -21,6 +21,7 @@ import {
   TodayStatusCell,
   TooManyDailiesWarning,
 } from "@/components/dailies";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { useSettings } from "@/hooks/useSettings";
@@ -48,19 +49,11 @@ export const Route = createFileRoute("/dailies/")({
 const RECENT_DAYS_COUNT = 6;
 
 function DailiesPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your dailies...</h1>
-    </div>
-  );
+  return <EntityPending entity="dailies" />;
 }
 
 function DailiesError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading your dailies.</h1>
-    </div>
-  );
+  return <EntityError entity="dailies" />;
 }
 
 function formatMmDd(dateKey: string): string {

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
@@ -1,11 +1,61 @@
+import { useState } from "react";
+
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ExternalLink } from "lucide-react";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/popover";
 import { Button } from "@/components/ui/button";
 import { RadialProgress } from "@/components/ui/RadialProgress";
 import { fetchCourses } from "@/utils";
+
+function ProgressIndicator({
+  current,
+  total,
+}: {
+  current: number;
+  total: number;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <PopoverTrigger
+        type="button"
+        aria-label={`Progress: ${current} of ${total}`}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        className="inline-flex items-center"
+      >
+        <RadialProgress
+          current={current}
+          total={total}
+          size={20}
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        align="center"
+        side="top"
+        sideOffset={6}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        className="w-auto px-2 py-1 text-xs whitespace-nowrap"
+      >
+        {current}
+        {" / "}
+        {total}
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 export function DashboardCoursesInProgress() {
   const {
@@ -52,26 +102,10 @@ export function DashboardCoursesInProgress() {
             >
               {course.progressTotal > 0
                 ? (
-                  <span className="group relative inline-flex items-center">
-                    <RadialProgress
-                      current={course.progressCurrent}
-                      total={course.progressTotal}
-                      size={20}
-                    />
-                    <span
-                      className="
-                        pointer-events-none invisible absolute top-full left-1/2
-                        z-10 mt-1 -translate-x-1/2 rounded-sm bg-popover px-1.5
-                        py-0.5 text-xs whitespace-nowrap text-popover-foreground
-                        shadow-md
-                        group-hover:visible
-                      "
-                    >
-                      {course.progressCurrent}
-                      {" / "}
-                      {course.progressTotal}
-                    </span>
-                  </span>
+                  <ProgressIndicator
+                    current={course.progressCurrent}
+                    total={course.progressTotal}
+                  />
                 )
                 : <span className="size-5" />}
               <Link

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2, PlusIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createDomain,
   deleteSingleDomain,
@@ -59,16 +60,19 @@ function SingleDomainEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const skipBlocker = useRef(false);
 
   const {
     data,
-  } = useQuery({
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  } = useEditFormPage({
+    id,
+    isNew,
     queryKey: ["domain", id],
     queryFn: () => fetchSingleDomain(id),
-    enabled: !isNew,
+    relatedQueryKeys: [["domains"]],
   });
 
   const {
@@ -161,15 +165,9 @@ function SingleDomainEdit() {
         else {
           await upsertDomain(id, domainData);
           domainId = id;
-          await queryClient.invalidateQueries({
-            queryKey: ["domain", id],
-          });
         }
-
-        await queryClient.invalidateQueries({
-          queryKey: ["domains"],
-        });
-        skipBlocker.current = true;
+        await invalidateRelated();
+        skipBlock();
         await navigate({
           to: "/domains/$id",
           params: {
@@ -235,29 +233,19 @@ function SingleDomainEdit() {
     [excludedRows],
   );
 
-  async function handleDelete() {
-    try {
-      await deleteSingleDomain(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["domains"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/domains",
-      });
-    }
-    catch {
-      toast.error("Failed to delete domain. Please try again.");
-    }
-  }
+  const handleDelete = makeDeleteHandler({
+    deleteFn: deleteSingleDomain,
+    entityLabel: "domain",
+    navigateToList: () => navigate({
+      to: "/domains",
+    }),
+  });
 
   async function handleDuplicate() {
     try {
       const result = await duplicateDomain(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["domains"],
-      });
-      skipBlocker.current = true;
+      await invalidateRelated();
+      skipBlock();
       await navigate({
         to: "/domains/$id",
         params: {
@@ -472,7 +460,7 @@ function SingleDomainEdit() {
           </EditPageFooter>
         </form>
         <UnsavedChangesDialog
-          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+          shouldBlockFn={shouldBlockFn(hasChanges)}
         />
       </div>
     </div>

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, RadarIcon } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { RadarChart } from "@/components/radar/RadarChart";
@@ -35,21 +36,11 @@ function SingleDomain() {
   });
 
   if (isPending) {
-    return (
-      <div className="p-4">
-        <h1 className="mb-4 text-3xl">Hold on, loading your domain...</h1>
-      </div>
-    );
+    return <EntityPending entity="domain" />;
   }
 
   if (error) {
-    return (
-      <div className="p-4">
-        <h1 className="mb-4 text-3xl">
-          There was an error loading this domain.
-        </h1>
-      </div>
-    );
+    return <EntityError entity="domain" />;
   }
 
   const excludedTopics = data?.excludedTopics ?? [];

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -6,6 +6,7 @@ import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { DomainBox } from "@/components/boxes/DomainBox";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { fetchDomains } from "@/utils";
@@ -17,29 +18,11 @@ export const Route = createFileRoute("/domains/")({
 });
 
 function DomainsPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your domains...</h1>
-    </div>
-  );
+  return <EntityPending entity="domains" />;
 }
 
 function DomainsError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">
-        There was an error loading your domains.
-      </h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed data.
-      </p>
-    </div>
-  );
+  return <EntityError entity="domains" />;
 }
 
 function DomainsIndex() {

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -12,6 +11,7 @@ import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createProvider,
   deleteSinglePlatform,
@@ -42,16 +42,19 @@ function SingleProviderEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const skipBlocker = useRef(false);
 
   const {
     data,
-  } = useQuery({
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  } = useEditFormPage({
+    id,
+    isNew,
     queryKey: ["provider", id],
     queryFn: () => fetchSingleProvider(id),
-    enabled: !isNew,
+    relatedQueryKeys: [["providers"]],
   });
 
   const startingValues = useMemo(
@@ -101,15 +104,9 @@ function SingleProviderEdit() {
         else {
           await upsertProvider(id, providerData);
           providerId = id;
-          await queryClient.invalidateQueries({
-            queryKey: ["provider", id],
-          });
         }
-
-        await queryClient.invalidateQueries({
-          queryKey: ["providers"],
-        });
-        skipBlocker.current = true;
+        await invalidateRelated();
+        skipBlock();
         await navigate({
           to: "/providers/$id",
           params: {
@@ -138,21 +135,13 @@ function SingleProviderEdit() {
     state => state.values.isRecurring === "true",
   );
 
-  async function handleDelete() {
-    try {
-      await deleteSinglePlatform(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["providers"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/providers",
-      });
-    }
-    catch {
-      toast.error("Failed to delete provider. Please try again.");
-    }
-  }
+  const handleDelete = makeDeleteHandler({
+    deleteFn: deleteSinglePlatform,
+    entityLabel: "provider",
+    navigateToList: () => navigate({
+      to: "/providers",
+    }),
+  });
 
   return (
     <div>
@@ -324,7 +313,7 @@ function SingleProviderEdit() {
           </EditPageFooter>
         </form>
         <UnsavedChangesDialog
-          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+          shouldBlockFn={shouldBlockFn(hasChanges)}
         />
       </div>
     </div>

--- a/packages/client/src/routes/providers.$id.index.tsx
+++ b/packages/client/src/routes/providers.$id.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon, ExternalLink } from "lucide-react";
 
 import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { InfoRow } from "@/components/layout/InfoRow";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -12,30 +13,6 @@ import { fetchSingleProvider } from "@/utils";
 export const Route = createFileRoute("/providers/$id/")({
   component: SingleProviders,
 });
-
-function TopicPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your topics...</h1>
-    </div>
-  );
-}
-
-function TopicError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading your topics.</h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed course data.
-      </p>
-    </div>
-  );
-}
 
 function SingleProviders() {
   const {
@@ -50,11 +27,11 @@ function SingleProviders() {
   });
 
   if (isPending) {
-    <TopicPending />;
+    return <EntityPending entity="provider" />;
   }
 
   if (error) {
-    <TopicError />;
+    return <EntityError entity="provider" />;
   }
 
   return (

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -6,43 +6,26 @@ import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { ProviderBox } from "@/components/boxes/ProviderBox";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { fetchProviders } from "@/utils";
 
 export const Route = createFileRoute("/providers/")({
-  component: Topics,
-  errorComponent: TopicsError,
-  pendingComponent: TopicsPending,
+  component: Providers,
+  errorComponent: ProvidersError,
+  pendingComponent: ProvidersPending,
 });
 
-function TopicsPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your courses...</h1>
-    </div>
-  );
+function ProvidersPending() {
+  return <EntityPending entity="providers" />;
 }
 
-function TopicsError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">
-        There was an error loading your courses.
-      </h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed course data.
-      </p>
-    </div>
-  );
+function ProvidersError() {
+  return <EntityError entity="providers" />;
 }
 
-function Topics() {
+function Providers() {
   const {
     data,
   } = useQuery({

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon, ExternalLinkIcon } from "lucide-react";
 
 import { DailyRecentDaysStrip } from "@/components/dailies";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ResourcesTable } from "@/components/tasks/ResourcesTable";
@@ -15,19 +16,11 @@ export const Route = createFileRoute("/tasks/$id/")({
 });
 
 function TaskPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your task...</h1>
-    </div>
-  );
+  return <EntityPending entity="task" />;
 }
 
 function TaskError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading this task.</h1>
-    </div>
-  );
+  return <EntityError entity="task" />;
 }
 
 function SingleTask() {

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -7,6 +7,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
 
 import { TaskBox } from "@/components/boxes/TaskBox";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -25,19 +26,11 @@ export const Route = createFileRoute("/tasks/")({
 });
 
 function TasksPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your tasks...</h1>
-    </div>
-  );
+  return <EntityPending entity="tasks" />;
 }
 
 function TasksError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading your tasks.</h1>
-    </div>
-  );
+  return <EntityError entity="tasks" />;
 }
 
 function Tasks() {

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -12,6 +12,7 @@ import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createTopic,
   deleteSingleTopic,
@@ -38,16 +39,19 @@ function SingleTopicEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const skipBlocker = useRef(false);
 
   const {
     data,
-  } = useQuery({
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  } = useEditFormPage({
+    id,
+    isNew,
     queryKey: ["topic", id],
     queryFn: () => fetchSingleTopic(id),
-    enabled: !isNew,
+    relatedQueryKeys: [["topics"], ["domains"]],
   });
 
   const {
@@ -102,18 +106,9 @@ function SingleTopicEdit() {
         else {
           await upsertTopic(id, topicData);
           topicId = id;
-          await queryClient.invalidateQueries({
-            queryKey: ["topic", id],
-          });
         }
-
-        await queryClient.invalidateQueries({
-          queryKey: ["topics"],
-        });
-        await queryClient.invalidateQueries({
-          queryKey: ["domains"],
-        });
-        skipBlocker.current = true;
+        await invalidateRelated();
+        skipBlock();
         await navigate({
           to: "/topics/$id",
           params: {
@@ -137,21 +132,13 @@ function SingleTopicEdit() {
   const isSubmitting = useStore(form.store, state => state.isSubmitting);
   const hasChanges = formHasChanges(currentValues, startingValues);
 
-  async function handleDelete() {
-    try {
-      await deleteSingleTopic(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["topics"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/topics",
-      });
-    }
-    catch {
-      toast.error("Failed to delete topic. Please try again.");
-    }
-  }
+  const handleDelete = makeDeleteHandler({
+    deleteFn: deleteSingleTopic,
+    entityLabel: "topic",
+    navigateToList: () => navigate({
+      to: "/topics",
+    }),
+  });
 
   return (
     <div>
@@ -250,7 +237,7 @@ function SingleTopicEdit() {
           </EditPageFooter>
         </form>
         <UnsavedChangesDialog
-          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+          shouldBlockFn={shouldBlockFn(hasChanges)}
         />
       </div>
     </div>

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon } from "lucide-react";
 
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -10,30 +11,6 @@ import { fetchSingleTopic } from "@/utils";
 export const Route = createFileRoute("/topics/$id/")({
   component: SingleTopic,
 });
-
-function TopicPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your topics...</h1>
-    </div>
-  );
-}
-
-function TopicError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">There was an error loading your topics.</h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed course data.
-      </p>
-    </div>
-  );
-}
 
 function SingleTopic() {
   const {
@@ -48,11 +25,11 @@ function SingleTopic() {
   });
 
   if (isPending) {
-    <TopicPending />;
+    return <EntityPending entity="topic" />;
   }
 
   if (error) {
-    <TopicError />;
+    return <EntityError entity="topic" />;
   }
 
   return (

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -13,6 +13,7 @@ import {
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
+import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,29 +34,11 @@ export const Route = createFileRoute("/topics/")({
 });
 
 function TopicsPending() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">Hold on, loading your courses...</h1>
-    </div>
-  );
+  return <EntityPending entity="topics" />;
 }
 
 function TopicsError() {
-  return (
-    <div className="p-4">
-      <h1 className="mb-4 text-3xl">
-        There was an error loading your courses.
-      </h1>
-      <p>
-        Try to use the
-        {" "}
-        <Link to="/onboard">Onboarding Wizard</Link>
-        {" "}
-        again, or
-        load in properly formed course data.
-      </p>
-    </div>
-  );
+  return <EntityError entity="topics" />;
 }
 
 function sortTopics(

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -17,6 +17,11 @@ interface SuccessObj {
   status: string;
 }
 
+interface CreateResponse {
+  status: string;
+  id: string;
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
@@ -27,6 +32,112 @@ async function fetchJson<T>(url: string): Promise<T> {
   return await response.json();
 }
 
+async function postJson<T>(
+  url: string,
+  data?: object,
+  errorLabel?: string,
+): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    ...(data === undefined
+      ? {}
+      : {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `${errorLabel ?? `POST ${url}`} failed (${response.status} ${response.statusText})${body ? `: ${body}` : ""}`,
+    );
+  }
+  return await response.json();
+}
+
+async function putJson<T>(
+  url: string,
+  data: object,
+  errorLabel?: string,
+): Promise<T> {
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `${errorLabel ?? `PUT ${url}`} failed (${response.status} ${response.statusText})${body ? `: ${body}` : ""}`,
+    );
+  }
+  return await response.json();
+}
+
+async function deleteJson<T>(url: string, errorLabel?: string): Promise<T> {
+  const response = await fetch(url, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${errorLabel ?? `DELETE ${url}`} failed (${response.status} ${response.statusText})`,
+    );
+  }
+  return await response.json();
+}
+
+interface EntityClient<TEntity, TList> {
+  list: () => Promise<TList>;
+  get: (id: string) => Promise<TEntity>;
+  create: (data: Record<string, unknown>) => Promise<CreateResponse>;
+  upsert: (id: string, data: Record<string, unknown>) => Promise<SuccessObj>;
+  delete: (id: string) => Promise<SuccessObj>;
+  duplicate: (id: string) => Promise<CreateResponse>;
+}
+
+function createEntityClient<TEntity, TList = TEntity[]>(
+  endpoint: string,
+  label: string,
+): EntityClient<TEntity, TList> {
+  const base = `/api/${endpoint}`;
+  return {
+    list: () => fetchJson<TList>(base),
+    get: id => fetchJson<TEntity>(`${base}/${id}`),
+    create: data =>
+      postJson<CreateResponse>(base, data, `Failed to create ${label}`),
+    upsert: (id, data) =>
+      putJson<SuccessObj>(`${base}/${id}`, data, `Failed to update ${label}`),
+    delete: id =>
+      deleteJson<SuccessObj>(`${base}/${id}`, `Failed to delete ${label}`),
+    duplicate: id =>
+      postJson<CreateResponse>(
+        `${base}/${id}/duplicate`,
+        undefined,
+        `Failed to duplicate ${label}`,
+      ),
+  };
+}
+
+export const coursesApi = createEntityClient<Course, CourseInCourses[]>(
+  "courses",
+  "course",
+);
+export const topicsApi = createEntityClient<Topic, TopicForTopicsPage[]>(
+  "topics",
+  "topic",
+);
+export const providersApi = createEntityClient<CourseProvider>(
+  "providers",
+  "provider",
+);
+export const domainsApi = createEntityClient<Domain>("domains", "domain");
+export const dailiesApi = createEntityClient<Daily>("dailies", "daily");
+export const tasksApi = createEntityClient<Task>("tasks", "task");
+
 export async function fetchTest(): Promise<Test> {
   return fetchJson<Test>("/api");
 }
@@ -35,50 +146,43 @@ export async function fetchDbTest(): Promise<DbTest[]> {
   return fetchJson<DbTest[]>("/api/dbTest");
 }
 
-export async function fetchTopics(): Promise<TopicForTopicsPage[]> {
-  return fetchJson<TopicForTopicsPage[]>("/api/topics");
-}
+export const fetchTopics = topicsApi.list;
+export const fetchProviders = providersApi.list;
+export const fetchCourses = coursesApi.list;
+export const fetchDomains = domainsApi.list;
+export const fetchDailies = dailiesApi.list;
+export const fetchTasks = tasksApi.list;
 
-export async function fetchProviders(): Promise<CourseProvider[]> {
-  return fetchJson<CourseProvider[]>("/api/providers");
-}
+export const fetchSingleCourse = coursesApi.get;
+export const fetchSingleTopic = topicsApi.get;
+export const fetchSingleProvider = providersApi.get;
+export const fetchSingleDomain = domainsApi.get;
+export const fetchSingleDaily = dailiesApi.get;
+export const fetchSingleTask = tasksApi.get;
 
-export async function fetchCourses(): Promise<CourseInCourses[]> {
-  return fetchJson<CourseInCourses[]>("/api/courses");
-}
+export const upsertCourse = coursesApi.upsert;
+export const upsertTopic = topicsApi.upsert;
+export const upsertProvider = providersApi.upsert;
+export const upsertDomain = domainsApi.upsert;
+export const upsertDaily = dailiesApi.upsert;
+export const upsertTask = tasksApi.upsert;
 
-export async function deleteSingleCourse(id: string): Promise<Course> {
-  console.log("delete single course");
-  return await fetch(`/api/courses/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
+export const createTopic = topicsApi.create;
+export const createProvider = providersApi.create;
+export const createDomain = domainsApi.create;
+export const createDaily = dailiesApi.create;
+export const createTask = tasksApi.create;
 
-export async function deleteSinglePlatform(id: string): Promise<Course> {
-  console.log("delete single platform");
-  return await fetch(`/api/providers/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
+export const deleteSingleCourse = coursesApi.delete;
+export const deleteSingleTopic = topicsApi.delete;
+export const deleteSinglePlatform = providersApi.delete;
+export const deleteSingleDomain = domainsApi.delete;
+export const deleteSingleDaily = dailiesApi.delete;
+export const deleteSingleTask = tasksApi.delete;
 
-export async function deleteSingleTopic(id: string): Promise<Course> {
-  console.log("delete single topic");
-  return await fetch(`/api/topics/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
-
-export async function fetchSingleCourse(id: string): Promise<Course> {
-  return fetchJson<Course>(`/api/courses/${id}`);
-}
-
-export async function fetchSingleTopic(id: string): Promise<Topic> {
-  return fetchJson<Topic>(`/api/topics/${id}`);
-}
-
-export async function fetchSingleProvider(id: string): Promise<CourseProvider> {
-  return fetchJson<CourseProvider>(`/api/providers/${id}`);
-}
+export const duplicateCourse = coursesApi.duplicate;
+export const duplicateDomain = domainsApi.duplicate;
+export const duplicateDaily = dailiesApi.duplicate;
 
 export async function fetchSeed(): Promise<SuccessObj> {
   return await fetch("/api/seed").then(res => res.json());
@@ -86,26 +190,6 @@ export async function fetchSeed(): Promise<SuccessObj> {
 
 export async function fetchClear(): Promise<SuccessObj> {
   return await fetch("/api/clearData").then(res => res.json());
-}
-
-export async function upsertCourse(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<SuccessObj> {
-  const response = await fetch(`/api/courses/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(
-      `Failed to update course (${response.status} ${response.statusText}): ${body}`,
-    );
-  }
-  return await response.json();
 }
 
 export async function incrementCourseProgress(
@@ -116,81 +200,11 @@ export async function incrementCourseProgress(
   progressCurrent: number;
   progressTotal: number;
 }> {
-  const response = await fetch(`/api/courses/${id}/incrementProgress`, {
-    method: "POST",
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to increment course progress: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function createTopic(
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch("/api/topics", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create topic: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function upsertTopic(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<SuccessObj> {
-  const response = await fetch(`/api/topics/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to update topic: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function createProvider(
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch("/api/providers", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create provider: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function upsertProvider(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<SuccessObj> {
-  const response = await fetch(`/api/providers/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to update provider: ${response.statusText}`);
-  }
-  return await response.json();
+  return postJson(
+    `/api/courses/${id}/incrementProgress`,
+    undefined,
+    "Failed to increment course progress",
+  );
 }
 
 export async function postOnboardForm(
@@ -205,202 +219,8 @@ export async function postOnboardForm(
   }).then(res => res.json());
 }
 
-export async function fetchDomains(): Promise<Domain[]> {
-  return fetchJson<Domain[]>("/api/domains");
-}
-
-export async function fetchSingleDomain(id: string): Promise<Domain> {
-  return fetchJson<Domain>(`/api/domains/${id}`);
-}
-
-export async function deleteSingleDomain(
-  id: string,
-): Promise<{ status: string }> {
-  return await fetch(`/api/domains/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
-
-export async function createDomain(
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch("/api/domains", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create domain: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function upsertDomain(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<SuccessObj> {
-  const response = await fetch(`/api/domains/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to update domain: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function fetchDailies(): Promise<Daily[]> {
-  return fetchJson<Daily[]>("/api/dailies");
-}
-
-export async function fetchSingleDaily(id: string): Promise<Daily> {
-  return fetchJson<Daily>(`/api/dailies/${id}`);
-}
-
-export async function createDaily(
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch("/api/dailies", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create daily: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function upsertDaily(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch(`/api/dailies/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to update daily: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function deleteSingleDaily(
-  id: string,
-): Promise<{ status: string }> {
-  return await fetch(`/api/dailies/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
-
-export async function fetchTasks(): Promise<Task[]> {
-  return fetchJson<Task[]>("/api/tasks");
-}
-
-export async function fetchSingleTask(id: string): Promise<Task> {
-  return fetchJson<Task>(`/api/tasks/${id}`);
-}
-
-export async function createTask(
-  data: Record<string, unknown>,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch("/api/tasks", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create task: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function upsertTask(
-  id: string,
-  data: Record<string, unknown>,
-): Promise<SuccessObj> {
-  const response = await fetch(`/api/tasks/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to update task: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function deleteSingleTask(
-  id: string,
-): Promise<SuccessObj> {
-  return await fetch(`/api/tasks/${id}`, {
-    method: "DELETE",
-  }).then(res => res.json());
-}
-
-export async function duplicateDomain(
-  id: string,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch(`/api/domains/${id}/duplicate`, {
-    method: "POST",
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to duplicate domain: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function duplicateCourse(
-  id: string,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch(`/api/courses/${id}/duplicate`, {
-    method: "POST",
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to duplicate course: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
-export async function duplicateDaily(
-  id: string,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch(`/api/dailies/${id}/duplicate`, {
-    method: "POST",
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to duplicate daily: ${response.statusText}`);
-  }
-  return await response.json();
-}
-
 export async function fetchRadar(domainId: string): Promise<Radar> {
-  const response = await fetch(`/api/domains/${domainId}/radar`);
-  if (!response.ok) {
-    throw new Error(`Failed to load radar: ${response.statusText}`);
-  }
-  return await response.json();
+  return fetchJson<Radar>(`/api/domains/${domainId}/radar`);
 }
 
 interface RadarConfigPayload {
@@ -416,17 +236,11 @@ export async function upsertRadarConfig(
   domainId: string,
   data: RadarConfigPayload,
 ): Promise<SuccessObj> {
-  const response = await fetch(`/api/domains/${domainId}/radar`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to save radar config: ${response.statusText}`);
-  }
-  return await response.json();
+  return putJson(
+    `/api/domains/${domainId}/radar`,
+    data,
+    "Failed to save radar config",
+  );
 }
 
 interface BlipPayload {
@@ -439,19 +253,12 @@ interface BlipPayload {
 export async function createRadarBlip(
   domainId: string,
   data: BlipPayload,
-): Promise<{ status: string;
-  id: string; }> {
-  const response = await fetch(`/api/domains/${domainId}/radar/blips`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to create blip: ${response.statusText}`);
-  }
-  return await response.json();
+): Promise<CreateResponse> {
+  return postJson(
+    `/api/domains/${domainId}/radar/blips`,
+    data,
+    "Failed to create blip",
+  );
 }
 
 export async function upsertRadarBlip(
@@ -459,36 +266,21 @@ export async function upsertRadarBlip(
   blipId: string,
   data: BlipPayload,
 ): Promise<SuccessObj> {
-  const response = await fetch(
+  return putJson(
     `/api/domains/${domainId}/radar/blips/${blipId}`,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    },
+    data,
+    "Failed to update blip",
   );
-  if (!response.ok) {
-    throw new Error(`Failed to update blip: ${response.statusText}`);
-  }
-  return await response.json();
 }
 
 export async function deleteRadarBlip(
   domainId: string,
   blipId: string,
 ): Promise<SuccessObj> {
-  const response = await fetch(
+  return deleteJson(
     `/api/domains/${domainId}/radar/blips/${blipId}`,
-    {
-      method: "DELETE",
-    },
+    "Failed to delete blip",
   );
-  if (!response.ok) {
-    throw new Error(`Failed to delete blip: ${response.statusText}`);
-  }
-  return await response.json();
 }
 
 export interface BulkBlipEntry {
@@ -506,18 +298,9 @@ export async function bulkCreateRadarBlips(
   count: number;
   ids: string[];
   skippedDuplicates?: number; }> {
-  const response = await fetch(
+  return postJson(
     `/api/domains/${domainId}/radar/blips/bulk`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    },
+    data,
+    "Failed to bulk-create blips",
   );
-  if (!response.ok) {
-    throw new Error(`Failed to bulk-create blips: ${response.statusText}`);
-  }
-  return await response.json();
 }

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -39,6 +39,7 @@
     "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths",
     "dev": "nodemon --exec tsx src/app.ts",
     "test": "node --test",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "push:prod": "dotenv -e .env.production -- drizzle-kit push",
     "push:dev": "dotenv -e .env -- drizzle-kit push",
     "push": "pnpm run push:prod && pnpm run push:dev",

--- a/packages/middleware/src/routes/api/courses/deleteCourse.ts
+++ b/packages/middleware/src/routes/api/courses/deleteCourse.ts
@@ -5,8 +5,10 @@ export default createDeleteHandler({
   description: "Delete a course by ID",
   table: courses,
   idColumn: courses.id,
-  junction: {
-    table: topicsToCourses,
-    foreignKey: topicsToCourses.courseId,
-  },
+  junctions: [
+    {
+      table: topicsToCourses,
+      foreignKey: topicsToCourses.courseId,
+    },
+  ],
 });

--- a/packages/middleware/src/routes/api/courses/duplicateCourse.ts
+++ b/packages/middleware/src/routes/api/courses/duplicateCourse.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { courses, topicsToCourses } from "@/db/schema";
+import { sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -33,10 +34,7 @@ export default async function (server: FastifyInstance) {
       });
 
       if (!source) {
-        reply.status(404);
-        return {
-          error: "Course not found",
-        };
+        return sendNotFound(reply, "Course");
       }
 
       const newId = uuidv4();

--- a/packages/middleware/src/routes/api/courses/incrementCourseProgress.ts
+++ b/packages/middleware/src/routes/api/courses/incrementCourseProgress.ts
@@ -3,6 +3,7 @@ import { FastifyInstance } from "fastify";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { courses } from "@/db/schema";
+import { sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
 
 const incrementSchema = {
@@ -30,10 +31,7 @@ export default async function (server: FastifyInstance) {
       });
 
       if (!course) {
-        return reply.status(404).send({
-          status: "error",
-          message: "Course not found",
-        });
+        return sendNotFound(reply, "Course");
       }
 
       const current = course.progressCurrent ?? 0;

--- a/packages/middleware/src/routes/api/courses/root.ts
+++ b/packages/middleware/src/routes/api/courses/root.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { processCost } from "@/utils/processCost";
 import { processTopics } from "@/utils/processTopics";
-import type { Course, CourseFromServer } from "@emstack/types/src";
+import type { Course, CourseFromServer, DailyCompletion } from "@emstack/types/src";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -26,11 +26,18 @@ export default async function (server: FastifyInstance) {
             },
           },
         },
+        dailies: {
+          columns: {
+            id: true,
+            name: true,
+            completions: true,
+          },
+        },
       },
     });
 
-    const processedData: Course[] = rawData.map((course: CourseFromServer) => {
-      const costData = processCost(course);
+    const processedData: Course[] = rawData.map((course) => {
+      const costData = processCost(course as unknown as CourseFromServer);
 
       const topics = processTopics(course.topicsToCourses);
 
@@ -52,6 +59,11 @@ export default async function (server: FastifyInstance) {
               id: course.courseProvider.id,
             }
             : undefined,
+        dailies: (course.dailies ?? []).map(d => ({
+          id: d.id,
+          name: d.name,
+          completions: (d.completions ?? []) as DailyCompletion[],
+        })),
       };
     });
 

--- a/packages/middleware/src/routes/api/courses/upsertCourse.ts
+++ b/packages/middleware/src/routes/api/courses/upsertCourse.ts
@@ -1,111 +1,94 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { courses, topicsToCourses } from "@/db/schema";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import {
-  idParamSchema,
+  courseStatusEnum,
   nullableBoolean,
   nullableInteger,
   nullableString,
 } from "@/utils/schemas";
-import { syncJunctionTable } from "@/utils/syncJunctionTable";
-import { v4 as uuidv4 } from "uuid";
 
-const upsertSchema = {
-  schema: {
-    description: "Create or update a course",
-    params: idParamSchema,
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        description: nullableString,
-        url: nullableString,
-        status: {
-          type: "string",
-          enum: ["active", "inactive", "complete"],
-        },
-        progressCurrent: nullableInteger,
-        progressTotal: nullableInteger,
-        cost: nullableString,
-        isCostFromPlatform: {
-          type: "boolean",
-        },
-        dateExpires: nullableString,
-        isExpires: nullableBoolean,
-        topicId: nullableString,
-        courseProviderId: nullableString,
+interface CourseBody {
+  name: string;
+  description?: string | null;
+  url?: string | null;
+  status?: "active" | "inactive" | "complete";
+  progressCurrent?: number | null;
+  progressTotal?: number | null;
+  cost?: string | null;
+  isCostFromPlatform?: boolean;
+  dateExpires?: string | null;
+  isExpires?: boolean | null;
+  topicId?: string | null;
+  courseProviderId?: string | null;
+}
+
+const updateableColumns = [
+  "name",
+  "description",
+  "url",
+  "status",
+  "progressCurrent",
+  "progressTotal",
+  "cost",
+  "isCostFromPlatform",
+  "dateExpires",
+  "isExpires",
+  "courseProviderId",
+] as const;
+
+export default createUpsertHandler<CourseBody>({
+  description: "Create or update a course",
+  table: courses,
+  bodySchema: {
+    type: "object",
+    required: ["name"],
+    properties: {
+      name: {
+        type: "string",
       },
+      description: nullableString,
+      url: nullableString,
+      status: courseStatusEnum,
+      progressCurrent: nullableInteger,
+      progressTotal: nullableInteger,
+      cost: nullableString,
+      isCostFromPlatform: {
+        type: "boolean",
+      },
+      dateExpires: nullableString,
+      isExpires: nullableBoolean,
+      topicId: nullableString,
+      courseProviderId: nullableString,
     },
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.put(
-    "/:id",
-    upsertSchema,
-    async function (request, reply) {
-      const {
-        id,
-      } = request.params;
-      const body = request.body;
-
-      const courseData = {
-        id: id || uuidv4(),
-        name: body.name,
-        description: body.description ?? null,
-        url: body.url ?? null,
-        status: body.status as "active" | "inactive" | "complete" | undefined,
-        progressCurrent: body.progressCurrent ?? null,
-        progressTotal: body.progressTotal ?? null,
-        cost: body.cost ?? null,
-        isCostFromPlatform: body.isCostFromPlatform ?? false,
-        dateExpires: body.dateExpires ?? null,
-        isExpires: body.isExpires ?? null,
-        courseProviderId: body.courseProviderId ?? null,
-      };
-
-      await db
-        .insert(courses)
-        .values(courseData)
-        .onConflictDoUpdate({
-          target: courses.id,
-          set: {
-            name: courseData.name,
-            description: courseData.description,
-            url: courseData.url,
-            status: courseData.status,
-            progressCurrent: courseData.progressCurrent,
-            progressTotal: courseData.progressTotal,
-            cost: courseData.cost,
-            isCostFromPlatform: courseData.isCostFromPlatform,
-            dateExpires: courseData.dateExpires,
-            isExpires: courseData.isExpires,
-            courseProviderId: courseData.courseProviderId,
-          },
-        });
-
-      await syncJunctionTable(
-        topicsToCourses,
-        topicsToCourses.courseId,
-        courseData.id,
+  buildRow: (body, id) => ({
+    id,
+    name: body.name,
+    description: body.description ?? null,
+    url: body.url ?? null,
+    status: body.status,
+    progressCurrent: body.progressCurrent ?? null,
+    progressTotal: body.progressTotal ?? null,
+    cost: body.cost ?? null,
+    isCostFromPlatform: body.isCostFromPlatform ?? false,
+    dateExpires: body.dateExpires ?? null,
+    isExpires: body.isExpires ?? null,
+    courseProviderId: body.courseProviderId ?? null,
+  }),
+  updateableColumns,
+  generateIdIfMissing: true,
+  returnId: true,
+  junctions: [
+    {
+      table: topicsToCourses,
+      foreignKey: topicsToCourses.courseId,
+      buildRows: (body, id) =>
         body.topicId
           ? [{
             topicId: body.topicId,
-            courseId: courseData.id,
+            courseId: id,
           }]
           : [],
-      );
-
-      return {
-        status: "ok",
-        id: courseData.id,
-      };
     },
-  );
-}
+  ],
+});

--- a/packages/middleware/src/routes/api/dailies/createDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/createDaily.ts
@@ -2,43 +2,14 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { dailies } from "@/db/schema";
+import {
+  completionSchema,
+  criteriaSchema,
+  nullableDailyStatusEnum,
+  nullableString,
+} from "@/utils/schemas";
 import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
 import { v4 as uuidv4 } from "uuid";
-
-const completionSchema = {
-  type: "object",
-  required: ["date"],
-  properties: {
-    date: {
-      type: "string",
-    },
-    status: {
-      type: "string",
-      enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],
-    },
-    note: {
-      type: "string",
-    },
-  },
-} as const;
-
-const criteriaSchema = {
-  type: "object",
-  properties: {
-    incomplete: {
-      type: "string",
-    },
-    touched: {
-      type: "string",
-    },
-    goal: {
-      type: "string",
-    },
-    exceeded: {
-      type: "string",
-    },
-  },
-} as const;
 
 const createSchema = {
   schema: {
@@ -50,29 +21,16 @@ const createSchema = {
         name: {
           type: "string",
         },
-        location: {
-          type: ["string", "null"],
-        },
-        description: {
-          type: ["string", "null"],
-        },
+        location: nullableString,
+        description: nullableString,
         completions: {
           type: "array",
           items: completionSchema,
         },
-        courseProviderId: {
-          type: ["string", "null"],
-        },
-        courseId: {
-          type: ["string", "null"],
-        },
-        taskId: {
-          type: ["string", "null"],
-        },
-        status: {
-          type: ["string", "null"],
-          enum: ["active", "complete", "paused", null],
-        },
+        courseProviderId: nullableString,
+        courseId: nullableString,
+        taskId: nullableString,
+        status: nullableDailyStatusEnum,
         criteria: criteriaSchema,
       },
     },

--- a/packages/middleware/src/routes/api/dailies/upsertDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/upsertDaily.ts
@@ -2,59 +2,20 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { dailies } from "@/db/schema";
+import {
+  completionSchema,
+  criteriaSchema,
+  idParamSchema,
+  nullableDailyStatusEnum,
+  nullableString,
+} from "@/utils/schemas";
 import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
 import { v4 as uuidv4 } from "uuid";
-
-const completionSchema = {
-  type: "object",
-  required: ["date"],
-  properties: {
-    date: {
-      type: "string",
-    },
-    status: {
-      type: "string",
-      enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],
-    },
-    note: {
-      type: "string",
-    },
-  },
-} as const;
-
-const criteriaSchema = {
-  type: "object",
-  properties: {
-    incomplete: {
-      type: "string",
-    },
-    touched: {
-      type: "string",
-    },
-    goal: {
-      type: "string",
-    },
-    exceeded: {
-      type: "string",
-    },
-    freeze: {
-      type: "string",
-    },
-  },
-} as const;
 
 const upsertSchema = {
   schema: {
     description: "Create or update a daily",
-    params: {
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-        },
-      },
-      required: ["id"],
-    },
+    params: idParamSchema,
     body: {
       type: "object",
       required: ["name"],
@@ -62,29 +23,16 @@ const upsertSchema = {
         name: {
           type: "string",
         },
-        location: {
-          type: ["string", "null"],
-        },
-        description: {
-          type: ["string", "null"],
-        },
+        location: nullableString,
+        description: nullableString,
         completions: {
           type: "array",
           items: completionSchema,
         },
-        courseProviderId: {
-          type: ["string", "null"],
-        },
-        courseId: {
-          type: ["string", "null"],
-        },
-        taskId: {
-          type: ["string", "null"],
-        },
-        status: {
-          type: ["string", "null"],
-          enum: ["active", "complete", "paused", null],
-        },
+        courseProviderId: nullableString,
+        courseId: nullableString,
+        taskId: nullableString,
+        status: nullableDailyStatusEnum,
         criteria: criteriaSchema,
       },
     },

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -1,7 +1,3 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { eq } from "drizzle-orm";
-import { db } from "@/db";
 import {
   domainExcludedTopics,
   domains,
@@ -10,36 +6,32 @@ import {
   radarRings,
   topicsToDomains,
 } from "@/db/schema";
-import { idParamSchema } from "@/utils/schemas";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
 
-const deleteSchema = {
-  schema: {
-    description: "Delete a domain by ID",
-    params: idParamSchema,
-  },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.delete("/:id", deleteSchema, async function (request) {
-    const {
-      id,
-    } = request.params;
-
-    await db.delete(radarBlips).where(eq(radarBlips.domainId, id));
-    await db.delete(radarQuadrants).where(eq(radarQuadrants.domainId, id));
-    await db.delete(radarRings).where(eq(radarRings.domainId, id));
-    await db
-      .delete(topicsToDomains)
-      .where(eq(topicsToDomains.domainId, id));
-    await db
-      .delete(domainExcludedTopics)
-      .where(eq(domainExcludedTopics.domainId, id));
-    await db.delete(domains).where(eq(domains.id, id));
-
-    return {
-      status: "ok",
-    };
-  });
-}
+export default createDeleteHandler({
+  description: "Delete a domain by ID",
+  table: domains,
+  idColumn: domains.id,
+  junctions: [
+    {
+      table: radarBlips,
+      foreignKey: radarBlips.domainId,
+    },
+    {
+      table: radarQuadrants,
+      foreignKey: radarQuadrants.domainId,
+    },
+    {
+      table: radarRings,
+      foreignKey: radarRings.domainId,
+    },
+    {
+      table: topicsToDomains,
+      foreignKey: topicsToDomains.domainId,
+    },
+    {
+      table: domainExcludedTopics,
+      foreignKey: domainExcludedTopics.domainId,
+    },
+  ],
+});

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import type { Domain } from "@emstack/types/src";
+import { sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
 
 const getDomainSchema = {
@@ -82,10 +83,7 @@ export default async function (server: FastifyInstance) {
       });
 
       if (!domain) {
-        reply.status(404);
-        return {
-          error: "Domain not found",
-        };
+        return sendNotFound(reply, "Domain");
       }
 
       const topicsById = new Map<string, {

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -1,117 +1,89 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { domainExcludedTopics, domains, topicsToDomains } from "@/db/schema";
-import { idParamSchema, nullableBoolean, nullableString } from "@/utils/schemas";
-import { syncJunctionTable } from "@/utils/syncJunctionTable";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
+import { nullableBoolean, nullableString } from "@/utils/schemas";
 
-const upsertSchema = {
-  schema: {
-    description: "Create or update a domain",
-    params: idParamSchema,
-    body: {
-      type: "object",
-      required: ["title"],
-      properties: {
-        title: {
+interface DomainBody {
+  title: string;
+  description?: string | null;
+  hasRadar?: boolean | null;
+  topicIds?: string[];
+  excludedTopics?: { topicId: string;
+    reason?: string | null; }[];
+}
+
+export default createUpsertHandler<DomainBody>({
+  description: "Create or update a domain",
+  table: domains,
+  bodySchema: {
+    type: "object",
+    required: ["title"],
+    properties: {
+      title: {
+        type: "string",
+        minLength: 1,
+      },
+      description: nullableString,
+      hasRadar: nullableBoolean,
+      topicIds: {
+        type: "array",
+        items: {
           type: "string",
-          minLength: 1,
         },
-        description: nullableString,
-        hasRadar: nullableBoolean,
-        topicIds: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-        excludedTopics: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["topicId"],
-            properties: {
-              topicId: {
-                type: "string",
-              },
-              reason: nullableString,
+      },
+      excludedTopics: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["topicId"],
+          properties: {
+            topicId: {
+              type: "string",
             },
+            reason: nullableString,
           },
         },
       },
     },
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.put(
-    "/:id",
-    upsertSchema,
-    async function (request, reply) {
-      const {
-        id,
-      } = request.params;
-      const body = request.body;
-
-      const title = body.title.trim();
-      if (!title) {
-        reply.status(400);
-        return {
-          error: "Title is required",
-        };
-      }
-
-      const domainData = {
-        id,
-        title,
-        description: body.description ?? null,
-        hasRadar: body.hasRadar ?? null,
-      };
-
-      await db
-        .insert(domains)
-        .values(domainData)
-        .onConflictDoUpdate({
-          target: domains.id,
-          set: {
-            title: domainData.title,
-            description: domainData.description,
-            hasRadar: domainData.hasRadar,
-          },
-        });
-
-      await syncJunctionTable(
-        topicsToDomains,
-        topicsToDomains.domainId,
-        id,
+  validate: (body) => {
+    if (!body.title.trim()) {
+      return "Title is required";
+    }
+    return null;
+  },
+  buildRow: (body, id) => ({
+    id,
+    title: body.title.trim(),
+    description: body.description ?? null,
+    hasRadar: body.hasRadar ?? null,
+  }),
+  updateableColumns: ["title", "description", "hasRadar"],
+  junctions: [
+    {
+      table: topicsToDomains,
+      foreignKey: topicsToDomains.domainId,
+      buildRows: (body, id) =>
         (body.topicIds ?? []).map(topicId => ({
           topicId,
           domainId: id,
         })),
-      );
-
-      const dedupedExclusions = new Map<string, string | null>();
-      for (const entry of body.excludedTopics ?? []) {
-        if (!dedupedExclusions.has(entry.topicId)) {
-          dedupedExclusions.set(entry.topicId, entry.reason ?? null);
+    },
+    {
+      table: domainExcludedTopics,
+      foreignKey: domainExcludedTopics.domainId,
+      buildRows: (body, id) => {
+        const dedup = new Map<string, string | null>();
+        for (const entry of body.excludedTopics ?? []) {
+          if (!dedup.has(entry.topicId)) {
+            dedup.set(entry.topicId, entry.reason ?? null);
+          }
         }
-      }
-      await syncJunctionTable(
-        domainExcludedTopics,
-        domainExcludedTopics.domainId,
-        id,
-        Array.from(dedupedExclusions.entries()).map(([topicId, reason]) => ({
+        return Array.from(dedup.entries()).map(([topicId, reason]) => ({
           topicId,
           domainId: id,
           reason,
-        })),
-      );
-
-      return {
-        status: "ok",
-      };
+        }));
+      },
     },
-  );
-}
+  ],
+});

--- a/packages/middleware/src/routes/api/providers/upsertProvider.ts
+++ b/packages/middleware/src/routes/api/providers/upsertProvider.ts
@@ -1,89 +1,71 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { courseProviders } from "@/db/schema";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import {
-  idParamSchema,
   nullableBoolean,
   nullableInteger,
   nullableString,
 } from "@/utils/schemas";
 
-const upsertSchema = {
-  schema: {
-    description: "Create or update a provider",
-    params: idParamSchema,
-    body: {
-      type: "object",
-      required: ["name", "url"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        description: nullableString,
-        url: {
-          type: "string",
-        },
-        cost: nullableString,
-        isRecurring: nullableBoolean,
-        recurDate: nullableString,
-        recurPeriodUnit: {
-          type: ["string", "null"],
-          enum: ["days", "months", "years", null],
-        },
-        recurPeriod: nullableInteger,
-        isCourseFeesShared: nullableBoolean,
+interface ProviderBody {
+  name: string;
+  url: string;
+  description?: string | null;
+  cost?: string | null;
+  isRecurring?: boolean | null;
+  recurDate?: string | null;
+  recurPeriodUnit?: "days" | "months" | "years" | null;
+  recurPeriod?: number | null;
+  isCourseFeesShared?: boolean | null;
+}
+
+const updateableColumns = [
+  "name",
+  "description",
+  "url",
+  "cost",
+  "isRecurring",
+  "recurDate",
+  "recurPeriodUnit",
+  "recurPeriod",
+  "isCourseFeesShared",
+] as const;
+
+export default createUpsertHandler<ProviderBody>({
+  description: "Create or update a provider",
+  table: courseProviders,
+  bodySchema: {
+    type: "object",
+    required: ["name", "url"],
+    properties: {
+      name: {
+        type: "string",
       },
+      description: nullableString,
+      url: {
+        type: "string",
+      },
+      cost: nullableString,
+      isRecurring: nullableBoolean,
+      recurDate: nullableString,
+      recurPeriodUnit: {
+        type: ["string", "null"],
+        enum: ["days", "months", "years", null],
+      },
+      recurPeriod: nullableInteger,
+      isCourseFeesShared: nullableBoolean,
     },
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.put(
-    "/:id",
-    upsertSchema,
-    async function (request, reply) {
-      const {
-        id,
-      } = request.params;
-      const body = request.body;
-
-      const providerData = {
-        id,
-        name: body.name,
-        description: body.description ?? null,
-        url: body.url,
-        cost: body.cost ?? null,
-        isRecurring: body.isRecurring ?? null,
-        recurDate: body.recurDate ?? null,
-        recurPeriodUnit: body.recurPeriodUnit as "days" | "months" | "years" | undefined,
-        recurPeriod: body.recurPeriod ?? null,
-        isCourseFeesShared: body.isCourseFeesShared ?? null,
-      };
-
-      await db
-        .insert(courseProviders)
-        .values(providerData)
-        .onConflictDoUpdate({
-          target: courseProviders.id,
-          set: {
-            name: providerData.name,
-            description: providerData.description,
-            url: providerData.url,
-            cost: providerData.cost,
-            isRecurring: providerData.isRecurring,
-            recurDate: providerData.recurDate,
-            recurPeriodUnit: providerData.recurPeriodUnit,
-            recurPeriod: providerData.recurPeriod,
-            isCourseFeesShared: providerData.isCourseFeesShared,
-          },
-        });
-
-      return {
-        status: "ok",
-      };
-    },
-  );
-}
+  buildRow: (body, id) => ({
+    id,
+    name: body.name,
+    description: body.description ?? null,
+    url: body.url,
+    cost: body.cost ?? null,
+    isRecurring: body.isRecurring ?? null,
+    recurDate: body.recurDate ?? null,
+    recurPeriodUnit: body.recurPeriodUnit ?? undefined,
+    recurPeriod: body.recurPeriod ?? null,
+    isCourseFeesShared: body.isCourseFeesShared ?? null,
+  }),
+  updateableColumns,
+});

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -2,49 +2,8 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { resources, taskTodos, tasks } from "@/db/schema";
-import { nullableString } from "@/utils/schemas";
+import { nullableString, resourceSchema, todoSchema } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
-
-const resourceLevel = {
-  type: ["string", "null"],
-  enum: ["low", "medium", "high", null],
-} as const;
-
-const resourceSchema = {
-  type: "object",
-  required: ["name"],
-  properties: {
-    id: {
-      type: "string",
-    },
-    name: {
-      type: "string",
-    },
-    url: nullableString,
-    easeOfStarting: resourceLevel,
-    timeNeeded: resourceLevel,
-    interactivity: resourceLevel,
-    usedYet: {
-      type: "boolean",
-    },
-  },
-} as const;
-
-const todoSchema = {
-  type: "object",
-  required: ["name"],
-  properties: {
-    id: {
-      type: "string",
-    },
-    name: {
-      type: "string",
-    },
-    isComplete: {
-      type: "boolean",
-    },
-  },
-} as const;
 
 const createSchema = {
   schema: {

--- a/packages/middleware/src/routes/api/tasks/deleteTask.ts
+++ b/packages/middleware/src/routes/api/tasks/deleteTask.ts
@@ -1,31 +1,18 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { eq } from "drizzle-orm";
-import { db } from "@/db";
 import { resources, taskTodos, tasks } from "@/db/schema";
-import { idParamSchema } from "@/utils/schemas";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
 
-const deleteSchema = {
-  schema: {
-    description: "Delete a task by ID",
-    params: idParamSchema,
-  },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.delete("/:id", deleteSchema, async function (request) {
-    const {
-      id,
-    } = request.params;
-
-    await db.delete(resources).where(eq(resources.taskId, id));
-    await db.delete(taskTodos).where(eq(taskTodos.taskId, id));
-    await db.delete(tasks).where(eq(tasks.id, id));
-
-    return {
-      status: "ok",
-    };
-  });
-}
+export default createDeleteHandler({
+  description: "Delete a task by ID",
+  table: tasks,
+  idColumn: tasks.id,
+  junctions: [
+    {
+      table: resources,
+      foreignKey: resources.taskId,
+    },
+    {
+      table: taskTodos,
+      foreignKey: taskTodos.taskId,
+    },
+  ],
+});

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -3,49 +3,13 @@ import { FastifyInstance } from "fastify";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { resources, taskTodos, tasks } from "@/db/schema";
-import { idParamSchema, nullableString } from "@/utils/schemas";
+import {
+  idParamSchema,
+  nullableString,
+  resourceSchema,
+  todoSchema,
+} from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
-
-const resourceLevel = {
-  type: ["string", "null"],
-  enum: ["low", "medium", "high", null],
-} as const;
-
-const resourceSchema = {
-  type: "object",
-  required: ["name"],
-  properties: {
-    id: {
-      type: "string",
-    },
-    name: {
-      type: "string",
-    },
-    url: nullableString,
-    easeOfStarting: resourceLevel,
-    timeNeeded: resourceLevel,
-    interactivity: resourceLevel,
-    usedYet: {
-      type: "boolean",
-    },
-  },
-} as const;
-
-const todoSchema = {
-  type: "object",
-  required: ["name"],
-  properties: {
-    id: {
-      type: "string",
-    },
-    name: {
-      type: "string",
-    },
-    isComplete: {
-      type: "boolean",
-    },
-  },
-} as const;
 
 const upsertSchema = {
   schema: {

--- a/packages/middleware/src/routes/api/topics/deleteTopic.ts
+++ b/packages/middleware/src/routes/api/topics/deleteTopic.ts
@@ -1,7 +1,3 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { eq } from "drizzle-orm";
-import { db } from "@/db";
 import {
   domainExcludedTopics,
   radarBlips,
@@ -9,37 +5,28 @@ import {
   topicsToCourses,
   topicsToDomains,
 } from "@/db/schema";
-import { idParamSchema } from "@/utils/schemas";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
 
-const deleteSchema = {
-  schema: {
-    description: "Delete a topic by ID",
-    params: idParamSchema,
-  },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.delete("/:id", deleteSchema, async function (request) {
-    const {
-      id,
-    } = request.params;
-
-    await db.delete(radarBlips).where(eq(radarBlips.topicId, id));
-    await db
-      .delete(topicsToCourses)
-      .where(eq(topicsToCourses.topicId, id));
-    await db
-      .delete(topicsToDomains)
-      .where(eq(topicsToDomains.topicId, id));
-    await db
-      .delete(domainExcludedTopics)
-      .where(eq(domainExcludedTopics.topicId, id));
-    await db.delete(topics).where(eq(topics.id, id));
-
-    return {
-      status: "ok",
-    };
-  });
-}
+export default createDeleteHandler({
+  description: "Delete a topic by ID",
+  table: topics,
+  idColumn: topics.id,
+  junctions: [
+    {
+      table: radarBlips,
+      foreignKey: radarBlips.topicId,
+    },
+    {
+      table: topicsToCourses,
+      foreignKey: topicsToCourses.topicId,
+    },
+    {
+      table: topicsToDomains,
+      foreignKey: topicsToDomains.topicId,
+    },
+    {
+      table: domainExcludedTopics,
+      foreignKey: domainExcludedTopics.topicId,
+    },
+  ],
+});

--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -37,7 +37,8 @@ export default async function (server: FastifyInstance) {
       const processedData: TopicForTopicsPage[] = rawData.map((topic: TopicsFromServer) => {
         const courseCount = topic.topicsToCourses?.length ?? 0;
 
-        const domainsById = new Map<string, { id: string; title: string }>();
+        const domainsById = new Map<string, { id: string;
+          title: string; }>();
         for (const ttd of topic.topicsToDomains ?? []) {
           if (ttd.domain?.id && ttd.domain.title && !domainsById.has(ttd.domain.id)) {
             domainsById.set(ttd.domain.id, {

--- a/packages/middleware/src/routes/api/topics/upsertTopic.ts
+++ b/packages/middleware/src/routes/api/topics/upsertTopic.ts
@@ -1,82 +1,56 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { topics, topicsToDomains } from "@/db/schema";
-import { idParamSchema, nullableString } from "@/utils/schemas";
-import { syncJunctionTable } from "@/utils/syncJunctionTable";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
+import { nullableString } from "@/utils/schemas";
 
-const upsertSchema = {
-  schema: {
-    description: "Update a topic",
-    params: idParamSchema,
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
+interface TopicBody {
+  name: string;
+  description?: string | null;
+  reason?: string | null;
+  domainIds?: string[];
+}
+
+export default createUpsertHandler<TopicBody>({
+  description: "Update a topic",
+  table: topics,
+  bodySchema: {
+    type: "object",
+    required: ["name"],
+    properties: {
+      name: {
+        type: "string",
+        minLength: 1,
+      },
+      description: nullableString,
+      reason: nullableString,
+      domainIds: {
+        type: "array",
+        items: {
           type: "string",
-          minLength: 1,
-        },
-        description: nullableString,
-        reason: nullableString,
-        domainIds: {
-          type: "array",
-          items: {
-            type: "string",
-          },
         },
       },
     },
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.put(
-    "/:id",
-    upsertSchema,
-    async function (request, reply) {
-      const {
-        id,
-      } = request.params;
-      const body = request.body;
-
-      const topicData = {
-        id,
-        name: body.name,
-        description: body.description ?? null,
-        reason: body.reason ?? null,
-      };
-
-      await db
-        .insert(topics)
-        .values(topicData)
-        .onConflictDoUpdate({
-          target: topics.id,
-          set: {
-            name: topicData.name,
-            description: topicData.description,
-            reason: topicData.reason,
-          },
-        });
-
-      if (body.domainIds !== undefined) {
+  buildRow: (body, id) => ({
+    id,
+    name: body.name,
+    description: body.description ?? null,
+    reason: body.reason ?? null,
+  }),
+  updateableColumns: ["name", "description", "reason"],
+  junctions: [
+    {
+      table: topicsToDomains,
+      foreignKey: topicsToDomains.topicId,
+      buildRows: (body, id) => {
+        if (body.domainIds === undefined) {
+          return undefined;
+        }
         const uniqueDomainIds = Array.from(new Set(body.domainIds));
-        await syncJunctionTable(
-          topicsToDomains,
-          topicsToDomains.topicId,
-          id,
-          uniqueDomainIds.map(domainId => ({
-            topicId: id,
-            domainId,
-          })),
-        );
-      }
-
-      return {
-        status: "ok",
-      };
+        return uniqueDomainIds.map(domainId => ({
+          topicId: id,
+          domainId,
+        }));
+      },
     },
-  );
-}
+  ],
+});

--- a/packages/middleware/src/utils/createDeleteHandler.ts
+++ b/packages/middleware/src/utils/createDeleteHandler.ts
@@ -5,21 +5,23 @@ import { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import { idParamSchema } from "./schemas";
 
+interface JunctionRef {
+  table: PgTable;
+  foreignKey: AnyPgColumn;
+}
+
 interface DeleteHandlerOptions {
   description: string;
   table: PgTable;
   idColumn: AnyPgColumn;
-  junction?: {
-    table: PgTable;
-    foreignKey: AnyPgColumn;
-  };
+  junctions?: JunctionRef[];
 }
 
 export function createDeleteHandler({
   description,
   table,
   idColumn,
-  junction,
+  junctions = [],
 }: DeleteHandlerOptions) {
   const schema = {
     schema: {
@@ -36,7 +38,7 @@ export function createDeleteHandler({
         id,
       } = request.params;
 
-      if (junction) {
+      for (const junction of junctions) {
         await db.delete(junction.table).where(eq(junction.foreignKey, id));
       }
       await db.delete(table).where(eq(idColumn, id));

--- a/packages/middleware/src/utils/createUpsertHandler.ts
+++ b/packages/middleware/src/utils/createUpsertHandler.ts
@@ -1,0 +1,106 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance, FastifyReply } from "fastify";
+import { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { idParamSchema } from "./schemas";
+import { syncJunctionTable } from "./syncJunctionTable";
+
+type Row = Record<string, unknown>;
+
+interface JunctionConfig<TBody> {
+  table: PgTable;
+  foreignKey: AnyPgColumn;
+  /**
+   * Return `undefined` to skip syncing this junction for this request
+   * (leaves existing rows untouched). Return `[]` to clear all rows.
+   */
+  buildRows: (body: TBody, id: string) => Row[] | undefined;
+}
+
+interface UpsertHandlerOptions<TBody> {
+  description: string;
+  table: PgTable;
+  /** JSON Schema for the request body (passed straight through to Fastify). */
+  bodySchema: object;
+  buildRow: (body: TBody, id: string) => Row;
+  updateableColumns: readonly string[];
+  junctions?: readonly JunctionConfig<TBody>[];
+  /** When true, missing or empty `id` params get a fresh uuid. */
+  generateIdIfMissing?: boolean;
+  /** Return an error message string to abort with 400, or null to proceed. */
+  validate?: (body: TBody) => string | null;
+  /** When true, response includes the row's id. */
+  returnId?: boolean;
+}
+
+export function createUpsertHandler<TBody = Record<string, unknown>>(
+  options: UpsertHandlerOptions<TBody>,
+) {
+  const schema = {
+    schema: {
+      description: options.description,
+      params: idParamSchema,
+      body: options.bodySchema,
+    },
+  } as const;
+
+  return async function (server: FastifyInstance) {
+    const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+    fastify.put("/:id", schema, async function (request, reply: FastifyReply) {
+      const params = request.params as { id: string };
+      const body = request.body as TBody;
+
+      if (options.validate) {
+        const errorMessage = options.validate(body);
+        if (errorMessage !== null) {
+          reply.status(400);
+          return {
+            status: "error",
+            message: errorMessage,
+          };
+        }
+      }
+
+      const id = params.id || (options.generateIdIfMissing ? uuidv4() : params.id);
+
+      const row = options.buildRow(body, id);
+
+      const setClause: Row = {};
+      for (const col of options.updateableColumns) {
+        setClause[col] = row[col];
+      }
+
+      await db
+        .insert(options.table)
+        .values(row as never)
+        .onConflictDoUpdate({
+          target: (options.table as unknown as { id: AnyPgColumn }).id,
+          set: setClause,
+        });
+
+      for (const junction of options.junctions ?? []) {
+        const rows = junction.buildRows(body, id);
+        if (rows !== undefined) {
+          await syncJunctionTable(
+            junction.table,
+            junction.foreignKey,
+            id,
+            rows,
+          );
+        }
+      }
+
+      if (options.returnId) {
+        return {
+          status: "ok",
+          id,
+        };
+      }
+      return {
+        status: "ok",
+      };
+    });
+  };
+}

--- a/packages/middleware/src/utils/errors.ts
+++ b/packages/middleware/src/utils/errors.ts
@@ -1,0 +1,15 @@
+import { FastifyReply } from "fastify";
+
+export function sendNotFound(reply: FastifyReply, resource: string) {
+  return reply.status(404).send({
+    status: "error",
+    message: `${resource} not found`,
+  });
+}
+
+export function sendBadRequest(reply: FastifyReply, message: string) {
+  return reply.status(400).send({
+    status: "error",
+    message,
+  });
+}

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -19,3 +19,91 @@ export const nullableBoolean = {
 export const nullableInteger = {
   type: ["integer", "null"],
 } as const;
+
+export const courseStatusEnum = {
+  type: "string",
+  enum: ["active", "inactive", "complete"],
+} as const;
+
+export const nullableDailyStatusEnum = {
+  type: ["string", "null"],
+  enum: ["active", "complete", "paused", null],
+} as const;
+
+export const nullableResourceLevelEnum = {
+  type: ["string", "null"],
+  enum: ["low", "medium", "high", null],
+} as const;
+
+export const dailyCompletionStatusEnum = {
+  type: "string",
+  enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],
+} as const;
+
+export const completionSchema = {
+  type: "object",
+  required: ["date"],
+  properties: {
+    date: {
+      type: "string",
+    },
+    status: dailyCompletionStatusEnum,
+    note: {
+      type: "string",
+    },
+  },
+} as const;
+
+export const criteriaSchema = {
+  type: "object",
+  properties: {
+    incomplete: {
+      type: "string",
+    },
+    touched: {
+      type: "string",
+    },
+    goal: {
+      type: "string",
+    },
+    exceeded: {
+      type: "string",
+    },
+  },
+} as const;
+
+export const resourceSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    url: nullableString,
+    easeOfStarting: nullableResourceLevelEnum,
+    timeNeeded: nullableResourceLevelEnum,
+    interactivity: nullableResourceLevelEnum,
+    usedYet: {
+      type: "boolean",
+    },
+  },
+} as const;
+
+export const todoSchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    isComplete: {
+      type: "boolean",
+    },
+  },
+} as const;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,8 @@
   "private": true,
   "scripts": {
     "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
-    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput"
+    "dev": "tsc -p tsconfig.build.json --watch --preserveWatchOutput",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
   "type": "module",
   "types": "dist/index.d.ts"

--- a/packages/types/src/Course.ts
+++ b/packages/types/src/Course.ts
@@ -1,8 +1,7 @@
-import type { CostData } from "@/CostData";
-
-import { Daily } from "@/Daily";
-import { MinimalTopic } from "@/MinimalTopic";
-import { Topic } from "@/Topic";
+import type { CostData } from "./CostData";
+import type { Daily } from "./Daily";
+import type { MinimalTopic } from "./MinimalTopic";
+import type { Topic } from "./Topic";
 
 export type CourseStatus = "active" | "inactive" | "complete" | "paused";
 

--- a/packages/types/src/CourseFromServer.ts
+++ b/packages/types/src/CourseFromServer.ts
@@ -1,6 +1,6 @@
-import { CourseStatus } from "@/Course";
-import { CourseProvider } from "@/CourseProvider";
-import { TopicsToCourses } from "@/TopicsToCourses";
+import type { CourseStatus } from "./Course";
+import type { CourseProvider } from "./CourseProvider";
+import type { TopicsToCourses } from "./TopicsToCourses";
 
 export interface CourseFromServer {
   id: string;

--- a/packages/types/src/CourseInCourses.ts
+++ b/packages/types/src/CourseInCourses.ts
@@ -24,5 +24,8 @@ export interface CourseInCourses {
     name: string;
     id: string;
   };
-
+  dailies?: {
+    id: string;
+    name: string;
+  }[];
 }

--- a/packages/types/src/CourseInCourses.ts
+++ b/packages/types/src/CourseInCourses.ts
@@ -1,4 +1,4 @@
-import { CourseStatus } from "./Course";
+import type { CourseStatus } from "./Course";
 
 export interface CourseInCourses {
   id: string;

--- a/packages/types/src/CourseProvider.ts
+++ b/packages/types/src/CourseProvider.ts
@@ -1,4 +1,4 @@
-import { CourseFromServer } from "./CourseFromServer";
+import type { CourseFromServer } from "./CourseFromServer";
 
 export type RecurPeriodUnit = "days" | "months" | "years";
 

--- a/packages/types/src/Topic.ts
+++ b/packages/types/src/Topic.ts
@@ -1,4 +1,4 @@
-import { Course } from "@/Course";
+import type { Course } from "./Course";
 
 export interface TopicDomain {
   id: string;

--- a/packages/types/src/TopicsFromServer.ts
+++ b/packages/types/src/TopicsFromServer.ts
@@ -1,5 +1,5 @@
-import { TopicsToCourses } from "@/TopicsToCourses";
-import { TopicsToDomains } from "@/TopicsToDomains";
+import type { TopicsToCourses } from "./TopicsToCourses";
+import type { TopicsToDomains } from "./TopicsToDomains";
 
 export interface TopicsFromServer {
   id: string;

--- a/packages/types/src/TopicsToCourses.ts
+++ b/packages/types/src/TopicsToCourses.ts
@@ -1,5 +1,5 @@
-import { Course } from "@/Course";
-import { TopicsFromServer } from "@/TopicsFromServer";
+import type { Course } from "./Course";
+import type { TopicsFromServer } from "./TopicsFromServer";
 
 export interface TopicsToCourses {
   topicId: string;

--- a/packages/types/src/TopicsToDomains.ts
+++ b/packages/types/src/TopicsToDomains.ts
@@ -1,5 +1,5 @@
-import { Domain } from "@/Domain";
-import { TopicsFromServer } from "@/TopicsFromServer";
+import type { Domain } from "./Domain";
+import type { TopicsFromServer } from "./TopicsFromServer";
 
 export interface TopicsToDomains {
   topicId: string;


### PR DESCRIPTION
Agent experience:
- Add `pnpm typecheck` scripts at root and per package
- Add `.claude/settings.json` with permission allowlist for common commands
- Update CLAUDE.md to reflect current entities (domains, dailies, tasks, radar),
  document single-test commands, db reset, and workflows for adding endpoints,
  pages, and shared types
- Update README.md with quick-start that points at CLAUDE.md
- Convert `@/`-aliased imports in @emstack/types to relative + `import type`
  so the package typechecks cleanly from outside

Middleware deduplication:
- Extend createDeleteHandler to support multi-junction cascade; migrate topics,
  domains, tasks, and courses delete handlers
- Add createUpsertHandler factory for the common insert + onConflictDoUpdate +
  syncJunctionTable pattern; migrate courses, topics, providers, and domains
  upsert handlers
- Extract shared JSON schemas (statusEnum, resourceLevel, dailyStatus,
  resource/todo/completion/criteria) and replace duplicates in tasks and dailies
- Add errors.ts helper with sendNotFound / sendBadRequest

Client deduplication:
- Generic CRUD client in fetchFunctions.ts via createEntityClient; named
  exports kept as thin re-exports so call sites are unchanged
- New EntityPending / EntityError components replace ~12 duplicated stubs;
  fix bugs along the way (providers.$id.index named TopicPending; topics and
  providers list pages showed "loading your courses"; topics.$id.index
  pending/error blocks were missing return statements)
- New ConfirmDialog component; migrate the daily-prompt dialog as proof
- New useEditFormPage hook handles skip-blocker, query invalidation, and a
  delete-handler factory; migrate topics, providers, courses, and domains
  edit routes