### PR TITLE
Refactor radar quadrants to slices and add within-scope topics

### DIFF
--- a/packages/client/src/components/radar/BlipBulkAdd.tsx
+++ b/packages/client/src/components/radar/BlipBulkAdd.tsx
@@ -291,7 +291,7 @@ export function BlipBulkAdd({
                 })}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Quadrant" />
+                <SelectValue placeholder="Slice" />
               </SelectTrigger>
               <SelectContent>
                 {quadrants.map(q => (

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -151,8 +151,8 @@ function computeProblems(
   if (!entry.quadrantId) {
     problems.push(
       entry.quadrantInput
-        ? `unknown quadrant "${entry.quadrantInput}"`
-        : "missing quadrant",
+        ? `unknown slice "${entry.quadrantInput}"`
+        : "missing slice",
     );
   }
   if (!entry.ringId) {
@@ -1069,7 +1069,7 @@ function ReviewTable({
         <TableRow>
           <TableHead className="min-w-32">Topic</TableHead>
           <TableHead className="min-w-56">Description</TableHead>
-          <TableHead className="min-w-32">Quadrant</TableHead>
+          <TableHead className="min-w-32">Slice</TableHead>
           <TableHead className="min-w-32">Ring</TableHead>
           <TableHead className="min-w-56">Radar Note</TableHead>
           <TableHead className="w-24">Edit</TableHead>

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -131,7 +131,7 @@ export function BlipTable({
       return;
     }
     if (!editDraft.quadrantId || !editDraft.ringId) {
-      toast.error("Pick a quadrant and ring.");
+      toast.error("Pick a slice and ring.");
       return;
     }
     setPendingId(blip.id);
@@ -181,10 +181,10 @@ export function BlipTable({
           onValueChange={setFilterQuadrant}
         >
           <SelectTrigger className="min-w-40">
-            <SelectValue placeholder="Quadrant" />
+            <SelectValue placeholder="Slice" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>All Quadrants</SelectItem>
+            <SelectItem value={ALL}>All Slices</SelectItem>
             {quadrants.map(q => (
               <SelectItem
                 key={q.id}
@@ -221,7 +221,7 @@ export function BlipTable({
           <TableHeader>
             <TableRow>
               <TableHead>Topic</TableHead>
-              <TableHead>Quadrant</TableHead>
+              <TableHead>Slice</TableHead>
               <TableHead>Ring</TableHead>
               <TableHead>Radar Note</TableHead>
               <TableHead className="w-1 text-right">Actions</TableHead>
@@ -283,7 +283,7 @@ export function BlipTable({
                         <div className="flex flex-col gap-3">
                           <div className="flex flex-col gap-1">
                             <label className="text-xs uppercase">
-                              Quadrant
+                              Slice
                             </label>
                             <Select
                               value={editDraft.quadrantId}
@@ -297,7 +297,7 @@ export function BlipTable({
                                     : prev)}
                             >
                               <SelectTrigger>
-                                <SelectValue placeholder="Choose quadrant" />
+                                <SelectValue placeholder="Choose slice" />
                               </SelectTrigger>
                               <SelectContent>
                                 {quadrants.map(q => (

--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -196,7 +196,7 @@ export function RadarChart({
           minHeight: size / 2,
         }}
       >
-        Configure at least one quadrant and one ring to display the radar.
+        Configure at least one slice and one ring to display the radar.
       </div>
     );
   }

--- a/packages/client/src/components/radar/RadarConfigIllustrations.tsx
+++ b/packages/client/src/components/radar/RadarConfigIllustrations.tsx
@@ -13,8 +13,8 @@ const QUADRANT_COLORS = [
 export function QuadrantsIllustration({
   names,
 }: QuadrantsIllustrationProps) {
-  const cleanNames = names.map(n => n.trim());
-  const slots = cleanNames.length > 0 ? cleanNames : ["", "", "", "", ""];
+  const filled = names.map(n => n.trim()).filter(n => n.length > 0);
+  const slots = filled.length > 0 ? filled : ["", "", "", ""];
   const count = slots.length;
 
   const cx = 100;
@@ -53,9 +53,9 @@ export function QuadrantsIllustration({
   return (
     <svg
       viewBox="0 0 200 200"
-      className="size-40"
+      className="size-72"
       role="img"
-      aria-label="Quadrants illustration"
+      aria-label="Slices illustration"
     >
       {sectors.map(s => (
         <path
@@ -106,7 +106,7 @@ export function RingsIllustration({
   return (
     <svg
       viewBox="0 0 200 200"
-      className="size-40"
+      className="size-72"
       role="img"
       aria-label="Rings illustration"
     >

--- a/packages/client/src/routes/domains.$id.radar.edit.tsx
+++ b/packages/client/src/routes/domains.$id.radar.edit.tsx
@@ -220,7 +220,9 @@ function RadarEdit() {
     }
     setWithinScopeDescription(domainDetail.withinScopeDescription ?? "");
     setOutOfScopeDescription(domainDetail.outOfScopeDescription ?? "");
-    setWithinScopeTopicIds((domainDetail.topics ?? []).map(t => t.id));
+    setWithinScopeTopicIds(
+      (domainDetail.withinScopeTopics ?? []).map(t => t.id),
+    );
     setOutOfScopeTopicIds((domainDetail.excludedTopics ?? []).map(t => t.id));
     setDetailsHydrated(true);
   }, [domainDetail, detailsHydrated]);
@@ -307,8 +309,18 @@ function RadarEdit() {
   }
 
   async function saveConfig() {
-    if (quadrants.some(q => !q.name.trim())) {
-      toast.error("Every quadrant needs a name.");
+    const filledQuadrants = quadrants.filter((q, idx) => {
+      if (q.name.trim()) {
+        return true;
+      }
+      return idx < QUADRANT_COUNT - 1;
+    });
+    if (filledQuadrants.some(q => !q.name.trim())) {
+      toast.error("Every slice needs a name (only the 5th may be empty).");
+      return;
+    }
+    if (filledQuadrants.length === 0) {
+      toast.error("Add at least one slice.");
       return;
     }
     if (rings.some(r => !r.name.trim())) {
@@ -322,10 +334,10 @@ function RadarEdit() {
     setIsSavingConfig(true);
     try {
       await upsertRadarConfig(id, {
-        quadrants: quadrants.map(q => ({
+        quadrants: filledQuadrants.map((q, idx) => ({
           id: q.id,
           name: q.name.trim(),
-          position: q.position,
+          position: idx,
         })),
         rings: rings.map(r => ({
           id: r.id,
@@ -359,7 +371,7 @@ function RadarEdit() {
         hasRadar: domainDetail.hasRadar ?? null,
         withinScopeDescription: withinScopeDescription.trim() || null,
         outOfScopeDescription: outOfScopeDescription.trim() || null,
-        topicIds: withinScopeTopicIds,
+        withinScopeTopicIds,
         excludedTopics: outOfScopeTopicIds.map((topicId) => {
           const existing = (domainDetail.excludedTopics ?? []).find(
             t => t.id === topicId,
@@ -386,11 +398,11 @@ function RadarEdit() {
 
   function addBlipDraft() {
     if (quadrants.length === 0 || rings.length === 0) {
-      toast.error("Add at least one quadrant and ring first.");
+      toast.error("Add at least one slice and ring first.");
       return;
     }
     if (!allConfigPersisted) {
-      toast.error("Save your quadrants and rings before adding blips.");
+      toast.error("Save your slices and rings before adding blips.");
       return;
     }
     setBlips(prev => [
@@ -411,7 +423,7 @@ function RadarEdit() {
       return;
     }
     if (!blip.quadrantId || !blip.ringId) {
-      toast.error("Pick a quadrant and ring.");
+      toast.error("Pick a slice and ring.");
       return;
     }
     setPendingBlipKey(blip.localKey);
@@ -571,38 +583,48 @@ function RadarEdit() {
           `}
         >
           <section className="flex flex-col gap-4">
-            <h2 className="text-2xl">Quadrants</h2>
+            <h2 className="text-2xl">Slices</h2>
             <p className="text-sm text-muted-foreground">
-              Quadrants are the categories on your radar.
+              Slices are the categories on your radar. The 5th is optional —
+              leave it blank for a 4-slice radar.
             </p>
             <div className="flex justify-center">
               <QuadrantsIllustration names={quadrants.map(q => q.name)} />
             </div>
             <ul className="flex flex-col gap-2">
-              {quadrants.map((q, idx) => (
-                <li
-                  key={q.localKey}
-                  className="flex flex-row items-center gap-2"
-                >
-                  <span className="w-6 text-sm text-muted-foreground">
-                    {idx + 1}
-                    .
-                  </span>
-                  <Input
-                    value={q.name}
-                    onChange={e =>
-                      setQuadrants(prev =>
-                        prev.map(item =>
-                          item.localKey === q.localKey
-                            ? {
-                              ...item,
-                              name: e.target.value,
-                            }
-                            : item))}
-                    placeholder="Quadrant name"
-                  />
-                </li>
-              ))}
+              {quadrants.map((q, idx) => {
+                const isOptional = idx === QUADRANT_COUNT - 1;
+                const isInactive = isOptional && !q.name.trim();
+                return (
+                  <li
+                    key={q.localKey}
+                    className={`
+                      flex flex-row items-center gap-2
+                      ${isInactive ? "opacity-60" : ""}
+                    `}
+                  >
+                    <span className="w-6 text-sm text-muted-foreground">
+                      {idx + 1}
+                      .
+                    </span>
+                    <Input
+                      value={q.name}
+                      onChange={e =>
+                        setQuadrants(prev =>
+                          prev.map(item =>
+                            item.localKey === q.localKey
+                              ? {
+                                ...item,
+                                name: e.target.value,
+                              }
+                              : item))}
+                      placeholder={
+                        isOptional ? "Slice name (optional)" : "Slice name"
+                      }
+                    />
+                  </li>
+                );
+              })}
             </ul>
           </section>
 
@@ -763,7 +785,7 @@ function RadarEdit() {
           <h2 className="text-2xl">Blips</h2>
           {!allConfigPersisted && (
             <p className="text-sm text-amber-700">
-              Save your quadrants and rings before adding blips.
+              Save your slices and rings before adding blips.
             </p>
           )}
 
@@ -861,7 +883,7 @@ function RadarEdit() {
                       </div>
                       <div className="flex flex-col gap-3">
                         <div className="flex flex-col gap-1">
-                          <label className="text-xs uppercase">Quadrant</label>
+                          <label className="text-xs uppercase">Slice</label>
                           <Select
                             value={blip.quadrantId}
                             onValueChange={value =>
@@ -875,7 +897,7 @@ function RadarEdit() {
                                     : b))}
                           >
                             <SelectTrigger>
-                              <SelectValue placeholder="Choose quadrant" />
+                              <SelectValue placeholder="Choose slice" />
                             </SelectTrigger>
                             <SelectContent>
                               {persistedQuadrants.map(q => (

--- a/packages/client/src/routes/domains.$id.radar.index.tsx
+++ b/packages/client/src/routes/domains.$id.radar.index.tsx
@@ -121,7 +121,7 @@ function RadarView() {
             <InfoArea header="Get Started">
               <div className="flex flex-col gap-4 py-4">
                 <p>
-                  This radar has not been configured yet. Define quadrants and
+                  This radar has not been configured yet. Define slices and
                   rings before adding blips.
                 </p>
                 <Link

--- a/packages/middleware/src/db/clearData.ts
+++ b/packages/middleware/src/db/clearData.ts
@@ -1,9 +1,10 @@
-import { courseProviders, courses, domains, topics, topicsToCourses, topicsToDomains } from "@/db/schema";
+import { courseProviders, courses, domains, domainWithinScopeTopics, topics, topicsToCourses, topicsToDomains } from "@/db/schema";
 import { db } from "@/db/index";
 
 export async function clearData() {
   await db.delete(topicsToCourses);
   await db.delete(topicsToDomains);
+  await db.delete(domainWithinScopeTopics);
   await db.delete(topics);
   await db.delete(courses);
   await db.delete(courseProviders);

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -224,6 +224,7 @@ export const topicsRelations = relations(topics, ({
   topicsToDomains: many(topicsToDomains),
   radarBlips: many(radarBlips),
   domainExclusions: many(domainExcludedTopics),
+  domainWithinScope: many(domainWithinScopeTopics),
   tasks: many(tasks),
 }));
 
@@ -246,6 +247,7 @@ export const domainsRelations = relations(domains, ({
   radarRings: many(radarRings),
   radarBlips: many(radarBlips),
   excludedTopics: many(domainExcludedTopics),
+  withinScopeTopics: many(domainWithinScopeTopics),
 }));
 
 export const domainExcludedTopics = pgTable(
@@ -277,6 +279,39 @@ export const domainExcludedTopicsRelations = relations(
     }),
     domain: one(domains, {
       fields: [domainExcludedTopics.domainId],
+      references: [domains.id],
+    }),
+  }),
+);
+
+export const domainWithinScopeTopics = pgTable(
+  "domain_within_scope_topics",
+  {
+    topicId: varchar("topic_id")
+      .notNull()
+      .references(() => topics.id),
+    domainId: varchar("domain_id")
+      .notNull()
+      .references(() => domains.id),
+  },
+  t => [
+    primaryKey({
+      columns: [t.topicId, t.domainId],
+    }),
+  ],
+);
+
+export const domainWithinScopeTopicsRelations = relations(
+  domainWithinScopeTopics,
+  ({
+    one,
+  }) => ({
+    topic: one(topics, {
+      fields: [domainWithinScopeTopics.topicId],
+      references: [topics.id],
+    }),
+    domain: one(domains, {
+      fields: [domainWithinScopeTopics.domainId],
       references: [domains.id],
     }),
   }),

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -1,7 +1,12 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import { domainExcludedTopics, domains, topicsToDomains } from "@/db/schema";
+import {
+  domainExcludedTopics,
+  domains,
+  domainWithinScopeTopics,
+  topicsToDomains,
+} from "@/db/schema";
 import { nullableBoolean, nullableString } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
 
@@ -37,6 +42,12 @@ const createSchema = {
               },
               reason: nullableString,
             },
+          },
+        },
+        withinScopeTopicIds: {
+          type: "array",
+          items: {
+            type: "string",
           },
         },
       },
@@ -92,6 +103,18 @@ export default async function (server: FastifyInstance) {
             topicId,
             domainId: id,
             reason,
+          })),
+        );
+      }
+
+      const uniqueWithinScopeTopicIds = Array.from(
+        new Set(body.withinScopeTopicIds ?? []),
+      );
+      if (uniqueWithinScopeTopicIds.length > 0) {
+        await db.insert(domainWithinScopeTopics).values(
+          uniqueWithinScopeTopicIds.map(topicId => ({
+            topicId,
+            domainId: id,
           })),
         );
       }

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -1,6 +1,7 @@
 import {
   domainExcludedTopics,
   domains,
+  domainWithinScopeTopics,
   radarBlips,
   radarQuadrants,
   radarRings,
@@ -32,6 +33,10 @@ export default createDeleteHandler({
     {
       table: domainExcludedTopics,
       foreignKey: domainExcludedTopics.domainId,
+    },
+    {
+      table: domainWithinScopeTopics,
+      foreignKey: domainWithinScopeTopics.domainId,
     },
   ],
 });

--- a/packages/middleware/src/routes/api/domains/duplicateDomain.ts
+++ b/packages/middleware/src/routes/api/domains/duplicateDomain.ts
@@ -4,6 +4,7 @@ import { db } from "@/db";
 import {
   domainExcludedTopics,
   domains,
+  domainWithinScopeTopics,
   topicsToDomains,
 } from "@/db/schema";
 import { idParamSchema } from "@/utils/schemas";
@@ -34,6 +35,7 @@ export default async function (server: FastifyInstance) {
         with: {
           topicsToDomains: true,
           excludedTopics: true,
+          withinScopeTopics: true,
         },
       });
 
@@ -69,6 +71,14 @@ export default async function (server: FastifyInstance) {
       }));
       if (exclusions.length > 0) {
         await db.insert(domainExcludedTopics).values(exclusions);
+      }
+
+      const withinScopeLinks = (source.withinScopeTopics ?? []).map(w => ({
+        topicId: w.topicId,
+        domainId: newId,
+      }));
+      if (withinScopeLinks.length > 0) {
+        await db.insert(domainWithinScopeTopics).values(withinScopeLinks);
       }
 
       return {

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -79,6 +79,17 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
+          withinScopeTopics: {
+            with: {
+              topic: {
+                columns: {
+                  id: true,
+                  name: true,
+                  description: true,
+                },
+              },
+            },
+          },
         },
       });
 
@@ -157,6 +168,19 @@ export default async function (server: FastifyInstance) {
         })
         .filter((row): row is NonNullable<typeof row> => Boolean(row));
 
+      const withinScopeTopics = (domain.withinScopeTopics ?? [])
+        .map((row) => {
+          if (!row.topic) {
+            return null;
+          }
+          return {
+            id: row.topic.id,
+            name: row.topic.name,
+            description: row.topic.description ?? null,
+          };
+        })
+        .filter((row): row is NonNullable<typeof row> => Boolean(row));
+
       const result: Domain = {
         id: domain.id,
         title: domain.title,
@@ -167,6 +191,7 @@ export default async function (server: FastifyInstance) {
         topicCount: topics.length,
         topics,
         excludedTopics,
+        withinScopeTopics,
       };
 
       return result;

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -1,4 +1,9 @@
-import { domainExcludedTopics, domains, topicsToDomains } from "@/db/schema";
+import {
+  domainExcludedTopics,
+  domains,
+  domainWithinScopeTopics,
+  topicsToDomains,
+} from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { nullableBoolean, nullableString } from "@/utils/schemas";
 
@@ -11,6 +16,7 @@ interface DomainBody {
   topicIds?: string[];
   excludedTopics?: { topicId: string;
     reason?: string | null; }[];
+  withinScopeTopicIds?: string[];
 }
 
 export default createUpsertHandler<DomainBody>({
@@ -47,6 +53,12 @@ export default createUpsertHandler<DomainBody>({
           },
         },
       },
+      withinScopeTopicIds: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
     },
   },
   validate: (body) => {
@@ -74,18 +86,25 @@ export default createUpsertHandler<DomainBody>({
     {
       table: topicsToDomains,
       foreignKey: topicsToDomains.domainId,
-      buildRows: (body, id) =>
-        (body.topicIds ?? []).map(topicId => ({
+      buildRows: (body, id) => {
+        if (body.topicIds === undefined) {
+          return undefined;
+        }
+        return body.topicIds.map(topicId => ({
           topicId,
           domainId: id,
-        })),
+        }));
+      },
     },
     {
       table: domainExcludedTopics,
       foreignKey: domainExcludedTopics.domainId,
       buildRows: (body, id) => {
+        if (body.excludedTopics === undefined) {
+          return undefined;
+        }
         const dedup = new Map<string, string | null>();
-        for (const entry of body.excludedTopics ?? []) {
+        for (const entry of body.excludedTopics) {
           if (!dedup.has(entry.topicId)) {
             dedup.set(entry.topicId, entry.reason ?? null);
           }
@@ -94,6 +113,19 @@ export default createUpsertHandler<DomainBody>({
           topicId,
           domainId: id,
           reason,
+        }));
+      },
+    },
+    {
+      table: domainWithinScopeTopics,
+      foreignKey: domainWithinScopeTopics.domainId,
+      buildRows: (body, id) => {
+        if (body.withinScopeTopicIds === undefined) {
+          return undefined;
+        }
+        return Array.from(new Set(body.withinScopeTopicIds)).map(topicId => ({
+          topicId,
+          domainId: id,
         }));
       },
     },

--- a/packages/middleware/src/routes/api/topics/deleteTopic.ts
+++ b/packages/middleware/src/routes/api/topics/deleteTopic.ts
@@ -1,5 +1,6 @@
 import {
   domainExcludedTopics,
+  domainWithinScopeTopics,
   radarBlips,
   topics,
   topicsToCourses,
@@ -27,6 +28,10 @@ export default createDeleteHandler({
     {
       table: domainExcludedTopics,
       foreignKey: domainExcludedTopics.topicId,
+    },
+    {
+      table: domainWithinScopeTopics,
+      foreignKey: domainWithinScopeTopics.topicId,
     },
   ],
 });

--- a/packages/types/src/Domain.ts
+++ b/packages/types/src/Domain.ts
@@ -30,4 +30,5 @@ export interface Domain {
   topicCount?: number;
   topics?: DomainTopic[];
   excludedTopics?: DomainExcludedTopic[];
+  withinScopeTopics?: DomainTopic[];
 }


### PR DESCRIPTION
## Summary
This PR refactors the radar terminology from "quadrants" to "slices" and introduces a new `withinScopeTopics` feature to distinguish between topics explicitly included in a domain's scope versus those that are merely associated with it.

## Key Changes

### Terminology Update
- Renamed all user-facing references from "quadrant" to "slice" throughout the UI and error messages
- Updated illustrations and placeholders to reflect the new terminology
- Updated the 5th optional slice description to clarify it can be left empty for a 4-slice radar

### Within-Scope Topics Feature
- Added new `domainWithinScopeTopics` database table to track topics explicitly within a domain's scope
- Created database relations and schema definitions for the new table
- Updated domain creation, retrieval, duplication, and deletion endpoints to handle `withinScopeTopicIds`
- Modified the domain upsert handler to support the new `withinScopeTopicIds` field
- Updated the client to use `withinScopeTopics` instead of the generic `topics` field when initializing scope topic IDs

### Quadrant/Slice Validation Improvements
- Enhanced validation logic to allow the 5th slice to be empty (optional)
- Updated error messages to reflect that only filled slices require names
- Added check to ensure at least one slice is configured
- Fixed position assignment to use array index instead of stored position value

### UI/UX Enhancements
- Made the 5th slice visually distinct with reduced opacity when empty
- Updated placeholder text to indicate optional slices
- Increased illustration sizes from `size-40` to `size-72` for better visibility
- Improved filter and selection UI to use "slice" terminology consistently

### Data Handling
- Updated topic ID handling in domain upsert to properly distinguish between different topic association types
- Added deduplication for within-scope topic IDs
- Ensured proper cleanup of within-scope topic associations when domains or topics are deleted

https://claude.ai/code/session_014k6YejoJBvG9GHWFrmzJ2Z