### PR TITLE
Add filter option counts to select dropdowns

### DIFF
--- a/packages/client/src/components/FilterOptionCount.tsx
+++ b/packages/client/src/components/FilterOptionCount.tsx
@@ -1,0 +1,15 @@
+interface FilterOptionCountProps {
+  count: number;
+}
+
+export function FilterOptionCount({
+  count,
+}: FilterOptionCountProps) {
+  return (
+    <span
+      className="text-muted-foreground ml-auto pl-3 text-xs tabular-nums"
+    >
+      {count}
+    </span>
+  );
+}

--- a/packages/client/src/components/FilterOptionCount.tsx
+++ b/packages/client/src/components/FilterOptionCount.tsx
@@ -7,7 +7,7 @@ export function FilterOptionCount({
 }: FilterOptionCountProps) {
   return (
     <span
-      className="text-muted-foreground ml-auto pl-3 text-xs tabular-nums"
+      className="ml-auto pl-3 text-xs text-muted-foreground tabular-nums"
     >
       {count}
     </span>

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -19,6 +19,7 @@ import { ContentBox } from "@/components/boxes/ContentBox";
 import { CourseBox } from "@/components/boxes/CourseBox";
 import { CoursesTable } from "@/components/boxes/CoursesTable";
 import { EntityError, EntityPending } from "@/components/EntityStates";
+import { FilterOptionCount } from "@/components/FilterOptionCount";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -147,6 +148,16 @@ function Courses() {
 
   const hasActiveFilters = filterProvider || filterTopic;
 
+  const totalCourseCount = data?.length ?? 0;
+  const noProviderCount = useMemo(
+    () => data?.filter(c => !c.provider).length ?? 0,
+    [data],
+  );
+  const noTopicCount = useMemo(
+    () => data?.filter(c => !c.topics || c.topics.length === 0).length ?? 0,
+    [data],
+  );
+
   return (
     <div>
       <PageHeader
@@ -191,14 +202,21 @@ function Courses() {
                     <SelectValue placeholder="Provider" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Providers</SelectItem>
-                    <SelectItem value="none">No Provider</SelectItem>
+                    <SelectItem value="all">
+                      <span>All Providers</span>
+                      <FilterOptionCount count={totalCourseCount} />
+                    </SelectItem>
+                    <SelectItem value="none">
+                      <span>No Provider</span>
+                      <FilterOptionCount count={noProviderCount} />
+                    </SelectItem>
                     {providers?.map(p => (
                       <SelectItem
                         key={p.id}
                         value={p.id}
                       >
-                        {p.name}
+                        <span>{p.name}</span>
+                        <FilterOptionCount count={p.courseCount ?? 0} />
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -213,14 +231,21 @@ function Courses() {
                     <SelectValue placeholder="Topic" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Topics</SelectItem>
-                    <SelectItem value="none">No Topic</SelectItem>
+                    <SelectItem value="all">
+                      <span>All Topics</span>
+                      <FilterOptionCount count={totalCourseCount} />
+                    </SelectItem>
+                    <SelectItem value="none">
+                      <span>No Topic</span>
+                      <FilterOptionCount count={noTopicCount} />
+                    </SelectItem>
                     {topics?.map(t => (
                       <SelectItem
                         key={t.id}
                         value={t.id}
                       >
-                        {t.name}
+                        <span>{t.name}</span>
+                        <FilterOptionCount count={t.courseCount ?? 0} />
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -8,6 +8,7 @@ import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
 
 import { TaskBox } from "@/components/boxes/TaskBox";
 import { EntityError, EntityPending } from "@/components/EntityStates";
+import { FilterOptionCount } from "@/components/FilterOptionCount";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -75,6 +76,20 @@ function Tasks() {
 
   const hasActiveFilters = !!filterTopic;
 
+  const taskCountByTopic = useMemo(() => {
+    const counts = new Map<string, number>();
+    data?.forEach((t) => {
+      const id = t.topic?.id;
+      if (id) counts.set(id, (counts.get(id) ?? 0) + 1);
+    });
+    return counts;
+  }, [data]);
+  const totalTaskCount = data?.length ?? 0;
+  const noTopicCount = useMemo(
+    () => data?.filter(t => !t.topic).length ?? 0,
+    [data],
+  );
+
   return (
     <div>
       <PageHeader
@@ -126,14 +141,23 @@ function Tasks() {
                 <SelectValue placeholder="Topic" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All Topics</SelectItem>
-                <SelectItem value="none">No Topic</SelectItem>
+                <SelectItem value="all">
+                  <span>All Topics</span>
+                  <FilterOptionCount count={totalTaskCount} />
+                </SelectItem>
+                <SelectItem value="none">
+                  <span>No Topic</span>
+                  <FilterOptionCount count={noTopicCount} />
+                </SelectItem>
                 {topics?.map(t => (
                   <SelectItem
                     key={t.id}
                     value={t.id}
                   >
-                    {t.name}
+                    <span>{t.name}</span>
+                    <FilterOptionCount
+                      count={taskCountByTopic.get(t.id) ?? 0}
+                    />
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -14,6 +14,7 @@ import {
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
 import { EntityError, EntityPending } from "@/components/EntityStates";
+import { FilterOptionCount } from "@/components/FilterOptionCount";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import {
@@ -104,6 +105,18 @@ function Topics() {
 
   const hasActiveFilters = filterDomain;
 
+  const totalTopicCount = useMemo(
+    () => data?.filter(t => t.name !== "").length ?? 0,
+    [data],
+  );
+  const noDomainCount = useMemo(
+    () =>
+      data?.filter(
+        t => t.name !== "" && (!t.domains || t.domains.length === 0),
+      ).length ?? 0,
+    [data],
+  );
+
   return (
     <div>
       <PageHeader
@@ -149,14 +162,21 @@ function Topics() {
                     <SelectValue placeholder="Domain" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Domains</SelectItem>
-                    <SelectItem value="none">No Domain</SelectItem>
+                    <SelectItem value="all">
+                      <span>All Domains</span>
+                      <FilterOptionCount count={totalTopicCount} />
+                    </SelectItem>
+                    <SelectItem value="none">
+                      <span>No Domain</span>
+                      <FilterOptionCount count={noDomainCount} />
+                    </SelectItem>
                     {domains?.map(d => (
                       <SelectItem
                         key={d.id}
                         value={d.id}
                       >
-                        {d.title}
+                        <span>{d.title}</span>
+                        <FilterOptionCount count={d.topicCount ?? 0} />
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
## Summary
This PR adds item counts to filter dropdown options across the courses, tasks, and topics pages, providing users with visibility into how many items match each filter option.

## Key Changes
- Created new `FilterOptionCount` component to display counts in a consistent, right-aligned format with muted styling
- **Courses page**: Added counts for provider and topic filters, including calculations for items with no provider/topic
- **Tasks page**: Added counts for topic filters, including calculation for tasks with no topic
- **Topics page**: Added counts for domain filters, including calculation for topics with no domain
- Wrapped filter option labels in `<span>` elements to accommodate the count component alongside text

## Implementation Details
- Count calculations use `useMemo` to optimize performance and prevent unnecessary recalculations
- Counts are computed from the existing data arrays with appropriate filtering logic (e.g., checking for empty arrays or null values)
- The `FilterOptionCount` component uses `ml-auto` to right-align counts and `tabular-nums` for consistent number width
- Existing `courseCount` and `topicCount` properties from API responses are leveraged where available

https://claude.ai/code/session_01AoTYKzuPVmujdwesojQuDs