### PR TITLE
Split topics list into radar and non-radar categories

### DIFF
--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -49,6 +49,13 @@ function SingleDomain() {
       && radarData.quadrants.length > 0
       && radarData.rings.length > 0;
 
+  const blipTopicIds = new Set(
+    (radarData?.blips ?? []).map(blip => blip.topicId),
+  );
+  const allTopics = data?.topics ?? [];
+  const topicsNotOnRadar = allTopics.filter(t => !blipTopicIds.has(t.id));
+  const topicsOnRadar = allTopics.filter(t => blipTopicIds.has(t.id));
+
   return (
     <div>
       <PageHeader
@@ -125,38 +132,74 @@ function SingleDomain() {
             </InfoArea>
           )}
         </div>
-        <div>
+        <div
+          className={`
+            grid grid-cols-1 gap-8
+            md:grid-cols-2
+          `}
+        >
           <InfoArea
-            header="Topics"
-            condition={!!data?.topicCount && data.topicCount > 0}
+            header="Topics not on Radar"
+            condition={topicsNotOnRadar.length > 0}
           >
             <ul className="ml-5 list-disc">
-              {data?.topics
-                && data.topics.map(topic => (
-                  <li key={topic.id}>
-                    <Link
-                      to="/topics/$id"
-                      params={{
-                        id: topic.id + "",
-                      }}
-                      className={`
-                        font-bold text-blue-800
-                        hover:text-blue-600
-                      `}
-                    >
-                      {topic.name}
-                    </Link>
-                    {topic.courses && topic.courses.length > 0 && (
-                      <span className="ml-2 text-xs text-muted-foreground">
-                        (
-                        {topic.courses.length}
-                        {" course"}
-                        {topic.courses.length === 1 ? "" : "s"}
-                        )
-                      </span>
-                    )}
-                  </li>
-                ))}
+              {topicsNotOnRadar.map(topic => (
+                <li key={topic.id}>
+                  <Link
+                    to="/topics/$id"
+                    params={{
+                      id: topic.id + "",
+                    }}
+                    className={`
+                      font-bold text-blue-800
+                      hover:text-blue-600
+                    `}
+                  >
+                    {topic.name}
+                  </Link>
+                  {topic.courses && topic.courses.length > 0 && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      (
+                      {topic.courses.length}
+                      {" course"}
+                      {topic.courses.length === 1 ? "" : "s"}
+                      )
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </InfoArea>
+          <InfoArea
+            header="Topics on Radar"
+            condition={topicsOnRadar.length > 0}
+          >
+            <ul className="ml-5 list-disc">
+              {topicsOnRadar.map(topic => (
+                <li key={topic.id}>
+                  <Link
+                    to="/topics/$id"
+                    params={{
+                      id: topic.id + "",
+                    }}
+                    className={`
+                      font-bold text-blue-800
+                      hover:text-blue-600
+                    `}
+                  >
+                    {topic.name}
+                  </Link>
+                  {topic.courses && topic.courses.length > 0 && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      (
+                      {topic.courses.length}
+                      {" course"}
+                      {topic.courses.length === 1 ? "" : "s"}
+                      )
+                    </span>
+                  )}
+                </li>
+              ))}
             </ul>
           </InfoArea>
         </div>


### PR DESCRIPTION
## Summary
Refactored the topics display on the domain detail page to separate topics into two categories: those that appear on the radar and those that don't. This provides better visibility into which topics are actively tracked versus which ones exist but aren't yet represented on the radar.

## Key Changes
- Added logic to compute `blipTopicIds` set from radar blips to identify which topics are on the radar
- Filtered all topics into two separate arrays: `topicsOnRadar` and `topicsNotOnRadar`
- Split the single "Topics" section into two separate `InfoArea` components:
  - "Topics not on Radar" - displays topics without blips on the radar
  - "Topics on Radar" - displays topics that have blips on the radar
- Updated the layout to use a responsive grid (1 column on mobile, 2 columns on medium+ screens) to accommodate both sections
- Removed the `topicCount` condition check in favor of checking the actual filtered array lengths

## Implementation Details
- Both topic lists maintain the same styling and functionality (links to topic detail pages, course count badges)
- The separation is computed client-side by comparing topic IDs with blip topic IDs
- Each section only renders if it has content (via the `condition` prop on `InfoArea`)

https://claude.ai/code/session_01BV3uTvQx7ZSb9JaPXeu2hR