### PR TITLE
Refine LLM-assisted radar prompt with topic descriptions and exhaustiveness caveats

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -158,7 +158,8 @@ interface BuildPromptArgs {
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   existingBlips: { topicName: string;
-    description?: string | null; }[];
+    radarNote?: string | null;
+    topicDescription?: string | null; }[];
 }
 
 function buildLlmPrompt(args: BuildPromptArgs): string {
@@ -181,8 +182,16 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
   const existingList = existingBlips.length > 0
     ? existingBlips
       .map((b) => {
-        const desc = b.description?.trim();
-        return desc ? `- ${b.topicName}: ${desc}` : `- ${b.topicName}`;
+        const note = b.radarNote?.trim();
+        const topicDesc = b.topicDescription?.trim();
+        const lines = [`- ${b.topicName}`];
+        lines.push(
+          topicDesc
+            ? `  - general description: ${topicDesc}`
+            : `  - general description: (missing — supply one in your output if you keep this blip)`,
+        );
+        lines.push(`  - radar note: ${note || "(none)"}`);
+        return lines.join("\n");
       })
       .join("\n")
     : "- (none yet)";
@@ -199,10 +208,16 @@ And these rings (innermost first):
 ${ringList || "- (none defined)"}
 
 Topics already linked to this domain, with the courses I'm taking and current
-progress for each (use this to gauge what I've actually been investing time in):
+progress for each (use this to gauge what I've actually been investing time in).
+The course list under each topic is NOT exhaustive — I may have studied related
+material outside of what's listed, or just not added it to the system yet — so
+treat course progress as a signal, not the full picture:
 ${formatTopicsWithCourses(domainTopics)}
 
-Topics already on the radar (with current radar notes, if any):
+Topics already on the radar, with each topic's general description (if any)
+and its current radar note (if any). If the general description is marked
+missing for a topic you keep in your output, supply a description in the
+result so it gets filled in:
 ${existingList}
 
 Topics I have explicitly EXCLUDED from this radar — do NOT suggest these,
@@ -216,16 +231,17 @@ JSON array of entries, using this exact shape (no other keys, no commentary):
 [
   {
     "topic": "Topic name",
-    "description": "A short factual description of what the topic IS — used as the topic's description if the topic doesn't already exist. Null if you have nothing to add.",
-    "radarNote": "A short note explaining WHY this topic belongs on the radar in this quadrant/ring (e.g. why it's worth adopting, what to assess, why to hold). Null if no note.",
+    "description": "A short factual description of what the topic IS — saved as the topic's description if the topic is new, or if the topic exists but has no description yet (marked missing above). Null only when the topic already has a description and you have nothing to add.",
+    "radarNote": "A short note explaining WHY this topic belongs on the radar in this quadrant/ring. Keep high-level framing to a minimum; prefer specific, concrete references — which courses, projects, prior placements, or trade-offs drive the choice — over generic justifications. Null if no note.",
     "quadrant": "One of the quadrant names above (exact match)",
     "ring": "One of the ring names above (exact match)"
   }
 ]
 
-The "description" describes the topic itself (it's only saved when the topic is
-new — for existing topics it's ignored). The "radarNote" is the reasoning for
-this specific radar placement and is always saved as the blip's note.
+The "description" describes the topic itself (it's saved when the topic is
+new, or when an existing topic has no description yet — otherwise it's
+ignored). The "radarNote" is the reasoning for this specific radar placement
+and is always saved as the blip's note.
 
 You may include topics already on the radar to suggest a better radar note or
 a different placement for them. The reviewer will choose whether to overwrite,
@@ -247,8 +263,9 @@ export function BlipLlmAssist({
   onComplete,
 }: BlipLlmAssistProps) {
   const prompt = useMemo(
-    () =>
-      buildLlmPrompt({
+    () => {
+      const topicById = new Map(topics.map(t => [t.id, t]));
+      return buildLlmPrompt({
         domainTitle,
         domainDescription,
         domainTopics,
@@ -257,9 +274,11 @@ export function BlipLlmAssist({
         rings,
         existingBlips: existingBlips.map(b => ({
           topicName: b.topicName,
-          description: b.description,
+          radarNote: b.description,
+          topicDescription: topicById.get(b.topicId)?.description ?? null,
         })),
-      }),
+      });
+    },
     [
       domainTitle,
       domainDescription,
@@ -268,6 +287,7 @@ export function BlipLlmAssist({
       quadrants,
       rings,
       existingBlips,
+      topics,
     ],
   );
 

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -10,9 +10,10 @@ import type {
 
 import { useMemo, useState } from "react";
 
-import { CopyIcon, Loader2 } from "lucide-react";
+import { CheckIcon, CopyIcon, Loader2, PencilIcon, XIcon } from "lucide-react";
 import { toast } from "sonner";
 
+import { Input } from "@/components/forms/input";
 import { Textarea } from "@/components/forms/textarea";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,8 +24,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
   bulkCreateRadarBlips,
+  deleteRadarBlip,
+  deleteSingleTopic,
   upsertRadarBlip,
+  upsertTopic,
 } from "@/utils";
 
 interface BlipLlmAssistProps {
@@ -40,7 +52,12 @@ interface BlipLlmAssistProps {
   onComplete: () => void;
 }
 
-type Resolution = "create" | "overwrite" | "updateDescription" | "skip";
+type Resolution
+  = | "create"
+    | "overwriteAll"
+    | "updateBlip"
+    | "removeBlip"
+    | "skip";
 
 interface LlmEntry {
   topic?: unknown;
@@ -48,29 +65,54 @@ interface LlmEntry {
   ring?: unknown;
   description?: unknown;
   radarNote?: unknown;
+  action?: unknown;
+}
+
+interface EditDraft {
+  description: string;
+  radarNote: string;
+  quadrantId: string;
+  ringId: string;
 }
 
 interface ResolvedLlmEntry {
   topicName: string;
   matchedTopicId: string | null;
   willCreateTopic: boolean;
+
   quadrantInput: string;
-  quadrantId: string | null;
   ringInput: string;
-  ringId: string | null;
-  topicDescription: string | null;
+
+  // Effective values (initially the LLM's, replaced by user edits)
+  description: string | null;
   radarNote: string | null;
+  quadrantId: string | null;
+  ringId: string | null;
+
+  // Existing state at parse time
   existingBlipId: string | null;
   existingQuadrantId: string | null;
   existingRingId: string | null;
-  existingDescription: string | null;
+  existingRadarNote: string | null;
+  existingTopicDescription: string | null;
+
+  // Topic association counts (for delete-topic safety check)
+  topicCourseCount: number;
+  topicTaskCount: number;
+  topicDailyCount: number;
+
   resolution: Resolution;
+  deleteTopicOnRemove: boolean;
+  editing: boolean;
+  editDraft: EditDraft | null;
+
   problems: string[];
 }
 
 function computeProblems(
   entry: Pick<ResolvedLlmEntry,
-    "topicName" | "quadrantInput" | "quadrantId" | "ringInput" | "ringId">,
+  "topicName" | "quadrantInput" | "quadrantId" | "ringInput" | "ringId"
+  | "resolution" | "existingBlipId">,
   excludedNames?: Set<string>,
 ): string[] {
   const problems: string[] = [];
@@ -79,6 +121,22 @@ function computeProblems(
   }
   else if (excludedNames?.has(entry.topicName.toLowerCase())) {
     problems.push("topic is excluded from this radar");
+  }
+  // Skip and remove resolutions don't need quadrant/ring validation.
+  if (entry.resolution === "skip") {
+    return problems;
+  }
+  if (entry.resolution === "removeBlip") {
+    if (!entry.existingBlipId) {
+      problems.push("no existing blip to remove");
+    }
+    return problems;
+  }
+  if (entry.resolution === "updateBlip") {
+    if (!entry.existingBlipId) {
+      problems.push("no existing blip to update");
+    }
+    return problems;
   }
   if (!entry.quadrantId) {
     problems.push(
@@ -188,7 +246,7 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
         lines.push(
           topicDesc
             ? `  - general description: ${topicDesc}`
-            : `  - general description: (missing — supply one in your output if you keep this blip)`,
+            : "  - general description: (missing — supply one in your output if you keep this blip)",
         );
         lines.push(`  - radar note: ${note || "(none)"}`);
         return lines.join("\n");
@@ -231,23 +289,67 @@ JSON array of entries, using this exact shape (no other keys, no commentary):
 [
   {
     "topic": "Topic name",
+    "action": "add | update | remove (optional — see below)",
     "description": "A short factual description of what the topic IS — saved as the topic's description if the topic is new, or if the topic exists but has no description yet (marked missing above). Null only when the topic already has a description and you have nothing to add.",
     "radarNote": "A short note explaining WHY this topic belongs on the radar in this quadrant/ring. Keep high-level framing to a minimum; prefer specific, concrete references — which courses, projects, prior placements, or trade-offs drive the choice — over generic justifications. Null if no note.",
-    "quadrant": "One of the quadrant names above (exact match)",
-    "ring": "One of the ring names above (exact match)"
+    "quadrant": "One of the quadrant names above (exact match) — null/omit if action is remove",
+    "ring": "One of the ring names above (exact match) — null/omit if action is remove"
   }
 ]
+
+The optional "action" field tells me what to do with the topic:
+- "add" — propose a new blip (default for topics not currently on the radar).
+- "update" — keep the topic on the radar but suggest a different placement
+  and/or radar note (default for topics already on the radar).
+- "remove" — the topic is currently on the radar but no longer fits this
+  domain's focus; propose taking it off. Include a brief radar note
+  explaining why (or null). quadrant and ring may be omitted.
+
+If you omit "action" I'll default it from whether the topic is already on the
+radar. Only suggest "remove" for topics from the existing-on-radar list above.
 
 The "description" describes the topic itself (it's saved when the topic is
 new, or when an existing topic has no description yet — otherwise it's
 ignored). The "radarNote" is the reasoning for this specific radar placement
 and is always saved as the blip's note.
 
-You may include topics already on the radar to suggest a better radar note or
-a different placement for them. The reviewer will choose whether to overwrite,
-update only the radar note, or skip each one. Do not include any topic from
-the excluded list above.
+You may include topics already on the radar to suggest a better radar note,
+a different placement, or removal. The reviewer will choose whether to
+overwrite, update only, remove, or skip each one. Do not include any topic
+from the excluded list above.
 `;
+}
+
+function valuesEqual(a: string | null, b: string | null): boolean {
+  return (a ?? "") === (b ?? "");
+}
+
+function descriptionChanged(r: ResolvedLlmEntry): boolean {
+  if (r.willCreateTopic) {
+    return false;
+  }
+  return !valuesEqual(r.description, r.existingTopicDescription);
+}
+
+function radarNoteChanged(r: ResolvedLlmEntry): boolean {
+  if (!r.existingBlipId) {
+    return false;
+  }
+  return !valuesEqual(r.radarNote, r.existingRadarNote);
+}
+
+function quadrantChanged(r: ResolvedLlmEntry): boolean {
+  if (!r.existingBlipId) {
+    return false;
+  }
+  return r.quadrantId !== r.existingQuadrantId;
+}
+
+function ringChanged(r: ResolvedLlmEntry): boolean {
+  if (!r.existingBlipId) {
+    return false;
+  }
+  return r.ringId !== r.existingRingId;
 }
 
 export function BlipLlmAssist({
@@ -340,6 +442,12 @@ export function BlipLlmAssist({
     return map;
   }, [rings]);
 
+  const topicById = useMemo(() => {
+    const map = new Map<string, TopicForTopicsPage>();
+    topics.forEach(t => map.set(t.id, t));
+    return map;
+  }, [topics]);
+
   const excludedNamesLower = useMemo(() => {
     const set = new Set<string>();
     excludedTopics.forEach((t) => {
@@ -387,6 +495,26 @@ export function BlipLlmAssist({
     }
   }
 
+  function defaultResolution(args: {
+    isExcluded: boolean;
+    llmAction: string | null;
+    existingBlipId: string | null;
+  }): Resolution {
+    if (args.isExcluded) {
+      return "skip";
+    }
+    if (args.llmAction === "remove" && args.existingBlipId) {
+      return "removeBlip";
+    }
+    if (args.llmAction === "update" && args.existingBlipId) {
+      return "overwriteAll";
+    }
+    if (args.llmAction === "add" && !args.existingBlipId) {
+      return "create";
+    }
+    return args.existingBlipId ? "overwriteAll" : "create";
+  }
+
   function parseAndResolve() {
     setParseError(null);
     let parsed: unknown;
@@ -411,11 +539,14 @@ export function BlipLlmAssist({
       const quadrantInput
         = typeof entry.quadrant === "string" ? entry.quadrant.trim() : "";
       const ringInput = typeof entry.ring === "string" ? entry.ring.trim() : "";
-      const topicDescription = typeof entry.description === "string"
+      const llmDescription = typeof entry.description === "string"
         ? entry.description.trim() || null
         : null;
-      const radarNote = typeof entry.radarNote === "string"
+      const llmRadarNote = typeof entry.radarNote === "string"
         ? entry.radarNote.trim() || null
+        : null;
+      const llmAction = typeof entry.action === "string"
+        ? entry.action.trim().toLowerCase() || null
         : null;
 
       const quadrantMatch = quadrantInput
@@ -431,30 +562,45 @@ export function BlipLlmAssist({
         ? existingBlipByTopicId.get(topicMatch.id) ?? null
         : null;
 
+      const isExcluded = excludedNamesLower.has(topicName.toLowerCase());
+      const resolution = defaultResolution({
+        isExcluded,
+        llmAction,
+        existingBlipId: existingBlip?.id ?? null,
+      });
+
       const partial = {
         topicName,
         quadrantInput,
         quadrantId: quadrantMatch?.id ?? null,
         ringInput,
         ringId: ringMatch?.id ?? null,
+        resolution,
+        existingBlipId: existingBlip?.id ?? null,
       };
 
-      const isExcluded = excludedNamesLower.has(topicName.toLowerCase());
       return {
-        ...partial,
+        topicName,
         matchedTopicId: topicMatch?.id ?? null,
         willCreateTopic: !!topicName && !topicMatch,
-        topicDescription,
-        radarNote,
+        quadrantInput,
+        ringInput,
+        description: llmDescription,
+        radarNote: llmRadarNote,
+        quadrantId: quadrantMatch?.id ?? null,
+        ringId: ringMatch?.id ?? null,
         existingBlipId: existingBlip?.id ?? null,
         existingQuadrantId: existingBlip?.quadrantId ?? null,
         existingRingId: existingBlip?.ringId ?? null,
-        existingDescription: existingBlip?.description ?? null,
-        resolution: isExcluded
-          ? "skip"
-          : existingBlip
-            ? "overwrite"
-            : "create",
+        existingRadarNote: existingBlip?.description ?? null,
+        existingTopicDescription: topicMatch?.description ?? null,
+        topicCourseCount: topicMatch?.courseCount ?? 0,
+        topicTaskCount: topicMatch?.taskCount ?? 0,
+        topicDailyCount: topicMatch?.dailyCount ?? 0,
+        resolution,
+        deleteTopicOnRemove: false,
+        editing: false,
+        editDraft: null,
         problems: computeProblems(partial, excludedNamesLower),
       };
     });
@@ -470,7 +616,7 @@ export function BlipLlmAssist({
         if (i !== idx) {
           return entry;
         }
-        const next = {
+        const next: ResolvedLlmEntry = {
           ...entry,
           ...patch,
         };
@@ -482,12 +628,87 @@ export function BlipLlmAssist({
     });
   }
 
+  function startEdit(idx: number) {
+    setResolved((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return prev.map((entry, i) => {
+        if (i !== idx) {
+          return entry;
+        }
+        const draft: EditDraft = {
+          description: entry.description ?? "",
+          radarNote: entry.radarNote ?? "",
+          quadrantId: entry.quadrantId ?? "",
+          ringId: entry.ringId ?? "",
+        };
+        return {
+          ...entry,
+          editing: true,
+          editDraft: draft,
+        };
+      });
+    });
+  }
+
+  function commitEdit(idx: number) {
+    setResolved((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return prev.map((entry, i) => {
+        if (i !== idx || !entry.editDraft) {
+          return entry;
+        }
+        const draft = entry.editDraft;
+        const next: ResolvedLlmEntry = {
+          ...entry,
+          description: draft.description.trim() ? draft.description.trim() : null,
+          radarNote: draft.radarNote.trim() ? draft.radarNote.trim() : null,
+          quadrantId: draft.quadrantId || null,
+          ringId: draft.ringId || null,
+          editing: false,
+          editDraft: null,
+        };
+        return {
+          ...next,
+          problems: computeProblems(next, excludedNamesLower),
+        };
+      });
+    });
+  }
+
+  function cancelEdit(idx: number) {
+    updateEntry(idx, {
+      editing: false,
+      editDraft: null,
+    });
+  }
+
+  function updateDraft(idx: number, patch: Partial<EditDraft>) {
+    setResolved((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return prev.map((entry, i) => {
+        if (i !== idx || !entry.editDraft) {
+          return entry;
+        }
+        return {
+          ...entry,
+          editDraft: {
+            ...entry.editDraft,
+            ...patch,
+          },
+        };
+      });
+    });
+  }
+
   function isActionable(r: ResolvedLlmEntry): boolean {
     if (r.resolution === "skip") {
       return false;
-    }
-    if (r.resolution === "updateDescription") {
-      return r.existingBlipId !== null;
     }
     return r.problems.length === 0;
   }
@@ -503,42 +724,23 @@ export function BlipLlmAssist({
     }
     setIsSubmitting(true);
     try {
-      const toOverwrite = actionable.filter(
-        r => r.resolution === "overwrite" && r.existingBlipId,
-      );
-      const toUpdateDescription = actionable.filter(
-        r => r.resolution === "updateDescription" && r.existingBlipId,
-      );
       const toCreate = actionable.filter(r => r.resolution === "create");
-
-      let overwriteCount = 0;
-      for (const r of toOverwrite) {
-        await upsertRadarBlip(domainId, r.existingBlipId as string, {
-          topicId: r.matchedTopicId as string,
-          quadrantId: r.quadrantId as string,
-          ringId: r.ringId as string,
-          description: r.radarNote,
-        });
-        overwriteCount += 1;
-      }
-
-      let descriptionUpdateCount = 0;
-      for (const r of toUpdateDescription) {
-        await upsertRadarBlip(domainId, r.existingBlipId as string, {
-          topicId: r.matchedTopicId as string,
-          quadrantId: r.existingQuadrantId as string,
-          ringId: r.existingRingId as string,
-          description: r.radarNote,
-        });
-        descriptionUpdateCount += 1;
-      }
+      const toOverwriteAll = actionable.filter(
+        r => r.resolution === "overwriteAll" && r.existingBlipId,
+      );
+      const toUpdateBlip = actionable.filter(
+        r => r.resolution === "updateBlip" && r.existingBlipId,
+      );
+      const toRemove = actionable.filter(
+        r => r.resolution === "removeBlip" && r.existingBlipId,
+      );
 
       let createCount = 0;
       if (toCreate.length > 0) {
         const blips: BulkBlipEntry[] = toCreate.map(r => ({
           topicId: r.matchedTopicId,
           newTopicName: r.matchedTopicId ? null : r.topicName,
-          newTopicDescription: r.matchedTopicId ? null : r.topicDescription,
+          newTopicDescription: r.matchedTopicId ? null : r.description,
           quadrantId: r.quadrantId as string,
           ringId: r.ringId as string,
           description: r.radarNote,
@@ -549,15 +751,60 @@ export function BlipLlmAssist({
         createCount = result.count;
       }
 
+      let overwriteCount = 0;
+      for (const r of toOverwriteAll) {
+        await upsertRadarBlip(domainId, r.existingBlipId as string, {
+          topicId: r.matchedTopicId as string,
+          quadrantId: r.quadrantId as string,
+          ringId: r.ringId as string,
+          description: r.radarNote,
+        });
+        if (r.matchedTopicId && descriptionChanged(r)) {
+          await upsertTopic(r.matchedTopicId, {
+            name: r.topicName,
+            description: r.description,
+          });
+        }
+        overwriteCount += 1;
+      }
+
+      let updateCount = 0;
+      for (const r of toUpdateBlip) {
+        await upsertRadarBlip(domainId, r.existingBlipId as string, {
+          topicId: r.matchedTopicId as string,
+          quadrantId: (r.quadrantId ?? r.existingQuadrantId) as string,
+          ringId: (r.ringId ?? r.existingRingId) as string,
+          description: r.radarNote,
+        });
+        updateCount += 1;
+      }
+
+      let removeBlipCount = 0;
+      let removeTopicCount = 0;
+      for (const r of toRemove) {
+        await deleteRadarBlip(domainId, r.existingBlipId as string);
+        removeBlipCount += 1;
+        if (r.deleteTopicOnRemove && r.matchedTopicId) {
+          await deleteSingleTopic(r.matchedTopicId);
+          removeTopicCount += 1;
+        }
+      }
+
       const parts: string[] = [];
       if (createCount > 0) {
         parts.push(`added ${createCount}`);
       }
       if (overwriteCount > 0) {
-        parts.push(`updated ${overwriteCount}`);
+        parts.push(`overwrote ${overwriteCount}`);
       }
-      if (descriptionUpdateCount > 0) {
-        parts.push(`described ${descriptionUpdateCount}`);
+      if (updateCount > 0) {
+        parts.push(`updated ${updateCount}`);
+      }
+      if (removeBlipCount > 0) {
+        parts.push(`removed ${removeBlipCount}`);
+      }
+      if (removeTopicCount > 0) {
+        parts.push(`deleted ${removeTopicCount} topic${removeTopicCount === 1 ? "" : "s"}`);
       }
       toast.success(`Done — ${parts.join(", ")}.`);
       setJsonText("");
@@ -572,25 +819,38 @@ export function BlipLlmAssist({
     }
   }
 
-  const newTopicCount = resolved?.filter(
-    r => r.willCreateTopic && r.problems.length === 0 && r.resolution !== "skip",
-  ).length ?? 0;
-  const createCount = resolved?.filter(
-    r => r.resolution === "create" && r.problems.length === 0,
-  ).length ?? 0;
-  const overwriteCount = resolved?.filter(
-    r => r.resolution === "overwrite" && r.problems.length === 0,
-  ).length ?? 0;
-  const descriptionUpdateCount = resolved?.filter(
-    r => r.resolution === "updateDescription" && r.existingBlipId,
-  ).length ?? 0;
-  const skipCount = resolved?.filter(r => r.resolution === "skip").length ?? 0;
-  const problemCount = resolved?.filter(
-    r => r.problems.length > 0
-      && r.resolution !== "skip"
-      && r.resolution !== "updateDescription",
-  ).length ?? 0;
-  const actionableCount = createCount + overwriteCount + descriptionUpdateCount;
+  const counts = useMemo(() => {
+    const c = {
+      create: 0,
+      overwriteAll: 0,
+      updateBlip: 0,
+      removeBlip: 0,
+      skip: 0,
+      problem: 0,
+      newTopic: 0,
+    };
+    if (!resolved) {
+      return c;
+    }
+    for (const r of resolved) {
+      if (r.resolution === "skip") {
+        c.skip += 1;
+        continue;
+      }
+      if (r.problems.length > 0) {
+        c.problem += 1;
+        continue;
+      }
+      if (r.willCreateTopic && r.resolution === "create") {
+        c.newTopic += 1;
+      }
+      c[r.resolution] += 1;
+    }
+    return c;
+  }, [resolved]);
+
+  const actionableCount
+    = counts.create + counts.overwriteAll + counts.updateBlip + counts.removeBlip;
 
   return (
     <div className="flex flex-col gap-4 rounded-sm border p-4">
@@ -613,7 +873,7 @@ export function BlipLlmAssist({
         </div>
         <pre
           className={`
-            max-h-60 overflow-auto rounded-sm bg-muted p-3 text-xs
+            bg-muted max-h-60 overflow-auto rounded-sm p-3 text-xs
             whitespace-pre-wrap
           `}
         >
@@ -626,11 +886,11 @@ export function BlipLlmAssist({
         <Textarea
           value={jsonText}
           onChange={e => setJsonText(e.target.value)}
-          placeholder='[{ "topic": "...", "description": "...", "radarNote": "...", "quadrant": "...", "ring": "..." }]'
+          placeholder='[{ "topic": "...", "action": "add | update | remove", "description": "...", "radarNote": "...", "quadrant": "...", "ring": "..." }]'
           className="min-h-32 font-mono text-xs"
         />
         {parseError && (
-          <p className="text-sm text-destructive">{parseError}</p>
+          <p className="text-destructive text-sm">{parseError}</p>
         )}
         <div>
           <Button
@@ -646,272 +906,54 @@ export function BlipLlmAssist({
       {resolved && (
         <div className="flex flex-col gap-2">
           <h4 className="text-sm font-semibold">3. Review</h4>
-          <p className="text-sm text-muted-foreground">
-            {createCount}
+          <p className="text-muted-foreground text-sm">
+            {counts.create}
             {" "}
             to add ·
             {" "}
-            {overwriteCount}
+            {counts.overwriteAll}
             {" "}
             to overwrite ·
             {" "}
-            {descriptionUpdateCount}
-            {" "}
-            note
-            {descriptionUpdateCount === 1 ? "" : "s"}
+            {counts.updateBlip}
             {" "}
             to update ·
             {" "}
-            {skipCount}
+            {counts.removeBlip}
+            {" "}
+            to remove ·
+            {" "}
+            {counts.skip}
             {" "}
             to skip ·
             {" "}
-            {problemCount}
+            {counts.problem}
             {" "}
             problem
-            {problemCount === 1 ? "" : "s"}
+            {counts.problem === 1 ? "" : "s"}
             {" "}
             ·
             {" "}
-            {newTopicCount}
+            {counts.newTopic}
             {" "}
             new topic
-            {newTopicCount === 1 ? "" : "s"}
+            {counts.newTopic === 1 ? "" : "s"}
           </p>
-          <ul className="flex flex-col gap-2 text-sm">
-            {resolved.map((r, idx) => {
-              const hasProblems = r.problems.length > 0;
-              const isSkipped = r.resolution === "skip";
-              const conflicts = r.existingBlipId !== null;
-              const existingQuadrantName = r.existingQuadrantId
-                ? quadrantById.get(r.existingQuadrantId)?.name ?? "?"
-                : null;
-              const existingRingName = r.existingRingId
-                ? ringById.get(r.existingRingId)?.name ?? "?"
-                : null;
-              return (
-                <li
-                  key={idx}
-                  className={`
-                    flex flex-col gap-2 rounded-sm border px-3 py-2
-                    ${isSkipped
-                  ? "border-muted bg-muted/30 opacity-70"
-                  : hasProblems
-                    ? "border-red-200 bg-red-50"
-                    : conflicts
-                      ? "border-amber-300 bg-amber-50"
-                      : "bg-white"}
-                  `}
-                >
-                  <div className="flex flex-row flex-wrap items-center gap-2">
-                    <span className="font-medium">{r.topicName || "(no topic)"}</span>
-                    {r.willCreateTopic && (
-                      <span
-                        className={`
-                          rounded-sm bg-emerald-100 px-1.5 py-0.5 text-xs
-                          text-emerald-800
-                        `}
-                      >
-                        New topic
-                      </span>
-                    )}
-                    {!r.willCreateTopic && r.matchedTopicId && (
-                      <span
-                        className={`
-                          rounded-sm bg-blue-100 px-1.5 py-0.5 text-xs
-                          text-blue-800
-                        `}
-                      >
-                        Existing topic
-                      </span>
-                    )}
-                    {conflicts && (
-                      <span
-                        className={`
-                          rounded-sm bg-amber-200 px-1.5 py-0.5 text-xs
-                          text-amber-900
-                        `}
-                      >
-                        Already on radar
-                      </span>
-                    )}
-                    {hasProblems && !isSkipped && (
-                      <span
-                        className={`
-                          rounded-sm bg-red-100 px-1.5 py-0.5 text-xs
-                          text-red-800
-                        `}
-                      >
-                        {r.problems.join("; ")}
-                      </span>
-                    )}
-                  </div>
 
-                  {conflicts && (
-                    <div className="text-xs text-muted-foreground">
-                      Currently:
-                      {" "}
-                      <span className="font-medium">
-                        {existingQuadrantName ?? "?"}
-                        {" · "}
-                        {existingRingName ?? "?"}
-                      </span>
-                      {r.existingDescription && (
-                        <>
-                          {" — note: "}
-                          <span className="italic">{r.existingDescription}</span>
-                        </>
-                      )}
-                    </div>
-                  )}
+          <ReviewTable
+            resolved={resolved}
+            quadrants={quadrants}
+            rings={rings}
+            quadrantById={quadrantById}
+            ringById={ringById}
+            topicById={topicById}
+            updateEntry={updateEntry}
+            startEdit={startEdit}
+            commitEdit={commitEdit}
+            cancelEdit={cancelEdit}
+            updateDraft={updateDraft}
+          />
 
-                  {r.willCreateTopic && r.topicDescription && (
-                    <div className="text-xs text-muted-foreground">
-                      <span className="font-medium uppercase">
-                        Topic description (new):
-                      </span>
-                      {" "}
-                      <span className="italic">{r.topicDescription}</span>
-                    </div>
-                  )}
-
-                  {r.radarNote && (
-                    <div className="text-xs text-muted-foreground">
-                      <span className="font-medium uppercase">Radar note:</span>
-                      {" "}
-                      <span className="italic">{r.radarNote}</span>
-                    </div>
-                  )}
-
-                  <div
-                    className={`
-                      grid grid-cols-1 gap-2
-                      sm:grid-cols-3
-                    `}
-                  >
-                    <div className="flex flex-col gap-1">
-                      <label className="text-xs text-muted-foreground uppercase">
-                        Quadrant
-                        {r.quadrantInput && (
-                          <>
-                            {" "}
-                            <span
-                              className="text-muted-foreground/70 normal-case"
-                            >
-                              (LLM:
-                              {" "}
-                              {r.quadrantInput}
-                              )
-                            </span>
-                          </>
-                        )}
-                      </label>
-                      <Select
-                        value={r.quadrantId ?? ""}
-                        onValueChange={value =>
-                          updateEntry(idx, {
-                            quadrantId: value || null,
-                          })}
-                        disabled={isSkipped || r.resolution === "updateDescription"}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Pick a quadrant" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {quadrants.map(q => (
-                            <SelectItem
-                              key={q.id}
-                              value={q.id}
-                            >
-                              {q.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label className="text-xs text-muted-foreground uppercase">
-                        Ring
-                        {r.ringInput && (
-                          <>
-                            {" "}
-                            <span
-                              className="text-muted-foreground/70 normal-case"
-                            >
-                              (LLM:
-                              {" "}
-                              {r.ringInput}
-                              )
-                            </span>
-                          </>
-                        )}
-                      </label>
-                      <Select
-                        value={r.ringId ?? ""}
-                        onValueChange={value =>
-                          updateEntry(idx, {
-                            ringId: value || null,
-                          })}
-                        disabled={isSkipped || r.resolution === "updateDescription"}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Pick a ring" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {rings.map(rg => (
-                            <SelectItem
-                              key={rg.id}
-                              value={rg.id}
-                            >
-                              {rg.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label className="text-xs text-muted-foreground uppercase">
-                        Action
-                      </label>
-                      <Select
-                        value={r.resolution}
-                        onValueChange={value =>
-                          updateEntry(idx, {
-                            resolution: value as Resolution,
-                          })}
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {conflicts
-                            ? (
-                              <>
-                                <SelectItem value="overwrite">
-                                  Overwrite existing
-                                </SelectItem>
-                                <SelectItem value="updateDescription">
-                                  Update radar note only
-                                </SelectItem>
-                                <SelectItem value="skip">
-                                  Skip (keep existing)
-                                </SelectItem>
-                              </>
-                            )
-                            : (
-                              <>
-                                <SelectItem value="create">Add</SelectItem>
-                                <SelectItem value="skip">Skip</SelectItem>
-                              </>
-                            )}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
           <div className="flex flex-row gap-2">
             <Button
               type="button"
@@ -933,6 +975,470 @@ export function BlipLlmAssist({
             </Button>
           </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+interface ReviewTableProps {
+  resolved: ResolvedLlmEntry[];
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  quadrantById: Map<string, RadarQuadrant>;
+  ringById: Map<string, RadarRing>;
+  topicById: Map<string, TopicForTopicsPage>;
+  updateEntry: (idx: number, patch: Partial<ResolvedLlmEntry>) => void;
+  startEdit: (idx: number) => void;
+  commitEdit: (idx: number) => void;
+  cancelEdit: (idx: number) => void;
+  updateDraft: (idx: number, patch: Partial<EditDraft>) => void;
+}
+
+function ReviewTable({
+  resolved,
+  quadrants,
+  rings,
+  quadrantById,
+  ringById,
+  topicById,
+  updateEntry,
+  startEdit,
+  commitEdit,
+  cancelEdit,
+  updateDraft,
+}: ReviewTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="min-w-32">Topic</TableHead>
+          <TableHead className="min-w-56">Description</TableHead>
+          <TableHead className="min-w-32">Quadrant</TableHead>
+          <TableHead className="min-w-32">Ring</TableHead>
+          <TableHead className="min-w-56">Radar Note</TableHead>
+          <TableHead className="w-24">Edit</TableHead>
+          <TableHead className="min-w-44">Action</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {resolved.map((r, idx) => (
+          <ReviewRow
+            key={idx}
+            idx={idx}
+            r={r}
+            quadrants={quadrants}
+            rings={rings}
+            quadrantById={quadrantById}
+            ringById={ringById}
+            topicById={topicById}
+            updateEntry={updateEntry}
+            startEdit={startEdit}
+            commitEdit={commitEdit}
+            cancelEdit={cancelEdit}
+            updateDraft={updateDraft}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+interface ReviewRowProps {
+  idx: number;
+  r: ResolvedLlmEntry;
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  quadrantById: Map<string, RadarQuadrant>;
+  ringById: Map<string, RadarRing>;
+  topicById: Map<string, TopicForTopicsPage>;
+  updateEntry: (idx: number, patch: Partial<ResolvedLlmEntry>) => void;
+  startEdit: (idx: number) => void;
+  commitEdit: (idx: number) => void;
+  cancelEdit: (idx: number) => void;
+  updateDraft: (idx: number, patch: Partial<EditDraft>) => void;
+}
+
+function ReviewRow({
+  idx,
+  r,
+  quadrants,
+  rings,
+  quadrantById,
+  ringById,
+  topicById,
+  updateEntry,
+  startEdit,
+  commitEdit,
+  cancelEdit,
+  updateDraft,
+}: ReviewRowProps) {
+  const isSkipped = r.resolution === "skip";
+  const isRemove = r.resolution === "removeBlip";
+  const hasProblems = r.problems.length > 0;
+  const conflicts = r.existingBlipId !== null;
+
+  const rowTone = isSkipped
+    ? "opacity-60"
+    : hasProblems
+      ? "bg-destructive/10"
+      : isRemove
+        ? "bg-red-50/40"
+        : conflicts
+          ? "bg-amber-50/40"
+          : "";
+
+  // Description is unaffected by removal — when removing, only the blip goes
+  // away, not the topic by default.
+  const descCellEditable = !isSkipped;
+  const noteCellEditable = !isSkipped && !isRemove;
+  const placementCellEditable = !isSkipped && !isRemove;
+
+  const showDescDiff = descriptionChanged(r);
+  const showNoteDiff = radarNoteChanged(r);
+  const showQuadrantDiff = quadrantChanged(r);
+  const showRingDiff = ringChanged(r);
+
+  const existingQuadrantName = r.existingQuadrantId
+    ? quadrantById.get(r.existingQuadrantId)?.name ?? "?"
+    : null;
+  const existingRingName = r.existingRingId
+    ? ringById.get(r.existingRingId)?.name ?? "?"
+    : null;
+  const newQuadrantName = r.quadrantId
+    ? quadrantById.get(r.quadrantId)?.name ?? r.quadrantInput
+    : r.quadrantInput;
+  const newRingName = r.ringId
+    ? ringById.get(r.ringId)?.name ?? r.ringInput
+    : r.ringInput;
+
+  const canDeleteTopic
+    = isRemove
+      && r.matchedTopicId !== null
+      && r.topicCourseCount === 0
+      && r.topicTaskCount === 0
+      && r.topicDailyCount === 0;
+  const topic = r.matchedTopicId ? topicById.get(r.matchedTopicId) : null;
+
+  return (
+    <TableRow className={rowTone}>
+      <TableCell className="align-top">
+        <div className="flex flex-col gap-1">
+          <span className="font-medium">{r.topicName || "(no topic)"}</span>
+          <div className="flex flex-row flex-wrap gap-1">
+            {r.willCreateTopic && (
+              <span
+                className={`
+                  rounded-sm bg-emerald-100 px-1.5 py-0.5 text-[10px]
+                  text-emerald-800
+                `}
+              >
+                New topic
+              </span>
+            )}
+            {!r.willCreateTopic && r.matchedTopicId && (
+              <span
+                className={`
+                  rounded-sm bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800
+                `}
+              >
+                Existing topic
+              </span>
+            )}
+            {conflicts && (
+              <span
+                className={`
+                  rounded-sm bg-amber-200 px-1.5 py-0.5 text-[10px]
+                  text-amber-900
+                `}
+              >
+                On radar
+              </span>
+            )}
+          </div>
+          {hasProblems && !isSkipped && (
+            <span className="text-destructive text-[11px]">
+              {r.problems.join("; ")}
+            </span>
+          )}
+        </div>
+      </TableCell>
+
+      <TableCell className="align-top">
+        <DiffCell
+          existingValue={r.willCreateTopic ? null : r.existingTopicDescription}
+          newValue={r.description}
+          showDiff={showDescDiff}
+          editing={r.editing && descCellEditable}
+          draftValue={r.editDraft?.description ?? ""}
+          onDraftChange={value => updateDraft(idx, {
+            description: value,
+          })}
+          multiline
+        />
+      </TableCell>
+
+      <TableCell className="align-top">
+        {isRemove
+          ? <span className="text-muted-foreground text-xs">—</span>
+          : (
+            <PlacementCell
+              existingName={existingQuadrantName}
+              newName={newQuadrantName}
+              showDiff={showQuadrantDiff}
+              editing={r.editing && placementCellEditable}
+              draftId={r.editDraft?.quadrantId ?? ""}
+              options={quadrants}
+              onDraftChange={value => updateDraft(idx, {
+                quadrantId: value,
+              })}
+            />
+          )}
+      </TableCell>
+
+      <TableCell className="align-top">
+        {isRemove
+          ? <span className="text-muted-foreground text-xs">—</span>
+          : (
+            <PlacementCell
+              existingName={existingRingName}
+              newName={newRingName}
+              showDiff={showRingDiff}
+              editing={r.editing && placementCellEditable}
+              draftId={r.editDraft?.ringId ?? ""}
+              options={rings}
+              onDraftChange={value => updateDraft(idx, {
+                ringId: value,
+              })}
+            />
+          )}
+      </TableCell>
+
+      <TableCell className="align-top">
+        <DiffCell
+          existingValue={r.existingRadarNote}
+          newValue={r.radarNote}
+          showDiff={showNoteDiff}
+          editing={r.editing && noteCellEditable}
+          draftValue={r.editDraft?.radarNote ?? ""}
+          onDraftChange={value => updateDraft(idx, {
+            radarNote: value,
+          })}
+          multiline
+        />
+      </TableCell>
+
+      <TableCell className="align-top">
+        {!r.editing
+          ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => startEdit(idx)}
+              disabled={isSkipped}
+              aria-label="Edit"
+            >
+              <PencilIcon />
+            </Button>
+          )
+          : (
+            <div className="flex flex-row gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => commitEdit(idx)}
+                aria-label="Commit edit"
+              >
+                <CheckIcon />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => cancelEdit(idx)}
+                aria-label="Discard edit"
+              >
+                <XIcon />
+              </Button>
+            </div>
+          )}
+      </TableCell>
+
+      <TableCell className="align-top">
+        <div className="flex flex-col gap-1">
+          <Select
+            value={r.resolution}
+            onValueChange={value =>
+              updateEntry(idx, {
+                resolution: value as Resolution,
+              })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {conflicts
+                ? (
+                  <>
+                    <SelectItem value="overwriteAll">Overwrite All</SelectItem>
+                    <SelectItem value="updateBlip">Update Blip</SelectItem>
+                    <SelectItem value="removeBlip">Remove Blip</SelectItem>
+                    <SelectItem value="skip">Skip</SelectItem>
+                  </>
+                )
+                : (
+                  <>
+                    <SelectItem value="create">Add Blip</SelectItem>
+                    <SelectItem value="skip">Skip</SelectItem>
+                  </>
+                )}
+            </SelectContent>
+          </Select>
+          {isRemove && r.matchedTopicId && (
+            <label
+              className={`
+                flex flex-row items-center gap-1 text-[11px]
+                ${canDeleteTopic ? "" : "text-muted-foreground"}
+              `}
+              title={
+                canDeleteTopic
+                  ? undefined
+                  : `Topic has ${r.topicCourseCount} course(s), ${r.topicTaskCount} task(s), ${r.topicDailyCount} daily/dailies — keep`
+              }
+            >
+              <input
+                type="checkbox"
+                checked={r.deleteTopicOnRemove}
+                disabled={!canDeleteTopic}
+                onChange={e => updateEntry(idx, {
+                  deleteTopicOnRemove: e.target.checked,
+                })}
+              />
+              Also delete topic
+              {!canDeleteTopic && topic && (
+                <span className="text-[10px]">
+                  {" "}
+                  (in use)
+                </span>
+              )}
+            </label>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+interface DiffCellProps {
+  existingValue: string | null;
+  newValue: string | null;
+  showDiff: boolean;
+  editing: boolean;
+  draftValue: string;
+  onDraftChange: (value: string) => void;
+  multiline?: boolean;
+}
+
+function DiffCell({
+  existingValue,
+  newValue,
+  showDiff,
+  editing,
+  draftValue,
+  onDraftChange,
+  multiline,
+}: DiffCellProps) {
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      {showDiff && (
+        <span className="text-muted-foreground/70 italic line-through">
+          {existingValue || "(none)"}
+        </span>
+      )}
+      <span>
+        {newValue || (
+          <span className="text-muted-foreground italic">(none)</span>
+        )}
+      </span>
+      {editing && (
+        multiline
+          ? (
+            <Textarea
+              value={draftValue}
+              onChange={e => onDraftChange(e.target.value)}
+              className="mt-1 min-h-16 text-xs"
+            />
+          )
+          : (
+            <Input
+              value={draftValue}
+              onChange={e => onDraftChange(e.target.value)}
+              className="mt-1"
+            />
+          )
+      )}
+    </div>
+  );
+}
+
+interface PlacementCellProps {
+  existingName: string | null;
+  newName: string | null;
+  showDiff: boolean;
+  editing: boolean;
+  draftId: string;
+  options: { id: string;
+    name: string; }[];
+  onDraftChange: (value: string) => void;
+}
+
+function PlacementCell({
+  existingName,
+  newName,
+  showDiff,
+  editing,
+  draftId,
+  options,
+  onDraftChange,
+}: PlacementCellProps) {
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      {showDiff
+        ? (
+          <span className="flex flex-row items-center gap-1">
+            <span className="text-muted-foreground/70 line-through">
+              {existingName ?? "(none)"}
+            </span>
+            <span aria-hidden>→</span>
+            <span>{newName || "(none)"}</span>
+          </span>
+        )
+        : (
+          <span>
+            {newName || (
+              <span className="text-muted-foreground italic">(none)</span>
+            )}
+          </span>
+        )}
+      {editing && (
+        <Select
+          value={draftId}
+          onValueChange={onDraftChange}
+        >
+          <SelectTrigger className="mt-1">
+            <SelectValue placeholder="Select" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(o => (
+              <SelectItem
+                key={o.id}
+                value={o.id}
+              >{o.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       )}
     </div>
   );

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -873,7 +873,7 @@ export function BlipLlmAssist({
         </div>
         <pre
           className={`
-            bg-muted max-h-60 overflow-auto rounded-sm p-3 text-xs
+            max-h-60 overflow-auto rounded-sm bg-muted p-3 text-xs
             whitespace-pre-wrap
           `}
         >
@@ -890,7 +890,7 @@ export function BlipLlmAssist({
           className="min-h-32 font-mono text-xs"
         />
         {parseError && (
-          <p className="text-destructive text-sm">{parseError}</p>
+          <p className="text-sm text-destructive">{parseError}</p>
         )}
         <div>
           <Button
@@ -906,7 +906,7 @@ export function BlipLlmAssist({
       {resolved && (
         <div className="flex flex-col gap-2">
           <h4 className="text-sm font-semibold">3. Review</h4>
-          <p className="text-muted-foreground text-sm">
+          <p className="text-sm text-muted-foreground">
             {counts.create}
             {" "}
             to add ·
@@ -1156,7 +1156,7 @@ function ReviewRow({
             )}
           </div>
           {hasProblems && !isSkipped && (
-            <span className="text-destructive text-[11px]">
+            <span className="text-[11px] text-destructive">
               {r.problems.join("; ")}
             </span>
           )}
@@ -1179,7 +1179,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-muted-foreground text-xs">—</span>
+          ? <span className="text-xs text-muted-foreground">—</span>
           : (
             <PlacementCell
               existingName={existingQuadrantName}
@@ -1197,7 +1197,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-muted-foreground text-xs">—</span>
+          ? <span className="text-xs text-muted-foreground">—</span>
           : (
             <PlacementCell
               existingName={existingRingName}

--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -40,11 +40,23 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          tasks: {
+            with: {
+              daily: {
+                columns: {
+                  id: true,
+                },
+              },
+            },
+          },
         },
       });
 
       const processedData: TopicForTopicsPage[] = rawData.map((topic) => {
         const courseCount = topic.topicsToCourses?.length ?? 0;
+        const taskCount = topic.tasks?.length ?? 0;
+        const dailyCount
+          = topic.tasks?.filter(t => t.daily != null).length ?? 0;
 
         const domainsById = new Map<string, { id: string;
           title: string; }>();
@@ -71,6 +83,8 @@ export default async function (server: FastifyInstance) {
           description: topic.description,
           reason: topic.reason,
           courseCount: courseCount,
+          taskCount: taskCount,
+          dailyCount: dailyCount,
           domains: Array.from(domainsById.values()),
         };
       });

--- a/packages/types/src/TopicForTopicsPage.ts
+++ b/packages/types/src/TopicForTopicsPage.ts
@@ -8,5 +8,7 @@ export interface TopicForTopicsPage {
   name: string;
   description?: string | null;
   courseCount?: number;
+  taskCount?: number;
+  dailyCount?: number;
   domains?: TopicForTopicsPageDomain[];
 }


### PR DESCRIPTION
- Note that the per-topic course list isn't exhaustive so the LLM treats it
  as a signal rather than ground truth
- Surface each existing-on-radar topic's general description (separate from
  its radar note) and instruct the LLM to fill in a missing description when
  keeping the blip
- Encourage radar notes to keep high-level framing minimal and prefer
  specific, concrete references