### PR TITLE
Fix dialog closing when interacting with portaled popups

### DIFF
--- a/packages/client/src/components/tasks/TagsInput.tsx
+++ b/packages/client/src/components/tasks/TagsInput.tsx
@@ -87,6 +87,7 @@ export function TagsInput({
         })}
       value={value}
       onValueChange={(next: string[]) => onChange(next)}
+      inputValue={inputValue}
       onInputValueChange={(val: string) => setInputValue(val)}
       itemToStringLabel={(val: string) => val}
     >
@@ -102,9 +103,11 @@ export function TagsInput({
         <ComboboxChipsInput
           placeholder={placeholder}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && trimmed.length > 0 && !hasMatch) {
+            if (e.key === "Enter" && trimmed.length > 0) {
               e.preventDefault();
-              commitNewTag(trimmed);
+              if (!hasMatch) {
+                commitNewTag(trimmed);
+              }
             }
           }}
         />

--- a/packages/client/src/components/ui/dialog.tsx
+++ b/packages/client/src/components/ui/dialog.tsx
@@ -58,9 +58,22 @@ function DialogOverlay({
   );
 }
 
+const PORTALED_POPUP_SELECTOR = [
+  "[data-slot=\"combobox-content\"]",
+  "[data-slot=\"select-content\"]",
+  "[data-slot=\"popover-content\"]",
+].join(",");
+
+function isInsidePortaledPopup(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+  return !!target.closest(PORTALED_POPUP_SELECTOR);
+}
+
 function DialogContent({
   className,
   children,
+  onPointerDownOutside,
+  onInteractOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
@@ -81,6 +94,18 @@ function DialogContent({
           `,
           className,
         )}
+        onPointerDownOutside={(e) => {
+          if (isInsidePortaledPopup(e.target)) {
+            e.preventDefault();
+          }
+          onPointerDownOutside?.(e);
+        }}
+        onInteractOutside={(e) => {
+          if (isInsidePortaledPopup(e.target)) {
+            e.preventDefault();
+          }
+          onInteractOutside?.(e);
+        }}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
This PR fixes an issue where dialogs would close when interacting with portaled popups (combobox, select, popover) that are rendered inside the dialog. It also improves the TagsInput component's Enter key handling.

## Key Changes

- **Dialog Component**: Added logic to prevent dialog dismissal when pointer/interact events originate from portaled popups
  - Created `PORTALED_POPUP_SELECTOR` constant to identify portaled popup elements
  - Added `isInsidePortaledPopup()` helper function to check if an event target is within a portaled popup
  - Updated `DialogContent` to accept and handle `onPointerDownOutside` and `onInteractOutside` callbacks
  - Both callbacks now check if the event originated from a portaled popup and prevent default behavior if so

- **TagsInput Component**: Improved Enter key handling for tag creation
  - Added `inputValue` prop to the Combobox component to maintain input state
  - Modified Enter key logic to prevent default behavior whenever Enter is pressed with trimmed input, but only commit new tags when there's no matching existing tag
  - This prevents form submission while still allowing tag creation with Enter

## Implementation Details
The dialog fix uses event delegation to detect when interactions occur within portaled popups (identified by data-slot attributes) and prevents the dialog from closing in those cases. This allows users to interact with dropdown/select/popover components inside dialogs without accidentally dismissing the dialog.

https://claude.ai/code/session_01Kzj1c2P4h7iHbiM7Ma8zdQ