### PR TITLE
Add grid/table view toggle for topics page

### DIFF
--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -1,0 +1,98 @@
+import type { TopicForTopicsPage } from "@emstack/types/src";
+
+import { EntityLink } from "@/components/boxElements/EntityLink";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface TopicsTableProps {
+  topics: TopicForTopicsPage[];
+}
+
+export function TopicsTable({
+  topics,
+}: TopicsTableProps) {
+  return (
+    <div className="w-full rounded-md border bg-card">
+      <Table className="w-auto min-w-full">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="whitespace-nowrap">Name</TableHead>
+            <TableHead className="whitespace-nowrap">Domains</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead className="text-right whitespace-nowrap">
+              Courses
+            </TableHead>
+            <TableHead className="text-right whitespace-nowrap">
+              Tasks
+            </TableHead>
+            <TableHead className="text-right whitespace-nowrap">
+              Dailies
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {topics.map(topic => (
+            <TableRow key={topic.id}>
+              <TableCell className="font-medium whitespace-nowrap">
+                <EntityLink
+                  entity="topics"
+                  id={topic.id}
+                  className="hover:text-blue-600"
+                >
+                  {topic.name}
+                </EntityLink>
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                {topic.domains && topic.domains.length > 0
+                  ? (
+                    <div className="flex flex-wrap gap-1">
+                      {topic.domains.map(domain => (
+                        <span
+                          key={domain.id}
+                          className="
+                            rounded-sm bg-gray-100 px-2 py-0.5 text-xs
+                            text-gray-700
+                          "
+                        >
+                          {domain.title}
+                        </span>
+                      ))}
+                    </div>
+                  )
+                  : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+              </TableCell>
+              <TableCell className="max-w-md">
+                {topic.description
+                  ? (
+                    <span className="line-clamp-2 text-sm">
+                      {topic.description}
+                    </span>
+                  )
+                  : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {topic.courseCount ?? 0}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {topic.taskCount ?? 0}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {topic.dailyCount ?? 0}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -6,6 +6,8 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ArrowRightIcon,
+  LayoutGridIcon,
+  ListIcon,
   PlusIcon,
   SearchIcon,
   XIcon,
@@ -13,6 +15,7 @@ import {
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
+import { TopicsTable } from "@/components/boxes/TopicsTable";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { FilterOptionCount } from "@/components/FilterOptionCount";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -27,6 +30,15 @@ import {
 import { fetchDomains, fetchTopics } from "@/utils";
 
 type SortOption = "alpha-asc" | "alpha-desc" | "resources";
+type ViewMode = "grid" | "table";
+
+const VIEW_MODE_STORAGE_KEY = "topics:viewMode";
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === "undefined") return "grid";
+  const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+  return stored === "table" ? "table" : "grid";
+}
 
 export const Route = createFileRoute("/topics/")({
   component: Topics,
@@ -62,6 +74,14 @@ function Topics() {
   const [search, setSearch] = useState("");
   const [filterDomain, setFilterDomain] = useState<string | undefined>();
   const [sortBy, setSortBy] = useState<SortOption>("alpha-asc");
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+
+  const updateViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    }
+  };
 
   const {
     data,
@@ -215,62 +235,115 @@ function Topics() {
                     </SelectItem>
                   </SelectContent>
                 </Select>
+                <div
+                  className="
+                    ml-2 flex items-center rounded-md border border-input
+                    bg-transparent
+                  "
+                  role="group"
+                  aria-label="View mode"
+                >
+                  <Button
+                    type="button"
+                    variant={viewMode === "grid" ? "secondary" : "ghost"}
+                    size="icon"
+                    aria-label="Card view"
+                    aria-pressed={viewMode === "grid"}
+                    onClick={() => updateViewMode("grid")}
+                  >
+                    <LayoutGridIcon className="size-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={viewMode === "table" ? "secondary" : "ghost"}
+                    size="icon"
+                    aria-label="Table view"
+                    aria-pressed={viewMode === "table"}
+                    onClick={() => updateViewMode("table")}
+                  >
+                    <ListIcon className="size-4" />
+                  </Button>
+                </div>
               </div>
             </div>
           )}
         </div>
-        <div className="card-grid">
-          {(!data || data.length === 0) && (
-            <div className="flex flex-col gap-6">
-              <i>No courses yet!</i>
+        {(!data || data.length === 0) && (
+          <div className="flex flex-col gap-6">
+            <i>No courses yet!</i>
 
-              <Link
-                to="/onboard"
-                className=""
+            <Link
+              to="/onboard"
+              className=""
+            >
+              <Button>
+                Go to onboarding
+                {" "}
+                <ArrowRightIcon />
+              </Button>
+            </Link>
+          </div>
+        )}
+
+        {data && data.length > 0 && filteredAndSorted.length === 0 && (
+          <div className="text-muted-foreground">
+            <i>No topics match your filters.</i>
+          </div>
+        )}
+
+        {viewMode === "grid" && (
+          <div className="card-grid">
+            {filteredAndSorted.length > 0
+              && filteredAndSorted.map((topic: TopicForTopicsPage) => {
+                return (
+                  <TopicBox
+                    {...topic}
+                    key={topic.id}
+                  />
+                );
+              })}
+
+            <Link
+              to="/topics/$id/edit"
+              params={{
+                id: "new",
+              }}
+            >
+              <ContentBox
+                className="
+                  h-full items-center justify-center border-dashed p-8
+                  text-muted-foreground transition-colors
+                  hover:border-solid hover:bg-accent
+                  hover:text-accent-foreground
+                "
               >
-                <Button>
-                  Go to onboarding
-                  {" "}
-                  <ArrowRightIcon />
+                <PlusIcon size={32} />
+                <span className="text-lg font-medium">Add New Topic</span>
+              </ContentBox>
+            </Link>
+          </div>
+        )}
+
+        {viewMode === "table" && (
+          <div className="flex flex-col gap-4">
+            {filteredAndSorted.length > 0 && (
+              <TopicsTable topics={filteredAndSorted} />
+            )}
+            <div>
+              <Link
+                to="/topics/$id/edit"
+                params={{
+                  id: "new",
+                }}
+              >
+                <Button variant="outline">
+                  <PlusIcon className="size-4" />
+                  Add New Topic
                 </Button>
               </Link>
             </div>
-          )}
-
-          {filteredAndSorted.length > 0
-            && filteredAndSorted.map((topic: TopicForTopicsPage) => {
-              return (
-                <TopicBox
-                  {...topic}
-                  key={topic.id}
-                />
-              );
-            })}
-
-          {data && data.length > 0 && filteredAndSorted.length === 0 && (
-            <div className="text-muted-foreground">
-              <i>No topics match your filters.</i>
-            </div>
-          )}
-
-          <Link
-            to="/topics/$id/edit"
-            params={{
-              id: "new",
-            }}
-          >
-            <ContentBox
-              className="
-                h-full items-center justify-center border-dashed p-8
-                text-muted-foreground transition-colors
-                hover:border-solid hover:bg-accent hover:text-accent-foreground
-              "
-            >
-              <PlusIcon size={32} />
-              <span className="text-lg font-medium">Add New Topic</span>
-            </ContentBox>
-          </Link>
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Added a view mode toggle to the topics page, allowing users to switch between a grid view (card layout) and a table view. The selected view mode is persisted to localStorage.

## Key Changes
- Added `ViewMode` type and view mode state management with localStorage persistence
- Implemented view mode toggle buttons (grid/table) in the topics page header with proper ARIA labels
- Created new `TopicsTable` component to display topics in a tabular format with columns for name, domains, description, and resource counts
- Refactored the rendering logic to conditionally display either grid or table layout based on the selected view mode
- Improved empty state handling with separate messaging for "no data" vs "no matches" scenarios
- Added `LayoutGridIcon` and `ListIcon` imports from lucide-react for the toggle buttons

## Implementation Details
- View mode preference is stored in localStorage under the key `topics:viewMode`
- The `getInitialViewMode()` function safely handles SSR by checking for window availability
- The `updateViewMode()` function updates both state and localStorage atomically
- Table view includes proper styling with borders, responsive columns, and truncated descriptions
- Both grid and table views support the "Add New Topic" action

https://claude.ai/code/session_01XKNq9T4LZrBncXnA9xuKhU