### PR TITLE
Add task type management with tagging system

### DIFF
--- a/packages/client/src/components/TaskTypeEditModal.tsx
+++ b/packages/client/src/components/TaskTypeEditModal.tsx
@@ -1,0 +1,182 @@
+import type { TaskType } from "@emstack/types/src";
+
+import { useEffect, useState } from "react";
+
+import { Loader2, Trash2Icon } from "lucide-react";
+
+import { Input } from "@/components/input";
+import { TagsInput } from "@/components/tasks/TagsInput";
+import { Textarea } from "@/components/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface TaskTypeEditModalProps {
+  open: boolean;
+  taskType: TaskType | null;
+  isNew?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (next: TaskType) => void;
+  onDelete?: () => void;
+  isSaving?: boolean;
+  deleteDisabled?: boolean;
+  deleteDisabledReason?: string;
+}
+
+export function TaskTypeEditModal({
+  open,
+  taskType,
+  isNew = false,
+  onOpenChange,
+  onSave,
+  onDelete,
+  isSaving = false,
+  deleteDisabled = false,
+  deleteDisabledReason,
+}: TaskTypeEditModalProps) {
+  const [draft, setDraft] = useState<TaskType | null>(taskType);
+
+  useEffect(() => {
+    setDraft(taskType);
+  }, [taskType]);
+
+  if (!draft) {
+    return null;
+  }
+
+  function update(patch: Partial<TaskType>) {
+    setDraft((prev: TaskType | null) => (prev
+      ? {
+        ...prev,
+        ...patch,
+      }
+      : prev));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!draft) return;
+    onSave(draft);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isNew ? "Add Task Type" : "Edit Task Type"}
+          </DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              className="text-xs font-medium text-muted-foreground"
+              htmlFor="task-type-name"
+            >
+              Name
+            </label>
+            <Input
+              id="task-type-name"
+              type="text"
+              value={draft.name}
+              onChange={e => update({
+                name: e.target.value,
+              })}
+              required
+              placeholder="Task type name"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              className="text-xs font-medium text-muted-foreground"
+              htmlFor="task-type-when-to-use"
+            >
+              When to Use
+            </label>
+            <Textarea
+              id="task-type-when-to-use"
+              value={draft.whenToUse ?? ""}
+              onChange={e => update({
+                whenToUse: e.target.value,
+              })}
+              placeholder="Describe when this type of task fits best"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              Tags
+            </label>
+            <TagsInput
+              value={draft.tags ?? []}
+              onChange={tags => update({
+                tags,
+              })}
+              placeholder="e.g. skill:listening"
+              groupByPrefix
+            />
+            <p className="text-xs text-muted-foreground">
+              Use a
+              {" "}
+              <code className="rounded-sm bg-muted px-1">group:value</code>
+              {" "}
+              format (e.g.
+              {" "}
+              <code className="rounded-sm bg-muted px-1">skill:listening</code>
+              ) to group tags in the dropdown.
+            </p>
+          </div>
+          <DialogFooter className="sm:justify-between">
+            {onDelete && !isNew
+              ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={onDelete}
+                  disabled={isSaving || deleteDisabled}
+                  title={deleteDisabled ? deleteDisabledReason : undefined}
+                >
+                  <Trash2Icon className="size-4" />
+                  Remove
+                </Button>
+              )
+              : (
+                <span />
+              )}
+            <div
+              className="
+                flex flex-col-reverse gap-2
+                sm:flex-row
+              "
+            >
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSaving}
+              >
+                {isSaving && <Loader2 className="animate-spin" />}
+                Save
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -12,7 +12,9 @@ import {
   ComboboxChipsInput,
   ComboboxContent,
   ComboboxEmpty,
+  ComboboxGroup,
   ComboboxItem,
+  ComboboxLabel,
   ComboboxList,
   useComboboxAnchor,
 } from "@/components/combobox";
