### PR TITLE
Add scope management and radar configuration UI improvements

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -929,7 +929,7 @@ export function BlipLlmAssist({
         </div>
         <pre
           className={`
-            bg-muted max-h-60 overflow-auto rounded-sm p-3 text-xs
+            max-h-60 overflow-auto rounded-sm bg-muted p-3 text-xs
             whitespace-pre-wrap
           `}
         >
@@ -946,7 +946,7 @@ export function BlipLlmAssist({
           className="min-h-32 font-mono text-xs"
         />
         {parseError && (
-          <p className="text-destructive text-sm">{parseError}</p>
+          <p className="text-sm text-destructive">{parseError}</p>
         )}
         <div>
           <Button
@@ -962,7 +962,7 @@ export function BlipLlmAssist({
       {resolved && (
         <div className="flex flex-col gap-2">
           <h4 className="text-sm font-semibold">3. Review</h4>
-          <p className="text-muted-foreground text-sm">
+          <p className="text-sm text-muted-foreground">
             {counts.create}
             {" "}
             to add ·
@@ -1212,7 +1212,7 @@ function ReviewRow({
             )}
           </div>
           {hasProblems && !isSkipped && (
-            <span className="text-destructive text-[11px]">
+            <span className="text-[11px] text-destructive">
               {r.problems.join("; ")}
             </span>
           )}
@@ -1235,7 +1235,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-muted-foreground text-xs">—</span>
+          ? <span className="text-xs text-muted-foreground">—</span>
           : (
             <PlacementCell
               existingName={existingQuadrantName}
@@ -1253,7 +1253,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-muted-foreground text-xs">—</span>
+          ? <span className="text-xs text-muted-foreground">—</span>
           : (
             <PlacementCell
               existingName={existingRingName}

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -45,6 +45,10 @@ interface BlipLlmAssistProps {
   domainDescription?: string | null;
   domainTopics?: DomainTopic[];
   excludedTopics?: DomainExcludedTopic[];
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
+  withinScopeTopicNames?: string[];
+  outOfScopeTopicNames?: string[];
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   topics: TopicForTopicsPage[];
@@ -219,11 +223,22 @@ interface BuildPromptArgs {
   domainDescription?: string | null;
   domainTopics: DomainTopic[];
   excludedTopics: DomainExcludedTopic[];
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
+  withinScopeTopicNames?: string[];
+  outOfScopeTopicNames?: string[];
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   existingBlips: { topicName: string;
     radarNote?: string | null;
     topicDescription?: string | null; }[];
+}
+
+function formatTopicNameList(names: string[] | undefined): string {
+  if (!names || names.length === 0) {
+    return "- (none)";
+  }
+  return names.map(n => `- ${n}`).join("\n");
 }
 
 function buildLlmPrompt(args: BuildPromptArgs): string {
@@ -232,6 +247,10 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
     domainDescription,
     domainTopics,
     excludedTopics,
+    withinScopeDescription,
+    outOfScopeDescription,
+    withinScopeTopicNames,
+    outOfScopeTopicNames,
     quadrants,
     rings,
     existingBlips,
@@ -260,10 +279,29 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
       .join("\n")
     : "- (none yet)";
 
+  const withinScopeBlock = withinScopeDescription?.trim()
+    ? withinScopeDescription.trim()
+    : "(no within-scope description provided)";
+  const outOfScopeBlock = outOfScopeDescription?.trim()
+    ? outOfScopeDescription.trim()
+    : "(no out-of-scope description provided)";
+
   return `I'm placing topics on a tech-radar style chart for the "${domainLabel}" domain.
 
 Domain description:
 ${descriptionBlock}
+
+Within-scope description (lean toward topics like these):
+${withinScopeBlock}
+
+Within-scope topics (representative examples of what fits this radar):
+${formatTopicNameList(withinScopeTopicNames)}
+
+Out-of-scope description (lean away from topics like these):
+${outOfScopeBlock}
+
+Out-of-scope topics (representative examples of what does NOT fit):
+${formatTopicNameList(outOfScopeTopicNames)}
 
 The radar has these quadrants:
 ${quadrantList || "- (none defined)"}
@@ -364,6 +402,10 @@ export function BlipLlmAssist({
   domainDescription = null,
   domainTopics = [],
   excludedTopics = [],
+  withinScopeDescription = null,
+  outOfScopeDescription = null,
+  withinScopeTopicNames = [],
+  outOfScopeTopicNames = [],
   quadrants,
   rings,
   topics,
@@ -378,6 +420,10 @@ export function BlipLlmAssist({
         domainDescription,
         domainTopics,
         excludedTopics,
+        withinScopeDescription,
+        outOfScopeDescription,
+        withinScopeTopicNames,
+        outOfScopeTopicNames,
         quadrants,
         rings,
         existingBlips: existingBlips.map(b => ({
@@ -392,6 +438,10 @@ export function BlipLlmAssist({
       domainDescription,
       domainTopics,
       excludedTopics,
+      withinScopeDescription,
+      outOfScopeDescription,
+      withinScopeTopicNames,
+      outOfScopeTopicNames,
       quadrants,
       rings,
       existingBlips,
@@ -879,7 +929,7 @@ export function BlipLlmAssist({
         </div>
         <pre
           className={`
-            max-h-60 overflow-auto rounded-sm bg-muted p-3 text-xs
+            bg-muted max-h-60 overflow-auto rounded-sm p-3 text-xs
             whitespace-pre-wrap
           `}
         >
@@ -896,7 +946,7 @@ export function BlipLlmAssist({
           className="min-h-32 font-mono text-xs"
         />
         {parseError && (
-          <p className="text-sm text-destructive">{parseError}</p>
+          <p className="text-destructive text-sm">{parseError}</p>
         )}
         <div>
           <Button
@@ -912,7 +962,7 @@ export function BlipLlmAssist({
       {resolved && (
         <div className="flex flex-col gap-2">
           <h4 className="text-sm font-semibold">3. Review</h4>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             {counts.create}
             {" "}
             to add ·
@@ -1162,7 +1212,7 @@ function ReviewRow({
             )}
           </div>
           {hasProblems && !isSkipped && (
-            <span className="text-[11px] text-destructive">
+            <span className="text-destructive text-[11px]">
               {r.problems.join("; ")}
             </span>
           )}
@@ -1185,7 +1235,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-xs text-muted-foreground">—</span>
+          ? <span className="text-muted-foreground text-xs">—</span>
           : (
             <PlacementCell
               existingName={existingQuadrantName}
@@ -1203,7 +1253,7 @@ function ReviewRow({
 
       <TableCell className="align-top">
         {isRemove
-          ? <span className="text-xs text-muted-foreground">—</span>
+          ? <span className="text-muted-foreground text-xs">—</span>
           : (
             <PlacementCell
               existingName={existingRingName}

--- a/packages/client/src/components/radar/RadarConfigIllustrations.tsx
+++ b/packages/client/src/components/radar/RadarConfigIllustrations.tsx
@@ -1,0 +1,142 @@
+interface QuadrantsIllustrationProps {
+  names: string[];
+}
+
+const QUADRANT_COLORS = [
+  "fill-blue-100 stroke-blue-300",
+  "fill-emerald-100 stroke-emerald-300",
+  "fill-amber-100 stroke-amber-300",
+  "fill-rose-100 stroke-rose-300",
+  "fill-violet-100 stroke-violet-300",
+];
+
+export function QuadrantsIllustration({
+  names,
+}: QuadrantsIllustrationProps) {
+  const cleanNames = names.map(n => n.trim());
+  const slots = cleanNames.length > 0 ? cleanNames : ["", "", "", "", ""];
+  const count = slots.length;
+
+  const cx = 100;
+  const cy = 100;
+  const r = 80;
+  const labelRadius = 50;
+
+  const angleSize = (Math.PI * 2) / count;
+  const startOffset = -Math.PI / 2 - angleSize / 2;
+
+  const sectors = slots.map((name, idx) => {
+    const startAngle = startOffset + idx * angleSize;
+    const endAngle = startAngle + angleSize;
+    const x1 = cx + r * Math.cos(startAngle);
+    const y1 = cy + r * Math.sin(startAngle);
+    const x2 = cx + r * Math.cos(endAngle);
+    const y2 = cy + r * Math.sin(endAngle);
+    const largeArc = angleSize > Math.PI ? 1 : 0;
+
+    const path = `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+
+    const midAngle = startAngle + angleSize / 2;
+    const lx = cx + labelRadius * Math.cos(midAngle);
+    const ly = cy + labelRadius * Math.sin(midAngle);
+
+    return {
+      key: idx,
+      path,
+      lx,
+      ly,
+      label: name || `${idx + 1}`,
+      colorClass: QUADRANT_COLORS[idx % QUADRANT_COLORS.length],
+    };
+  });
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      className="size-40"
+      role="img"
+      aria-label="Quadrants illustration"
+    >
+      {sectors.map(s => (
+        <path
+          key={s.key}
+          d={s.path}
+          className={`
+            stroke-1
+            ${s.colorClass}
+          `}
+        />
+      ))}
+      {sectors.map(s => (
+        <text
+          key={`t-${s.key}`}
+          x={s.lx}
+          y={s.ly}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="fill-foreground text-[7px] font-medium"
+        >
+          {s.label.length > 14 ? `${s.label.slice(0, 13)}…` : s.label}
+        </text>
+      ))}
+    </svg>
+  );
+}
+
+interface RingsIllustrationProps {
+  names: string[];
+}
+
+export function RingsIllustration({
+  names,
+}: RingsIllustrationProps) {
+  const cleanNames = names.map(n => n.trim());
+  const slots = cleanNames.length > 0 ? cleanNames : [""];
+  const count = slots.length;
+
+  const cx = 100;
+  const cy = 100;
+  const maxR = 80;
+  const minR = 12;
+
+  const step = count > 1 ? (maxR - minR) / (count - 1) : 0;
+
+  const ringRadii = slots.map((_, idx) => maxR - idx * step);
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      className="size-40"
+      role="img"
+      aria-label="Rings illustration"
+    >
+      {ringRadii.map((rad, idx) => (
+        <circle
+          key={idx}
+          cx={cx}
+          cy={cy}
+          r={rad}
+          className="stroke-muted-foreground/40 fill-none"
+          strokeWidth={1}
+        />
+      ))}
+      {slots.map((name, idx) => {
+        const labelY = cy - ringRadii[idx]
+          + (idx === slots.length - 1 ? minR / 2 + 2 : step / 2 + 2);
+        const label = name.trim() || `${idx + 1}`;
+        return (
+          <text
+            key={idx}
+            x={cx}
+            y={labelY}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-foreground text-[7px] font-medium"
+          >
+            {label.length > 14 ? `${label.slice(0, 13)}…` : label}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/packages/client/src/components/radar/RadarConfigIllustrations.tsx
+++ b/packages/client/src/components/radar/RadarConfigIllustrations.tsx
@@ -116,7 +116,7 @@ export function RingsIllustration({
           cx={cx}
           cy={cy}
           r={rad}
-          className="stroke-muted-foreground/40 fill-none"
+          className="fill-none stroke-muted-foreground/40"
           strokeWidth={1}
         />
       ))}

--- a/packages/client/src/components/radar/TopicMultiSelect.tsx
+++ b/packages/client/src/components/radar/TopicMultiSelect.tsx
@@ -1,0 +1,64 @@
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  useComboboxAnchor,
+} from "@/components/combobox";
+
+interface TopicMultiSelectProps {
+  options: { value: string;
+    label: string; }[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+}
+
+export function TopicMultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+}: TopicMultiSelectProps) {
+  const anchor = useComboboxAnchor();
+  const optionsMap = new Map(options.map(o => [o.value, o.label]));
+
+  return (
+    <Combobox
+      multiple
+      items={options.map(o => o.value)}
+      value={value}
+      onValueChange={(val: string[]) => onChange(val)}
+      itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+    >
+      <ComboboxChips ref={anchor}>
+        {value.map(val => (
+          <ComboboxChip
+            key={val}
+            value={val}
+          >
+            {optionsMap.get(val) ?? val}
+          </ComboboxChip>
+        ))}
+        <ComboboxChipsInput placeholder={placeholder} />
+      </ComboboxChips>
+      <ComboboxContent anchor={anchor}>
+        <ComboboxEmpty>No topics found.</ComboboxEmpty>
+        <ComboboxList>
+          {(val: string) => (
+            <ComboboxItem
+              key={val}
+              value={val}
+            >
+              {optionsMap.get(val) ?? val}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -95,14 +95,14 @@ function SingleDomain() {
             header="About"
             condition={!!data?.description}
           >
-            <div className="bg-card rounded-md border p-4">
+            <div className="rounded-md border bg-card p-4">
               <p>{data?.description}</p>
             </div>
           </InfoArea>
           {radarReady && radarData && (
             <InfoArea header="Radar">
               <div
-                className="bg-card flex justify-center rounded-md border p-4"
+                className="flex justify-center rounded-md border bg-card p-4"
               >
                 <RadarChart
                   quadrants={radarData.quadrants}
@@ -147,7 +147,7 @@ function SingleDomain() {
                       {topic.name}
                     </Link>
                     {topic.courses && topic.courses.length > 0 && (
-                      <span className="text-muted-foreground ml-2 text-xs">
+                      <span className="ml-2 text-xs text-muted-foreground">
                         (
                         {topic.courses.length}
                         {" course"}
@@ -180,7 +180,7 @@ function SingleDomain() {
                   {topic.name}
                 </Link>
                 {topic.reason && (
-                  <span className="text-muted-foreground ml-2 text-sm">
+                  <span className="ml-2 text-sm text-muted-foreground">
                     —
                     {" "}
                     {topic.reason}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, RadarIcon } from "lucide-react";
 
-import { YesNoDisplay } from "@/components/boxElements/YesNoDisplay";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -86,36 +85,46 @@ function SingleDomain() {
         </div>
       </PageHeader>
       <div className="container flex flex-col gap-12">
-        <InfoArea
-          header="About"
-          condition={!!data?.description}
+        <div
+          className={`
+            grid grid-cols-1 gap-8
+            md:grid-cols-2
+          `}
         >
-          <p>{data?.description}</p>
-        </InfoArea>
-        <InfoArea header="Has Radar?">
-          <YesNoDisplay value={!!data?.hasRadar} />
-        </InfoArea>
-        {radarReady && radarData && (
-          <InfoArea header="Radar Preview">
-            <RadarChart
-              quadrants={radarData.quadrants}
-              rings={radarData.rings}
-              blips={radarData.blips}
-              size={400}
-              showLegend={false}
-              onBlipClick={blip =>
-                navigate({
-                  to: "/domains/$id/radar",
-                  params: {
-                    id,
-                  },
-                  search: {
-                    blipId: blip.id,
-                  },
-                })}
-            />
+          <InfoArea
+            header="About"
+            condition={!!data?.description}
+          >
+            <div className="bg-card rounded-md border p-4">
+              <p>{data?.description}</p>
+            </div>
           </InfoArea>
-        )}
+          {radarReady && radarData && (
+            <InfoArea header="Radar">
+              <div
+                className="bg-card flex justify-center rounded-md border p-4"
+              >
+                <RadarChart
+                  quadrants={radarData.quadrants}
+                  rings={radarData.rings}
+                  blips={radarData.blips}
+                  size={400}
+                  showLegend={false}
+                  onBlipClick={blip =>
+                    navigate({
+                      to: "/domains/$id/radar",
+                      params: {
+                        id,
+                      },
+                      search: {
+                        blipId: blip.id,
+                      },
+                    })}
+                />
+              </div>
+            </InfoArea>
+          )}
+        </div>
         <div>
           <InfoArea
             header="Topics"
@@ -138,7 +147,7 @@ function SingleDomain() {
                       {topic.name}
                     </Link>
                     {topic.courses && topic.courses.length > 0 && (
-                      <span className="ml-2 text-xs text-muted-foreground">
+                      <span className="text-muted-foreground ml-2 text-xs">
                         (
                         {topic.courses.length}
                         {" course"}
@@ -171,7 +180,7 @@ function SingleDomain() {
                   {topic.name}
                 </Link>
                 {topic.reason && (
-                  <span className="ml-2 text-sm text-muted-foreground">
+                  <span className="text-muted-foreground ml-2 text-sm">
                     —
                     {" "}
                     {topic.reason}

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -572,7 +572,7 @@ function RadarEdit() {
         >
           <section className="flex flex-col gap-4">
             <h2 className="text-2xl">Quadrants</h2>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-sm text-muted-foreground">
               Quadrants are the categories on your radar.
             </p>
             <div className="flex justify-center">
@@ -584,7 +584,7 @@ function RadarEdit() {
                   key={q.localKey}
                   className="flex flex-row items-center gap-2"
                 >
-                  <span className="text-muted-foreground w-6 text-sm">
+                  <span className="w-6 text-sm text-muted-foreground">
                     {idx + 1}
                     .
                   </span>
@@ -608,7 +608,7 @@ function RadarEdit() {
 
           <section className="flex flex-col gap-4">
             <h2 className="text-2xl">Rings</h2>
-            <p className="text-muted-foreground text-sm">
+            <p className="text-sm text-muted-foreground">
               Rings represent levels of adoption.
             </p>
             <div className="flex justify-center">
@@ -620,7 +620,7 @@ function RadarEdit() {
                   key={r.localKey}
                   className="flex flex-row items-center gap-2"
                 >
-                  <span className="text-muted-foreground w-6 text-sm">
+                  <span className="w-6 text-sm text-muted-foreground">
                     {idx + 1}
                     .
                   </span>
@@ -686,7 +686,7 @@ function RadarEdit() {
             <div className="flex flex-col gap-3 rounded-md border p-4">
               <div className="flex flex-col gap-1">
                 <h3 className="text-xl font-semibold">Within Scope</h3>
-                <p className="text-muted-foreground text-sm">
+                <p className="text-sm text-muted-foreground">
                   Used to nudge the LLM toward topics that fit this
                   radar&apos;s focus.
                 </p>
@@ -718,7 +718,7 @@ function RadarEdit() {
             <div className="flex flex-col gap-3 rounded-md border p-4">
               <div className="flex flex-col gap-1">
                 <h3 className="text-xl font-semibold">Out of Scope</h3>
-                <p className="text-muted-foreground text-sm">
+                <p className="text-sm text-muted-foreground">
                   Used to nudge the LLM away from topics that don&apos;t fit
                   this radar.
                 </p>
@@ -838,7 +838,7 @@ function RadarEdit() {
                               </h4>
                               <p
                                 className={`
-                                  text-muted-foreground text-sm
+                                  text-sm text-muted-foreground
                                   ${pickedTopic.description?.trim()
                               ? ""
                               : "italic"}
@@ -852,7 +852,7 @@ function RadarEdit() {
                           : blip.topicId && !topicNameById.has(blip.topicId)
                             ? (
                               <span
-                                className="text-muted-foreground text-xs"
+                                className="text-xs text-muted-foreground"
                               >
                                 (topic not in list)
                               </span>

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -20,6 +20,11 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { BlipBulkAdd } from "@/components/radar/BlipBulkAdd";
 import { BlipLlmAssist } from "@/components/radar/BlipLlmAssist";
 import { BlipTable } from "@/components/radar/BlipTable";
+import {
+  QuadrantsIllustration,
+  RingsIllustration,
+} from "@/components/radar/RadarConfigIllustrations";
+import { TopicMultiSelect } from "@/components/radar/TopicMultiSelect";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -34,6 +39,7 @@ import {
   fetchRadar,
   fetchSingleDomain,
   fetchTopics,
+  upsertDomain,
   upsertRadarBlip,
   upsertRadarConfig,
 } from "@/utils";
@@ -70,12 +76,13 @@ const DEFAULT_QUADRANTS = [
   "Tools",
   "Platforms",
   "Techniques",
+  "Practices",
 ];
 
 const DEFAULT_RINGS = ["Adopt", "Trial", "Assess", "Hold"];
 
-const MAX_QUADRANTS = 4;
-const MAX_RINGS = 4;
+const QUADRANT_COUNT = 5;
+const MAX_RINGS = 6;
 
 let localKeyCounter = 0;
 function nextLocalKey() {
@@ -84,7 +91,7 @@ function nextLocalKey() {
 }
 
 function quadrantsFromServer(items: RadarQuadrant[]): QuadrantDraft[] {
-  return items
+  const fromServer: QuadrantDraft[] = items
     .slice()
     .sort((a, b) => a.position - b.position)
     .map(q => ({
@@ -93,6 +100,18 @@ function quadrantsFromServer(items: RadarQuadrant[]): QuadrantDraft[] {
       position: q.position,
       localKey: q.id,
     }));
+  while (fromServer.length < QUADRANT_COUNT) {
+    const idx = fromServer.length;
+    fromServer.push({
+      name: DEFAULT_QUADRANTS[idx] ?? "",
+      position: idx,
+      localKey: nextLocalKey(),
+    });
+  }
+  return fromServer.map((q, idx) => ({
+    ...q,
+    position: idx,
+  }));
 }
 
 function ringsFromServer(items: RadarRing[]): RingDraft[] {
@@ -108,7 +127,7 @@ function ringsFromServer(items: RadarRing[]): RingDraft[] {
 }
 
 function defaultQuadrants(): QuadrantDraft[] {
-  return DEFAULT_QUADRANTS.map((name, idx) => ({
+  return DEFAULT_QUADRANTS.slice(0, QUADRANT_COUNT).map((name, idx) => ({
     name,
     position: idx,
     localKey: nextLocalKey(),
@@ -172,6 +191,13 @@ function RadarEdit() {
   const [hydrated, setHydrated] = useState(false);
   const [addMode, setAddMode] = useState<AddMode>("single");
 
+  const [withinScopeDescription, setWithinScopeDescription] = useState("");
+  const [outOfScopeDescription, setOutOfScopeDescription] = useState("");
+  const [withinScopeTopicIds, setWithinScopeTopicIds] = useState<string[]>([]);
+  const [outOfScopeTopicIds, setOutOfScopeTopicIds] = useState<string[]>([]);
+  const [detailsHydrated, setDetailsHydrated] = useState(false);
+  const [isSavingDetails, setIsSavingDetails] = useState(false);
+
   useEffect(() => {
     if (!data || hydrated) {
       return;
@@ -187,6 +213,17 @@ function RadarEdit() {
     setBlips(blipsFromServer(data.blips));
     setHydrated(true);
   }, [data, hydrated]);
+
+  useEffect(() => {
+    if (!domainDetail || detailsHydrated) {
+      return;
+    }
+    setWithinScopeDescription(domainDetail.withinScopeDescription ?? "");
+    setOutOfScopeDescription(domainDetail.outOfScopeDescription ?? "");
+    setWithinScopeTopicIds((domainDetail.topics ?? []).map(t => t.id));
+    setOutOfScopeTopicIds((domainDetail.excludedTopics ?? []).map(t => t.id));
+    setDetailsHydrated(true);
+  }, [domainDetail, detailsHydrated]);
 
   const persistedQuadrantIds = useMemo(
     () => new Set((data?.quadrants ?? []).map(q => q.id)),
@@ -243,32 +280,6 @@ function RadarEdit() {
     return set;
   }, [savedBlipsForTable, newBlipDrafts]);
 
-  function addQuadrant() {
-    setQuadrants((prev) => {
-      if (prev.length >= MAX_QUADRANTS) {
-        return prev;
-      }
-      return [
-        ...prev,
-        {
-          name: "",
-          position: prev.length,
-          localKey: nextLocalKey(),
-        },
-      ];
-    });
-  }
-
-  function removeQuadrant(localKey: string) {
-    setQuadrants(prev =>
-      prev
-        .filter(q => q.localKey !== localKey)
-        .map((q, idx) => ({
-          ...q,
-          position: idx,
-        })));
-  }
-
   function addRing() {
     setRings((prev) => {
       if (prev.length >= MAX_RINGS) {
@@ -304,10 +315,6 @@ function RadarEdit() {
       toast.error("Every ring needs a name.");
       return;
     }
-    if (quadrants.length > MAX_QUADRANTS) {
-      toast.error(`At most ${MAX_QUADRANTS} quadrants are allowed.`);
-      return;
-    }
     if (rings.length > MAX_RINGS) {
       toast.error(`At most ${MAX_RINGS} rings are allowed.`);
       return;
@@ -337,6 +344,43 @@ function RadarEdit() {
     }
     finally {
       setIsSavingConfig(false);
+    }
+  }
+
+  async function saveDetails() {
+    if (!domainDetail) {
+      return;
+    }
+    setIsSavingDetails(true);
+    try {
+      await upsertDomain(id, {
+        title: domainDetail.title,
+        description: domainDetail.description ?? null,
+        hasRadar: domainDetail.hasRadar ?? null,
+        withinScopeDescription: withinScopeDescription.trim() || null,
+        outOfScopeDescription: outOfScopeDescription.trim() || null,
+        topicIds: withinScopeTopicIds,
+        excludedTopics: outOfScopeTopicIds.map((topicId) => {
+          const existing = (domainDetail.excludedTopics ?? []).find(
+            t => t.id === topicId,
+          );
+          return {
+            topicId,
+            reason: existing?.reason ?? null,
+          };
+        }),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["domain", id],
+      });
+      setDetailsHydrated(false);
+      toast.success("Details saved.");
+    }
+    catch {
+      toast.error("Failed to save details.");
+    }
+    finally {
+      setIsSavingDetails(false);
     }
   }
 
@@ -528,17 +572,19 @@ function RadarEdit() {
         >
           <section className="flex flex-col gap-4">
             <h2 className="text-2xl">Quadrants</h2>
-            <p className="text-sm text-muted-foreground">
-              Quadrants are the categories on your radar. They are listed
-              clockwise starting from the top.
+            <p className="text-muted-foreground text-sm">
+              Quadrants are the categories on your radar.
             </p>
+            <div className="flex justify-center">
+              <QuadrantsIllustration names={quadrants.map(q => q.name)} />
+            </div>
             <ul className="flex flex-col gap-2">
               {quadrants.map((q, idx) => (
                 <li
                   key={q.localKey}
                   className="flex flex-row items-center gap-2"
                 >
-                  <span className="w-6 text-sm text-muted-foreground">
+                  <span className="text-muted-foreground w-6 text-sm">
                     {idx + 1}
                     .
                   </span>
@@ -555,53 +601,26 @@ function RadarEdit() {
                             : item))}
                     placeholder="Quadrant name"
                   />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeQuadrant(q.localKey)}
-                    aria-label="Remove quadrant"
-                  >
-                    <TrashIcon />
-                  </Button>
                 </li>
               ))}
             </ul>
-            <div className="flex flex-col gap-1">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={addQuadrant}
-                disabled={quadrants.length >= MAX_QUADRANTS}
-              >
-                <PlusIcon />
-                {" "}
-                Add Quadrant
-              </Button>
-              {quadrants.length >= MAX_QUADRANTS && (
-                <p className="text-xs text-muted-foreground">
-                  Maximum of
-                  {" "}
-                  {MAX_QUADRANTS}
-                  {" "}
-                  quadrants reached.
-                </p>
-              )}
-            </div>
           </section>
 
           <section className="flex flex-col gap-4">
             <h2 className="text-2xl">Rings</h2>
-            <p className="text-sm text-muted-foreground">
-              Rings represent levels — listed innermost first.
+            <p className="text-muted-foreground text-sm">
+              Rings represent levels of adoption.
             </p>
+            <div className="flex justify-center">
+              <RingsIllustration names={rings.map(r => r.name)} />
+            </div>
             <ul className="flex flex-col gap-2">
               {rings.map((r, idx) => (
                 <li
                   key={r.localKey}
                   className="flex flex-row items-center gap-2"
                 >
-                  <span className="w-6 text-sm text-muted-foreground">
+                  <span className="text-muted-foreground w-6 text-sm">
                     {idx + 1}
                     .
                   </span>
@@ -630,7 +649,7 @@ function RadarEdit() {
                 </li>
               ))}
             </ul>
-            <div className="flex flex-col gap-1">
+            <div>
               <Button
                 type="button"
                 variant="outline"
@@ -641,15 +660,6 @@ function RadarEdit() {
                 {" "}
                 Add Ring
               </Button>
-              {rings.length >= MAX_RINGS && (
-                <p className="text-xs text-muted-foreground">
-                  Maximum of
-                  {" "}
-                  {MAX_RINGS}
-                  {" "}
-                  rings reached.
-                </p>
-              )}
             </div>
           </section>
         </div>
@@ -664,6 +674,90 @@ function RadarEdit() {
             Save Configuration
           </Button>
         </div>
+
+        <section className="flex flex-col gap-6">
+          <h2 className="text-3xl">Details</h2>
+          <div
+            className={`
+              grid grid-cols-1 gap-6
+              md:grid-cols-2
+            `}
+          >
+            <div className="flex flex-col gap-3 rounded-md border p-4">
+              <div className="flex flex-col gap-1">
+                <h3 className="text-xl font-semibold">Within Scope</h3>
+                <p className="text-muted-foreground text-sm">
+                  Used to nudge the LLM toward topics that fit this
+                  radar&apos;s focus.
+                </p>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs uppercase">Description</label>
+                <Textarea
+                  value={withinScopeDescription}
+                  onChange={e => setWithinScopeDescription(e.target.value)}
+                  placeholder="What kinds of topics belong on this radar?"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs uppercase">Topics</label>
+                <TopicMultiSelect
+                  options={(topics ?? [])
+                    .filter(t => !outOfScopeTopicIds.includes(t.id))
+                    .map(t => ({
+                      value: t.id,
+                      label: t.name,
+                    }))}
+                  value={withinScopeTopicIds}
+                  onChange={setWithinScopeTopicIds}
+                  placeholder="Add topics in scope..."
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 rounded-md border p-4">
+              <div className="flex flex-col gap-1">
+                <h3 className="text-xl font-semibold">Out of Scope</h3>
+                <p className="text-muted-foreground text-sm">
+                  Used to nudge the LLM away from topics that don&apos;t fit
+                  this radar.
+                </p>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs uppercase">Description</label>
+                <Textarea
+                  value={outOfScopeDescription}
+                  onChange={e => setOutOfScopeDescription(e.target.value)}
+                  placeholder="What kinds of topics should be avoided?"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-xs uppercase">Topics</label>
+                <TopicMultiSelect
+                  options={(topics ?? [])
+                    .filter(t => !withinScopeTopicIds.includes(t.id))
+                    .map(t => ({
+                      value: t.id,
+                      label: t.name,
+                    }))}
+                  value={outOfScopeTopicIds}
+                  onChange={setOutOfScopeTopicIds}
+                  placeholder="Add topics out of scope..."
+                />
+              </div>
+            </div>
+          </div>
+          <div>
+            <Button
+              type="button"
+              onClick={saveDetails}
+              disabled={isSavingDetails || !domainDetail}
+            >
+              {isSavingDetails && <Loader2 className="animate-spin" />}
+              Save Details
+            </Button>
+          </div>
+        </section>
 
         <section className="flex flex-col gap-4">
           <h2 className="text-2xl">Blips</h2>
@@ -744,7 +838,7 @@ function RadarEdit() {
                               </h4>
                               <p
                                 className={`
-                                  text-sm text-muted-foreground
+                                  text-muted-foreground text-sm
                                   ${pickedTopic.description?.trim()
                               ? ""
                               : "italic"}
@@ -758,7 +852,7 @@ function RadarEdit() {
                           : blip.topicId && !topicNameById.has(blip.topicId)
                             ? (
                               <span
-                                className="text-xs text-muted-foreground"
+                                className="text-muted-foreground text-xs"
                               >
                                 (topic not in list)
                               </span>
@@ -920,6 +1014,14 @@ function RadarEdit() {
               domainDescription={domainDetail?.description ?? null}
               domainTopics={domainDetail?.topics ?? []}
               excludedTopics={domainDetail?.excludedTopics ?? []}
+              withinScopeDescription={withinScopeDescription}
+              outOfScopeDescription={outOfScopeDescription}
+              withinScopeTopicNames={withinScopeTopicIds
+                .map(tid => topicNameById.get(tid))
+                .filter((n): n is string => Boolean(n))}
+              outOfScopeTopicNames={outOfScopeTopicIds
+                .map(tid => topicNameById.get(tid))
+                .filter((n): n is string => Boolean(n))}
               quadrants={persistedQuadrants}
               rings={persistedRings}
               topics={topics ?? []}

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -213,6 +213,8 @@ export const domains = pgTable("domains", {
   }).notNull(),
   description: varchar(),
   hasRadar: boolean(),
+  withinScopeDescription: varchar("within_scope_description"),
+  outOfScopeDescription: varchar("out_of_scope_description"),
 });
 
 export const domainsRelations = relations(domains, ({

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -18,6 +18,8 @@ const createSchema = {
         },
         description: nullableString,
         hasRadar: nullableBoolean,
+        withinScopeDescription: nullableString,
+        outOfScopeDescription: nullableString,
         topicIds: {
           type: "array",
           items: {
@@ -64,6 +66,8 @@ export default async function (server: FastifyInstance) {
         title,
         description: body.description ?? null,
         hasRadar: body.hasRadar ?? null,
+        withinScopeDescription: body.withinScopeDescription ?? null,
+        outOfScopeDescription: body.outOfScopeDescription ?? null,
       });
 
       const uniqueTopicIds = Array.from(new Set(body.topicIds ?? []));

--- a/packages/middleware/src/routes/api/domains/duplicateDomain.ts
+++ b/packages/middleware/src/routes/api/domains/duplicateDomain.ts
@@ -50,6 +50,8 @@ export default async function (server: FastifyInstance) {
         title: `${source.title} (Copy)`,
         description: source.description ?? null,
         hasRadar: source.hasRadar ?? null,
+        withinScopeDescription: source.withinScopeDescription ?? null,
+        outOfScopeDescription: source.outOfScopeDescription ?? null,
       });
 
       const topicLinks = (source.topicsToDomains ?? []).map(t => ({

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -162,6 +162,8 @@ export default async function (server: FastifyInstance) {
         title: domain.title,
         description: domain.description,
         hasRadar: domain.hasRadar,
+        withinScopeDescription: domain.withinScopeDescription,
+        outOfScopeDescription: domain.outOfScopeDescription,
         topicCount: topics.length,
         topics,
         excludedTopics,

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -6,6 +6,8 @@ interface DomainBody {
   title: string;
   description?: string | null;
   hasRadar?: boolean | null;
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
   topicIds?: string[];
   excludedTopics?: { topicId: string;
     reason?: string | null; }[];
@@ -24,6 +26,8 @@ export default createUpsertHandler<DomainBody>({
       },
       description: nullableString,
       hasRadar: nullableBoolean,
+      withinScopeDescription: nullableString,
+      outOfScopeDescription: nullableString,
       topicIds: {
         type: "array",
         items: {
@@ -56,8 +60,16 @@ export default createUpsertHandler<DomainBody>({
     title: body.title.trim(),
     description: body.description ?? null,
     hasRadar: body.hasRadar ?? null,
+    withinScopeDescription: body.withinScopeDescription ?? null,
+    outOfScopeDescription: body.outOfScopeDescription ?? null,
   }),
-  updateableColumns: ["title", "description", "hasRadar"],
+  updateableColumns: [
+    "title",
+    "description",
+    "hasRadar",
+    "withinScopeDescription",
+    "outOfScopeDescription",
+  ],
   junctions: [
     {
       table: topicsToDomains,

--- a/packages/middleware/src/routes/api/radar/upsertRadarConfig.ts
+++ b/packages/middleware/src/routes/api/radar/upsertRadarConfig.ts
@@ -24,7 +24,7 @@ const upsertConfigSchema = {
       properties: {
         quadrants: {
           type: "array",
-          maxItems: 4,
+          maxItems: 5,
           items: {
             type: "object",
             required: ["name", "position"],
@@ -43,7 +43,7 @@ const upsertConfigSchema = {
         },
         rings: {
           type: "array",
-          maxItems: 4,
+          maxItems: 6,
           items: {
             type: "object",
             required: ["name", "position"],

--- a/packages/types/src/Domain.ts
+++ b/packages/types/src/Domain.ts
@@ -25,6 +25,8 @@ export interface Domain {
   title: string;
   description?: string | null;
   hasRadar?: boolean | null;
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
   topicCount?: number;
   topics?: DomainTopic[];
   excludedTopics?: DomainExcludedTopic[];


### PR DESCRIPTION
## Summary
This PR enhances the radar domain editor with scope management features and improves the radar configuration UI with visual illustrations. It allows users to define within-scope and out-of-scope descriptions and topics to guide LLM-assisted blip generation, while also increasing the maximum quadrant count and improving the visual presentation of radar configuration.

## Key Changes

- **Scope Management**: Added within-scope and out-of-scope description fields and topic selectors to the domain details section, allowing users to guide LLM behavior toward or away from specific topics
- **LLM Prompt Enhancement**: Updated the blip LLM assist prompt to include scope descriptions and topic examples, improving the quality of AI-generated suggestions
- **Quadrant Configuration**: 
  - Increased maximum quadrants from 4 to 5
  - Added "Practices" as a default quadrant
  - Removed manual add/remove quadrant UI (now fixed at 5 slots)
  - Quadrants are now always populated with defaults if empty
- **Visual Illustrations**: Added `QuadrantsIllustration` and `RingsIllustration` components to visually represent the radar configuration as users edit it
- **New Components**: 
  - `TopicMultiSelect` component for selecting multiple topics with a combobox interface
  - `RadarConfigIllustrations` module with quadrant and ring visualization components
- **Ring Configuration**: Increased maximum rings from 4 to 6
- **Domain Details UI**: Added a new "Details" section with a two-column layout for within-scope and out-of-scope configuration
- **Database Schema**: Added `withinScopeDescription` and `outOfScopeDescription` columns to the domains table
- **API Updates**: Updated domain creation, upsert, and retrieval endpoints to handle the new scope fields
- **Domain View Layout**: Improved the single domain view with a grid layout for better visual organization

## Implementation Details

- The scope management state is hydrated from the domain details on component mount and can be saved independently via the `saveDetails` function
- Topic multi-select prevents selecting the same topic in both within-scope and out-of-scope lists
- Radar illustrations dynamically render based on the current quadrant/ring names and count
- The LLM prompt builder includes formatted lists of scope topics and descriptions to guide AI suggestions

https://claude.ai/code/session_01ACpdpKbYRFt2ZShrJYoYb3