### PR TITLE
Include radar blips domains in topics page data

### DIFF
--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -2,7 +2,6 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import type { TopicForTopicsPage } from "@emstack/types/src";
-import { TopicsFromServer } from "@emstack/types/src/TopicsFromServer";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -31,10 +30,20 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          radarBlips: {
+            with: {
+              domain: {
+                columns: {
+                  id: true,
+                  title: true,
+                },
+              },
+            },
+          },
         },
       });
 
-      const processedData: TopicForTopicsPage[] = rawData.map((topic: TopicsFromServer) => {
+      const processedData: TopicForTopicsPage[] = rawData.map((topic) => {
         const courseCount = topic.topicsToCourses?.length ?? 0;
 
         const domainsById = new Map<string, { id: string;
@@ -44,6 +53,14 @@ export default async function (server: FastifyInstance) {
             domainsById.set(ttd.domain.id, {
               id: ttd.domain.id,
               title: ttd.domain.title,
+            });
+          }
+        }
+        for (const blip of topic.radarBlips ?? []) {
+          if (blip.domain?.id && blip.domain.title && !domainsById.has(blip.domain.id)) {
+            domainsById.set(blip.domain.id, {
+              id: blip.domain.id,
+              title: blip.domain.title,
             });
           }
         }


### PR DESCRIPTION
## Summary
Updated the topics API endpoint to include radar blips and their associated domains when fetching topic data for the topics page.

## Key Changes
- Removed unused `TopicsFromServer` type import
- Extended the database query to include `radarBlips` with their related `domain` information (id and title only)
- Updated the data processing logic to extract domains from radar blips in addition to courses
- Removed explicit type annotation on the `topic` parameter in the map function, allowing TypeScript to infer the type

## Implementation Details
- The radar blips query follows the same pattern as the existing courses relationship, selecting only necessary domain fields (`id` and `title`)
- Domain deduplication logic now processes both course domains and radar blip domains, preventing duplicate entries in the final `domainsById` map
- The change maintains backward compatibility by using optional chaining (`??`) when accessing radar blips

https://claude.ai/code/session_016hBo66zCfp3QHiUm7vaBcD