### PR TITLE
Merge task resource tags into task type tags on upsert

### DIFF
--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { resources, taskTodos, tasks } from "@/db/schema";
+import { resources, taskTodos, taskTypes, tasks } from "@/db/schema";
 import {
   idParamSchema,
   nullableString,
@@ -88,6 +88,37 @@ export default async function (server: FastifyInstance) {
               tags: r.tags ?? [],
             })),
           );
+        }
+
+        if (taskData.taskTypeId) {
+          const incomingResourceTags = Array.from(
+            new Set(body.resources.flatMap(r => r.tags ?? [])),
+          );
+          if (incomingResourceTags.length > 0) {
+            const taskType = await db.query.taskTypes.findFirst({
+              where: (t, {
+                eq: eqOp,
+              }) => eqOp(t.id, taskData.taskTypeId!),
+              columns: {
+                tags: true,
+              },
+            });
+            if (taskType) {
+              const existing = taskType.tags ?? [];
+              const merged = [...existing];
+              for (const tag of incomingResourceTags) {
+                if (!merged.includes(tag)) merged.push(tag);
+              }
+              if (merged.length > existing.length) {
+                await db
+                  .update(taskTypes)
+                  .set({
+                    tags: merged,
+                  })
+                  .where(eq(taskTypes.id, taskData.taskTypeId));
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Added functionality to automatically merge resource tags into task type tags when upserting a task. This ensures that task types accumulate tags from all associated resources over time.

## Key Changes
- Imported `taskTypes` table from the database schema
- Added logic to extract unique tags from all resources being associated with a task
- Query the task type to retrieve its existing tags
- Merge incoming resource tags with existing task type tags, avoiding duplicates
- Update the task type with the merged tags only if new tags were added

## Implementation Details
- Uses a `Set` to deduplicate tags from multiple resources before processing
- Only performs the database update if the merged tag list differs from the existing tags (optimization to avoid unnecessary writes)
- The merge operation preserves existing tags and appends new ones in order
- Only executes this logic when a `taskTypeId` is present in the task data

https://claude.ai/code/session_016HTb9bmWF6mRuzEvWHx4Pr