### PR TITLE
Preserve todo url when saving task or toggling resource

### DIFF
--- a/packages/client/src/components/tasks/ResourcesTable.tsx
+++ b/packages/client/src/components/tasks/ResourcesTable.tsx
@@ -174,6 +174,7 @@ export function ResourcesTable({
           id: t.id,
           name: t.name,
           isComplete: t.isComplete,
+          url: t.url ?? null,
         })),
       }),
     onSuccess: async () => {

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -92,6 +92,7 @@ function SingleTaskEdit() {
         id: t.id,
         name: t.name,
         isComplete: t.isComplete,
+        url: t.url ?? null,
       }));
 
       const taskData = {


### PR DESCRIPTION
## Summary
- Found while investigating the task-loading 500 (which turned out to be a missing `task_todos.url` column in production — fixed separately by pushing the schema).
- Two unrelated paths were silently nuking every todo's `url` because they rebuilt the todos array without the new `url` field, and the upsert handler deletes + re-inserts todos with `url: t.url ?? null`.

### Bugs fixed
- `packages/client/src/routes/tasks.$id.edit.tsx:91-95` — saving the task edit form (name / description / topic) wiped all todo links.
- `packages/client/src/components/tasks/ResourcesTable.tsx:173-177` — toggling a resource's "used" checkbox wiped all todo links.

Both now pass `url: t.url ?? null` alongside the existing fields.

## Test plan
- [ ] Edit a task's name/description on `/tasks/$id/edit`, save, and verify each todo still shows its "Go" button with the previous URL.
- [ ] On `/tasks/$id`, toggle a resource's "Used" checkbox; verify todo URLs are preserved.
- [ ] Adding/editing a todo link via `TodosChecklist` still works (regression check).

https://claude.ai/code/session_01H7xg5TtJEyowygEfewLpLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7xg5TtJEyowygEfewLpLN)_