### PR TITLE
Improve filter layout, daily chains, todo links, and comment column

### DIFF
--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -36,7 +36,9 @@ export function DailyRecentDaysStrip({
   size = "lg",
   showLabels = true,
 }: DailyRecentDaysStripProps) {
-  const days = getRecentDays(daily, count, getReferenceDateKey(daily), labelFormat);
+  const days = getRecentDays(daily, count, getReferenceDateKey(daily), labelFormat)
+    .slice()
+    .reverse();
 
   return (
     <div

--- a/packages/client/src/components/dailies/DailyStatusConnector.tsx
+++ b/packages/client/src/components/dailies/DailyStatusConnector.tsx
@@ -43,7 +43,10 @@ export function DailyStatusConnector({
         aria-hidden
         className={cn(
           baseClass,
-          "bg-neutral-400/15 dark:bg-neutral-500/20",
+          `
+            bg-neutral-400/15
+            dark:bg-neutral-500/20
+          `,
           className,
         )}
       />

--- a/packages/client/src/components/dailies/DailyStatusConnector.tsx
+++ b/packages/client/src/components/dailies/DailyStatusConnector.tsx
@@ -28,7 +28,7 @@ export function DailyStatusConnector({
   const isVertical = orientation === "vertical";
   const baseClass = isVertical ? "h-3 w-0.5" : "h-0.5 w-3";
 
-  if (left === null || right === null) {
+  if (left === null && right === null) {
     return (
       <div
         aria-hidden

--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -2,7 +2,6 @@ import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
 import { useState } from "react";
 
-import { DailyCommentPopover } from "./DailyCommentPopover";
 import { getDailyStatusOption } from "./dailyStatusMeta";
 import { DailyStatusModal } from "./DailyStatusModal";
 
@@ -66,7 +65,6 @@ export function TodayStatusCell({
             )}
         </button>
       </div>
-      {currentStatus !== null && <DailyCommentPopover daily={daily} />}
       <DailyStatusModal
         daily={daily}
         currentStatus={currentStatus}

--- a/packages/client/src/components/tasks/TodosChecklist.tsx
+++ b/packages/client/src/components/tasks/TodosChecklist.tsx
@@ -3,7 +3,14 @@ import type { Task, TaskTodo } from "@emstack/types/src";
 import { useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { PlusIcon, Trash2Icon } from "lucide-react";
+import {
+  ExternalLinkIcon,
+  LinkIcon,
+  PencilIcon,
+  PlusIcon,
+  Trash2Icon,
+  XIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Input } from "@/components/input";
@@ -22,6 +29,8 @@ export function TodosChecklist({
   const queryClient = useQueryClient();
   const todos = task.todos ?? [];
   const [draft, setDraft] = useState("");
+  const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
+  const [linkDraft, setLinkDraft] = useState("");
 
   const buildPayload = (nextTodos: TaskTodo[]) => ({
     name: task.name,
@@ -40,6 +49,7 @@ export function TodosChecklist({
       id: t.id,
       name: t.name,
       isComplete: t.isComplete,
+      url: t.url ?? null,
     })),
   });
 
@@ -89,6 +99,7 @@ export function TodosChecklist({
         taskId: task.id,
         name: trimmed,
         isComplete: false,
+        url: null,
         position: todos.length,
       },
     ];
@@ -97,6 +108,33 @@ export function TodosChecklist({
         setDraft("");
       },
     });
+  }
+
+  function handleSaveLink(todoId: string) {
+    const trimmed = linkDraft.trim();
+    const next = todos.map(t =>
+      t.id === todoId
+        ? {
+          ...t,
+          url: trimmed || null,
+        }
+        : t);
+    mutation.mutate(next, {
+      onSuccess: () => {
+        setEditingLinkId(null);
+        setLinkDraft("");
+      },
+    });
+  }
+
+  function startEditLink(todo: TaskTodo) {
+    setEditingLinkId(todo.id);
+    setLinkDraft(todo.url ?? "");
+  }
+
+  function cancelEditLink() {
+    setEditingLinkId(null);
+    setLinkDraft("");
   }
 
   return (
@@ -112,43 +150,136 @@ export function TodosChecklist({
             <li
               key={todo.id}
               className="
-                group flex flex-row items-center gap-2 p-2
+                group flex flex-col gap-2 p-2
                 hover:bg-muted/40
               "
             >
-              <input
-                type="checkbox"
-                checked={todo.isComplete}
-                disabled={mutation.isPending}
-                onChange={e => handleToggle(todo.id, e.target.checked)}
-                className="size-4"
-                aria-label={`Mark ${todo.name} as complete`}
-              />
-              <span
-                className={cn(
-                  "flex-1 text-sm",
-                  todo.isComplete
-                  && "text-muted-foreground line-through",
+              <div className="flex flex-row items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={todo.isComplete}
+                  disabled={mutation.isPending}
+                  onChange={e => handleToggle(todo.id, e.target.checked)}
+                  className="size-4"
+                  aria-label={`Mark ${todo.name} as complete`}
+                />
+                <span
+                  className={cn(
+                    "flex-1 text-sm",
+                    todo.isComplete
+                    && "text-muted-foreground line-through",
+                  )}
+                >
+                  {todo.name}
+                </span>
+                {todo.url
+                  ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      title={todo.url}
+                    >
+                      <a
+                        href={todo.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`Open link for ${todo.name}`}
+                      >
+                        <ExternalLinkIcon className="size-3.5" />
+                        Go
+                      </a>
+                    </Button>
+                  )
+                  : editingLinkId !== todo.id && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => startEditLink(todo)}
+                      disabled={mutation.isPending}
+                      className="
+                        text-muted-foreground opacity-0 transition
+                        group-hover:opacity-100
+                        focus-visible:opacity-100
+                      "
+                    >
+                      <LinkIcon className="size-3.5" />
+                      Add Link
+                    </Button>
+                  )}
+                {todo.url && editingLinkId !== todo.id && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => startEditLink(todo)}
+                    disabled={mutation.isPending}
+                    aria-label={`Edit link for ${todo.name}`}
+                    title="Edit link"
+                    className="
+                      text-muted-foreground opacity-0 transition
+                      group-hover:opacity-100
+                      focus-visible:opacity-100
+                    "
+                  >
+                    <PencilIcon className="size-3.5" />
+                  </Button>
                 )}
-              >
-                {todo.name}
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => handleDelete(todo.id)}
-                disabled={mutation.isPending}
-                aria-label={`Delete ${todo.name}`}
-                title="Delete to-do"
-                className="
-                  text-destructive opacity-0 transition
-                  group-hover:opacity-100
-                  focus-visible:opacity-100
-                "
-              >
-                <Trash2Icon className="size-3.5" />
-              </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => handleDelete(todo.id)}
+                  disabled={mutation.isPending}
+                  aria-label={`Delete ${todo.name}`}
+                  title="Delete to-do"
+                  className="
+                    text-destructive opacity-0 transition
+                    group-hover:opacity-100
+                    focus-visible:opacity-100
+                  "
+                >
+                  <Trash2Icon className="size-3.5" />
+                </Button>
+              </div>
+              {editingLinkId === todo.id && (
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    handleSaveLink(todo.id);
+                  }}
+                  className="flex flex-row items-center gap-2 pl-6"
+                >
+                  <Input
+                    value={linkDraft}
+                    onChange={e => setLinkDraft(e.target.value)}
+                    placeholder="https://..."
+                    type="url"
+                    autoFocus
+                    disabled={mutation.isPending}
+                  />
+                  <Button
+                    type="submit"
+                    variant="outline"
+                    size="sm"
+                    disabled={mutation.isPending}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={cancelEditLink}
+                    disabled={mutation.isPending}
+                    aria-label="Cancel link edit"
+                  >
+                    <XIcon className="size-3.5" />
+                  </Button>
+                </form>
+              )}
             </li>
           ))}
         </ul>

--- a/packages/client/src/components/ui/select.tsx
+++ b/packages/client/src/components/ui/select.tsx
@@ -173,7 +173,8 @@ function SelectItem({
           [&_svg]:pointer-events-none [&_svg]:shrink-0
           [&_svg:not([class*='size-'])]:size-4
           [&_svg:not([class*='text-'])]:text-muted-foreground
-          *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2
+          *:[span]:last:flex *:[span]:last:flex-1 *:[span]:last:items-center
+          *:[span]:last:justify-between *:[span]:last:gap-2
         `,
         className,
       )}

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
   DailiesLimitSetting,
+  DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
   DailyProgressCell,
@@ -189,6 +190,7 @@ function Dailies() {
                         {d.label}
                       </th>
                     ))}
+                    <th className="p-2 font-medium">Comment</th>
                     <th className="p-2 font-medium">Today&apos;s Status</th>
                     <th className="p-2 font-medium whitespace-nowrap">
                       Location
@@ -288,12 +290,7 @@ function Dailies() {
                         </td>
                         {days.map((day, i) => {
                           const isLast = i === days.length - 1;
-                          const linkToToday
-                            = isLast
-                              && day.status
-                              && day.status !== "incomplete"
-                              && currentStatus
-                              && currentStatus !== "incomplete";
+                          const linkToToday = isLast;
                           return (
                             <td
                               key={day.dateKey}
@@ -331,6 +328,11 @@ function Dailies() {
                             </td>
                           );
                         })}
+                        <td className="p-2">
+                          {currentStatus !== null && (
+                            <DailyCommentPopover daily={daily} />
+                          )}
+                        </td>
                         <td className="p-2">
                           <TodayStatusCell
                             daily={daily}

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
+  DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
   DailyProgressCell,
@@ -155,6 +156,7 @@ export function DashboardDailies() {
                     {d.label}
                   </th>
                 ))}
+                <th className="p-2 font-medium">Comment</th>
                 <th className="p-2 font-medium">Today&apos;s Status</th>
                 <th className="p-2 font-medium whitespace-nowrap">Location</th>
               </tr>
@@ -235,12 +237,7 @@ export function DashboardDailies() {
                     </td>
                     {days.map((day, i) => {
                       const isLast = i === days.length - 1;
-                      const linkToToday
-                        = isLast
-                          && day.status
-                          && day.status !== "incomplete"
-                          && currentStatus
-                          && currentStatus !== "incomplete";
+                      const linkToToday = isLast;
                       return (
                         <td
                           key={day.dateKey}
@@ -277,6 +274,11 @@ export function DashboardDailies() {
                         </td>
                       );
                     })}
+                    <td className="p-2">
+                      {currentStatus !== null && (
+                        <DailyCommentPopover daily={daily} />
+                      )}
+                    </td>
                     <td className="p-2">
                       <TodayStatusCell
                         daily={daily}

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -124,6 +124,7 @@ export const taskTodos = pgTable("task_todos", {
     length: 500,
   }).notNull(),
   isComplete: boolean("is_complete").default(false).notNull(),
+  url: varchar(),
   position: integer(),
 });
 

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -72,6 +72,7 @@ export default async function (server: FastifyInstance) {
             taskId: id,
             name: t.name,
             isComplete: t.isComplete ?? false,
+            url: t.url ?? null,
             position: index,
           })),
         );

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -83,6 +83,7 @@ export default async function (server: FastifyInstance) {
             taskId: t.taskId,
             name: t.name,
             isComplete: t.isComplete,
+            url: t.url ?? null,
             position: t.position,
           })),
         daily: task.daily

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -61,6 +61,7 @@ export default async function (server: FastifyInstance) {
           taskId: t.taskId,
           name: t.name,
           isComplete: t.isComplete,
+          url: t.url ?? null,
           position: t.position,
         })),
       daily: task.daily

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -96,6 +96,7 @@ export default async function (server: FastifyInstance) {
               taskId: id,
               name: t.name,
               isComplete: t.isComplete ?? false,
+              url: t.url ?? null,
               position: index,
             })),
           );

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -105,5 +105,6 @@ export const todoSchema = {
     isComplete: {
       type: "boolean",
     },
+    url: nullableString,
   },
 } as const;

--- a/packages/types/src/TaskTodo.ts
+++ b/packages/types/src/TaskTodo.ts
@@ -3,5 +3,6 @@ export interface TaskTodo {
   taskId: string;
   name: string;
   isComplete: boolean;
+  url?: string | null;
   position?: number | null;
 }


### PR DESCRIPTION
- Filter option counts and values now justify-between in select dropdowns
- Daily status connector draws a light incomplete line whenever one side
  is null but the other has any entry (including connecting to Today's
  Status), instead of drawing nothing
- Reverse the recent-days strip on Course/Daily/Task individual pages so
  the most recent day appears first
- Add optional url to task todos: schema, types, API handlers, and a
  TodosChecklist UI with an "Add Link" affordance, a "Go" button when a
  link is present, and inline edit/cancel
- Move the daily comment popover into its own column to the left of
  Today's Status on the Dashboard and Dailies index tables