### PR TITLE
Add BlipTable component for managing saved radar blips

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -47,6 +47,7 @@ interface LlmEntry {
   quadrant?: unknown;
   ring?: unknown;
   description?: unknown;
+  radarNote?: unknown;
 }
 
 interface ResolvedLlmEntry {
@@ -57,7 +58,8 @@ interface ResolvedLlmEntry {
   quadrantId: string | null;
   ringInput: string;
   ringId: string | null;
-  description: string | null;
+  topicDescription: string | null;
+  radarNote: string | null;
   existingBlipId: string | null;
   existingQuadrantId: string | null;
   existingRingId: string | null;
@@ -200,11 +202,11 @@ Topics already linked to this domain, with the courses I'm taking and current
 progress for each (use this to gauge what I've actually been investing time in):
 ${formatTopicsWithCourses(domainTopics)}
 
-Topics already on the radar (with current descriptions, if any):
+Topics already on the radar (with current radar notes, if any):
 ${existingList}
 
 Topics I have explicitly EXCLUDED from this radar — do NOT suggest these,
-even with a different description or placement. The reason for each is in
+even with a different note or placement. The reason for each is in
 parentheses; treat the reasons as binding context for what I don't want:
 ${formatExcludedTopics(excludedTopics)}
 
@@ -214,15 +216,20 @@ JSON array of entries, using this exact shape (no other keys, no commentary):
 [
   {
     "topic": "Topic name",
+    "description": "A short factual description of what the topic IS — used as the topic's description if the topic doesn't already exist. Null if you have nothing to add.",
+    "radarNote": "A short note explaining WHY this topic belongs on the radar in this quadrant/ring (e.g. why it's worth adopting, what to assess, why to hold). Null if no note.",
     "quadrant": "One of the quadrant names above (exact match)",
-    "ring": "One of the ring names above (exact match)",
-    "description": "Optional one-line note (or null)"
+    "ring": "One of the ring names above (exact match)"
   }
 ]
 
-You may include topics already on the radar to suggest a better description or
+The "description" describes the topic itself (it's only saved when the topic is
+new — for existing topics it's ignored). The "radarNote" is the reasoning for
+this specific radar placement and is always saved as the blip's note.
+
+You may include topics already on the radar to suggest a better radar note or
 a different placement for them. The reviewer will choose whether to overwrite,
-update only the description, or skip each one. Do not include any topic from
+update only the radar note, or skip each one. Do not include any topic from
 the excluded list above.
 `;
 }
@@ -384,8 +391,11 @@ export function BlipLlmAssist({
       const quadrantInput
         = typeof entry.quadrant === "string" ? entry.quadrant.trim() : "";
       const ringInput = typeof entry.ring === "string" ? entry.ring.trim() : "";
-      const description = typeof entry.description === "string"
+      const topicDescription = typeof entry.description === "string"
         ? entry.description.trim() || null
+        : null;
+      const radarNote = typeof entry.radarNote === "string"
+        ? entry.radarNote.trim() || null
         : null;
 
       const quadrantMatch = quadrantInput
@@ -414,7 +424,8 @@ export function BlipLlmAssist({
         ...partial,
         matchedTopicId: topicMatch?.id ?? null,
         willCreateTopic: !!topicName && !topicMatch,
-        description,
+        topicDescription,
+        radarNote,
         existingBlipId: existingBlip?.id ?? null,
         existingQuadrantId: existingBlip?.quadrantId ?? null,
         existingRingId: existingBlip?.ringId ?? null,
@@ -486,7 +497,7 @@ export function BlipLlmAssist({
           topicId: r.matchedTopicId as string,
           quadrantId: r.quadrantId as string,
           ringId: r.ringId as string,
-          description: r.description,
+          description: r.radarNote,
         });
         overwriteCount += 1;
       }
@@ -497,7 +508,7 @@ export function BlipLlmAssist({
           topicId: r.matchedTopicId as string,
           quadrantId: r.existingQuadrantId as string,
           ringId: r.existingRingId as string,
-          description: r.description,
+          description: r.radarNote,
         });
         descriptionUpdateCount += 1;
       }
@@ -507,9 +518,10 @@ export function BlipLlmAssist({
         const blips: BulkBlipEntry[] = toCreate.map(r => ({
           topicId: r.matchedTopicId,
           newTopicName: r.matchedTopicId ? null : r.topicName,
+          newTopicDescription: r.matchedTopicId ? null : r.topicDescription,
           quadrantId: r.quadrantId as string,
           ringId: r.ringId as string,
-          description: r.description,
+          description: r.radarNote,
         }));
         const result = await bulkCreateRadarBlips(domainId, {
           blips,
@@ -594,7 +606,7 @@ export function BlipLlmAssist({
         <Textarea
           value={jsonText}
           onChange={e => setJsonText(e.target.value)}
-          placeholder='[{ "topic": "...", "quadrant": "...", "ring": "..." }]'
+          placeholder='[{ "topic": "...", "description": "...", "radarNote": "...", "quadrant": "...", "ring": "..." }]'
           className="min-h-32 font-mono text-xs"
         />
         {parseError && (
@@ -625,7 +637,7 @@ export function BlipLlmAssist({
             {" "}
             {descriptionUpdateCount}
             {" "}
-            description
+            note
             {descriptionUpdateCount === 1 ? "" : "s"}
             {" "}
             to update ·
@@ -726,10 +738,28 @@ export function BlipLlmAssist({
                       </span>
                       {r.existingDescription && (
                         <>
-                          {" — "}
+                          {" — note: "}
                           <span className="italic">{r.existingDescription}</span>
                         </>
                       )}
+                    </div>
+                  )}
+
+                  {r.willCreateTopic && r.topicDescription && (
+                    <div className="text-xs text-muted-foreground">
+                      <span className="font-medium uppercase">
+                        Topic description (new):
+                      </span>
+                      {" "}
+                      <span className="italic">{r.topicDescription}</span>
+                    </div>
+                  )}
+
+                  {r.radarNote && (
+                    <div className="text-xs text-muted-foreground">
+                      <span className="font-medium uppercase">Radar note:</span>
+                      {" "}
+                      <span className="italic">{r.radarNote}</span>
                     </div>
                   )}
 
@@ -841,7 +871,7 @@ export function BlipLlmAssist({
                                   Overwrite existing
                                 </SelectItem>
                                 <SelectItem value="updateDescription">
-                                  Update description only
+                                  Update radar note only
                                 </SelectItem>
                                 <SelectItem value="skip">
                                   Skip (keep existing)

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -1,0 +1,440 @@
+import type {
+  RadarBlip,
+  TopicForTopicsPage,
+} from "@emstack/types/src";
+
+import { useMemo, useState } from "react";
+
+import { Loader2, PencilIcon, TrashIcon, XIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/forms/input";
+import { Textarea } from "@/components/forms/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface QuadrantInfo {
+  id: string;
+  name: string;
+}
+
+interface RingInfo {
+  id: string;
+  name: string;
+}
+
+interface BlipTableProps {
+  blips: RadarBlip[];
+  quadrants: QuadrantInfo[];
+  rings: RingInfo[];
+  topics: TopicForTopicsPage[];
+  onSave: (
+    blip: RadarBlip,
+    patch: { quadrantId: string;
+      ringId: string;
+      description: string | null; },
+  ) => Promise<void>;
+  onRemove: (blip: RadarBlip) => Promise<void>;
+}
+
+const ALL = "__all__";
+
+interface EditDraft {
+  quadrantId: string;
+  ringId: string;
+  description: string;
+}
+
+export function BlipTable({
+  blips,
+  quadrants,
+  rings,
+  topics,
+  onSave,
+  onRemove,
+}: BlipTableProps) {
+  const [search, setSearch] = useState("");
+  const [filterQuadrant, setFilterQuadrant] = useState<string>(ALL);
+  const [filterRing, setFilterRing] = useState<string>(ALL);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const quadrantById = useMemo(() => {
+    const map = new Map<string, QuadrantInfo>();
+    quadrants.forEach(q => map.set(q.id, q));
+    return map;
+  }, [quadrants]);
+
+  const ringById = useMemo(() => {
+    const map = new Map<string, RingInfo>();
+    rings.forEach(r => map.set(r.id, r));
+    return map;
+  }, [rings]);
+
+  const topicById = useMemo(() => {
+    const map = new Map<string, TopicForTopicsPage>();
+    topics.forEach(t => map.set(t.id, t));
+    return map;
+  }, [topics]);
+
+  const filteredBlips = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return blips.filter((b) => {
+      if (filterQuadrant !== ALL && b.quadrantId !== filterQuadrant) {
+        return false;
+      }
+      if (filterRing !== ALL && b.ringId !== filterRing) {
+        return false;
+      }
+      if (query) {
+        const topicName = b.topicName?.toLowerCase() ?? "";
+        const note = b.description?.toLowerCase() ?? "";
+        if (!topicName.includes(query) && !note.includes(query)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [blips, search, filterQuadrant, filterRing]);
+
+  function startEdit(blip: RadarBlip) {
+    setEditingId(blip.id);
+    setEditDraft({
+      quadrantId: blip.quadrantId,
+      ringId: blip.ringId,
+      description: blip.description ?? "",
+    });
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditDraft(null);
+  }
+
+  async function commitEdit(blip: RadarBlip) {
+    if (!editDraft) {
+      return;
+    }
+    if (!editDraft.quadrantId || !editDraft.ringId) {
+      toast.error("Pick a quadrant and ring.");
+      return;
+    }
+    setPendingId(blip.id);
+    try {
+      await onSave(blip, {
+        quadrantId: editDraft.quadrantId,
+        ringId: editDraft.ringId,
+        description: editDraft.description.trim() || null,
+      });
+      setEditingId(null);
+      setEditDraft(null);
+    }
+    finally {
+      setPendingId(null);
+    }
+  }
+
+  async function handleRemove(blip: RadarBlip) {
+    setPendingId(blip.id);
+    try {
+      await onRemove(blip);
+      if (editingId === blip.id) {
+        setEditingId(null);
+        setEditDraft(null);
+      }
+    }
+    finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        className={`
+          grid grid-cols-1 gap-2
+          sm:grid-cols-[1fr_auto_auto]
+        `}
+      >
+        <Input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search topic or note"
+        />
+        <Select
+          value={filterQuadrant}
+          onValueChange={setFilterQuadrant}
+        >
+          <SelectTrigger className="min-w-40">
+            <SelectValue placeholder="Quadrant" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All Quadrants</SelectItem>
+            {quadrants.map(q => (
+              <SelectItem
+                key={q.id}
+                value={q.id}
+              >
+                {q.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={filterRing}
+          onValueChange={setFilterRing}
+        >
+          <SelectTrigger className="min-w-32">
+            <SelectValue placeholder="Ring" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All Rings</SelectItem>
+            {rings.map(r => (
+              <SelectItem
+                key={r.id}
+                value={r.id}
+              >
+                {r.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="rounded-sm border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Topic</TableHead>
+              <TableHead>Quadrant</TableHead>
+              <TableHead>Ring</TableHead>
+              <TableHead>Radar Note</TableHead>
+              <TableHead className="w-1 text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredBlips.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="text-center text-muted-foreground"
+                >
+                  {blips.length === 0
+                    ? "No blips yet."
+                    : "No blips match the current filters."}
+                </TableCell>
+              </TableRow>
+            )}
+            {filteredBlips.map((blip) => {
+              const isEditing = editingId === blip.id && editDraft !== null;
+              const isPending = pendingId === blip.id;
+              const topic = topicById.get(blip.topicId);
+              const topicDescription = topic?.description ?? null;
+              return isEditing
+                ? (
+                  <TableRow key={blip.id}>
+                    <TableCell colSpan={5}>
+                      <div
+                        className={`
+                          grid grid-cols-1 gap-4
+                          md:grid-cols-2
+                        `}
+                      >
+                        <div className="flex flex-col gap-1">
+                          <span
+                            className="text-xs text-muted-foreground uppercase"
+                          >
+                            Topic
+                          </span>
+                          <h3 className="text-lg font-semibold">
+                            {blip.topicName}
+                          </h3>
+                          {topicDescription
+                            ? (
+                              <p className="text-sm text-muted-foreground">
+                                {topicDescription}
+                              </p>
+                            )
+                            : (
+                              <p
+                                className={`
+                                  text-sm text-muted-foreground italic
+                                `}
+                              >
+                                (no topic description)
+                              </p>
+                            )}
+                        </div>
+                        <div className="flex flex-col gap-3">
+                          <div className="flex flex-col gap-1">
+                            <label className="text-xs uppercase">
+                              Quadrant
+                            </label>
+                            <Select
+                              value={editDraft.quadrantId}
+                              onValueChange={value =>
+                                setEditDraft(prev =>
+                                  prev
+                                    ? {
+                                      ...prev,
+                                      quadrantId: value,
+                                    }
+                                    : prev)}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Choose quadrant" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {quadrants.map(q => (
+                                  <SelectItem
+                                    key={q.id}
+                                    value={q.id}
+                                  >
+                                    {q.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <label className="text-xs uppercase">Ring</label>
+                            <Select
+                              value={editDraft.ringId}
+                              onValueChange={value =>
+                                setEditDraft(prev =>
+                                  prev
+                                    ? {
+                                      ...prev,
+                                      ringId: value,
+                                    }
+                                    : prev)}
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Choose ring" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {rings.map(r => (
+                                  <SelectItem
+                                    key={r.id}
+                                    value={r.id}
+                                  >
+                                    {r.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <label className="text-xs uppercase">
+                              Radar Note
+                            </label>
+                            <Textarea
+                              value={editDraft.description}
+                              onChange={e =>
+                                setEditDraft(prev =>
+                                  prev
+                                    ? {
+                                      ...prev,
+                                      description: e.target.value,
+                                    }
+                                    : prev)}
+                            />
+                          </div>
+                          <div className="flex flex-row gap-2">
+                            <Button
+                              type="button"
+                              onClick={() => commitEdit(blip)}
+                              disabled={isPending}
+                            >
+                              {isPending && (
+                                <Loader2 className="animate-spin" />
+                              )}
+                              Save
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={cancelEdit}
+                              disabled={isPending}
+                            >
+                              <XIcon />
+                              {" "}
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+                : (
+                  <TableRow key={blip.id}>
+                    <TableCell className="font-medium">
+                      {blip.topicName}
+                    </TableCell>
+                    <TableCell>
+                      {quadrantById.get(blip.quadrantId)?.name ?? "—"}
+                    </TableCell>
+                    <TableCell>
+                      {ringById.get(blip.ringId)?.name ?? "—"}
+                    </TableCell>
+                    <TableCell
+                      className={`
+                        max-w-xs text-sm whitespace-pre-wrap
+                        text-muted-foreground
+                      `}
+                    >
+                      {blip.description?.trim() || "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex flex-row justify-end gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => startEdit(blip)}
+                          disabled={isPending || editingId !== null}
+                        >
+                          <PencilIcon />
+                          {" "}
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleRemove(blip)}
+                          disabled={isPending || editingId !== null}
+                        >
+                          {isPending
+                            ? <Loader2 className="animate-spin" />
+                            : <TrashIcon />}
+                          {" "}
+                          Remove
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -19,6 +19,7 @@ import { Textarea } from "@/components/forms/textarea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { BlipBulkAdd } from "@/components/radar/BlipBulkAdd";
 import { BlipLlmAssist } from "@/components/radar/BlipLlmAssist";
+import { BlipTable } from "@/components/radar/BlipTable";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -207,15 +208,40 @@ function RadarEdit() {
     return map;
   }, [topics]);
 
+  const topicById = useMemo(() => {
+    const map = new Map<string, { name: string;
+      description?: string | null; }>();
+    (topics ?? []).forEach((t) => {
+      map.set(t.id, {
+        name: t.name,
+        description: t.description,
+      });
+    });
+    return map;
+  }, [topics]);
+
+  const savedBlipsForTable = useMemo(() => {
+    return (data?.blips ?? []).filter(b => b.id);
+  }, [data]);
+
+  const newBlipDrafts = useMemo(() => {
+    return blips.filter(b => !b.id);
+  }, [blips]);
+
   const usedTopicIds = useMemo(() => {
     const set = new Set<string>();
-    blips.forEach((b) => {
+    savedBlipsForTable.forEach((b) => {
+      if (b.topicId) {
+        set.add(b.topicId);
+      }
+    });
+    newBlipDrafts.forEach((b) => {
       if (b.topicId) {
         set.add(b.topicId);
       }
     });
     return set;
-  }, [blips]);
+  }, [savedBlipsForTable, newBlipDrafts]);
 
   function addQuadrant() {
     setQuadrants((prev) => {
@@ -396,6 +422,43 @@ function RadarEdit() {
       setPendingBlipKey(null);
     }
     setBlips(prev => prev.filter(b => b.localKey !== blip.localKey));
+  }
+
+  async function handleTableSave(
+    blip: RadarBlip,
+    patch: { quadrantId: string;
+      ringId: string;
+      description: string | null; },
+  ) {
+    try {
+      await upsertRadarBlip(id, blip.id, {
+        topicId: blip.topicId,
+        quadrantId: patch.quadrantId,
+        ringId: patch.ringId,
+        description: patch.description,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["radar", id],
+      });
+      toast.success("Blip saved.");
+    }
+    catch {
+      toast.error("Failed to save blip.");
+      throw new Error("save failed");
+    }
+  }
+
+  async function handleTableRemove(blip: RadarBlip) {
+    try {
+      await deleteRadarBlip(id, blip.id);
+      await queryClient.invalidateQueries({
+        queryKey: ["radar", id],
+      });
+    }
+    catch {
+      toast.error("Failed to delete blip.");
+      throw new Error("delete failed");
+    }
   }
 
   async function handleBulkComplete() {
@@ -609,156 +672,202 @@ function RadarEdit() {
               Save your quadrants and rings before adding blips.
             </p>
           )}
-          <ul className="flex flex-col gap-4">
-            {blips.map(blip => (
-              <li
-                key={blip.localKey}
-                className="flex flex-col gap-2 rounded-sm border p-4"
-              >
-                <div
-                  className={`
-                    grid grid-cols-1 gap-2
-                    sm:grid-cols-2
-                  `}
-                >
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs uppercase">Topic</label>
-                    <Select
-                      value={blip.topicId}
-                      onValueChange={value =>
-                        setBlips(prev =>
-                          prev.map(b =>
-                            b.localKey === blip.localKey
-                              ? {
-                                ...b,
-                                topicId: value,
-                              }
-                              : b))}
+
+          {allConfigPersisted && (
+            <BlipTable
+              blips={savedBlipsForTable}
+              quadrants={persistedQuadrants}
+              rings={persistedRings}
+              topics={topics ?? []}
+              onSave={handleTableSave}
+              onRemove={handleTableRemove}
+            />
+          )}
+
+          {newBlipDrafts.length > 0 && (
+            <ul className="flex flex-col gap-4">
+              {newBlipDrafts.map((blip) => {
+                const pickedTopic = blip.topicId
+                  ? topicById.get(blip.topicId)
+                  : null;
+                return (
+                  <li
+                    key={blip.localKey}
+                    className="flex flex-col gap-3 rounded-sm border p-4"
+                  >
+                    <h3 className="text-lg font-semibold">Add Blip</h3>
+                    <div
+                      className={`
+                        grid grid-cols-1 gap-4
+                        md:grid-cols-2
+                      `}
                     >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Choose topic" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {(topics ?? [])
-                          .filter(
-                            t =>
-                              t.id === blip.topicId || !usedTopicIds.has(t.id),
+                      <div className="flex flex-col gap-2">
+                        <label className="text-xs uppercase">Topic</label>
+                        <Select
+                          value={blip.topicId}
+                          onValueChange={value =>
+                            setBlips(prev =>
+                              prev.map(b =>
+                                b.localKey === blip.localKey
+                                  ? {
+                                    ...b,
+                                    topicId: value,
+                                  }
+                                  : b))}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Choose topic" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {(topics ?? [])
+                              .filter(
+                                t =>
+                                  t.id === blip.topicId
+                                  || !usedTopicIds.has(t.id),
+                              )
+                              .map(t => (
+                                <SelectItem
+                                  key={t.id}
+                                  value={t.id}
+                                >
+                                  {t.name}
+                                </SelectItem>
+                              ))}
+                          </SelectContent>
+                        </Select>
+                        {pickedTopic
+                          ? (
+                            <div className="flex flex-col gap-1">
+                              <h4 className="text-base font-semibold">
+                                {pickedTopic.name}
+                              </h4>
+                              <p
+                                className={`
+                                  text-sm text-muted-foreground
+                                  ${pickedTopic.description?.trim()
+                              ? ""
+                              : "italic"}
+                                `}
+                              >
+                                {pickedTopic.description?.trim()
+                                  || "(no topic description)"}
+                              </p>
+                            </div>
                           )
-                          .map(t => (
-                            <SelectItem
-                              key={t.id}
-                              value={t.id}
-                            >
-                              {t.name}
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                    {blip.topicId && !topicNameById.has(blip.topicId) && (
-                      <span className="text-xs text-muted-foreground">
-                        (topic not in list)
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs uppercase">Quadrant</label>
-                    <Select
-                      value={blip.quadrantId}
-                      onValueChange={value =>
-                        setBlips(prev =>
-                          prev.map(b =>
-                            b.localKey === blip.localKey
-                              ? {
-                                ...b,
-                                quadrantId: value,
-                              }
-                              : b))}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Choose quadrant" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {persistedQuadrants.map(q => (
-                          <SelectItem
-                            key={q.id}
-                            value={q.id}
+                          : blip.topicId && !topicNameById.has(blip.topicId)
+                            ? (
+                              <span
+                                className="text-xs text-muted-foreground"
+                              >
+                                (topic not in list)
+                              </span>
+                            )
+                            : null}
+                      </div>
+                      <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs uppercase">Quadrant</label>
+                          <Select
+                            value={blip.quadrantId}
+                            onValueChange={value =>
+                              setBlips(prev =>
+                                prev.map(b =>
+                                  b.localKey === blip.localKey
+                                    ? {
+                                      ...b,
+                                      quadrantId: value,
+                                    }
+                                    : b))}
                           >
-                            {q.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs uppercase">Ring</label>
-                    <Select
-                      value={blip.ringId}
-                      onValueChange={value =>
-                        setBlips(prev =>
-                          prev.map(b =>
-                            b.localKey === blip.localKey
-                              ? {
-                                ...b,
-                                ringId: value,
-                              }
-                              : b))}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Choose ring" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {persistedRings.map(r => (
-                          <SelectItem
-                            key={r.id}
-                            value={r.id}
+                            <SelectTrigger>
+                              <SelectValue placeholder="Choose quadrant" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {persistedQuadrants.map(q => (
+                                <SelectItem
+                                  key={q.id}
+                                  value={q.id}
+                                >
+                                  {q.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs uppercase">Ring</label>
+                          <Select
+                            value={blip.ringId}
+                            onValueChange={value =>
+                              setBlips(prev =>
+                                prev.map(b =>
+                                  b.localKey === blip.localKey
+                                    ? {
+                                      ...b,
+                                      ringId: value,
+                                    }
+                                    : b))}
                           >
-                            {r.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label className="text-xs uppercase">Description</label>
-                    <Textarea
-                      value={blip.description}
-                      onChange={e =>
-                        setBlips(prev =>
-                          prev.map(b =>
-                            b.localKey === blip.localKey
-                              ? {
-                                ...b,
-                                description: e.target.value,
-                              }
-                              : b))}
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-row gap-2">
-                  <Button
-                    type="button"
-                    onClick={() => saveBlip(blip)}
-                    disabled={pendingBlipKey === blip.localKey}
-                  >
-                    {pendingBlipKey === blip.localKey && (
-                      <Loader2 className="animate-spin" />
-                    )}
-                    {blip.id ? "Update Blip" : "Save Blip"}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => removeBlip(blip)}
-                    disabled={pendingBlipKey === blip.localKey}
-                  >
-                    <TrashIcon />
-                    {" "}
-                    Remove
-                  </Button>
-                </div>
-              </li>
-            ))}
-          </ul>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Choose ring" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {persistedRings.map(r => (
+                                <SelectItem
+                                  key={r.id}
+                                  value={r.id}
+                                >
+                                  {r.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <label className="text-xs uppercase">Radar Note</label>
+                          <Textarea
+                            value={blip.description}
+                            onChange={e =>
+                              setBlips(prev =>
+                                prev.map(b =>
+                                  b.localKey === blip.localKey
+                                    ? {
+                                      ...b,
+                                      description: e.target.value,
+                                    }
+                                    : b))}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-row gap-2">
+                      <Button
+                        type="button"
+                        onClick={() => saveBlip(blip)}
+                        disabled={pendingBlipKey === blip.localKey}
+                      >
+                        {pendingBlipKey === blip.localKey && (
+                          <Loader2 className="animate-spin" />
+                        )}
+                        Save Blip
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => removeBlip(blip)}
+                        disabled={pendingBlipKey === blip.localKey}
+                      >
+                        <TrashIcon />
+                        {" "}
+                        Cancel
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
 
           <div className="flex flex-row flex-wrap gap-2">
             <Button

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -286,6 +286,7 @@ export async function deleteRadarBlip(
 export interface BulkBlipEntry {
   topicId?: string | null;
   newTopicName?: string | null;
+  newTopicDescription?: string | null;
   description?: string | null;
   quadrantId: string;
   ringId: string;

--- a/packages/middleware/src/routes/api/radar/bulkCreateBlips.ts
+++ b/packages/middleware/src/routes/api/radar/bulkCreateBlips.ts
@@ -31,6 +31,7 @@ const bulkCreateBlipsSchema = {
             properties: {
               topicId: nullableString,
               newTopicName: nullableString,
+              newTopicDescription: nullableString,
               description: nullableString,
               quadrantId: {
                 type: "string",
@@ -89,9 +90,11 @@ export default async function (server: FastifyInstance) {
           }
           else {
             const newId = uuidv4();
+            const trimmedDescription = entry.newTopicDescription?.trim() || null;
             await db.insert(topics).values({
               id: newId,
               name: trimmed,
+              description: trimmedDescription,
             }).onConflictDoNothing();
             const refetched = await db.query.topics.findFirst({
               where: (t, {


### PR DESCRIPTION
## Summary
This PR introduces a new `BlipTable` component to manage saved radar blips separately from draft blips, improving the UX for editing existing blips on a radar.

## Key Changes

- **New BlipTable component** (`packages/client/src/components/radar/BlipTable.tsx`):
  - Displays saved blips in a filterable, searchable table
  - Supports filtering by quadrant and ring
  - Inline editing of blip properties (quadrant, ring, radar note)
  - Delete functionality for existing blips
  - Responsive design with expanded edit view on row selection

- **Refactored radar edit page** (`packages/client/src/routes/domains.$id.radar.edit.tsx`):
  - Separated saved blips from draft blips using `savedBlipsForTable` and `newBlipDrafts`
  - Renders `BlipTable` for saved blips with `handleTableSave` and `handleTableRemove` callbacks
  - Kept draft blip form UI for creating new blips
  - Updated label from "Description" to "Radar Note" for clarity
  - Improved layout with better visual separation between saved and draft blips

- **Enhanced LLM assist** (`packages/client/src/components/radar/BlipLlmAssist.tsx`):
  - Separated topic description from radar note in LLM suggestions
  - Added `radarNote` field to LLM output schema
  - Updated prompts to clarify the distinction: topic description describes the topic itself, radar note explains why it belongs on the radar
  - Allows suggesting better radar notes for existing blips

- **API updates**:
  - Added `newTopicDescription` field to bulk blip creation schema
  - Updated fetch function types to support topic descriptions

## Implementation Details

- BlipTable uses memoized maps for efficient lookups of quadrants, rings, and topics
- Edit state is managed locally within the table component
- Pending operations are tracked to disable UI interactions during async operations
- The component handles both viewing and editing modes with a clean toggle between them
- Saved blips are now managed through the table's `onSave` and `onRemove` callbacks, which invalidate the radar query to refresh data

https://claude.ai/code/session_01K5JmMhyjaZFsWZq8DQL3gQ