### PR TITLE
Add Dailies list mode toggle and mobile dashboard home button

### DIFF
--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -1,0 +1,132 @@
+import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
+
+import { Link } from "@tanstack/react-router";
+import { FlameIcon, LaughIcon } from "lucide-react";
+
+import { DailyCommentPopover } from "./DailyCommentPopover";
+import { DailyCourseIndicator } from "./DailyCourseIndicator";
+import { DailyLocationCell } from "./DailyLocationCell";
+import { DailyProgressCell } from "./DailyProgressCell";
+import { DailyRecentDaysStrip } from "./DailyRecentDaysStrip";
+import { DailyTaskIndicator } from "./DailyTaskIndicator";
+import { TodayStatusCell } from "./TodayStatusCell";
+
+import { cn } from "@/lib/utils";
+import {
+  findStatusForDate,
+  getCurrentChain,
+  getTotalCompletedDays,
+} from "@/utils";
+
+interface DailiesActiveListViewProps {
+  dailies: Daily[];
+  todayKey: string;
+  onChangeStatus: (daily: Daily, status: DailyCompletionStatus) => void;
+  mutationPending: boolean;
+  recentDaysCount?: number;
+}
+
+export function DailiesActiveListView({
+  dailies,
+  todayKey,
+  onChangeStatus,
+  mutationPending,
+  recentDaysCount = 6,
+}: DailiesActiveListViewProps) {
+  return (
+    <ul className="flex flex-col divide-y">
+      {dailies.map((daily) => {
+        const currentStatus = findStatusForDate(daily, todayKey);
+        const chain = getCurrentChain(daily, todayKey);
+        const total = getTotalCompletedDays(daily);
+        return (
+          <li
+            key={daily.id}
+            className="flex flex-col gap-2 py-3"
+          >
+            <div className="flex flex-row items-start justify-between gap-2">
+              <div className="flex min-w-0 flex-col gap-1">
+                <span className="inline-flex items-center gap-1.5">
+                  <Link
+                    to="/dailies/$id"
+                    params={{
+                      id: daily.id,
+                    }}
+                    className="
+                      truncate font-medium
+                      hover:text-blue-600
+                    "
+                  >
+                    {daily.name}
+                  </Link>
+                  <DailyCourseIndicator daily={daily} />
+                  <DailyTaskIndicator daily={daily} />
+                </span>
+                {daily.description && (
+                  <span
+                    className="line-clamp-2 text-xs text-muted-foreground"
+                    title={daily.description}
+                  >
+                    {daily.description}
+                  </span>
+                )}
+              </div>
+              <DailyProgressCell daily={daily} />
+            </div>
+
+            <div className="flex flex-row items-center gap-3 text-xs">
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1",
+                  currentStatus === "incomplete"
+                    ? "text-muted-foreground"
+                    : chain > 0
+                      ? "text-orange-600"
+                      : "text-muted-foreground",
+                )}
+                title={chain > 0 ? `${chain}-day chain` : "No active chain"}
+              >
+                <FlameIcon className="size-3.5" />
+                {chain}
+              </span>
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1",
+                  total > 0 ? "text-emerald-600" : "text-muted-foreground",
+                )}
+                title={`${total} total day${total === 1 ? "" : "s"} completed`}
+              >
+                <LaughIcon className="size-3.5" />
+                {total}
+              </span>
+              <div className="ml-auto flex flex-row items-center gap-1">
+                {currentStatus !== null && (
+                  <DailyCommentPopover daily={daily} />
+                )}
+                <DailyLocationCell
+                  location={daily.location}
+                  taskId={daily.taskId ?? daily.task?.id ?? null}
+                />
+              </div>
+            </div>
+
+            <DailyRecentDaysStrip
+              daily={daily}
+              count={recentDaysCount + 1}
+              size="sm"
+              showLabels={true}
+              labelFormat="mmdd"
+            />
+
+            <TodayStatusCell
+              daily={daily}
+              currentStatus={currentStatus}
+              disabled={mutationPending}
+              onChange={status => onChangeStatus(daily, status)}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/client/src/components/dailies/DailiesViewModeToggle.tsx
+++ b/packages/client/src/components/dailies/DailiesViewModeToggle.tsx
@@ -1,0 +1,73 @@
+import type { DailiesViewMode } from "@/context/SettingsProviderContext";
+
+import { LayoutListIcon, TableIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface DailiesViewModeToggleProps {
+  mode: DailiesViewMode;
+  onChange: (mode: DailiesViewMode) => void;
+  className?: string;
+}
+
+export function DailiesViewModeToggle({
+  mode,
+  onChange,
+  className,
+}: DailiesViewModeToggleProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Dailies view mode"
+      className={cn(
+        "inline-flex items-center rounded-md border bg-background p-0.5",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Table view"
+        aria-pressed={mode === "table"}
+        onClick={() => onChange("table")}
+        className={cn(
+          `
+            inline-flex size-7 items-center justify-center rounded-sm
+            transition-colors
+            focus-visible:ring-2 focus-visible:ring-ring
+            focus-visible:outline-none
+          `,
+          mode === "table"
+            ? "bg-muted text-foreground"
+            : `
+              text-muted-foreground
+              hover:bg-muted/60
+            `,
+        )}
+      >
+        <TableIcon className="size-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="List view"
+        aria-pressed={mode === "list"}
+        onClick={() => onChange("list")}
+        className={cn(
+          `
+            inline-flex size-7 items-center justify-center rounded-sm
+            transition-colors
+            focus-visible:ring-2 focus-visible:ring-ring
+            focus-visible:outline-none
+          `,
+          mode === "list"
+            ? "bg-muted text-foreground"
+            : `
+              text-muted-foreground
+              hover:bg-muted/60
+            `,
+        )}
+      >
+        <LayoutListIcon className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -1,4 +1,6 @@
 export { CRITERIA_PRESETS } from "./criteriaPresets";
+export { DailiesActiveListView } from "./DailiesActiveListView";
+export { DailiesViewModeToggle } from "./DailiesViewModeToggle";
 export { DailyCommentPopover } from "./DailyCommentPopover";
 export { DailyStatusModal } from "./DailyStatusModal";
 export { DailyCompletionsManager } from "./DailyCompletionsManager";

--- a/packages/client/src/context/SettingsProvider.tsx
+++ b/packages/client/src/context/SettingsProvider.tsx
@@ -1,3 +1,4 @@
+import type { DailiesViewMode } from "@/context/SettingsProviderContext";
 import type { ReactNode } from "react";
 
 import { useEffect, useState } from "react";
@@ -9,6 +10,27 @@ import {
 
 const STORAGE_KEY = "emstack-settings";
 
+interface PersistedSettings {
+  maxActiveDailies?: number;
+  dailiesViewMode?: DailiesViewMode | null;
+}
+
+function readPersistedSettings(): PersistedSettings {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as PersistedSettings;
+    }
+  }
+  catch {
+    // ignore malformed value
+  }
+  return {};
+}
+
 interface SettingsProviderProps {
   children: ReactNode;
 }
@@ -17,23 +39,23 @@ export function SettingsProvider({
   children,
 }: SettingsProviderProps) {
   const [maxActiveDailies, setMaxActiveDailiesState] = useState<number>(() => {
-    if (typeof window === "undefined") {
-      return DEFAULT_MAX_ACTIVE_DAILIES;
-    }
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return DEFAULT_MAX_ACTIVE_DAILIES;
-      const parsed = JSON.parse(raw);
-      const value = Number(parsed?.maxActiveDailies);
-      if (Number.isFinite(value) && value > 0) {
-        return Math.floor(value);
-      }
-    }
-    catch {
-      // ignore malformed value
+    const persisted = readPersistedSettings();
+    const value = Number(persisted.maxActiveDailies);
+    if (Number.isFinite(value) && value > 0) {
+      return Math.floor(value);
     }
     return DEFAULT_MAX_ACTIVE_DAILIES;
   });
+
+  const [dailiesViewMode, setDailiesViewModeState]
+    = useState<DailiesViewMode | null>(() => {
+      const persisted = readPersistedSettings();
+      if (persisted.dailiesViewMode === "table"
+        || persisted.dailiesViewMode === "list") {
+        return persisted.dailiesViewMode;
+      }
+      return null;
+    });
 
   useEffect(() => {
     try {
@@ -41,13 +63,14 @@ export function SettingsProvider({
         STORAGE_KEY,
         JSON.stringify({
           maxActiveDailies,
+          dailiesViewMode,
         }),
       );
     }
     catch {
       // ignore quota errors
     }
-  }, [maxActiveDailies]);
+  }, [maxActiveDailies, dailiesViewMode]);
 
   const setMaxActiveDailies = (value: number) => {
     if (Number.isFinite(value) && value > 0) {
@@ -55,13 +78,19 @@ export function SettingsProvider({
     }
   };
 
+  const setDailiesViewMode = (value: DailiesViewMode | null) => {
+    setDailiesViewModeState(value);
+  };
+
   return (
     <SettingsProviderContext.Provider
       value={{
         settings: {
           maxActiveDailies,
+          dailiesViewMode,
         },
         setMaxActiveDailies,
+        setDailiesViewMode,
       }}
     >
       {children}

--- a/packages/client/src/context/SettingsProviderContext.ts
+++ b/packages/client/src/context/SettingsProviderContext.ts
@@ -1,23 +1,29 @@
 import { createContext } from "react";
 
+export type DailiesViewMode = "table" | "list";
+
 export interface AppSettings {
   maxActiveDailies: number;
+  dailiesViewMode: DailiesViewMode | null;
 }
 
 export const DEFAULT_MAX_ACTIVE_DAILIES = 5;
 
 export const DEFAULT_SETTINGS: AppSettings = {
   maxActiveDailies: DEFAULT_MAX_ACTIVE_DAILIES,
+  dailiesViewMode: null,
 };
 
 interface SettingsProviderState {
   settings: AppSettings;
   setMaxActiveDailies: (value: number) => void;
+  setDailiesViewMode: (value: DailiesViewMode | null) => void;
 }
 
 const initialState: SettingsProviderState = {
   settings: DEFAULT_SETTINGS,
   setMaxActiveDailies: () => null,
+  setDailiesViewMode: () => null,
 };
 
 export const SettingsProviderContext

--- a/packages/client/src/hooks/useDailiesViewMode.ts
+++ b/packages/client/src/hooks/useDailiesViewMode.ts
@@ -1,0 +1,24 @@
+import type { DailiesViewMode } from "@/context/SettingsProviderContext";
+
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useSettings } from "@/hooks/useSettings";
+
+interface UseDailiesViewModeResult {
+  mode: DailiesViewMode;
+  setMode: (mode: DailiesViewMode) => void;
+}
+
+export function useDailiesViewMode(): UseDailiesViewModeResult {
+  const isMobile = useIsMobile();
+  const {
+    settings, setDailiesViewMode,
+  } = useSettings();
+
+  const mode: DailiesViewMode = settings.dailiesViewMode
+    ?? (isMobile ? "list" : "table");
+
+  return {
+    mode,
+    setMode: setDailiesViewMode,
+  };
+}

--- a/packages/client/src/hooks/useIsMobile.ts
+++ b/packages/client/src/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mql.matches);
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
   Link,
   Outlet,
 } from "@tanstack/react-router";
-import { MenuIcon } from "lucide-react";
+import { HomeIcon, MenuIcon } from "lucide-react";
 
 import { NavDropdown } from "@/components/layout/NavDropdown";
 import { Toaster } from "@/components/sonner";
@@ -133,6 +133,26 @@ const RootComponent: React.FunctionComponent = () => {
             className={navLinkClass}
           >
             Tasks
+          </Link>
+        </div>
+        <div
+          className={`
+            flex flex-row items-center gap-2
+            md:hidden
+          `}
+        >
+          <Link
+            to="/dashboard"
+            aria-label="Dashboard home"
+            className="
+              inline-flex size-9 items-center justify-center rounded-md border
+              bg-background
+              hover:bg-accent
+              focus-visible:ring-2 focus-visible:ring-ring
+              focus-visible:outline-none
+            "
+          >
+            <HomeIcon className="size-4" />
           </Link>
         </div>
         <div

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -11,7 +11,9 @@ import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
+  DailiesActiveListView,
   DailiesLimitSetting,
+  DailiesViewModeToggle,
   DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
@@ -25,6 +27,7 @@ import {
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
+import { useDailiesViewMode } from "@/hooks/useDailiesViewMode";
 import { useSettings } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
 import {
@@ -68,6 +71,9 @@ function Dailies() {
   const {
     settings,
   } = useSettings();
+  const {
+    mode, setMode,
+  } = useDailiesViewMode();
 
   const {
     data: dailies,
@@ -168,194 +174,220 @@ function Dailies() {
                 />
               </span>
             )}
-            action={<DailiesLimitSetting />}
+            action={(
+              <>
+                <DailiesViewModeToggle
+                  mode={mode}
+                  onChange={setMode}
+                />
+                <DailiesLimitSetting />
+              </>
+            )}
           >
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse text-sm">
-                <thead>
-                  <tr className="text-left text-xs text-muted-foreground">
-                    <th className="p-2 font-medium">Title</th>
-                    <th className="p-2 font-medium">Progress</th>
-                    <th className="p-2 font-medium">Description</th>
-                    <th className="p-2 font-medium">Streak</th>
-                    <th className="p-2 font-medium">Total</th>
-                    {dayHeaders.map(d => (
-                      <th
-                        key={d.dateKey}
-                        className={cn(
-                          "px-1 py-2 text-center font-medium",
-                          d.isToday && "text-foreground",
-                        )}
-                      >
-                        {d.label}
-                      </th>
-                    ))}
-                    <th className="p-2 font-medium">Comment</th>
-                    <th className="p-2 font-medium">Today&apos;s Status</th>
-                    <th className="p-2 font-medium whitespace-nowrap">
-                      Location
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activeDailies.map((daily) => {
-                    const currentStatus = findStatusForDate(daily, todayKey);
-                    const chain = getCurrentChain(daily, todayKey);
-                    const total = getTotalCompletedDays(daily);
-                    const days = getRecentDays(
-                      daily,
-                      RECENT_DAYS_COUNT + 1,
-                      todayKey,
-                      "mmdd",
-                    ).slice(0, -1);
-                    return (
-                      <tr
-                        key={daily.id}
-                        className="
-                          group border-t align-middle
-                          hover:bg-muted/40
-                        "
-                      >
-                        <td className="p-2">
-                          <span className="inline-flex items-center gap-1.5">
-                            <Link
-                              to="/dailies/$id"
-                              from="/dailies"
-                              params={{
-                                id: daily.id,
-                              }}
-                              className="
-                                font-medium
-                                hover:text-blue-600
-                              "
-                            >
-                              {daily.name}
-                            </Link>
-                            <DailyCourseIndicator daily={daily} />
-                            <DailyTaskIndicator daily={daily} />
-                          </span>
-                        </td>
-                        <td className="p-2">
-                          <DailyProgressCell daily={daily} />
-                        </td>
-                        <td className="max-w-xs p-2">
-                          {daily.description
-                            ? (
-                              <span
-                                className="block truncate text-muted-foreground"
-                                title={daily.description}
-                              >
-                                {daily.description}
-                              </span>
-                            )
-                            : (
-                              <span className="text-muted-foreground/60">
-                                <i>No description</i>
-                              </span>
-                            )}
-                        </td>
-                        <td className="p-2">
-                          <span
-                            className={cn(
-                              "inline-flex items-center gap-1 text-xs",
-                              currentStatus === "incomplete"
-                                ? "text-muted-foreground"
-                                : chain > 0
-                                  ? "text-orange-600"
-                                  : "text-muted-foreground",
-                            )}
-                            title={
-                              chain > 0
-                                ? `${chain}-day chain`
-                                : "No active chain"
-                            }
-                          >
-                            <FlameIcon className="size-3.5" />
-                            {chain}
-                          </span>
-                        </td>
-                        <td className="p-2">
-                          <span
-                            className={cn(
-                              "inline-flex items-center gap-1 text-xs",
-                              total > 0
-                                ? "text-emerald-600"
-                                : "text-muted-foreground",
-                            )}
-                            title={`${total} total day${total === 1 ? "" : "s"} completed`}
-                          >
-                            <LaughIcon className="size-3.5" />
-                            {total}
-                          </span>
-                        </td>
-                        {days.map((day, i) => {
-                          const isLast = i === days.length - 1;
-                          const linkToToday = isLast;
-                          return (
-                            <td
-                              key={day.dateKey}
-                              className="relative px-1 py-2 align-middle"
-                            >
-                              {i > 0 && (
-                                <DailyStatusConnector
-                                  left={days[i - 1].status}
-                                  right={day.status}
-                                  className="
-                                    absolute top-1/2 right-[calc(50%+12px)]
-                                    left-[calc(-50%+12px)] z-0 w-auto
-                                    -translate-y-1/2
-                                  "
-                                />
-                              )}
-                              {linkToToday && (
-                                <DailyStatusConnector
-                                  left={day.status}
-                                  right={currentStatus}
-                                  className="
-                                    absolute top-1/2 -right-2
-                                    left-[calc(50%+12px)] z-0 w-auto
-                                    -translate-y-1/2
-                                  "
-                                />
-                              )}
-                              <div className="relative z-10 flex justify-center">
-                                <DailyStatusCircle
-                                  status={day.status}
-                                  size="sm"
-                                  title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
-                                />
-                              </div>
-                            </td>
-                          );
-                        })}
-                        <td className="p-2">
-                          {currentStatus !== null && (
-                            <DailyCommentPopover daily={daily} />
+            {mode === "list" && (
+              <DailiesActiveListView
+                dailies={activeDailies}
+                todayKey={todayKey}
+                mutationPending={mutation.isPending}
+                recentDaysCount={RECENT_DAYS_COUNT}
+                onChangeStatus={(daily, status) => mutation.mutate({
+                  daily,
+                  status,
+                })}
+              />
+            )}
+            {mode === "table" && (
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-sm">
+                  <thead>
+                    <tr className="text-left text-xs text-muted-foreground">
+                      <th className="p-2 font-medium">Title</th>
+                      <th className="p-2 font-medium">Progress</th>
+                      <th className="p-2 font-medium">Description</th>
+                      <th className="p-2 font-medium">Streak</th>
+                      <th className="p-2 font-medium">Total</th>
+                      {dayHeaders.map(d => (
+                        <th
+                          key={d.dateKey}
+                          className={cn(
+                            "px-1 py-2 text-center font-medium",
+                            d.isToday && "text-foreground",
                           )}
-                        </td>
-                        <td className="p-2">
-                          <TodayStatusCell
-                            daily={daily}
-                            currentStatus={currentStatus}
-                            disabled={mutation.isPending}
-                            onChange={status => mutation.mutate({
-                              daily,
-                              status,
-                            })}
-                          />
-                        </td>
-                        <td className="p-2 whitespace-nowrap">
-                          <DailyLocationCell
-                            location={daily.location}
-                            taskId={daily.taskId ?? daily.task?.id ?? null}
-                          />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+                        >
+                          {d.label}
+                        </th>
+                      ))}
+                      <th className="p-2 font-medium">Comment</th>
+                      <th className="p-2 font-medium">Today&apos;s Status</th>
+                      <th className="p-2 font-medium whitespace-nowrap">
+                        Location
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activeDailies.map((daily) => {
+                      const currentStatus = findStatusForDate(daily, todayKey);
+                      const chain = getCurrentChain(daily, todayKey);
+                      const total = getTotalCompletedDays(daily);
+                      const days = getRecentDays(
+                        daily,
+                        RECENT_DAYS_COUNT + 1,
+                        todayKey,
+                        "mmdd",
+                      ).slice(0, -1);
+                      return (
+                        <tr
+                          key={daily.id}
+                          className="
+                            group border-t align-middle
+                            hover:bg-muted/40
+                          "
+                        >
+                          <td className="p-2">
+                            <span className="inline-flex items-center gap-1.5">
+                              <Link
+                                to="/dailies/$id"
+                                from="/dailies"
+                                params={{
+                                  id: daily.id,
+                                }}
+                                className="
+                                  font-medium
+                                  hover:text-blue-600
+                                "
+                              >
+                                {daily.name}
+                              </Link>
+                              <DailyCourseIndicator daily={daily} />
+                              <DailyTaskIndicator daily={daily} />
+                            </span>
+                          </td>
+                          <td className="p-2">
+                            <DailyProgressCell daily={daily} />
+                          </td>
+                          <td className="max-w-xs p-2">
+                            {daily.description
+                              ? (
+                                <span
+                                  className="
+                                    block truncate text-muted-foreground
+                                  "
+                                  title={daily.description}
+                                >
+                                  {daily.description}
+                                </span>
+                              )
+                              : (
+                                <span className="text-muted-foreground/60">
+                                  <i>No description</i>
+                                </span>
+                              )}
+                          </td>
+                          <td className="p-2">
+                            <span
+                              className={cn(
+                                "inline-flex items-center gap-1 text-xs",
+                                currentStatus === "incomplete"
+                                  ? "text-muted-foreground"
+                                  : chain > 0
+                                    ? "text-orange-600"
+                                    : "text-muted-foreground",
+                              )}
+                              title={
+                                chain > 0
+                                  ? `${chain}-day chain`
+                                  : "No active chain"
+                              }
+                            >
+                              <FlameIcon className="size-3.5" />
+                              {chain}
+                            </span>
+                          </td>
+                          <td className="p-2">
+                            <span
+                              className={cn(
+                                "inline-flex items-center gap-1 text-xs",
+                                total > 0
+                                  ? "text-emerald-600"
+                                  : "text-muted-foreground",
+                              )}
+                              title={`${total} total day${total === 1 ? "" : "s"} completed`}
+                            >
+                              <LaughIcon className="size-3.5" />
+                              {total}
+                            </span>
+                          </td>
+                          {days.map((day, i) => {
+                            const isLast = i === days.length - 1;
+                            const linkToToday = isLast;
+                            return (
+                              <td
+                                key={day.dateKey}
+                                className="relative px-1 py-2 align-middle"
+                              >
+                                {i > 0 && (
+                                  <DailyStatusConnector
+                                    left={days[i - 1].status}
+                                    right={day.status}
+                                    className="
+                                      absolute top-1/2 right-[calc(50%+12px)]
+                                      left-[calc(-50%+12px)] z-0 w-auto
+                                      -translate-y-1/2
+                                    "
+                                  />
+                                )}
+                                {linkToToday && (
+                                  <DailyStatusConnector
+                                    left={day.status}
+                                    right={currentStatus}
+                                    className="
+                                      absolute top-1/2 -right-2
+                                      left-[calc(50%+12px)] z-0 w-auto
+                                      -translate-y-1/2
+                                    "
+                                  />
+                                )}
+                                <div
+                                  className="relative z-10 flex justify-center"
+                                >
+                                  <DailyStatusCircle
+                                    status={day.status}
+                                    size="sm"
+                                    title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+                                  />
+                                </div>
+                              </td>
+                            );
+                          })}
+                          <td className="p-2">
+                            {currentStatus !== null && (
+                              <DailyCommentPopover daily={daily} />
+                            )}
+                          </td>
+                          <td className="p-2">
+                            <TodayStatusCell
+                              daily={daily}
+                              currentStatus={currentStatus}
+                              disabled={mutation.isPending}
+                              onChange={status => mutation.mutate({
+                                daily,
+                                status,
+                              })}
+                            />
+                          </td>
+                          <td className="p-2 whitespace-nowrap">
+                            <DailyLocationCell
+                              location={daily.location}
+                              taskId={daily.taskId ?? daily.task?.id ?? null}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </DashboardCard>
         )}
 

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -7,6 +7,8 @@ import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
+  DailiesActiveListView,
+  DailiesViewModeToggle,
   DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
@@ -17,6 +19,7 @@ import {
   TodayStatusCell,
   TooManyDailiesWarning,
 } from "@/components/dailies";
+import { useDailiesViewMode } from "@/hooks/useDailiesViewMode";
 import { useSettings } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
 import {
@@ -43,6 +46,9 @@ export function DashboardDailies() {
   const {
     settings,
   } = useSettings();
+  const {
+    mode, setMode,
+  } = useDailiesViewMode();
 
   const {
     data: dailies, isPending, error,
@@ -114,15 +120,21 @@ export function DashboardDailies() {
         </span>
       )}
       action={(
-        <Link
-          to="/dailies"
-          className="
-            text-sm text-primary underline-offset-2
-            hover:underline
-          "
-        >
-          View all
-        </Link>
+        <>
+          <DailiesViewModeToggle
+            mode={mode}
+            onChange={setMode}
+          />
+          <Link
+            to="/dailies"
+            className="
+              text-sm text-primary underline-offset-2
+              hover:underline
+            "
+          >
+            View all
+          </Link>
+        </>
       )}
     >
       {isPending && (
@@ -136,7 +148,19 @@ export function DashboardDailies() {
           <i>No dailies yet.</i>
         </p>
       )}
-      {sortedDailies && sortedDailies.length > 0 && (
+      {sortedDailies && sortedDailies.length > 0 && mode === "list" && (
+        <DailiesActiveListView
+          dailies={sortedDailies}
+          todayKey={todayKey}
+          mutationPending={mutation.isPending}
+          recentDaysCount={RECENT_DAYS_COUNT}
+          onChangeStatus={(daily, status) => mutation.mutate({
+            daily,
+            status,
+          })}
+        />
+      )}
+      {sortedDailies && sortedDailies.length > 0 && mode === "table" && (
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-sm">
             <thead>


### PR DESCRIPTION
Compact list view of active dailies for narrow viewports, defaulted on
mobile, with a toggle persisted via settings. Mobile nav also exposes a
Dashboard home shortcut alongside the menu.