### PR TITLE
Add inline create functionality to combobox fields

### DIFF
--- a/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+
+import { Loader2 } from "lucide-react";
+
+import { Input } from "@/components/forms/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+export interface CreateFieldConfig {
+  name: string;
+  label: string;
+  required?: boolean;
+  type?: "text" | "url" | "email";
+  placeholder?: string;
+  /** When true, this field is pre-filled with the user's typed input */
+  isPrimary?: boolean;
+}
+
+export interface CreateConfig {
+  /** Singular display label used in messages, e.g. "provider" */
+  itemLabel: string;
+  /** Fields to render in the inline create form. The field marked isPrimary
+   * (or the first field) is pre-filled from the combobox input. */
+  fields: CreateFieldConfig[];
+  /** Called with the form values; resolves with the new entity's id. */
+  onCreate: (values: Record<string, unknown>) => Promise<string>;
+}
+
+interface ComboboxCreatePanelProps {
+  config: CreateConfig;
+  initialPrimaryValue: string;
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (values: Record<string, unknown>) => void;
+}
+
+function getPrimaryFieldName(config: CreateConfig): string {
+  return (
+    config.fields.find(f => f.isPrimary)?.name
+    ?? config.fields[0]?.name
+    ?? "name"
+  );
+}
+
+export function ComboboxCreatePanel({
+  config,
+  initialPrimaryValue,
+  submitting,
+  onCancel,
+  onSubmit,
+}: ComboboxCreatePanelProps) {
+  const primaryFieldName = getPrimaryFieldName(config);
+
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {};
+    for (const f of config.fields) {
+      initial[f.name] = f.name === primaryFieldName ? initialPrimaryValue : "";
+    }
+    return initial;
+  });
+
+  useEffect(() => {
+    setValues(prev => ({
+      ...prev,
+      [primaryFieldName]: initialPrimaryValue,
+    }));
+  }, [initialPrimaryValue, primaryFieldName]);
+
+  const canSubmit = config.fields.every(
+    f => !f.required || (values[f.name] ?? "").trim().length > 0,
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || submitting) return;
+    const trimmed: Record<string, unknown> = {};
+    for (const f of config.fields) {
+      const v = (values[f.name] ?? "").trim();
+      trimmed[f.name] = v === "" ? null : v;
+    }
+    onSubmit(trimmed);
+  }
+
+  return (
+    <div
+      className="
+        border-border bg-muted/30 mt-2 flex flex-col gap-3 rounded-md border p-4
+      "
+    >
+      <div className="text-sm font-medium">
+        New
+        {" "}
+        {config.itemLabel}
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3"
+      >
+        {config.fields.map(f => (
+          <div
+            key={f.name}
+            className="flex flex-col gap-1"
+          >
+            <Label
+              htmlFor={`combobox-create-${f.name}`}
+              className="text-sm"
+            >
+              {f.label}
+              {f.required && <span className="text-destructive"> *</span>}
+            </Label>
+            <Input
+              id={`combobox-create-${f.name}`}
+              type={f.type ?? "text"}
+              value={values[f.name] ?? ""}
+              placeholder={f.placeholder}
+              onChange={e =>
+                setValues(prev => ({
+                  ...prev,
+                  [f.name]: e.target.value,
+                }))}
+              disabled={submitting}
+              autoFocus={f.name === primaryFieldName}
+            />
+          </div>
+        ))}
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!canSubmit || submitting}
+          >
+            {submitting && <Loader2 className="size-4 animate-spin" />}
+            Create
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
@@ -84,7 +84,7 @@ export function ComboboxCreatePanel({
   return (
     <div
       className="
-        border-border bg-muted/30 mt-2 flex flex-col gap-3 rounded-md border p-4
+        mt-2 flex flex-col gap-3 rounded-md border border-border bg-muted/30 p-4
       "
     >
       <div className="text-sm font-medium">

--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -1,3 +1,10 @@
+import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+
+import { useState } from "react";
+
+import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
+
 import {
   Combobox,
   ComboboxContent,
@@ -6,7 +13,9 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/combobox";
+import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
+import { Button } from "@/components/ui/button";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
 interface ComboboxFieldProps {
@@ -16,6 +25,7 @@ interface ComboboxFieldProps {
   placeholder?: string;
   className?: string;
   disabled?: boolean;
+  create?: CreateConfig;
 }
 
 export function ComboboxField({
@@ -24,20 +34,55 @@ export function ComboboxField({
   placeholder,
   className = "text-2xl",
   disabled,
+  create,
 }: ComboboxFieldProps) {
   const {
     field, isInvalid,
   } = useIsFieldInvalid<string>();
 
+  const [inputValue, setInputValue] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+
   const optionsMap = new Map(options.map(o => [o.value, o.label]));
+
+  const trimmedInput = inputValue.trim();
+  const hasExactMatch = trimmedInput.length > 0
+    && options.some(o => o.label.toLowerCase() === trimmedInput.toLowerCase());
+
+  const showAddRow = !!create && trimmedInput.length > 0 && !hasExactMatch;
+
+  function openCreate() {
+    setCreateOpen(true);
+  }
+
+  async function handleCreateSubmit(values: Record<string, unknown>) {
+    if (!create) return;
+    setCreating(true);
+    try {
+      const newId = await create.onCreate(values);
+      field.handleChange(newId);
+      setCreateOpen(false);
+      setInputValue("");
+    }
+    catch (err) {
+      console.error(`Failed to create ${create.itemLabel}:`, err);
+      toast.error(`Failed to create ${create.itemLabel}. Please try again.`);
+    }
+    finally {
+      setCreating(false);
+    }
+  }
 
   return (
     <Field data-invalid={isInvalid}>
       <FieldLabel className={className}>{label}</FieldLabel>
       <Combobox
+        items={options.map(o => o.value)}
         value={field.state.value || null}
         onValueChange={val => field.handleChange(val ?? "")}
-        itemToStringLabel={val => optionsMap.get(val) ?? ""}
+        onInputValueChange={val => setInputValue(val)}
+        itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
       >
         <ComboboxInput
           placeholder={placeholder}
@@ -46,19 +91,78 @@ export function ComboboxField({
           disabled={disabled}
         />
         <ComboboxContent>
-          <ComboboxEmpty>No items found.</ComboboxEmpty>
+          {showAddRow && (
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                openCreate();
+              }}
+              className="
+                border-border
+                hover:bg-accent hover:text-accent-foreground
+                flex w-full items-center gap-2 border-b p-2 text-left text-sm
+              "
+            >
+              <PlusIcon className="size-4" />
+              <span>
+                Add new
+                {" "}
+                {create?.itemLabel}
+                :
+                {" "}
+                <strong>{trimmedInput}</strong>
+              </span>
+            </button>
+          )}
+          <ComboboxEmpty>
+            {create
+              ? (
+                <div className="flex w-full flex-col items-center gap-2 py-3">
+                  <span>No items found.</span>
+                  {trimmedInput && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        openCreate();
+                      }}
+                    >
+                      <PlusIcon className="size-4" />
+                      Add new
+                      {" "}
+                      {create.itemLabel}
+                    </Button>
+                  )}
+                </div>
+              )
+              : (
+                "No items found."
+              )}
+          </ComboboxEmpty>
           <ComboboxList>
-            {options.map(option => (
+            {(value: string) => (
               <ComboboxItem
-                key={option.value}
-                value={option.value}
+                key={value}
+                value={value}
               >
-                {option.label}
+                {optionsMap.get(value) ?? value}
               </ComboboxItem>
-            ))}
+            )}
           </ComboboxList>
         </ComboboxContent>
       </Combobox>
+      {create && createOpen && (
+        <ComboboxCreatePanel
+          config={create}
+          initialPrimaryValue={trimmedInput}
+          submitting={creating}
+          onCancel={() => setCreateOpen(false)}
+          onSubmit={handleCreateSubmit}
+        />
+      )}
       {isInvalid && <FieldError errors={field.state.meta.errors} />}
     </Field>
   );

--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -99,9 +99,9 @@ export function ComboboxField({
                 openCreate();
               }}
               className="
-                border-border
+                flex w-full items-center gap-2 border-b border-border p-2
+                text-left text-sm
                 hover:bg-accent hover:text-accent-foreground
-                flex w-full items-center gap-2 border-b p-2 text-left text-sm
               "
             >
               <PlusIcon className="size-4" />

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -112,9 +112,9 @@ export function MultiComboboxField({
                 openCreate();
               }}
               className="
-                border-border
+                flex w-full items-center gap-2 border-b border-border p-2
+                text-left text-sm
                 hover:bg-accent hover:text-accent-foreground
-                flex w-full items-center gap-2 border-b p-2 text-left text-sm
               "
             >
               <PlusIcon className="size-4" />

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -1,3 +1,10 @@
+import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+
+import { useState } from "react";
+
+import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
+
 import {
   Combobox,
   ComboboxChip,
@@ -9,7 +16,9 @@ import {
   ComboboxList,
   useComboboxAnchor,
 } from "@/components/combobox";
+import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
+import { Button } from "@/components/ui/button";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
 interface MultiComboboxFieldProps {
@@ -18,6 +27,7 @@ interface MultiComboboxFieldProps {
     label: string; }[];
   placeholder?: string;
   className?: string;
+  create?: CreateConfig;
 }
 
 export function MultiComboboxField({
@@ -25,22 +35,59 @@ export function MultiComboboxField({
   options,
   placeholder,
   className = "text-2xl",
+  create,
 }: MultiComboboxFieldProps) {
   const {
     field, isInvalid,
   } = useIsFieldInvalid<string[]>();
   const anchor = useComboboxAnchor();
 
+  const [inputValue, setInputValue] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+
   const optionsMap = new Map(options.map(o => [o.value, o.label]));
+
+  const trimmedInput = inputValue.trim();
+  const hasExactMatch = trimmedInput.length > 0
+    && options.some(o => o.label.toLowerCase() === trimmedInput.toLowerCase());
+  const showAddRow = !!create && trimmedInput.length > 0 && !hasExactMatch;
+
+  function openCreate() {
+    setCreateOpen(true);
+  }
+
+  async function handleCreateSubmit(values: Record<string, unknown>) {
+    if (!create) return;
+    setCreating(true);
+    try {
+      const newId = await create.onCreate(values);
+      const current = field.state.value || [];
+      if (!current.includes(newId)) {
+        field.handleChange([...current, newId]);
+      }
+      setCreateOpen(false);
+      setInputValue("");
+    }
+    catch (err) {
+      console.error(`Failed to create ${create.itemLabel}:`, err);
+      toast.error(`Failed to create ${create.itemLabel}. Please try again.`);
+    }
+    finally {
+      setCreating(false);
+    }
+  }
 
   return (
     <Field data-invalid={isInvalid}>
       <FieldLabel className={className}>{label}</FieldLabel>
       <Combobox
         multiple
+        items={options.map(o => o.value)}
         value={field.state.value || []}
         onValueChange={val => field.handleChange(val)}
-        itemToStringLabel={val => optionsMap.get(val) ?? ""}
+        onInputValueChange={val => setInputValue(val)}
+        itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
       >
         <ComboboxChips ref={anchor}>
           {(field.state.value || []).map(val => (
@@ -57,19 +104,78 @@ export function MultiComboboxField({
           />
         </ComboboxChips>
         <ComboboxContent anchor={anchor}>
-          <ComboboxEmpty>No items found.</ComboboxEmpty>
+          {showAddRow && (
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                openCreate();
+              }}
+              className="
+                border-border
+                hover:bg-accent hover:text-accent-foreground
+                flex w-full items-center gap-2 border-b p-2 text-left text-sm
+              "
+            >
+              <PlusIcon className="size-4" />
+              <span>
+                Add new
+                {" "}
+                {create?.itemLabel}
+                :
+                {" "}
+                <strong>{trimmedInput}</strong>
+              </span>
+            </button>
+          )}
+          <ComboboxEmpty>
+            {create
+              ? (
+                <div className="flex w-full flex-col items-center gap-2 py-3">
+                  <span>No items found.</span>
+                  {trimmedInput && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        openCreate();
+                      }}
+                    >
+                      <PlusIcon className="size-4" />
+                      Add new
+                      {" "}
+                      {create.itemLabel}
+                    </Button>
+                  )}
+                </div>
+              )
+              : (
+                "No items found."
+              )}
+          </ComboboxEmpty>
           <ComboboxList>
-            {options.map(option => (
+            {(value: string) => (
               <ComboboxItem
-                key={option.value}
-                value={option.value}
+                key={value}
+                value={value}
               >
-                {option.label}
+                {optionsMap.get(value) ?? value}
               </ComboboxItem>
-            ))}
+            )}
           </ComboboxList>
         </ComboboxContent>
       </Combobox>
+      {create && createOpen && (
+        <ComboboxCreatePanel
+          config={create}
+          initialPrimaryValue={trimmedInput}
+          submitting={creating}
+          onCancel={() => setCreateOpen(false)}
+          onSubmit={handleCreateSubmit}
+        />
+      )}
       {isInvalid && <FieldError errors={field.state.meta.errors} />}
     </Field>
   );

--- a/packages/client/src/components/formFields/index.ts
+++ b/packages/client/src/components/formFields/index.ts
@@ -1,4 +1,5 @@
 export { ComboboxField } from "./ComboboxField";
+export type { CreateConfig, CreateFieldConfig } from "./ComboboxCreatePanel";
 export { DatePickerField } from "./DatePickerField";
 export { InputField } from "./InputField";
 export { NumberField } from "./NumberField";

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -3,7 +3,7 @@ import type { AnyFieldApi } from "@tanstack/react-form";
 import { useMemo } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
+  createProvider,
+  createTopic,
   deleteSingleCourse,
   duplicateCourse,
   fetchProviders,
@@ -48,6 +50,7 @@ function SingleCourseEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const {
     data,
@@ -240,6 +243,24 @@ function SingleCourseEdit() {
               label="Topic"
               options={topicOptions}
               placeholder="Search topics..."
+              create={{
+                itemLabel: "topic",
+                fields: [
+                  {
+                    name: "name",
+                    label: "Name",
+                    required: true,
+                    isPrimary: true,
+                  },
+                ],
+                onCreate: async (values) => {
+                  const result = await createTopic(values);
+                  await queryClient.invalidateQueries({
+                    queryKey: ["topics"],
+                  });
+                  return result.id;
+                },
+              }}
             />
           )}
         </form.AppField>
@@ -250,6 +271,31 @@ function SingleCourseEdit() {
               label="Provider"
               options={providerOptions}
               placeholder="Search providers..."
+              create={{
+                itemLabel: "provider",
+                fields: [
+                  {
+                    name: "name",
+                    label: "Name",
+                    required: true,
+                    isPrimary: true,
+                  },
+                  {
+                    name: "url",
+                    label: "URL",
+                    required: true,
+                    type: "url",
+                    placeholder: "https://...",
+                  },
+                ],
+                onCreate: async (values) => {
+                  const result = await createProvider(values);
+                  await queryClient.invalidateQueries({
+                    queryKey: ["providers"],
+                  });
+                  return result.id;
+                },
+              }}
             />
           )}
         </form.AppField>

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -175,8 +175,8 @@ function Courses() {
                 <div className="relative">
                   <SearchIcon
                     className="
-                      text-muted-foreground absolute top-1/2 left-2.5 size-4
-                      -translate-y-1/2
+                      absolute top-1/2 left-2.5 size-4 -translate-y-1/2
+                      text-muted-foreground
                     "
                   />
                   <input
@@ -185,12 +185,12 @@ function Courses() {
                     value={search}
                     onChange={e => setSearch(e.target.value)}
                     className="
-                      border-input
+                      h-9 rounded-md border border-input bg-transparent pr-3
+                      pl-8 text-sm shadow-xs transition-[color,box-shadow]
+                      outline-none
                       placeholder:text-muted-foreground
-                      focus-visible:border-ring focus-visible:ring-ring/50
-                      h-9 rounded-md border bg-transparent pr-3 pl-8 text-sm
-                      shadow-xs transition-[color,box-shadow] outline-none
-                      focus-visible:ring-[3px]
+                      focus-visible:border-ring focus-visible:ring-[3px]
+                      focus-visible:ring-ring/50
                     "
                   />
                 </div>
@@ -254,7 +254,7 @@ function Courses() {
               </div>
 
               <div className="flex items-center gap-2">
-                <span className="text-muted-foreground text-sm">Sort</span>
+                <span className="text-sm text-muted-foreground">Sort</span>
                 <Select
                   value={sortBy}
                   onValueChange={v => setSortBy(v as SortOption)}
@@ -284,7 +284,7 @@ function Courses() {
                 </Button>
                 <div
                   className="
-                    border-input ml-2 flex items-center rounded-md border
+                    ml-2 flex items-center rounded-md border border-input
                     bg-transparent
                   "
                   role="group"
@@ -361,11 +361,10 @@ function Courses() {
             >
               <ContentBox
                 className="
-                  text-muted-foreground
-                  hover:bg-accent hover:text-accent-foreground
                   h-full items-center justify-center border-dashed p-8
-                  transition-colors
-                  hover:border-solid
+                  text-muted-foreground transition-colors
+                  hover:border-solid hover:bg-accent
+                  hover:text-accent-foreground
                 "
               >
                 <PlusIcon size={32} />

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -152,7 +152,19 @@ function Courses() {
       <PageHeader
         pageTitle="Your Courses"
         pageSection=""
-      />
+      >
+        <Link
+          to="/courses/$id/edit"
+          params={{
+            id: "new",
+          }}
+        >
+          <Button>
+            <PlusIcon className="size-4" />
+            New Course
+          </Button>
+        </Link>
+      </PageHeader>
       <div className="container flex flex-col gap-4">
         <div>
           {data && data.length > 0 && (
@@ -163,8 +175,8 @@ function Courses() {
                 <div className="relative">
                   <SearchIcon
                     className="
-                      absolute top-1/2 left-2.5 size-4 -translate-y-1/2
-                      text-muted-foreground
+                      text-muted-foreground absolute top-1/2 left-2.5 size-4
+                      -translate-y-1/2
                     "
                   />
                   <input
@@ -173,12 +185,12 @@ function Courses() {
                     value={search}
                     onChange={e => setSearch(e.target.value)}
                     className="
-                      h-9 rounded-md border border-input bg-transparent pr-3
-                      pl-8 text-sm shadow-xs transition-[color,box-shadow]
-                      outline-none
+                      border-input
                       placeholder:text-muted-foreground
-                      focus-visible:border-ring focus-visible:ring-[3px]
-                      focus-visible:ring-ring/50
+                      focus-visible:border-ring focus-visible:ring-ring/50
+                      h-9 rounded-md border bg-transparent pr-3 pl-8 text-sm
+                      shadow-xs transition-[color,box-shadow] outline-none
+                      focus-visible:ring-[3px]
                     "
                   />
                 </div>
@@ -242,7 +254,7 @@ function Courses() {
               </div>
 
               <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Sort</span>
+                <span className="text-muted-foreground text-sm">Sort</span>
                 <Select
                   value={sortBy}
                   onValueChange={v => setSortBy(v as SortOption)}
@@ -272,7 +284,7 @@ function Courses() {
                 </Button>
                 <div
                   className="
-                    ml-2 flex items-center rounded-md border border-input
+                    border-input ml-2 flex items-center rounded-md border
                     bg-transparent
                   "
                   role="group"
@@ -349,10 +361,11 @@ function Courses() {
             >
               <ContentBox
                 className="
+                  text-muted-foreground
+                  hover:bg-accent hover:text-accent-foreground
                   h-full items-center justify-center border-dashed p-8
-                  text-muted-foreground transition-colors
-                  hover:border-solid hover:bg-accent
-                  hover:text-accent-foreground
+                  transition-colors
+                  hover:border-solid
                 "
               >
                 <PlusIcon size={32} />

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -33,6 +33,7 @@ import { useSettings } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
 import {
   createDaily,
+  createProvider,
   deleteSingleDaily,
   duplicateDaily,
   fetchCourses,
@@ -410,13 +411,13 @@ function SingleDailyEdit() {
           className="flex max-w-2xl flex-col gap-8"
         >
           <div
-            className="flex flex-col gap-3 rounded-md border bg-card p-4"
+            className="bg-card flex flex-col gap-3 rounded-md border p-4"
           >
             <div className="flex flex-row items-center justify-between gap-2">
               <h2 className="text-2xl">Link this Daily</h2>
               <div className="flex shrink-0 flex-row items-center gap-2">
                 <WandSparklesIcon
-                  className="size-6 text-muted-foreground"
+                  className="text-muted-foreground size-6"
                   aria-hidden="true"
                 />
                 <Button
@@ -538,6 +539,31 @@ function SingleDailyEdit() {
                   label="Provider"
                   options={providerOptions}
                   placeholder="Search providers..."
+                  create={{
+                    itemLabel: "provider",
+                    fields: [
+                      {
+                        name: "name",
+                        label: "Name",
+                        required: true,
+                        isPrimary: true,
+                      },
+                      {
+                        name: "url",
+                        label: "URL",
+                        required: true,
+                        type: "url",
+                        placeholder: "https://...",
+                      },
+                    ],
+                    onCreate: async (values) => {
+                      const result = await createProvider(values);
+                      await queryClient.invalidateQueries({
+                        queryKey: ["providers"],
+                      });
+                      return result.id;
+                    },
+                  }}
                 />
               )}
             </form.AppField>
@@ -578,7 +604,7 @@ function SingleDailyEdit() {
                     ))}
                   </div>
                   {field.state.value === "complete" && (
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Marking complete locks log editing.
                     </p>
                   )}
@@ -587,10 +613,10 @@ function SingleDailyEdit() {
             </form.AppField>
           )}
 
-          <div className="flex flex-col gap-4 rounded-md border bg-card p-4">
+          <div className="bg-card flex flex-col gap-4 rounded-md border p-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-2xl">Status Criteria</h2>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 Optional notes describing what each status means for this
                 daily.
               </p>

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -411,13 +411,13 @@ function SingleDailyEdit() {
           className="flex max-w-2xl flex-col gap-8"
         >
           <div
-            className="bg-card flex flex-col gap-3 rounded-md border p-4"
+            className="flex flex-col gap-3 rounded-md border bg-card p-4"
           >
             <div className="flex flex-row items-center justify-between gap-2">
               <h2 className="text-2xl">Link this Daily</h2>
               <div className="flex shrink-0 flex-row items-center gap-2">
                 <WandSparklesIcon
-                  className="text-muted-foreground size-6"
+                  className="size-6 text-muted-foreground"
                   aria-hidden="true"
                 />
                 <Button
@@ -604,7 +604,7 @@ function SingleDailyEdit() {
                     ))}
                   </div>
                   {field.state.value === "complete" && (
-                    <p className="text-muted-foreground text-xs">
+                    <p className="text-xs text-muted-foreground">
                       Marking complete locks log editing.
                     </p>
                   )}
@@ -613,10 +613,10 @@ function SingleDailyEdit() {
             </form.AppField>
           )}
 
-          <div className="bg-card flex flex-col gap-4 rounded-md border p-4">
+          <div className="flex flex-col gap-4 rounded-md border bg-card p-4">
             <div className="flex flex-col gap-1">
               <h2 className="text-2xl">Status Criteria</h2>
-              <p className="text-muted-foreground text-sm">
+              <p className="text-sm text-muted-foreground">
                 Optional notes describing what each status means for this
                 daily.
               </p>

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -134,24 +134,23 @@ function Dailies() {
       <PageHeader
         pageTitle="Dailies"
         pageSection=""
-      />
+      >
+        <Link
+          to="/dailies/$id/edit"
+          params={{
+            id: "new",
+          }}
+        >
+          <Button>
+            <PlusIcon className="size-4" />
+            New Daily
+          </Button>
+        </Link>
+      </PageHeader>
       <div className="container flex flex-col gap-4">
-        <div className="flex justify-end">
-          <Link
-            to="/dailies/$id/edit"
-            params={{
-              id: "new",
-            }}
-          >
-            <Button variant="outline">
-              <PlusIcon className="size-4" />
-              Add Daily
-            </Button>
-          </Link>
-        </div>
 
         {(!sortedDailies || sortedDailies.length === 0) && (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             <i>No dailies yet!</i>
           </p>
         )}
@@ -173,7 +172,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-left text-xs text-muted-foreground">
+                  <tr className="text-muted-foreground text-left text-xs">
                     <th className="p-2 font-medium">Title</th>
                     <th className="p-2 font-medium">Progress</th>
                     <th className="p-2 font-medium">Description</th>
@@ -211,8 +210,9 @@ function Dailies() {
                       <tr
                         key={daily.id}
                         className="
-                          group border-t align-middle
+                          group
                           hover:bg-muted/40
+                          border-t align-middle
                         "
                       >
                         <td className="p-2">
@@ -241,7 +241,7 @@ function Dailies() {
                           {daily.description
                             ? (
                               <span
-                                className="block truncate text-muted-foreground"
+                                className="text-muted-foreground block truncate"
                                 title={daily.description}
                               >
                                 {daily.description}
@@ -361,7 +361,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-left text-xs text-muted-foreground">
+                  <tr className="text-muted-foreground text-left text-xs">
                     <th className="p-2 font-medium">Name</th>
                     <th className="p-2 font-medium whitespace-nowrap">
                       Last Entry
@@ -419,7 +419,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-left text-xs text-muted-foreground">
+                  <tr className="text-muted-foreground text-left text-xs">
                     <th className="p-2 font-medium">Name</th>
                     <th className="p-2 font-medium whitespace-nowrap">
                       Last Entry

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -150,7 +150,7 @@ function Dailies() {
       <div className="container flex flex-col gap-4">
 
         {(!sortedDailies || sortedDailies.length === 0) && (
-          <p className="text-muted-foreground text-sm">
+          <p className="text-sm text-muted-foreground">
             <i>No dailies yet!</i>
           </p>
         )}
@@ -172,7 +172,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-muted-foreground text-left text-xs">
+                  <tr className="text-left text-xs text-muted-foreground">
                     <th className="p-2 font-medium">Title</th>
                     <th className="p-2 font-medium">Progress</th>
                     <th className="p-2 font-medium">Description</th>
@@ -210,9 +210,8 @@ function Dailies() {
                       <tr
                         key={daily.id}
                         className="
-                          group
+                          group border-t align-middle
                           hover:bg-muted/40
-                          border-t align-middle
                         "
                       >
                         <td className="p-2">
@@ -241,7 +240,7 @@ function Dailies() {
                           {daily.description
                             ? (
                               <span
-                                className="text-muted-foreground block truncate"
+                                className="block truncate text-muted-foreground"
                                 title={daily.description}
                               >
                                 {daily.description}
@@ -361,7 +360,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-muted-foreground text-left text-xs">
+                  <tr className="text-left text-xs text-muted-foreground">
                     <th className="p-2 font-medium">Name</th>
                     <th className="p-2 font-medium whitespace-nowrap">
                       Last Entry
@@ -419,7 +418,7 @@ function Dailies() {
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
-                  <tr className="text-muted-foreground text-left text-xs">
+                  <tr className="text-left text-xs text-muted-foreground">
                     <th className="p-2 font-medium">Name</th>
                     <th className="p-2 font-medium whitespace-nowrap">
                       Last Entry

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -38,7 +38,19 @@ function DomainsIndex() {
       <PageHeader
         pageTitle="Domains"
         pageSection=""
-      />
+      >
+        <Link
+          to="/domains/$id/edit"
+          params={{
+            id: "new",
+          }}
+        >
+          <Button>
+            <PlusIcon className="size-4" />
+            New Domain
+          </Button>
+        </Link>
+      </PageHeader>
       <div className="container">
         <div className="card-grid">
           {(!data || data.length === 0) && (
@@ -82,9 +94,11 @@ function DomainsIndex() {
           >
             <ContentBox
               className="
+                text-muted-foreground
+                hover:bg-accent hover:text-accent-foreground
                 h-full items-center justify-center border-dashed p-8
-                text-muted-foreground transition-colors
-                hover:border-solid hover:bg-accent hover:text-accent-foreground
+                transition-colors
+                hover:border-solid
               "
             >
               <PlusIcon size={32} />

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -94,11 +94,9 @@ function DomainsIndex() {
           >
             <ContentBox
               className="
-                text-muted-foreground
-                hover:bg-accent hover:text-accent-foreground
                 h-full items-center justify-center border-dashed p-8
-                transition-colors
-                hover:border-solid
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
               "
             >
               <PlusIcon size={32} />

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -92,11 +92,9 @@ function Providers() {
           >
             <ContentBox
               className="
-                text-muted-foreground
-                hover:bg-accent hover:text-accent-foreground
                 h-full items-center justify-center border-dashed p-8
-                transition-colors
-                hover:border-solid
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
               "
             >
               <PlusIcon size={32} />

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -38,7 +38,19 @@ function Providers() {
       <PageHeader
         pageTitle="Providers"
         pageSection=""
-      />
+      >
+        <Link
+          to="/providers/$id/edit"
+          params={{
+            id: "new",
+          }}
+        >
+          <Button>
+            <PlusIcon className="size-4" />
+            New Provider
+          </Button>
+        </Link>
+      </PageHeader>
       <div className="container">
         <div className="card-grid">
           {(!data || data.length === 0) && (
@@ -80,9 +92,11 @@ function Providers() {
           >
             <ContentBox
               className="
+                text-muted-foreground
+                hover:bg-accent hover:text-accent-foreground
                 h-full items-center justify-center border-dashed p-8
-                text-muted-foreground transition-colors
-                hover:border-solid hover:bg-accent hover:text-accent-foreground
+                transition-colors
+                hover:border-solid
               "
             >
               <PlusIcon size={32} />

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
+  createDomain,
   createTopic,
   deleteSingleTopic,
   fetchDomains,
@@ -39,6 +40,7 @@ function SingleTopicEdit() {
   } = Route.useParams();
   const isNew = id === "new";
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const {
     data,
@@ -197,6 +199,24 @@ function SingleTopicEdit() {
                 label="Domains"
                 options={domainOptions}
                 placeholder="Search domains..."
+                create={{
+                  itemLabel: "domain",
+                  fields: [
+                    {
+                      name: "title",
+                      label: "Title",
+                      required: true,
+                      isPrimary: true,
+                    },
+                  ],
+                  onCreate: async (values) => {
+                    const result = await createDomain(values);
+                    await queryClient.invalidateQueries({
+                      queryKey: ["domains"],
+                    });
+                    return result.id;
+                  },
+                }}
               />
             )}
           </form.AppField>


### PR DESCRIPTION
## Summary
This PR adds the ability to create new items directly from combobox fields without leaving the form. Users can now type a value that doesn't exist in the dropdown and create it inline with a configurable form panel.

## Key Changes
- **New `ComboboxCreatePanel` component**: A reusable inline form panel for creating new items with configurable fields, validation, and loading states
- **Enhanced `ComboboxField` and `MultiComboboxField`**: Both now support an optional `create` config prop that enables inline creation with:
  - "Add new" button shown when input doesn't match existing options
  - Pre-filled primary field with user's typed input
  - Automatic query invalidation after creation
  - Error handling with toast notifications
- **Updated form pages**: Added create configs to:
  - Course edit: Create topics and providers
  - Daily edit: Create providers
  - Topic edit: Create domains
- **UI improvements**: Moved "New" buttons to `PageHeader` component for courses, dailies, domains, and providers index pages for better consistency

## Implementation Details
- The `CreateConfig` interface defines the creation behavior with configurable fields, labels, and an async `onCreate` callback
- Input value tracking enables smart "Add new" button visibility (only shown when input is non-empty and doesn't match existing options)
- Form submission trims whitespace and converts empty strings to null for cleaner data
- Uses `useQueryClient` to invalidate relevant queries after successful creation
- Maintains focus management with `autoFocus` on the primary field

https://claude.ai/code/session_01EEx2qozFmLe59gYeLWknmq