### PR TITLE
Dashboard tweaks: amortization formula, layout, dailies streak/connector fixes

### DIFF
--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -78,20 +78,15 @@ type SortDir = "asc" | "desc";
 function Dailies() {
   const queryClient = useQueryClient();
   const todayKey = getTodayKey();
-  const {
-    settings,
-  } = useSettings();
-  const {
-    mode, setMode,
-  } = useDailiesViewMode();
+  const { settings } = useSettings();
+  const { mode, setMode } = useDailiesViewMode();
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
-      setSortDir(prev => (prev === "asc" ? "desc" : "asc"));
-    }
-    else {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
       setSortKey(key);
       setSortDir(key === "progress" ? "desc" : "asc");
     }
@@ -101,35 +96,40 @@ function Dailies() {
     if (sortKey !== key) {
       return <ArrowUpDownIcon className="size-3 opacity-40" />;
     }
-    return sortDir === "asc"
-      ? <ArrowUpIcon className="size-3" />
-      : <ArrowDownIcon className="size-3" />;
+    return sortDir === "asc" ? (
+      <ArrowUpIcon className="size-3" />
+    ) : (
+      <ArrowDownIcon className="size-3" />
+    );
   }
 
-  const {
-    data: dailies,
-  } = useQuery({
+  const { data: dailies } = useQuery({
     queryKey: ["dailies"],
     queryFn: () => fetchDailies(),
   });
 
   const mutation = useMutation({
     mutationFn: ({
-      daily, status, note,
-    }: { daily: Daily;
+      daily,
+      status,
+      note,
+    }: {
+      daily: Daily;
       status: DailyCompletionStatus;
-      note?: string | null; }) => {
+      note?: string | null;
+    }) => {
       const withStatus = withCompletion(daily, todayKey, status);
-      const completions = note === undefined
-        ? withStatus
-        : withCompletionNote(
-          {
-            ...daily,
-            completions: withStatus,
-          },
-          todayKey,
-          note,
-        );
+      const completions =
+        note === undefined
+          ? withStatus
+          : withCompletionNote(
+              {
+                ...daily,
+                completions: withStatus,
+              },
+              todayKey,
+              note,
+            );
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -151,49 +151,47 @@ function Dailies() {
 
   const baseSorted = dailies
     ? [...dailies].sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, {
-        sensitivity: "base",
-      }))
+        a.name.localeCompare(b.name, undefined, {
+          sensitivity: "base",
+        }),
+      )
     : undefined;
 
-  const activeDailies = (baseSorted?.filter(
-    d => d.status !== "complete" && d.status !== "paused",
-  ) ?? []).slice().sort((a, b) => {
-    if (sortKey === "progress") {
-      const diff = getDailyProgressPercent(a) - getDailyProgressPercent(b);
-      if (diff !== 0) return sortDir === "asc" ? diff : -diff;
-    }
-    const cmp = a.name.localeCompare(b.name, undefined, {
-      sensitivity: "base",
+  const activeDailies = (
+    baseSorted?.filter(
+      (d) => d.status !== "complete" && d.status !== "paused",
+    ) ?? []
+  )
+    .slice()
+    .sort((a, b) => {
+      if (sortKey === "progress") {
+        const diff = getDailyProgressPercent(a) - getDailyProgressPercent(b);
+        if (diff !== 0) return sortDir === "asc" ? diff : -diff;
+      }
+      const cmp = a.name.localeCompare(b.name, undefined, {
+        sensitivity: "base",
+      });
+      return sortKey === "name" && sortDir === "desc" ? -cmp : cmp;
     });
-    return sortKey === "name" && sortDir === "desc" ? -cmp : cmp;
-  });
-  const pausedDailies = baseSorted?.filter(d => d.status === "paused") ?? [];
-  const completedDailies = baseSorted?.filter(d => d.status === "complete")
-    ?? [];
+  const pausedDailies = baseSorted?.filter((d) => d.status === "paused") ?? [];
+  const completedDailies =
+    baseSorted?.filter((d) => d.status === "complete") ?? [];
 
-  const dayHeaders = activeDailies.length > 0
-    ? getRecentDays(
-      activeDailies[0],
-      RECENT_DAYS_COUNT + 1,
-      todayKey,
-      "mmdd",
-    )
-      .slice(0, -1)
-      .reverse()
-      .map(d => ({
-        dateKey: d.dateKey,
-        label: formatMmDd(d.dateKey),
-        isToday: d.isToday,
-      }))
-    : [];
+  const dayHeaders =
+    activeDailies.length > 0
+      ? getRecentDays(activeDailies[0], RECENT_DAYS_COUNT + 1, todayKey, "mmdd")
+          .slice(0, -1)
+          .reverse()
+          .map((d) => ({
+            dateKey: d.dateKey,
+            label: formatMmDd(d.dateKey),
+            isToday: d.isToday,
+          }))
+      : [];
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Dailies"
-        pageSection=""
-      >
+      <PageHeader pageTitle="Dailies" pageSection="">
         <Link
           to="/dailies/$id/edit"
           params={{
@@ -207,7 +205,6 @@ function Dailies() {
         </Link>
       </PageHeader>
       <div className="container flex flex-col gap-4">
-
         {(!baseSorted || baseSorted.length === 0) && (
           <p className="text-sm text-muted-foreground">
             <i>No dailies yet!</i>
@@ -216,7 +213,7 @@ function Dailies() {
 
         {activeDailies.length > 0 && (
           <DashboardCard
-            title={(
+            title={
               <span className="inline-flex items-center gap-2">
                 Active Dailies
                 <TooManyDailiesWarning
@@ -225,16 +222,13 @@ function Dailies() {
                   size="sm"
                 />
               </span>
-            )}
-            action={(
+            }
+            action={
               <>
-                <DailiesViewModeToggle
-                  mode={mode}
-                  onChange={setMode}
-                />
+                <DailiesViewModeToggle mode={mode} onChange={setMode} />
                 <DailiesLimitSetting />
               </>
-            )}
+            }
           >
             {mode === "list" && (
               <DailiesActiveListView
@@ -242,11 +236,13 @@ function Dailies() {
                 todayKey={todayKey}
                 mutationPending={mutation.isPending}
                 recentDaysCount={RECENT_DAYS_COUNT}
-                onChangeStatus={(daily, status, note) => mutation.mutate({
-                  daily,
-                  status,
-                  note,
-                })}
+                onChangeStatus={(daily, status, note) =>
+                  mutation.mutate({
+                    daily,
+                    status,
+                    note,
+                  })
+                }
               />
             )}
             {mode === "table" && (
@@ -282,17 +278,21 @@ function Dailies() {
                           {sortIndicator("name")}
                         </button>
                       </th>
-                      <th className="p-2 font-medium whitespace-nowrap">Type</th>
+                      <th className="p-2 font-medium whitespace-nowrap">
+                        Type
+                      </th>
                       <th className="max-w-xs p-2 font-medium">Description</th>
-                      <th className="p-2 font-medium whitespace-nowrap">Streak</th>
-                      <th className="p-2 font-medium whitespace-nowrap">Total</th>
+                      <th className="p-2 font-medium whitespace-nowrap">
+                        Streak
+                      </th>
+                      <th className="p-2 font-medium whitespace-nowrap">
+                        Total
+                      </th>
                       <th className="p-2 font-medium" />
-                      <th
-                        className="w-36 p-2 font-medium whitespace-nowrap"
-                      >
+                      <th className="w-36 p-2 font-medium whitespace-nowrap">
                         Today&apos;s Status
                       </th>
-                      {dayHeaders.map(d => (
+                      {dayHeaders.map((d) => (
                         <th
                           key={d.dateKey}
                           className={cn(
@@ -318,7 +318,9 @@ function Dailies() {
                         RECENT_DAYS_COUNT + 1,
                         todayKey,
                         "mmdd",
-                      ).slice(0, -1).reverse();
+                      )
+                        .slice(0, -1)
+                        .reverse();
                       return (
                         <tr
                           key={daily.id}
@@ -352,28 +354,27 @@ function Dailies() {
                             </span>
                           </td>
                           <td className="max-w-xs p-2">
-                            {daily.description
-                              ? (
-                                <span
-                                  className="
+                            {daily.description ? (
+                              <span
+                                className="
                                     block truncate text-muted-foreground
                                   "
-                                  title={daily.description}
-                                >
-                                  {daily.description}
-                                </span>
-                              )
-                              : (
-                                <span className="text-muted-foreground/60">
-                                  <i>No description</i>
-                                </span>
-                              )}
+                                title={daily.description}
+                              >
+                                {daily.description}
+                              </span>
+                            ) : (
+                              <span className="text-muted-foreground/60">
+                                <i>No description</i>
+                              </span>
+                            )}
                           </td>
                           <td className="p-2">
                             <span
                               className={cn(
                                 "inline-flex items-center gap-1 text-xs",
-                                currentStatus === "incomplete"
+                                currentStatus === null ||
+                                  currentStatus === "incomplete"
                                   ? "text-muted-foreground"
                                   : chain > 0
                                     ? "text-orange-600"
@@ -413,10 +414,12 @@ function Dailies() {
                               daily={daily}
                               currentStatus={currentStatus}
                               disabled={mutation.isPending}
-                              onChange={status => mutation.mutate({
-                                daily,
-                                status,
-                              })}
+                              onChange={(status) =>
+                                mutation.mutate({
+                                  daily,
+                                  status,
+                                })
+                              }
                             />
                           </td>
                           {days.map((day, i) => {
@@ -431,7 +434,7 @@ function Dailies() {
                                     right={day.status}
                                     className="
                                       absolute top-1/2 right-[calc(50%+12px)]
-                                      -left-2 z-0 -translate-y-1/2
+                                      -left-2 z-0 w-auto -translate-y-1/2
                                     "
                                   />
                                 )}
@@ -446,9 +449,7 @@ function Dailies() {
                                     "
                                   />
                                 )}
-                                <div
-                                  className="relative z-10 flex justify-center"
-                                >
+                                <div className="relative z-10 flex justify-center">
                                   <DailyStatusCircle
                                     status={day.status}
                                     size="sm"

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -54,15 +54,18 @@ function buildRows(courses: CourseInCourses[] | undefined): AmortizationRow[] {
   if (!courses) return [];
   return courses.map((course) => {
     const rawCost = parseCost(course.cost?.cost);
-    const splitBy
-      = course.cost?.splitBy && course.cost.splitBy > 0 ? course.cost.splitBy : 1;
+    const splitBy =
+      course.cost?.splitBy && course.cost.splitBy > 0 ? course.cost.splitBy : 1;
     const effectiveCost = rawCost / splitBy;
     const progressCurrent = course.progressCurrent ?? 0;
     const progressTotal = course.progressTotal ?? 0;
-    const progressFraction
-      = progressTotal > 0 ? progressCurrent / progressTotal : 0;
-    const amortization
-      = progressCurrent > 0 ? effectiveCost / progressCurrent : null;
+    const progressFraction =
+      progressTotal > 0 ? progressCurrent / progressTotal : 0;
+    const percentComplete =
+      progressTotal > 0
+        ? Number(((progressCurrent / progressTotal) * 100).toFixed(2))
+        : 0;
+    const amortization = percentComplete > 0 ? rawCost / percentComplete : null;
     return {
       course,
       effectiveCost,
@@ -115,7 +118,9 @@ function compareRows(
 
 export function DashboardCoursesByAmortization() {
   const {
-    data: courses, isPending, error,
+    data: courses,
+    isPending,
+    error,
   } = useQuery({
     queryKey: ["courses"],
     queryFn: () => fetchCourses(),
@@ -132,34 +137,36 @@ export function DashboardCoursesByAmortization() {
       setSortDir(key === "name" || key === "provider" ? "asc" : "desc");
       return;
     }
-    setSortDir(prev => (prev === "asc" ? "desc" : "asc"));
+    setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
   }
 
   function sortIcon(key: SortKey) {
     if (sortKey !== key) {
       return <ChevronsUpDownIcon className="size-3 opacity-50" />;
     }
-    return sortDir === "asc"
-      ? <ChevronUpIcon className="size-3" />
-      : <ChevronDownIcon className="size-3" />;
+    return sortDir === "asc" ? (
+      <ChevronUpIcon className="size-3" />
+    ) : (
+      <ChevronDownIcon className="size-3" />
+    );
   }
 
   const rows = useMemo(() => {
     const all = buildRows(courses);
-    const filtered = showUnstarted ? all : all.filter(r => !r.isUnstarted);
+    const filtered = showUnstarted ? all : all.filter((r) => !r.isUnstarted);
     return filtered.slice().sort((a, b) => compareRows(a, b, sortKey, sortDir));
   }, [courses, showUnstarted, sortKey, sortDir]);
 
   return (
     <DashboardCard
       title="Courses by Amortization"
-      action={(
+      action={
         <div className="flex items-center gap-3">
           <button
             type="button"
             role="switch"
             aria-checked={showUnstarted}
-            onClick={() => setShowUnstarted(prev => !prev)}
+            onClick={() => setShowUnstarted((prev) => !prev)}
             className="
               text-muted-foreground
               hover:text-foreground
@@ -197,7 +204,7 @@ export function DashboardCoursesByAmortization() {
             View all
           </Link>
         </div>
-      )}
+      }
     >
       {isPending && (
         <p className="text-muted-foreground text-sm">Loading courses...</p>
@@ -213,7 +220,7 @@ export function DashboardCoursesByAmortization() {
       {rows.length > 0 && (
         <div
           className="
-            max-h-80 w-full overflow-auto rounded-md border
+            max-h-80 w-full overflow-auto
             [scrollbar-width:thin]
           "
         >
@@ -285,33 +292,35 @@ export function DashboardCoursesByAmortization() {
                     {sortIcon("amortization")}
                   </button>
                 </TableHead>
-                <TableHead className="text-right whitespace-nowrap">Go</TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  Go
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map(({
-                course,
-                effectiveCost,
-                progressCurrent,
-                progressTotal,
-                amortization,
-                isUnstarted,
-              }) => (
-                <TableRow key={course.id}>
-                  <TableCell className="font-medium whitespace-nowrap">
-                    <Link
-                      to="/courses/$id"
-                      params={{
-                        id: course.id,
-                      }}
-                      className="hover:text-blue-600"
-                    >
-                      {course.name}
-                    </Link>
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap">
-                    {course.provider
-                      ? (
+              {rows.map(
+                ({
+                  course,
+                  effectiveCost,
+                  progressCurrent,
+                  progressTotal,
+                  amortization,
+                  isUnstarted,
+                }) => (
+                  <TableRow key={course.id}>
+                    <TableCell className="font-medium whitespace-nowrap">
+                      <Link
+                        to="/courses/$id"
+                        params={{
+                          id: course.id,
+                        }}
+                        className="hover:text-blue-600"
+                      >
+                        {course.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {course.provider ? (
                         <Link
                           to="/providers/$id"
                           params={{
@@ -324,44 +333,38 @@ export function DashboardCoursesByAmortization() {
                         >
                           {course.provider.name}
                         </Link>
-                      )
-                      : <span className="text-muted-foreground">—</span>}
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    {formatCurrency(effectiveCost)}
-                  </TableCell>
-                  <TableCell
-                    className="text-right whitespace-nowrap"
-                    title={
-                      progressTotal > 0
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {formatCurrency(effectiveCost)}
+                    </TableCell>
+                    <TableCell
+                      className="text-right whitespace-nowrap"
+                      title={
+                        progressTotal > 0
+                          ? `${progressCurrent} / ${progressTotal}`
+                          : undefined
+                      }
+                    >
+                      {progressTotal > 0
                         ? `${progressCurrent} / ${progressTotal}`
-                        : undefined
-                    }
-                  >
-                    {progressTotal > 0
-                      ? `${progressCurrent} / ${progressTotal}`
-                      : progressCurrent}
-                  </TableCell>
-                  <TableCell
-                    className="text-right whitespace-nowrap"
-                    title={
-                      isUnstarted
-                        ? "Unstarted — no progress yet"
-                        : undefined
-                    }
-                  >
-                    {amortization === null
-                      ? "—"
-                      : formatCurrency(amortization)}
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    {course.url
-                      ? (
-                        <Button
-                          asChild
-                          size="sm"
-                          variant="outline"
-                        >
+                        : progressCurrent}
+                    </TableCell>
+                    <TableCell
+                      className="text-right whitespace-nowrap"
+                      title={
+                        isUnstarted ? "Unstarted — no progress yet" : undefined
+                      }
+                    >
+                      {amortization === null
+                        ? "—"
+                        : formatCurrency(amortization)}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {course.url ? (
+                        <Button asChild size="sm" variant="outline">
                           <a
                             href={course.url}
                             target="_blank"
@@ -371,13 +374,13 @@ export function DashboardCoursesByAmortization() {
                             <ExternalLink />
                           </a>
                         </Button>
-                      )
-                      : (
+                      ) : (
                         <span className="text-muted-foreground">—</span>
                       )}
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
             </TableBody>
           </Table>
         </div>

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -56,17 +56,15 @@ type SortDir = "asc" | "desc";
 export function DashboardDailies() {
   const queryClient = useQueryClient();
   const todayKey = getTodayKey();
-  const {
-    settings,
-  } = useSettings();
-  const {
-    mode, setMode,
-  } = useDailiesViewMode();
+  const { settings } = useSettings();
+  const { mode, setMode } = useDailiesViewMode();
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const {
-    data: dailies, isPending, error,
+    data: dailies,
+    isPending,
+    error,
   } = useQuery({
     queryKey: ["dailies"],
     queryFn: () => fetchDailies(),
@@ -74,21 +72,26 @@ export function DashboardDailies() {
 
   const mutation = useMutation({
     mutationFn: ({
-      daily, status, note,
-    }: { daily: Daily;
+      daily,
+      status,
+      note,
+    }: {
+      daily: Daily;
       status: DailyCompletionStatus;
-      note?: string | null; }) => {
+      note?: string | null;
+    }) => {
       const withStatus = withCompletion(daily, todayKey, status);
-      const completions = note === undefined
-        ? withStatus
-        : withCompletionNote(
-          {
-            ...daily,
-            completions: withStatus,
-          },
-          todayKey,
-          note,
-        );
+      const completions =
+        note === undefined
+          ? withStatus
+          : withCompletionNote(
+              {
+                ...daily,
+                completions: withStatus,
+              },
+              todayKey,
+              note,
+            );
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -109,28 +112,27 @@ export function DashboardDailies() {
   });
 
   const filtered = dailies
-    ? dailies.filter(d => d.status !== "complete" && d.status !== "paused")
+    ? dailies.filter((d) => d.status !== "complete" && d.status !== "paused")
     : undefined;
 
   const sortedDailies = filtered
     ? [...filtered].sort((a, b) => {
-      if (sortKey === "progress") {
-        const diff = getDailyProgressPercent(a) - getDailyProgressPercent(b);
-        if (diff !== 0) return sortDir === "asc" ? diff : -diff;
-      }
-      const cmp = a.name.localeCompare(b.name, undefined, {
-        sensitivity: "base",
-      });
-      return sortKey === "name" && sortDir === "desc" ? -cmp : cmp;
-    })
+        if (sortKey === "progress") {
+          const diff = getDailyProgressPercent(a) - getDailyProgressPercent(b);
+          if (diff !== 0) return sortDir === "asc" ? diff : -diff;
+        }
+        const cmp = a.name.localeCompare(b.name, undefined, {
+          sensitivity: "base",
+        });
+        return sortKey === "name" && sortDir === "desc" ? -cmp : cmp;
+      })
     : undefined;
   const activeCount = sortedDailies?.length ?? 0;
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
-      setSortDir(prev => (prev === "asc" ? "desc" : "asc"));
-    }
-    else {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
       setSortKey(key);
       setSortDir(key === "progress" ? "desc" : "asc");
     }
@@ -140,30 +142,28 @@ export function DashboardDailies() {
     if (sortKey !== key) {
       return <ArrowUpDownIcon className="size-3 opacity-40" />;
     }
-    return sortDir === "asc"
-      ? <ArrowUpIcon className="size-3" />
-      : <ArrowDownIcon className="size-3" />;
+    return sortDir === "asc" ? (
+      <ArrowUpIcon className="size-3" />
+    ) : (
+      <ArrowDownIcon className="size-3" />
+    );
   }
 
-  const dayHeaders = sortedDailies && sortedDailies.length > 0
-    ? getRecentDays(
-      sortedDailies[0],
-      RECENT_DAYS_COUNT + 1,
-      todayKey,
-      "mmdd",
-    )
-      .slice(0, -1)
-      .reverse()
-      .map(d => ({
-        dateKey: d.dateKey,
-        label: formatMmDd(d.dateKey),
-        isToday: d.isToday,
-      }))
-    : [];
+  const dayHeaders =
+    sortedDailies && sortedDailies.length > 0
+      ? getRecentDays(sortedDailies[0], RECENT_DAYS_COUNT + 1, todayKey, "mmdd")
+          .slice(0, -1)
+          .reverse()
+          .map((d) => ({
+            dateKey: d.dateKey,
+            label: formatMmDd(d.dateKey),
+            isToday: d.isToday,
+          }))
+      : [];
 
   return (
     <DashboardCard
-      title={(
+      title={
         <span className="inline-flex items-center gap-2">
           Dailies
           <TooManyDailiesWarning
@@ -172,13 +172,10 @@ export function DashboardDailies() {
             size="sm"
           />
         </span>
-      )}
-      action={(
+      }
+      action={
         <>
-          <DailiesViewModeToggle
-            mode={mode}
-            onChange={setMode}
-          />
+          <DailiesViewModeToggle mode={mode} onChange={setMode} />
           <Link
             to="/dailies"
             className="
@@ -189,7 +186,7 @@ export function DashboardDailies() {
             View all
           </Link>
         </>
-      )}
+      }
     >
       {isPending && (
         <p className="text-sm text-muted-foreground">Loading dailies...</p>
@@ -208,11 +205,13 @@ export function DashboardDailies() {
           todayKey={todayKey}
           mutationPending={mutation.isPending}
           recentDaysCount={RECENT_DAYS_COUNT}
-          onChangeStatus={(daily, status, note) => mutation.mutate({
-            daily,
-            status,
-            note,
-          })}
+          onChangeStatus={(daily, status, note) =>
+            mutation.mutate({
+              daily,
+              status,
+              note,
+            })
+          }
         />
       )}
       {sortedDailies && sortedDailies.length > 0 && mode === "table" && (
@@ -252,12 +251,10 @@ export function DashboardDailies() {
                 <th className="p-2 font-medium">Streak</th>
                 <th className="p-2 font-medium">Total</th>
                 <th className="p-2 font-medium" />
-                <th
-                  className="p-2 font-medium whitespace-nowrap"
-                >
+                <th className="p-2 font-medium whitespace-nowrap">
                   Today&apos;s Status
                 </th>
-                {dayHeaders.map(d => (
+                {dayHeaders.map((d) => (
                   <th
                     key={d.dateKey}
                     className={cn(
@@ -281,7 +278,9 @@ export function DashboardDailies() {
                   RECENT_DAYS_COUNT + 1,
                   todayKey,
                   "mmdd",
-                ).slice(0, -1).reverse();
+                )
+                  .slice(0, -1)
+                  .reverse();
                 return (
                   <tr
                     key={daily.id}
@@ -317,16 +316,15 @@ export function DashboardDailies() {
                       <span
                         className={cn(
                           "inline-flex items-center gap-1 text-xs",
-                          currentStatus === "incomplete"
+                          currentStatus === null ||
+                            currentStatus === "incomplete"
                             ? "text-muted-foreground"
                             : chain > 0
                               ? "text-orange-600"
                               : "text-muted-foreground",
                         )}
                         title={
-                          chain > 0
-                            ? `${chain}-day chain`
-                            : "No active chain"
+                          chain > 0 ? `${chain}-day chain` : "No active chain"
                         }
                       >
                         <FlameIcon className="size-3.5" />
@@ -357,10 +355,12 @@ export function DashboardDailies() {
                         daily={daily}
                         currentStatus={currentStatus}
                         disabled={mutation.isPending}
-                        onChange={status => mutation.mutate({
-                          daily,
-                          status,
-                        })}
+                        onChange={(status) =>
+                          mutation.mutate({
+                            daily,
+                            status,
+                          })
+                        }
                       />
                     </td>
                     {days.map((day, i) => {

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
@@ -70,7 +70,9 @@ function formatCurrency(value: number): string {
 
 export function DashboardUnderutilizedProviders() {
   const {
-    data: providers, isPending, error,
+    data: providers,
+    isPending,
+    error,
   } = useQuery({
     queryKey: ["providers"],
     queryFn: () => fetchProviders(),
@@ -81,7 +83,7 @@ export function DashboardUnderutilizedProviders() {
   return (
     <DashboardCard
       title="Underutilized Providers"
-      action={(
+      action={
         <Link
           to="/providers"
           className="
@@ -91,7 +93,7 @@ export function DashboardUnderutilizedProviders() {
         >
           View all
         </Link>
-      )}
+      }
     >
       {isPending && (
         <p className="text-sm text-muted-foreground">Loading providers...</p>
@@ -107,7 +109,7 @@ export function DashboardUnderutilizedProviders() {
       {rows.length > 0 && (
         <div
           className="
-            max-h-80 w-full overflow-auto rounded-md border
+            max-h-80 w-full overflow-auto
             [scrollbar-width:thin]
           "
         >
@@ -130,57 +132,53 @@ export function DashboardUnderutilizedProviders() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map(({
-                provider, amortization, inactiveCount, completeCount,
-              }) => (
-                <TableRow key={provider.id}>
-                  <TableCell className="font-medium whitespace-nowrap">
-                    <Link
-                      to="/providers/$id"
-                      params={{
-                        id: provider.id,
-                      }}
-                      className="hover:text-blue-600"
-                    >
-                      {provider.name}
-                    </Link>
-                  </TableCell>
-                  <TableCell
-                    className="text-right whitespace-nowrap"
-                    title={
-                      amortization === null
-                        ? "No completed courses yet"
-                        : undefined
-                    }
-                  >
-                    {amortization === null
-                      ? "—"
-                      : formatCurrency(amortization)}
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    {inactiveCount}
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    {completeCount}
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      asChild
-                    >
-                      <a
-                        href={provider.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
+              {rows.map(
+                ({ provider, amortization, inactiveCount, completeCount }) => (
+                  <TableRow key={provider.id}>
+                    <TableCell className="font-medium whitespace-nowrap">
+                      <Link
+                        to="/providers/$id"
+                        params={{
+                          id: provider.id,
+                        }}
+                        className="hover:text-blue-600"
                       >
-                        Go
-                        <ExternalLink />
-                      </a>
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+                        {provider.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell
+                      className="text-right whitespace-nowrap"
+                      title={
+                        amortization === null
+                          ? "No completed courses yet"
+                          : undefined
+                      }
+                    >
+                      {amortization === null
+                        ? "—"
+                        : formatCurrency(amortization)}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {inactiveCount}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {completeCount}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      <Button variant="outline" size="sm" asChild>
+                        <a
+                          href={provider.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Go
+                          <ExternalLink />
+                        </a>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
             </TableBody>
           </Table>
         </div>

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -32,15 +32,7 @@ function Dashboard() {
               md:flex-1
             "
           >
-            <DashboardCoursesInProgress />
-          </div>
-          <div
-            className="
-              min-w-0
-              md:flex-1
-            "
-          >
-            <DashboardRadars />
+            <DashboardUnderutilizedProviders />
           </div>
           <div
             className="
@@ -60,10 +52,18 @@ function Dashboard() {
           <div
             className="
               min-w-0
-              md:w-1/2
+              md:flex-1
             "
           >
-            <DashboardUnderutilizedProviders />
+            <DashboardCoursesInProgress />
+          </div>
+          <div
+            className="
+              min-w-0
+              md:flex-1
+            "
+          >
+            <DashboardRadars />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Amortization formula** — Courses by Amortization now uses `rawCost / percentComplete`, matching the formula used on the course detail page. (e.g. a \$500 provider fee shared by 2 courses with 1/12 progress: `500 / 8.33 ≈ \$60.02`.)
- **Table borders** — Removed `rounded-md border` from the inner table wrappers in both Courses by Amortization and Underutilized Providers cards so the tables blend into the card without a double border.
- **Dashboard layout** — Underutilized Providers and Courses by Amortization now share row 2 (each `flex-1`); Courses In Progress and Radars share row 3.
- **Dailies streak color** — When Today's Status is unset (`null`), the flame icon and streak text now render `text-muted-foreground` instead of orange. Applied in both `-DashboardDailies.tsx` and `dailies.index.tsx`.
- **Timeline connector gap** — Added `w-auto` to the `i === 0` connector so it stretches between its `left`/`right` anchors instead of being clamped to the base `w-3`. Applied in both `-DashboardDailies.tsx` and `dailies.index.tsx`.

## Test plan

- [ ] Open the dashboard and confirm row 2 is Underutilized Providers + Courses by Amortization, row 3 is Courses In Progress + Radars
- [ ] Confirm the Courses by Amortization and Underutilized Providers cards have no double border
- [ ] Verify amortization values match the course detail page for a course with split cost and partial progress
- [ ] On the dashboard Dailies card and the /dailies page, confirm the streak flame is grey when Today's Status is unset, orange when a status is selected with an active chain
- [ ] On the dashboard Dailies card and the /dailies page, confirm the connector between Today's Status and the first day circle stretches the full gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)