### PR TITLE
Strip markdown code fences from LLM JSON responses

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -59,6 +59,12 @@ type Resolution
     | "removeBlip"
     | "skip";
 
+function stripCodeFence(input: string): string {
+  const trimmed = input.trim();
+  const fenceMatch = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  return fenceMatch ? fenceMatch[1].trim() : trimmed;
+}
+
 interface LlmEntry {
   topic?: unknown;
   quadrant?: unknown;
@@ -519,7 +525,7 @@ export function BlipLlmAssist({
     setParseError(null);
     let parsed: unknown;
     try {
-      parsed = JSON.parse(jsonText);
+      parsed = JSON.parse(stripCodeFence(jsonText));
     }
     catch (err) {
       const message = err instanceof Error ? err.message : "Invalid JSON";


### PR DESCRIPTION
## Summary
Added support for parsing JSON responses from LLM that are wrapped in markdown code fences (e.g., ```json ... ```). This improves compatibility with LLM outputs that include formatting markers.

## Changes
- Added `stripCodeFence()` utility function that removes markdown code fence syntax from input strings
- Updated JSON parsing in the BlipLlmAssist component to strip code fences before parsing
- The function handles both fenced and non-fenced input gracefully, returning the original trimmed input if no fence is detected

## Implementation Details
The `stripCodeFence()` function uses a regex pattern to match and extract content between triple backticks, optionally followed by a language identifier. This allows the component to handle LLM responses that include markdown formatting while maintaining backward compatibility with plain JSON input.

https://claude.ai/code/session_01QnA3R8PT3gCiPd4BH2S9vA