### PR TITLE
Add faint connector for incomplete entries and refine status modal

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -277,7 +277,7 @@ export function DailyCompletionsManager({
               ? completionsByDate.get(nextDateKey)?.status ?? null
               : null;
             const showVerticalConnector
-              = nextStatus !== null && nextStatus !== "incomplete";
+              = status !== null && nextStatus !== null;
             return (
               <li
                 key={dateKey}

--- a/packages/client/src/components/dailies/DailyStatusConnector.tsx
+++ b/packages/client/src/components/dailies/DailyStatusConnector.tsx
@@ -28,11 +28,24 @@ export function DailyStatusConnector({
   const isVertical = orientation === "vertical";
   const baseClass = isVertical ? "h-3 w-0.5" : "h-0.5 w-3";
 
-  if (!isLinked(left) || !isLinked(right)) {
+  if (left === null || right === null) {
     return (
       <div
         aria-hidden
         className={cn(baseClass, className)}
+      />
+    );
+  }
+
+  if (!isLinked(left) || !isLinked(right)) {
+    return (
+      <div
+        aria-hidden
+        className={cn(
+          baseClass,
+          "bg-neutral-400/15 dark:bg-neutral-500/20",
+          className,
+        )}
       />
     );
   }

--- a/packages/client/src/components/dailies/DailyStatusModal.tsx
+++ b/packages/client/src/components/dailies/DailyStatusModal.tsx
@@ -109,7 +109,7 @@ export function DailyStatusModal({
                     value={opt.value}
                     checked={isSelected}
                     onChange={() => setSelected(opt.value)}
-                    className="mt-1 size-4 shrink-0"
+                    className="sr-only"
                   />
                   <div className="flex flex-col gap-1">
                     <div
@@ -143,6 +143,18 @@ export function DailyStatusModal({
               );
             })}
           </fieldset>
+          {daily.description && (
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold">Reason</span>
+              <p
+                className="
+                  text-sm whitespace-pre-wrap text-muted-foreground
+                "
+              >
+                {daily.description}
+              </p>
+            </div>
+          )}
           <DialogFooter>
             <Button
               type="button"

--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -55,7 +55,7 @@ export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
     label: "Freeze",
     icon: <SnowflakeIcon className="size-4" />,
     circleClass: "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
-    pillClass: "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
+    pillClass: "bg-sky-50/60 text-sky-700 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-300 dark:border-sky-900/40",
     borderColor: "#bae6fd",
   },
 ];

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -535,8 +535,8 @@ function SingleDailyEdit() {
           <form.AppField name="description">
             {field => (
               <field.TextareaField
-                label="Description"
-                placeholder="What is this daily about?"
+                label="Reason"
+                placeholder="Why are you doing this daily?"
               />
             )}
           </form.AppField>


### PR DESCRIPTION
- Render a very faint grey vertical connector between adjacent logged
  entries when at least one is incomplete; skip lines entirely when an
  adjacent day has no entry.
- Hide the radio input in the daily status modal so only the option
  boxes are visible.
- Darken the Freeze text in the status modal so the label is legible.
- Show the daily's reason (description) below the status options.
- Rename the "Description" label on the daily edit form to "Reason".

https://claude.ai/code/session_01CanFwDh7Dy1kVxFgr1HsNr