### PR TITLE
Add optional notes/comments to daily status updates

### DIFF
--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -26,7 +26,11 @@ import {
 interface DailiesActiveListViewProps {
   dailies: Daily[];
   todayKey: string;
-  onChangeStatus: (daily: Daily, status: DailyCompletionStatus) => void;
+  onChangeStatus: (
+    daily: Daily,
+    status: DailyCompletionStatus,
+    note: string | null,
+  ) => void;
   mutationPending: boolean;
   recentDaysCount?: number;
 }
@@ -161,7 +165,8 @@ export function DailiesActiveListView({
                     daily={daily}
                     currentStatus={currentStatus}
                     disabled={mutationPending}
-                    onChange={status => onChangeStatus(daily, status)}
+                    onChange={(status, note) =>
+                      onChangeStatus(daily, status, note)}
                   />
                 </div>
                 {currentStatus !== null && (

--- a/packages/client/src/components/dailies/DailyStatusModal.tsx
+++ b/packages/client/src/components/dailies/DailyStatusModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import { DAILY_STATUS_OPTIONS } from "./dailyStatusMeta";
 
+import { Textarea } from "@/components/forms/textarea";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,7 +14,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { getTodayKey } from "@/utils";
 
 const CRITERIA_KEY_BY_STATUS: Record<DailyCompletionStatus, keyof NonNullable<Daily["criteria"]>> = {
   incomplete: "incomplete",
@@ -28,7 +31,7 @@ interface DailyStatusModalProps {
   currentStatus: DailyCompletionStatus | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onChange: (status: DailyCompletionStatus) => void;
+  onChange: (status: DailyCompletionStatus, note: string | null) => void;
   disabled?: boolean;
 }
 
@@ -40,22 +43,31 @@ export function DailyStatusModal({
   onChange,
   disabled = false,
 }: DailyStatusModalProps) {
+  const todayKey = getTodayKey();
+  const currentNote
+    = daily.completions.find(c => c.date === todayKey)?.note ?? "";
+
   const [selected, setSelected] = useState<DailyCompletionStatus | null>(
     currentStatus,
   );
+  const [comment, setComment] = useState(currentNote);
 
   useEffect(() => {
     if (open) {
       setSelected(currentStatus);
+      setComment(currentNote);
     }
-  }, [open, currentStatus]);
+  }, [open, currentStatus, currentNote]);
 
   const criteria = daily.criteria ?? {};
+  const trimmedComment = comment.trim();
+  const noteChanged = trimmedComment !== currentNote.trim();
+  const statusChanged = selected !== null && selected !== currentStatus;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (selected && selected !== currentStatus) {
-      onChange(selected);
+    if (selected && (statusChanged || noteChanged)) {
+      onChange(selected, trimmedComment || null);
     }
     onOpenChange(false);
   }
@@ -161,6 +173,22 @@ export function DailyStatusModal({
               );
             })}
           </fieldset>
+          <div className="mt-4 flex flex-col gap-2">
+            <Label htmlFor="dailyStatusComment">
+              Comment
+              <span className="ml-1 text-xs font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Textarea
+              id="dailyStatusComment"
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              placeholder="Add a comment for today..."
+              maxLength={500}
+              className="min-h-20"
+            />
+          </div>
           <DialogFooter>
             <Button
               type="button"
@@ -172,7 +200,8 @@ export function DailyStatusModal({
             </Button>
             <Button
               type="submit"
-              disabled={disabled || !selected || selected === currentStatus}
+              disabled={disabled || !selected
+                || (!statusChanged && !noteChanged)}
             >
               Save
             </Button>

--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -11,7 +11,7 @@ interface TodayStatusCellProps {
   daily: Daily;
   currentStatus: DailyCompletionStatus | null;
   disabled: boolean;
-  onChange: (status: DailyCompletionStatus) => void;
+  onChange: (status: DailyCompletionStatus, note: string | null) => void;
 }
 
 export function TodayStatusCell({

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -48,6 +48,7 @@ import {
   getTotalCompletedDays,
   upsertDaily,
   withCompletion,
+  withCompletionNote,
 } from "@/utils";
 
 export const Route = createFileRoute("/dailies/")({
@@ -114,10 +115,21 @@ function Dailies() {
 
   const mutation = useMutation({
     mutationFn: ({
-      daily, status,
+      daily, status, note,
     }: { daily: Daily;
-      status: DailyCompletionStatus; }) => {
-      const completions = withCompletion(daily, todayKey, status);
+      status: DailyCompletionStatus;
+      note?: string | null; }) => {
+      const withStatus = withCompletion(daily, todayKey, status);
+      const completions = note === undefined
+        ? withStatus
+        : withCompletionNote(
+          {
+            ...daily,
+            completions: withStatus,
+          },
+          todayKey,
+          note,
+        );
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -230,9 +242,10 @@ function Dailies() {
                 todayKey={todayKey}
                 mutationPending={mutation.isPending}
                 recentDaysCount={RECENT_DAYS_COUNT}
-                onChangeStatus={(daily, status) => mutation.mutate({
+                onChangeStatus={(daily, status, note) => mutation.mutate({
                   daily,
                   status,
+                  note,
                 })}
               />
             )}

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -40,6 +40,7 @@ import {
   getTotalCompletedDays,
   upsertDaily,
   withCompletion,
+  withCompletionNote,
 } from "@/utils";
 
 const RECENT_DAYS_COUNT = 6;
@@ -73,10 +74,21 @@ export function DashboardDailies() {
 
   const mutation = useMutation({
     mutationFn: ({
-      daily, status,
+      daily, status, note,
     }: { daily: Daily;
-      status: DailyCompletionStatus; }) => {
-      const completions = withCompletion(daily, todayKey, status);
+      status: DailyCompletionStatus;
+      note?: string | null; }) => {
+      const withStatus = withCompletion(daily, todayKey, status);
+      const completions = note === undefined
+        ? withStatus
+        : withCompletionNote(
+          {
+            ...daily,
+            completions: withStatus,
+          },
+          todayKey,
+          note,
+        );
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -196,9 +208,10 @@ export function DashboardDailies() {
           todayKey={todayKey}
           mutationPending={mutation.isPending}
           recentDaysCount={RECENT_DAYS_COUNT}
-          onChangeStatus={(daily, status) => mutation.mutate({
+          onChangeStatus={(daily, status, note) => mutation.mutate({
             daily,
             status,
+            note,
           })}
         />
       )}


### PR DESCRIPTION
## Summary
This PR adds the ability to attach optional notes or comments when updating daily completion statuses. Users can now provide context or additional information alongside their status changes.

## Key Changes
- **DailyStatusModal**: Added a textarea input field for optional comments (max 500 characters) that appears below the status selection options
- **Note persistence**: Comments are stored in the daily completion record and retrieved when reopening the modal
- **Updated onChange signature**: Modified the `onChange` callback to pass both the status and note (`(status, note) => void`)
- **Smart save logic**: The Save button now enables when either the status or note has changed, not just when status changes
- **Utility function**: Added `withCompletionNote` utility function to handle updating completion notes in the data model
- **Propagated changes**: Updated all callers in `dailies.index.tsx`, `DashboardDailies.tsx`, and `DailiesActiveListView.tsx` to handle the new note parameter

## Implementation Details
- Notes are trimmed before saving and stored as `null` if empty
- The modal tracks both `statusChanged` and `noteChanged` to determine if the Save button should be enabled
- The note state is reset when the modal opens/closes to reflect the current day's data
- Uses existing UI components (`Textarea`, `Label`) from the component library

https://claude.ai/code/session_016GisniHrh5CMkiEFguxwqC