### PR TITLE
Hide empty filter options in select dropdowns

### DIFF
--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -218,11 +218,13 @@ function Courses() {
                       <span>All Providers</span>
                       <FilterOptionCount count={totalCourseCount} />
                     </SelectItem>
-                    <SelectItem value="none">
-                      <span>No Provider</span>
-                      <FilterOptionCount count={noProviderCount} />
-                    </SelectItem>
-                    {providers?.map(p => (
+                    {noProviderCount > 0 && (
+                      <SelectItem value="none">
+                        <span>No Provider</span>
+                        <FilterOptionCount count={noProviderCount} />
+                      </SelectItem>
+                    )}
+                    {providers?.filter(p => (p.courseCount ?? 0) > 0).map(p => (
                       <SelectItem
                         key={p.id}
                         value={p.id}
@@ -247,11 +249,13 @@ function Courses() {
                       <span>All Topics</span>
                       <FilterOptionCount count={totalCourseCount} />
                     </SelectItem>
-                    <SelectItem value="none">
-                      <span>No Topic</span>
-                      <FilterOptionCount count={noTopicCount} />
-                    </SelectItem>
-                    {topics?.map(t => (
+                    {noTopicCount > 0 && (
+                      <SelectItem value="none">
+                        <span>No Topic</span>
+                        <FilterOptionCount count={noTopicCount} />
+                      </SelectItem>
+                    )}
+                    {topics?.filter(t => (t.courseCount ?? 0) > 0).map(t => (
                       <SelectItem
                         key={t.id}
                         value={t.id}

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -145,21 +145,25 @@ function Tasks() {
                   <span>All Topics</span>
                   <FilterOptionCount count={totalTaskCount} />
                 </SelectItem>
-                <SelectItem value="none">
-                  <span>No Topic</span>
-                  <FilterOptionCount count={noTopicCount} />
-                </SelectItem>
-                {topics?.map(t => (
-                  <SelectItem
-                    key={t.id}
-                    value={t.id}
-                  >
-                    <span>{t.name}</span>
-                    <FilterOptionCount
-                      count={taskCountByTopic.get(t.id) ?? 0}
-                    />
+                {noTopicCount > 0 && (
+                  <SelectItem value="none">
+                    <span>No Topic</span>
+                    <FilterOptionCount count={noTopicCount} />
                   </SelectItem>
-                ))}
+                )}
+                {topics
+                  ?.filter(t => (taskCountByTopic.get(t.id) ?? 0) > 0)
+                  .map(t => (
+                    <SelectItem
+                      key={t.id}
+                      value={t.id}
+                    >
+                      <span>{t.name}</span>
+                      <FilterOptionCount
+                        count={taskCountByTopic.get(t.id) ?? 0}
+                      />
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
             {hasActiveFilters && (

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -166,11 +166,13 @@ function Topics() {
                       <span>All Domains</span>
                       <FilterOptionCount count={totalTopicCount} />
                     </SelectItem>
-                    <SelectItem value="none">
-                      <span>No Domain</span>
-                      <FilterOptionCount count={noDomainCount} />
-                    </SelectItem>
-                    {domains?.map(d => (
+                    {noDomainCount > 0 && (
+                      <SelectItem value="none">
+                        <span>No Domain</span>
+                        <FilterOptionCount count={noDomainCount} />
+                      </SelectItem>
+                    )}
+                    {domains?.filter(d => (d.topicCount ?? 0) > 0).map(d => (
                       <SelectItem
                         key={d.id}
                         value={d.id}


### PR DESCRIPTION
## Summary
Updated filter dropdowns across tasks, courses, and topics pages to hide filter options that have no associated items, improving the user experience by reducing clutter in the UI.

## Key Changes
- **Tasks page**: Hide "No Topic" option when count is 0, and filter out topics with no tasks
- **Courses page**: Hide "No Provider" option when count is 0, filter out providers with no courses, and hide "No Topic" option when count is 0, filter out topics with no courses
- **Topics page**: Hide "No Domain" option when count is 0, and filter out domains with no topics

## Implementation Details
- Wrapped "No [Category]" SelectItems with conditional rendering (`{count > 0 && ...}`)
- Added `.filter()` calls to category lists to exclude items with zero counts before mapping
- Applied consistent pattern across all three pages for maintainability
- No changes to data fetching or counting logic; filtering is purely presentational

https://claude.ai/code/session_01QzN6qWFMMQfwuktZm3EGFt