### PR TITLE
Refactor dailies list layout for responsive mobile/desktop views

### DIFF
--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -87,8 +87,15 @@ export function DailiesActiveListView({
                     >
                       {daily.name}
                     </Link>
-                    <DailyCourseIndicator daily={daily} />
-                    <DailyTaskIndicator daily={daily} />
+                    <span
+                      className="
+                        hidden items-center gap-1.5
+                        lg:inline-flex
+                      "
+                    >
+                      <DailyCourseIndicator daily={daily} />
+                      <DailyTaskIndicator daily={daily} />
+                    </span>
                   </span>
                   {daily.description && (
                     <span
@@ -127,6 +134,15 @@ export function DailiesActiveListView({
                       <LaughIcon className="size-3.5" />
                       {total}
                     </span>
+                    <span
+                      className="
+                        inline-flex items-center gap-1.5
+                        lg:hidden
+                      "
+                    >
+                      <DailyCourseIndicator daily={daily} />
+                      <DailyTaskIndicator daily={daily} />
+                    </span>
                   </div>
                 </div>
               </div>
@@ -136,8 +152,18 @@ export function DailiesActiveListView({
               />
             </div>
 
-            <div className="flex flex-row items-start gap-1">
-              <div className="flex shrink-0 flex-row items-start gap-1">
+            <div
+              className="
+                flex flex-col items-start gap-0
+                lg:flex-row lg:items-start lg:gap-1
+              "
+            >
+              <div
+                className="
+                  flex shrink-0 flex-row items-center gap-1.5
+                  lg:items-start lg:gap-1
+                "
+              >
                 <div className="flex flex-col items-center gap-0.5">
                   <TodayStatusCell
                     daily={daily}
@@ -147,50 +173,73 @@ export function DailiesActiveListView({
                   />
                   <span
                     className="
-                      text-[0.65rem] leading-none font-semibold text-foreground
+                      hidden text-[0.65rem] leading-none font-semibold
+                      text-foreground
+                      lg:inline-block
                     "
                   >
                     Today
                   </span>
                 </div>
                 {currentStatus !== null && (
-                  <div className="mt-1">
-                    <DailyCommentPopover daily={daily} />
+                  <div className="lg:mt-1">
+                    <DailyCommentPopover
+                      daily={daily}
+                      buttonClassName="
+                        size-9 [&_svg]:size-4
+                        lg:size-8 lg:[&_svg]:size-3.5
+                      "
+                    />
                   </div>
                 )}
               </div>
               <DailyStatusConnector
+                orientation="vertical"
                 left={currentStatus}
                 right={mostRecentPast?.status ?? null}
-                className="mt-[11px] w-2.5 shrink-0"
+                className="
+                  ml-3 h-3 shrink-0
+                  lg:hidden
+                "
               />
-              {recentDays.map((day, i) => (
-                <Fragment key={day.dateKey}>
-                  {i > 0 && (
-                    <DailyStatusConnector
-                      left={recentDays[i - 1].status}
-                      right={day.status}
-                      className="mt-[11px] w-2.5 shrink-0"
-                    />
-                  )}
-                  <div
-                    className="flex shrink-0 flex-col items-center gap-0.5"
-                  >
-                    <DailyStatusCircle
-                      status={day.status}
-                      size="sm"
-                      title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
-                    />
-                    <span
-                      className="
-                        text-[0.65rem] leading-none text-muted-foreground
-                      "
+              <DailyStatusConnector
+                orientation="horizontal"
+                left={currentStatus}
+                right={mostRecentPast?.status ?? null}
+                className="
+                  hidden
+                  lg:mt-[11px] lg:block lg:w-2.5 lg:shrink-0
+                "
+              />
+              <div className="flex flex-row items-start gap-1">
+                {recentDays.map((day, i) => (
+                  <Fragment key={day.dateKey}>
+                    {i > 0 && (
+                      <DailyStatusConnector
+                        left={recentDays[i - 1].status}
+                        right={day.status}
+                        className="mt-[11px] w-2.5 shrink-0"
+                      />
+                    )}
+                    <div
+                      className="flex shrink-0 flex-col items-center gap-0.5"
                     >
-                      {day.dayLabel}
-                    </span>
-                  </div>
-                </Fragment>
-              ))}
+                      <DailyStatusCircle
+                        status={day.status}
+                        size="sm"
+                        title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+                      />
+                      <span
+                        className="
+                          text-[0.65rem] leading-none text-muted-foreground
+                        "
+                      >
+                        {day.dayLabel}
+                      </span>
+                    </div>
+                  </Fragment>
+                ))}
+              </div>
             </div>
           </li>
         );

--- a/packages/client/src/components/dailies/DailyCommentPopover.tsx
+++ b/packages/client/src/components/dailies/DailyCommentPopover.tsx
@@ -22,10 +22,12 @@ import {
 
 interface DailyCommentPopoverProps {
   daily: Daily;
+  buttonClassName?: string;
 }
 
 export function DailyCommentPopover({
   daily,
+  buttonClassName,
 }: DailyCommentPopoverProps) {
   const todayKey = getTodayKey();
   const queryClient = useQueryClient();
@@ -151,6 +153,7 @@ export function DailyCommentPopover({
             hasNote
               ? "text-foreground"
               : "text-muted-foreground/40",
+            buttonClassName,
           )}
         >
           <MessageSquareIcon className="size-3.5" />


### PR DESCRIPTION
## Summary
This PR refactors the DailiesActiveListView component to provide a responsive layout that adapts to mobile and desktop screen sizes. The indicators and status connectors are repositioned based on viewport size to optimize space usage and improve the visual hierarchy.

## Key Changes
- **Responsive indicator placement**: Moved `DailyCourseIndicator` and `DailyTaskIndicator` to display below the daily name on mobile (lg:hidden) and inline on desktop (lg:inline-flex)
- **Dual status connectors**: Added both vertical (mobile) and horizontal (desktop) `DailyStatusConnector` components with appropriate responsive classes to show the connection between current and past status
- **Layout restructuring**: Changed the main status section from a fixed flex-row to a responsive flex-col on mobile and flex-row on desktop (lg:flex-row)
- **Status cell styling**: Updated the status cell container to use `items-center` on mobile and `items-start` on desktop, with responsive gap adjustments
- **Comment popover customization**: Added `buttonClassName` prop to `DailyCommentPopover` to allow size adjustments based on viewport (size-9 on mobile, size-8 on desktop)
- **Today label visibility**: Hidden the "Today" label on mobile and shown on desktop with responsive display classes
- **Wrapped recent days**: Enclosed the recent days history in a separate flex container for better layout control

## Implementation Details
- Used Tailwind's `lg:` breakpoint prefix for all responsive styling
- Maintained consistent spacing with `gap-1.5` on mobile and `gap-1` on desktop
- Preserved all existing functionality while improving mobile UX by reducing visual clutter

https://claude.ai/code/session_01PKvA6t25HFJPCrHKtURqGQ