@@ -28,6 +30,41 @@ interface MultiComboboxFieldProps {
   placeholder?: string;
   className?: string;
   create?: CreateConfig;
+  /**
+   * When true, options whose value matches `group:value` are partitioned by
+   * the substring before the first `:` and rendered under a group header.
+   * Options without a colon fall under an "Other" group rendered last.
+   */
+  groupByPrefix?: boolean;
+}
+
+function partitionOptions(options: { value: string;
+  label: string; }[]) {
+  const groups = new Map<string, { value: string;
+    label: string; }[]>();
+  const otherKey = "Other";
+  for (const opt of options) {
+    const idx = opt.value.indexOf(":");
+    const groupName = idx > 0 ? opt.value.slice(0, idx) : otherKey;
+    const bucket = groups.get(groupName);
+    if (bucket) {
+      bucket.push(opt);
+    }
+    else {
+      groups.set(groupName, [opt]);
+    }
+  }
+  const others = groups.get(otherKey);
+  if (others) {
+    groups.delete(otherKey);
+    groups.set(otherKey, others);
+  }
+  return groups;
+}
+
+function stripGroup(label: string) {
+  const idx = label.indexOf(":");
+  return idx > 0 ? label.slice(idx + 1) : label;
 }
 
 export function MultiComboboxField({
@@ -36,6 +73,7 @@ export function MultiComboboxField({
   placeholder,
   className = "text-2xl",
   create,
+  groupByPrefix = false,
 }: MultiComboboxFieldProps) {
   const {
     field, isInvalid,
@@ -83,7 +121,11 @@ export function MultiComboboxField({
       <FieldLabel className={className}>{label}</FieldLabel>
       <Combobox
         multiple
-        items={options.map(o => o.value)}
+        {...(groupByPrefix
+          ? {}
+          : {
+            items: options.map(o => o.value),
+          })}
         value={field.state.value || []}
         onValueChange={val => field.handleChange(val)}
         onInputValueChange={val => setInputValue(val)}
@@ -156,14 +198,30 @@ export function MultiComboboxField({
               )}
           </ComboboxEmpty>
           <ComboboxList>
-            {(value: string) => (
-              <ComboboxItem
-                key={value}
-                value={value}
-              >
-                {optionsMap.get(value) ?? value}
-              </ComboboxItem>
-            )}
+            {groupByPrefix
+              ? Array.from(partitionOptions(options).entries()).map(
+                ([groupName, groupOptions]) => (
+                  <ComboboxGroup key={groupName}>
+                    <ComboboxLabel>{groupName}</ComboboxLabel>
+                    {groupOptions.map(o => (
+                      <ComboboxItem
+                        key={o.value}
+                        value={o.value}
+                      >
+                        {stripGroup(o.label)}
+                      </ComboboxItem>
+                    ))}
+                  </ComboboxGroup>
+                ),
+              )
+              : (value: string) => (
+                <ComboboxItem
+                  key={value}
+                  value={value}
+                >
+                  {optionsMap.get(value) ?? value}
+                </ComboboxItem>
+              )}
           </ComboboxList>
         </ComboboxContent>
       </Combobox>

--- a/packages/client/src/components/tasks/ResourceEditModal.tsx
+++ b/packages/client/src/components/tasks/ResourceEditModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { Loader2, Trash2Icon } from "lucide-react";
 
 import { RESOURCE_LEVEL_OPTIONS } from "./resourceMeta";
+import { TagsInput } from "./TagsInput";
 
 import { Input } from "@/components/input";
 import { Button } from "@/components/ui/button";
@@ -26,6 +27,8 @@ import {
 interface ResourceEditModalProps {
   open: boolean;
   resource: Resource | null;
+  /** Tags suggested in the dropdown (typically from the parent task's task type). */
+  tagSuggestions?: string[];
   isNew?: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (next: Resource) => void;
@@ -75,6 +78,7 @@ function LevelSelect({
 export function ResourceEditModal({
   open,
   resource,
+  tagSuggestions = [],
   isNew = false,
   onOpenChange,
   onSave,
@@ -210,6 +214,22 @@ export function ResourceEditModal({
             />
             <span>Used yet?</span>
           </label>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              Tags
+            </label>
+            <TagsInput
+              value={draft.tags ?? []}
+              onChange={tags => update({
+                tags,
+              })}
+              suggestions={tagSuggestions}
+              placeholder={tagSuggestions.length > 0
+                ? "Pick or type a tag..."
+                : "Type a tag..."}
+              groupByPrefix
+            />
+          </div>
           <DialogFooter className="sm:justify-between">
             {onDelete && !isNew
               ? (

--- a/packages/client/src/components/tasks/ResourcesTable.tsx
+++ b/packages/client/src/components/tasks/ResourcesTable.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 
 import { ResourceEditModal } from "./ResourceEditModal";
 import { getResourceLevelClass, getResourceLevelLabel } from "./resourceMeta";
+import { TagChip } from "./TagChip";
 
 import { Input } from "@/components/input";
 import { Button } from "@/components/ui/button";
@@ -161,6 +162,7 @@ export function ResourcesTable({
         name: task.name,
         description: task.description ?? null,
         topicId: task.topicId ?? null,
+        taskTypeId: task.taskTypeId ?? null,
         resources: next.map(r => ({
           id: r.id,
           name: r.name,
@@ -169,6 +171,7 @@ export function ResourcesTable({
           timeNeeded: r.timeNeeded ?? null,
           interactivity: r.interactivity ?? null,
           usedYet: r.usedYet,
+          tags: r.tags ?? [],
         })),
         todos: (task.todos ?? []).map(t => ({
           id: t.id,
@@ -267,8 +270,11 @@ export function ResourcesTable({
       timeNeeded: null,
       interactivity: null,
       usedYet: false,
+      tags: [],
     });
   }
+
+  const tagSuggestions = task.taskType?.tags ?? [];
 
   if (resources.length === 0) {
     return (
@@ -289,6 +295,7 @@ export function ResourcesTable({
         <ResourceEditModal
           open={!!draftNewResource}
           resource={draftNewResource}
+          tagSuggestions={tagSuggestions}
           isNew
           onOpenChange={(open) => {
             if (!open) setDraftNewResource(null);
@@ -408,6 +415,7 @@ export function ResourcesTable({
               <th className="p-2 font-medium whitespace-nowrap">Time Needed</th>
               <th className="p-2 font-medium">Interactivity</th>
               <th className="p-2 font-medium whitespace-nowrap">Used yet?</th>
+              <th className="p-2 font-medium">Tags</th>
               <th className="p-2 font-medium">Location</th>
               <th className="w-10 p-2" />
             </tr>
@@ -416,7 +424,7 @@ export function ResourcesTable({
             {filtered.length === 0 && (
               <tr>
                 <td
-                  colSpan={7}
+                  colSpan={8}
                   className="p-4 text-center text-muted-foreground"
                 >
                   <i>No resources match these filters.</i>
@@ -459,6 +467,22 @@ export function ResourcesTable({
                         {r.usedYet ? "Used" : "Not yet"}
                       </span>
                     </label>
+                  </td>
+                  <td className="p-2">
+                    {r.tags.length > 0
+                      ? (
+                        <div className="flex flex-wrap gap-1">
+                          {r.tags.map(tag => (
+                            <TagChip
+                              key={tag}
+                              tag={tag}
+                            />
+                          ))}
+                        </div>
+                      )
+                      : (
+                        <span className="text-muted-foreground/60">—</span>
+                      )}
                   </td>
                   <td className="max-w-xs p-2">
                     {r.url
@@ -518,6 +542,7 @@ export function ResourcesTable({
       <ResourceEditModal
         open={!!editingResource}
         resource={editingResource}
+        tagSuggestions={tagSuggestions}
         onOpenChange={(open) => {
           if (!open) setEditingId(null);
         }}
@@ -530,6 +555,7 @@ export function ResourcesTable({
       <ResourceEditModal
         open={!!draftNewResource}
         resource={draftNewResource}
+        tagSuggestions={tagSuggestions}
         isNew
         onOpenChange={(open) => {
           if (!open) setDraftNewResource(null);

--- a/packages/client/src/components/tasks/TagChip.tsx
+++ b/packages/client/src/components/tasks/TagChip.tsx
@@ -1,0 +1,28 @@
+interface TagChipProps {
+  tag: string;
+}
+
+export function TagChip({
+  tag,
+}: TagChipProps) {
+  const idx = tag.indexOf(":");
+  const group = idx > 0 ? tag.slice(0, idx) : null;
+  const value = idx > 0 ? tag.slice(idx + 1) : tag;
+
+  return (
+    <span
+      className="
+        inline-flex items-center rounded-full border bg-muted/40 px-2 py-0.5
+        text-xs
+      "
+    >
+      {group && (
+        <span className="mr-1 text-muted-foreground">
+          {group}
+          :
+        </span>
+      )}
+      <span className="font-medium">{value}</span>
+    </span>
+  );
+}

--- a/packages/client/src/components/tasks/TagsInput.tsx
+++ b/packages/client/src/components/tasks/TagsInput.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+
+import { PlusIcon } from "lucide-react";
+
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  useComboboxAnchor,
+} from "@/components/combobox";
+
+interface TagsInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  /** Suggested tags to show in the dropdown. Free-text tags are always allowed. */
+  suggestions?: string[];
+  placeholder?: string;
+  groupByPrefix?: boolean;
+}
+
+function partitionTags(tags: string[]) {
+  const groups = new Map<string, string[]>();
+  const otherKey = "Other";
+  for (const tag of tags) {
+    const idx = tag.indexOf(":");
+    const groupName = idx > 0 ? tag.slice(0, idx) : otherKey;
+    const bucket = groups.get(groupName);
+    if (bucket) {
+      bucket.push(tag);
+    }
+    else {
+      groups.set(groupName, [tag]);
+    }
+  }
+  const others = groups.get(otherKey);
+  if (others) {
+    groups.delete(otherKey);
+    groups.set(otherKey, others);
+  }
+  return groups;
+}
+
+function stripGroup(tag: string) {
+  const idx = tag.indexOf(":");
+  return idx > 0 ? tag.slice(idx + 1) : tag;
+}
+
+export function TagsInput({
+  value,
+  onChange,
+  suggestions = [],
+  placeholder = "Add a tag...",
+  groupByPrefix = true,
+}: TagsInputProps) {
+  const anchor = useComboboxAnchor();
+  const [inputValue, setInputValue] = useState("");
+
+  const allOptionValues = Array.from(new Set([...suggestions, ...value]));
+
+  const trimmed = inputValue.trim();
+  const hasMatch = trimmed.length > 0
+    && allOptionValues.some(v => v.toLowerCase() === trimmed.toLowerCase());
+  const showAddRow = trimmed.length > 0 && !hasMatch;
+
+  function commitNewTag(tag: string) {
+    const t = tag.trim();
+    if (!t) return;
+    if (value.includes(t)) return;
+    onChange([...value, t]);
+    setInputValue("");
+  }
+
+  return (
+    <Combobox
+      multiple
+      {...(groupByPrefix
+        ? {}
+        : {
+          items: allOptionValues,
+        })}
+      value={value}
+      onValueChange={(next: string[]) => onChange(next)}
+      onInputValueChange={(val: string) => setInputValue(val)}
+      itemToStringLabel={(val: string) => val}
+    >
+      <ComboboxChips ref={anchor}>
+        {value.map(tag => (
+          <ComboboxChip
+            key={tag}
+            value={tag}
+          >
+            {tag}
+          </ComboboxChip>
+        ))}
+        <ComboboxChipsInput
+          placeholder={placeholder}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && trimmed.length > 0 && !hasMatch) {
+              e.preventDefault();
+              commitNewTag(trimmed);
+            }
+          }}
+        />
+      </ComboboxChips>
+      <ComboboxContent anchor={anchor}>
+        {showAddRow && (
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              commitNewTag(trimmed);
+            }}
+            className="
+              flex w-full items-center gap-2 border-b border-border p-2
+              text-left text-sm
+              hover:bg-accent hover:text-accent-foreground
+            "
+          >
+            <PlusIcon className="size-4" />
+            <span>
+              Add new tag:
+              {" "}
+              <strong>{trimmed}</strong>
+            </span>
+          </button>
+        )}
+        <ComboboxEmpty>No tags found.</ComboboxEmpty>
+        <ComboboxList>
+          {groupByPrefix
+            ? Array.from(partitionTags(allOptionValues).entries()).map(
+              ([groupName, groupTags]) => (
+                <ComboboxGroup key={groupName}>
+                  <ComboboxLabel>{groupName}</ComboboxLabel>
+                  {groupTags.map(tag => (
+                    <ComboboxItem
+                      key={tag}
+                      value={tag}
+                    >
+                      {stripGroup(tag)}
+                    </ComboboxItem>
+                  ))}
+                </ComboboxGroup>
+              ),
+            )
+            : (val: string) => (
+              <ComboboxItem
+                key={val}
+                value={val}
+              >
+                {val}
+              </ComboboxItem>
+            )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
@@ -85,7 +85,7 @@ export function DashboardUnderutilizedProviders() {
         <Link
           to="/providers"
           className="
-            text-primary text-sm underline-offset-2
+            text-sm text-primary underline-offset-2
             hover:underline
           "
         >
@@ -94,13 +94,13 @@ export function DashboardUnderutilizedProviders() {
       )}
     >
       {isPending && (
-        <p className="text-muted-foreground text-sm">Loading providers...</p>
+        <p className="text-sm text-muted-foreground">Loading providers...</p>
       )}
       {error && (
-        <p className="text-destructive text-sm">Failed to load providers.</p>
+        <p className="text-sm text-destructive">Failed to load providers.</p>
       )}
       {providers && rows.length === 0 && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-sm text-muted-foreground">
           <i>No underutilized providers.</i>
         </p>
       )}

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -1,21 +1,58 @@
-import { useQuery } from "@tanstack/react-query";
+import type { TaskType } from "@emstack/types/src";
+
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { EraserIcon, MoonIcon, SproutIcon, SunIcon } from "lucide-react";
+import {
+  EraserIcon,
+  MoonIcon,
+  PencilIcon,
+  PlusIcon,
+  SproutIcon,
+  SunIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { toast } from "sonner";
 
 import { PageHeader } from "@/components/layout/PageHeader";
+import { TagChip } from "@/components/tasks/TagChip";
+import { TaskTypeEditModal } from "@/components/TaskTypeEditModal";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "@/hooks/useTheme.ts";
-import { fetchClear, fetchSeed } from "@/utils";
+import {
+  createTaskType,
+  deleteSingleTaskType,
+  fetchClear,
+  fetchSeed,
+  fetchTaskTypes,
+  upsertTaskType,
+} from "@/utils";
 
 export const Route = createFileRoute("/settings")({
   component: Settings,
 });
 
+const NEW_TASK_TYPE_ID = "__new__";
+
+function makeEmptyTaskType(): TaskType {
+  return {
+    id: NEW_TASK_TYPE_ID,
+    name: "",
+    whenToUse: "",
+    tags: [],
+  };
+}
+
 function Settings() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const {
     theme, setTheme,
   } = useTheme();
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [creatingNew, setCreatingNew] = useState(false);
 
   const {
     isFetching: isSeedFetching,
@@ -33,6 +70,63 @@ function Settings() {
     enabled: false,
     queryKey: ["clear"],
     queryFn: () => fetchClear(),
+  });
+
+  const taskTypesQuery = useQuery({
+    queryKey: ["taskTypes"],
+    queryFn: () => fetchTaskTypes(),
+  });
+
+  const upsertMutation = useMutation({
+    mutationFn: (taskType: TaskType) =>
+      upsertTaskType(taskType.id, {
+        name: taskType.name,
+        whenToUse: taskType.whenToUse ?? null,
+        tags: taskType.tags ?? [],
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["taskTypes"],
+      });
+      setEditingId(null);
+      toast.success("Task type saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (taskType: TaskType) =>
+      createTaskType({
+        name: taskType.name,
+        whenToUse: taskType.whenToUse ?? null,
+        tags: taskType.tags ?? [],
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["taskTypes"],
+      });
+      setCreatingNew(false);
+      toast.success("Task type created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleTaskType(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["taskTypes"],
+      });
+      setEditingId(null);
+      toast.success("Task type deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
   });
 
   async function handleClearLocal() {
@@ -55,6 +149,11 @@ function Settings() {
       });
     }
   }
+
+  const taskTypes = taskTypesQuery.data ?? [];
+  const editingTaskType = editingId
+    ? taskTypes.find(t => t.id === editingId) ?? null
+    : null;
 
   return (
     <div>
@@ -80,6 +179,80 @@ function Settings() {
               Clear & Seed Data
             </Button>
           </div>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-xl font-semibold">Task Types</h2>
+            <Button
+              variant="outline"
+              onClick={() => setCreatingNew(true)}
+            >
+              <PlusIcon />
+              New Task Type
+            </Button>
+          </div>
+          {taskTypesQuery.isPending
+            ? <p className="text-sm text-muted-foreground">Loading...</p>
+            : taskTypes.length === 0
+              ? (
+                <p className="text-sm text-muted-foreground">
+                  No task types yet. Create one to start tagging resources.
+                </p>
+              )
+              : (
+                <ul className="flex flex-col divide-y rounded-md border">
+                  {taskTypes.map(t => (
+                    <li
+                      key={t.id}
+                      className="
+                        flex flex-wrap items-center justify-between gap-2 p-3
+                      "
+                    >
+                      <div className="flex flex-col gap-1">
+                        <span className="font-medium">{t.name}</span>
+                        {t.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {t.tags.slice(0, 4).map(tag => (
+                              <TagChip
+                                key={tag}
+                                tag={tag}
+                              />
+                            ))}
+                            {t.tags.length > 4 && (
+                              <span className="text-xs text-muted-foreground">
+                                +
+                                {t.tags.length - 4}
+                                {" "}
+                                more
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setEditingId(t.id)}
+                        >
+                          <PencilIcon className="size-4" />
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => deleteMutation.mutate(t.id)}
+                          disabled={deleteMutation.isPending}
+                        >
+                          <Trash2Icon className="size-4" />
+                          Delete
+                        </Button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
         </section>
 
         <section className="flex flex-col gap-3">
@@ -111,6 +284,30 @@ function Settings() {
           </div>
         </section>
       </div>
+
+      <TaskTypeEditModal
+        open={editingId !== null}
+        taskType={editingTaskType}
+        onOpenChange={(open) => {
+          if (!open) setEditingId(null);
+        }}
+        onSave={t => upsertMutation.mutate(t)}
+        onDelete={editingTaskType
+          ? () => deleteMutation.mutate(editingTaskType.id)
+          : undefined}
+        isSaving={upsertMutation.isPending || deleteMutation.isPending}
+      />
+
+      <TaskTypeEditModal
+        open={creatingNew}
+        taskType={creatingNew ? makeEmptyTaskType() : null}
+        isNew
+        onOpenChange={(open) => {
+          if (!open) setCreatingNew(false);
+        }}
+        onSave={t => createMutation.mutate(t)}
+        isSaving={createMutation.isPending}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -16,6 +16,7 @@ import {
   createTask,
   deleteSingleTask,
   fetchSingleTask,
+  fetchTaskTypes,
   fetchTopics,
   formHasChanges,
   upsertTask,
@@ -29,6 +30,7 @@ const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   description: z.string().max(2000),
   topicId: z.string(),
+  taskTypeId: z.string(),
 });
 
 function SingleTaskEdit() {
@@ -56,7 +58,19 @@ function SingleTaskEdit() {
     queryFn: () => fetchTopics(),
   });
 
+  const {
+    data: taskTypes,
+  } = useQuery({
+    queryKey: ["taskTypes"],
+    queryFn: () => fetchTaskTypes(),
+  });
+
   const topicOptions = (topics ?? []).map(t => ({
+    value: t.id,
+    label: t.name,
+  }));
+
+  const taskTypeOptions = (taskTypes ?? []).map(t => ({
     value: t.id,
     label: t.name,
   }));
@@ -66,6 +80,7 @@ function SingleTaskEdit() {
       name: data?.name ?? "",
       description: data?.description ?? "",
       topicId: data?.topicId ?? "",
+      taskTypeId: data?.taskTypeId ?? "",
     }),
     [data],
   );
@@ -86,6 +101,7 @@ function SingleTaskEdit() {
         timeNeeded: r.timeNeeded ?? null,
         interactivity: r.interactivity ?? null,
         usedYet: r.usedYet,
+        tags: r.tags ?? [],
       }));
 
       const existingTodos = (data?.todos ?? []).map(t => ({
@@ -99,6 +115,7 @@ function SingleTaskEdit() {
         name: value.name,
         description: value.description || null,
         topicId: value.topicId || null,
+        taskTypeId: value.taskTypeId || null,
         resources: existingResources,
         todos: existingTodos,
       };
@@ -198,6 +215,16 @@ function SingleTaskEdit() {
                 label="Topic"
                 options={topicOptions}
                 placeholder="Search topics..."
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="taskTypeId">
+            {field => (
+              <field.ComboboxField
+                label="Task Type"
+                options={taskTypeOptions}
+                placeholder="Search task types..."
               />
             )}
           </form.AppField>

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -9,6 +9,7 @@ import type {
   Daily,
   Radar,
   Task,
+  TaskType,
 } from "@emstack/types/src/index.js";
 import type { OnboardData } from "@emstack/types/src/OnboardData";
 import type { Topic } from "@emstack/types/src/Topic";
@@ -83,8 +84,22 @@ async function deleteJson<T>(url: string, errorLabel?: string): Promise<T> {
     method: "DELETE",
   });
   if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let serverMessage: string | undefined;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed && typeof parsed.message === "string") {
+          serverMessage = parsed.message;
+        }
+      }
+      catch {
+        serverMessage = text;
+      }
+    }
     throw new Error(
-      `${errorLabel ?? `DELETE ${url}`} failed (${response.status} ${response.statusText})`,
+      serverMessage
+      ?? `${errorLabel ?? `DELETE ${url}`} failed (${response.status} ${response.statusText})`,
     );
   }
   return await response.json();
@@ -137,6 +152,10 @@ export const providersApi = createEntityClient<CourseProvider>(
 export const domainsApi = createEntityClient<Domain>("domains", "domain");
 export const dailiesApi = createEntityClient<Daily>("dailies", "daily");
 export const tasksApi = createEntityClient<Task>("tasks", "task");
+export const taskTypesApi = createEntityClient<TaskType>(
+  "task-types",
+  "task type",
+);
 
 export async function fetchTest(): Promise<Test> {
   return fetchJson<Test>("/api");
@@ -152,6 +171,7 @@ export const fetchCourses = coursesApi.list;
 export const fetchDomains = domainsApi.list;
 export const fetchDailies = dailiesApi.list;
 export const fetchTasks = tasksApi.list;
+export const fetchTaskTypes = taskTypesApi.list;
 
 export const fetchSingleCourse = coursesApi.get;
 export const fetchSingleTopic = topicsApi.get;
@@ -159,6 +179,7 @@ export const fetchSingleProvider = providersApi.get;
 export const fetchSingleDomain = domainsApi.get;
 export const fetchSingleDaily = dailiesApi.get;
 export const fetchSingleTask = tasksApi.get;
+export const fetchSingleTaskType = taskTypesApi.get;
 
 export const upsertCourse = coursesApi.upsert;
 export const upsertTopic = topicsApi.upsert;
@@ -166,12 +187,14 @@ export const upsertProvider = providersApi.upsert;
 export const upsertDomain = domainsApi.upsert;
 export const upsertDaily = dailiesApi.upsert;
 export const upsertTask = tasksApi.upsert;
+export const upsertTaskType = taskTypesApi.upsert;
 
 export const createTopic = topicsApi.create;
 export const createProvider = providersApi.create;
 export const createDomain = domainsApi.create;
 export const createDaily = dailiesApi.create;
 export const createTask = tasksApi.create;
+export const createTaskType = taskTypesApi.create;
 
 export const deleteSingleCourse = coursesApi.delete;
 export const deleteSingleTopic = topicsApi.delete;
@@ -179,6 +202,7 @@ export const deleteSinglePlatform = providersApi.delete;
 export const deleteSingleDomain = domainsApi.delete;
 export const deleteSingleDaily = dailiesApi.delete;
 export const deleteSingleTask = tasksApi.delete;
+export const deleteSingleTaskType = taskTypesApi.delete;
 
 export const duplicateCourse = coursesApi.duplicate;
 export const duplicateDomain = domainsApi.duplicate;

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { boolean, date, integer, jsonb, numeric, pgEnum, pgTable, primaryKey, unique, varchar } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 export type DailyCompletionStatus = "incomplete" | "touched" | "goal" | "exceeded" | "freeze";
 
@@ -94,6 +94,15 @@ export const dailies = pgTable("dailies", {
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
 });
 
+export const taskTypes = pgTable("task_types", {
+  id: varchar().primaryKey(),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  whenToUse: varchar("when_to_use"),
+  tags: varchar().array().notNull().default(sql`'{}'::varchar[]`),
+});
+
 export const tasks = pgTable("tasks", {
   id: varchar().primaryKey(),
   name: varchar({
@@ -101,6 +110,7 @@ export const tasks = pgTable("tasks", {
   }).notNull(),
   description: varchar(),
   topicId: varchar("topic_id"),
+  taskTypeId: varchar("task_type_id"),
 });
 
 export const resources = pgTable("resources", {
@@ -115,6 +125,7 @@ export const resources = pgTable("resources", {
   interactivity: resourceLevelEnum(),
   usedYet: boolean("used_yet").default(false).notNull(),
   position: integer(),
+  tags: varchar().array().notNull().default(sql`'{}'::varchar[]`),
 });
 
 export const taskTodos = pgTable("task_todos", {
@@ -135,12 +146,22 @@ export const tasksRelations = relations(tasks, ({
     fields: [tasks.topicId],
     references: [topics.id],
   }),
+  taskType: one(taskTypes, {
+    fields: [tasks.taskTypeId],
+    references: [taskTypes.id],
+  }),
   resources: many(resources),
   todos: many(taskTodos),
   daily: one(dailies, {
     fields: [tasks.id],
     references: [dailies.taskId],
   }),
+}));
+
+export const taskTypesRelations = relations(taskTypes, ({
+  many,
+}) => ({
+  tasks: many(tasks),
 }));
 
 export const resourcesRelations = relations(resources, ({

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -14,6 +14,7 @@ import domains from "./domains/routes";
 import dailies from "./dailies/routes";
 import radar from "./radar/routes";
 import tasks from "./tasks/routes";
+import taskTypes from "./task-types/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -44,5 +45,8 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(tasks, {
     prefix: "/tasks",
+  });
+  fastify.register(taskTypes, {
+    prefix: "/task-types",
   });
 }

--- a/packages/middleware/src/routes/api/task-types/deleteTaskType.ts
+++ b/packages/middleware/src/routes/api/task-types/deleteTaskType.ts
@@ -1,0 +1,46 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { taskTypes, tasks } from "@/db/schema";
+import { idParamSchema } from "@/utils/schemas";
+import { sendConflict } from "@/utils/errors";
+
+const schema = {
+  schema: {
+    description: "Delete a task type by ID (only if no tasks reference it)",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.delete("/:id", schema, async function (request, reply) {
+    const {
+      id,
+    } = request.params;
+
+    const [{
+      count,
+    }] = await db
+      .select({
+        count: sql<number>`count(*)::int`,
+      })
+      .from(tasks)
+      .where(eq(tasks.taskTypeId, id));
+
+    if (count > 0) {
+      return sendConflict(
+        reply,
+        `Cannot delete task type: ${count} task${count === 1 ? "" : "s"} still reference it`,
+      );
+    }
+
+    await db.delete(taskTypes).where(eq(taskTypes.id, id));
+
+    return {
+      status: "ok",
+    };
+  });
+}

--- a/packages/middleware/src/routes/api/task-types/getTaskType.ts
+++ b/packages/middleware/src/routes/api/task-types/getTaskType.ts
@@ -1,0 +1,37 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { idParamSchema } from "@/utils/schemas";
+import { sendNotFound } from "@/utils/errors";
+
+const schema = {
+  schema: {
+    description: "Get a single task type by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id",
+    schema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const taskType = await db.query.taskTypes.findFirst({
+        where: (t, {
+          eq,
+        }) => eq(t.id, id),
+      });
+
+      if (!taskType) {
+        return sendNotFound(reply, "Task type");
+      }
+
+      return taskType;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/task-types/root.ts
+++ b/packages/middleware/src/routes/api/task-types/root.ts
@@ -1,0 +1,60 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { taskTypes } from "@/db/schema";
+import { nullableString, tagsArraySchema } from "@/utils/schemas";
+
+const createSchema = {
+  schema: {
+    description: "Create a new task type",
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        whenToUse: nullableString,
+        tags: tagsArraySchema,
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/",
+    async () => {
+      const rows = await db.query.taskTypes.findMany({
+        orderBy: (t, {
+          asc,
+        }) => asc(t.name),
+      });
+      return rows;
+    },
+  );
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(taskTypes).values({
+        id,
+        name: body.name,
+        whenToUse: body.whenToUse ?? null,
+        tags: body.tags ?? [],
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/task-types/routes.ts
+++ b/packages/middleware/src/routes/api/task-types/routes.ts
@@ -1,0 +1,16 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import root from "./root";
+import getTaskType from "./getTaskType";
+import upsertTaskType from "./upsertTaskType";
+import deleteTaskType from "./deleteTaskType";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(root);
+  fastify.register(getTaskType);
+  fastify.register(upsertTaskType);
+  fastify.register(deleteTaskType);
+}

--- a/packages/middleware/src/routes/api/task-types/upsertTaskType.ts
+++ b/packages/middleware/src/routes/api/task-types/upsertTaskType.ts
@@ -1,0 +1,34 @@
+import { taskTypes } from "@/db/schema";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
+import { nullableString, tagsArraySchema } from "@/utils/schemas";
+
+interface TaskTypeBody {
+  name: string;
+  whenToUse?: string | null;
+  tags?: string[];
+}
+
+const updateableColumns = ["name", "whenToUse", "tags"] as const;
+
+export default createUpsertHandler<TaskTypeBody>({
+  description: "Create or update a task type",
+  table: taskTypes,
+  bodySchema: {
+    type: "object",
+    required: ["name"],
+    properties: {
+      name: {
+        type: "string",
+      },
+      whenToUse: nullableString,
+      tags: tagsArraySchema,
+    },
+  },
+  buildRow: (body, id) => ({
+    id,
+    name: body.name,
+    whenToUse: body.whenToUse ?? null,
+    tags: body.tags ?? [],
+  }),
+  updateableColumns,
+});

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -17,6 +17,7 @@ const createSchema = {
         },
         description: nullableString,
         topicId: nullableString,
+        taskTypeId: nullableString,
         resources: {
           type: "array",
           items: resourceSchema,
@@ -45,6 +46,7 @@ export default async function (server: FastifyInstance) {
         name: body.name,
         description: body.description ?? null,
         topicId: body.topicId || null,
+        taskTypeId: body.taskTypeId || null,
       });
 
       const incoming = body.resources ?? [];
@@ -60,6 +62,7 @@ export default async function (server: FastifyInstance) {
             interactivity: r.interactivity ?? null,
             usedYet: r.usedYet ?? false,
             position: index,
+            tags: r.tags ?? [],
           })),
         );
       }

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -33,6 +33,13 @@ export default async function (server: FastifyInstance) {
               name: true,
             },
           },
+          taskType: {
+            columns: {
+              id: true,
+              name: true,
+              tags: true,
+            },
+          },
           resources: true,
           todos: true,
           daily: {
@@ -61,6 +68,14 @@ export default async function (server: FastifyInstance) {
             name: task.topic.name,
           }
           : null,
+        taskTypeId: task.taskTypeId ?? null,
+        taskType: task.taskType
+          ? {
+            id: task.taskType.id,
+            name: task.taskType.name,
+            tags: task.taskType.tags ?? [],
+          }
+          : null,
         resources: (task.resources ?? [])
           .slice()
           .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
@@ -74,6 +89,7 @@ export default async function (server: FastifyInstance) {
             interactivity: r.interactivity,
             usedYet: r.usedYet,
             position: r.position,
+            tags: r.tags ?? [],
           })),
         todos: (task.todos ?? [])
           .slice()

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -15,6 +15,13 @@ export default async function (server: FastifyInstance) {
             name: true,
           },
         },
+        taskType: {
+          columns: {
+            id: true,
+            name: true,
+            tags: true,
+          },
+        },
         resources: true,
         todos: true,
         daily: {
@@ -39,6 +46,14 @@ export default async function (server: FastifyInstance) {
           name: task.topic.name,
         }
         : null,
+      taskTypeId: task.taskTypeId ?? null,
+      taskType: task.taskType
+        ? {
+          id: task.taskType.id,
+          name: task.taskType.name,
+          tags: task.taskType.tags ?? [],
+        }
+        : null,
       resources: (task.resources ?? [])
         .slice()
         .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
@@ -52,6 +67,7 @@ export default async function (server: FastifyInstance) {
           interactivity: r.interactivity,
           usedYet: r.usedYet,
           position: r.position,
+          tags: r.tags ?? [],
         })),
       todos: (task.todos ?? [])
         .slice()

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -24,6 +24,7 @@ const upsertSchema = {
         },
         description: nullableString,
         topicId: nullableString,
+        taskTypeId: nullableString,
         resources: {
           type: "array",
           items: resourceSchema,
@@ -54,6 +55,7 @@ export default async function (server: FastifyInstance) {
         name: body.name,
         description: body.description ?? null,
         topicId: body.topicId || null,
+        taskTypeId: body.taskTypeId || null,
       };
 
       await db
@@ -65,6 +67,7 @@ export default async function (server: FastifyInstance) {
             name: taskData.name,
             description: taskData.description,
             topicId: taskData.topicId,
+            taskTypeId: taskData.taskTypeId,
           },
         });
 
@@ -82,6 +85,7 @@ export default async function (server: FastifyInstance) {
               interactivity: r.interactivity ?? null,
               usedYet: r.usedYet ?? false,
               position: index,
+              tags: r.tags ?? [],
             })),
           );
         }

--- a/packages/middleware/src/utils/errors.ts
+++ b/packages/middleware/src/utils/errors.ts
@@ -13,3 +13,10 @@ export function sendBadRequest(reply: FastifyReply, message: string) {
     message,
   });
 }
+
+export function sendConflict(reply: FastifyReply, message: string) {
+  return reply.status(409).send({
+    status: "error",
+    message,
+  });
+}

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -72,6 +72,14 @@ export const criteriaSchema = {
   },
 } as const;
 
+export const tagsArraySchema = {
+  type: "array",
+  items: {
+    type: "string",
+  },
+  default: [],
+} as const;
+
 export const resourceSchema = {
   type: "object",
   required: ["name"],
@@ -89,6 +97,7 @@ export const resourceSchema = {
     usedYet: {
       type: "boolean",
     },
+    tags: tagsArraySchema,
   },
 } as const;
 

--- a/packages/types/src/Resource.ts
+++ b/packages/types/src/Resource.ts
@@ -10,4 +10,5 @@ export interface Resource {
   interactivity?: ResourceLevel | null;
   usedYet: boolean;
   position?: number | null;
+  tags: string[];
 }

--- a/packages/types/src/Task.ts
+++ b/packages/types/src/Task.ts
@@ -16,6 +16,10 @@ export interface Task {
   topicId?: string | null;
   topic?: { id: string;
     name: string; } | null;
+  taskTypeId?: string | null;
+  taskType?: { id: string;
+    name: string;
+    tags: string[]; } | null;
   resources?: Resource[];
   todos?: TaskTodo[];
   daily?: TaskLinkedDaily | null;

--- a/packages/types/src/TaskType.ts
+++ b/packages/types/src/TaskType.ts
@@ -1,0 +1,6 @@
+export interface TaskType {
+  id: string;
+  name: string;
+  whenToUse?: string | null;
+  tags: string[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,4 @@ export * from "./Radar";
 export * from "./Resource";
 export * from "./Task";
 export * from "./TaskTodo";
+export * from "./TaskType";


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive task type management system that allows users to create, edit, and delete task types with associated tags. Task types can be assigned to tasks and their tags are suggested when adding resources to those tasks.

## Key Changes

### Backend (Middleware)
- Added new `task_types` database table with `id`, `name`, `whenToUse`, and `tags` columns
- Created task type API endpoints:
  - `GET /api/task-types` - List all task types
  - `POST /api/task-types` - Create new task type
  - `GET /api/task-types/:id` - Get single task type
  - `PUT/PATCH /api/task-types/:id` - Upsert task type
  - `DELETE /api/task-types/:id` - Delete task type (with validation to prevent deletion if tasks reference it)
- Added `taskTypeId` foreign key to `tasks` table
- Updated task endpoints to include task type data with tags in responses
- Added `sendConflict` error handler for 409 responses

### Frontend (Client)
- Created `TaskTypeEditModal` component for creating/editing task types with name, description, and tags
- Created `TagsInput` component - a combobox-based multi-select for tags with:
  - Support for free-text tag creation
  - Optional grouping by prefix (e.g., `skill:listening` groups under "skill")
  - Suggested tags from task type definitions
- Created `TagChip` component for displaying tags with group prefix styling
- Added task type management section to settings page with list, edit, and delete functionality
- Updated `MultiComboboxField` to support prefix-based grouping for better UX
- Added `taskTypeId` field to task edit form
- Updated resource edit modal to accept tag suggestions from parent task's task type
- Added `tags` field to Resource type

### Types
- Created `TaskType` interface in `@emstack/types`
- Updated `Task` interface to include `taskTypeId` and `taskType` fields
- Updated `Resource` interface to include `tags` array

## Notable Implementation Details
- Task types cannot be deleted if tasks reference them (409 Conflict response)
- Tags support a `group:value` format for organization in dropdowns
- Tag suggestions in resource creation are pulled from the parent task's assigned task type
- Settings page shows task type list with preview of first 4 tags and count of remaining tags
- Toast notifications provide feedback for all task type operations

https://claude.ai/code/session_01FGWyu9WdnncnqKDP5Y2NqJ