### PR TITLE
Rename Amortization to Cost per Unit; add provider mode to dashboard card

### DIFF
--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -84,7 +84,7 @@ function SingleCourse() {
                   >
                     {daily.name}
                   </Link>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     {`${chain}-day chain · ${total} total`}
                   </span>
                 </div>
@@ -171,7 +171,7 @@ function SingleCourse() {
             <p>{data?.cost.cost}</p>
           </InfoArea>
           <InfoArea
-            header="Amortization"
+            header="Cost per Unit"
             condition={!!percentComplete}
           >
             <p>

--- a/packages/client/src/routes/courses.$id.index.tsx
+++ b/packages/client/src/routes/courses.$id.index.tsx
@@ -84,7 +84,7 @@ function SingleCourse() {
                   >
                     {daily.name}
                   </Link>
-                  <span className="text-muted-foreground text-xs">
+                  <span className="text-xs text-muted-foreground">
                     {`${chain}-day chain · ${total} total`}
                   </span>
                 </div>

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -1,4 +1,4 @@
-import type { CourseInCourses } from "@emstack/types/src";
+import type { CourseInCourses, CourseProvider } from "@emstack/types/src";
 
 import { useMemo, useState } from "react";
 
@@ -21,20 +21,39 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { fetchCourses } from "@/utils";
+import { fetchCourses, fetchProviders } from "@/utils";
 
-type SortKey = "name" | "provider" | "cost" | "progress" | "amortization";
+type ViewMode = "courses" | "providers";
+
+type CourseSortKey = "name" | "provider" | "cost" | "progress" | "costPerUnit";
+type ProviderSortKey
+  = | "name"
+    | "courseCount"
+    | "completedUnits"
+    | "totalUnits"
+    | "cost"
+    | "costPerUnit";
 type SortDir = "asc" | "desc";
 
-interface AmortizationRow {
+interface CourseRow {
   course: CourseInCourses;
   effectiveCost: number;
   progressCurrent: number;
   progressTotal: number;
   progressFraction: number;
-  amortization: number | null;
+  costPerUnit: number | null;
   isUnstarted: boolean;
+}
+
+interface ProviderRow {
+  provider: CourseProvider;
+  courseCount: number;
+  completedUnits: number;
+  totalUnits: number;
+  cost: number;
+  costPerUnit: number | null;
 }
 
 function parseCost(value: string | null | undefined): number {
@@ -50,38 +69,72 @@ function formatCurrency(value: number): string {
   });
 }
 
-function buildRows(courses: CourseInCourses[] | undefined): AmortizationRow[] {
+function buildCourseRows(courses: CourseInCourses[] | undefined): CourseRow[] {
   if (!courses) return [];
   return courses.map((course) => {
     const rawCost = parseCost(course.cost?.cost);
-    const splitBy =
-      course.cost?.splitBy && course.cost.splitBy > 0 ? course.cost.splitBy : 1;
+    const splitBy
+      = course.cost?.splitBy && course.cost.splitBy > 0 ? course.cost.splitBy : 1;
     const effectiveCost = rawCost / splitBy;
     const progressCurrent = course.progressCurrent ?? 0;
     const progressTotal = course.progressTotal ?? 0;
-    const progressFraction =
-      progressTotal > 0 ? progressCurrent / progressTotal : 0;
-    const percentComplete =
-      progressTotal > 0
+    const progressFraction
+      = progressTotal > 0 ? progressCurrent / progressTotal : 0;
+    const percentComplete
+      = progressTotal > 0
         ? Number(((progressCurrent / progressTotal) * 100).toFixed(2))
         : 0;
-    const amortization = percentComplete > 0 ? rawCost / percentComplete : null;
+    const costPerUnit = percentComplete > 0 ? rawCost / percentComplete : null;
     return {
       course,
       effectiveCost,
       progressCurrent,
       progressTotal,
       progressFraction,
-      amortization,
+      costPerUnit,
       isUnstarted: progressCurrent === 0,
     };
   });
 }
 
-function compareRows(
-  a: AmortizationRow,
-  b: AmortizationRow,
-  key: SortKey,
+function buildProviderRows(
+  providers: CourseProvider[] | undefined,
+  courses: CourseInCourses[] | undefined,
+): ProviderRow[] {
+  if (!providers || !courses) return [];
+  const sharedFeeProviders = providers.filter(
+    p => p.isCourseFeesShared === true,
+  );
+  return sharedFeeProviders.map((provider) => {
+    const providerCourses = courses.filter(
+      c => c.provider?.id === provider.id,
+    );
+    const completedUnits = providerCourses.reduce(
+      (sum, c) => sum + (c.progressCurrent ?? 0),
+      0,
+    );
+    const totalUnits = providerCourses.reduce(
+      (sum, c) => sum + (c.progressTotal ?? 0),
+      0,
+    );
+    const cost = parseCost(provider.cost);
+    const costPerUnit
+      = totalUnits > 0 ? (completedUnits / totalUnits) * cost : null;
+    return {
+      provider,
+      courseCount: providerCourses.length,
+      completedUnits,
+      totalUnits,
+      cost,
+      costPerUnit,
+    };
+  });
+}
+
+function compareCourseRows(
+  a: CourseRow,
+  b: CourseRow,
+  key: CourseSortKey,
   dir: SortDir,
 ): number {
   const direction = dir === "asc" ? 1 : -1;
@@ -104,11 +157,11 @@ function compareRows(
       av = a.progressFraction;
       bv = b.progressFraction;
       break;
-    case "amortization":
+    case "costPerUnit":
     default:
-      // Treat unstarted (null) as the least amortized = highest cost-per-unit.
-      av = a.amortization ?? Number.POSITIVE_INFINITY;
-      bv = b.amortization ?? Number.POSITIVE_INFINITY;
+      // Treat unstarted (null) as the highest cost-per-unit.
+      av = a.costPerUnit ?? Number.POSITIVE_INFINITY;
+      bv = b.costPerUnit ?? Number.POSITIVE_INFINITY;
       break;
   }
   if (av < bv) return -1 * direction;
@@ -116,57 +169,191 @@ function compareRows(
   return a.course.name.localeCompare(b.course.name);
 }
 
+function compareProviderRows(
+  a: ProviderRow,
+  b: ProviderRow,
+  key: ProviderSortKey,
+  dir: SortDir,
+): number {
+  const direction = dir === "asc" ? 1 : -1;
+  let av: number | string;
+  let bv: number | string;
+  switch (key) {
+    case "name":
+      av = a.provider.name.toLowerCase();
+      bv = b.provider.name.toLowerCase();
+      break;
+    case "courseCount":
+      av = a.courseCount;
+      bv = b.courseCount;
+      break;
+    case "completedUnits":
+      av = a.completedUnits;
+      bv = b.completedUnits;
+      break;
+    case "totalUnits":
+      av = a.totalUnits;
+      bv = b.totalUnits;
+      break;
+    case "cost":
+      av = a.cost;
+      bv = b.cost;
+      break;
+    case "costPerUnit":
+    default:
+      av = a.costPerUnit ?? Number.POSITIVE_INFINITY;
+      bv = b.costPerUnit ?? Number.POSITIVE_INFINITY;
+      break;
+  }
+  if (av < bv) return -1 * direction;
+  if (av > bv) return 1 * direction;
+  return a.provider.name.localeCompare(b.provider.name);
+}
+
 export function DashboardCoursesByAmortization() {
   const {
     data: courses,
-    isPending,
-    error,
+    isPending: isCoursesPending,
+    error: coursesError,
   } = useQuery({
     queryKey: ["courses"],
     queryFn: () => fetchCourses(),
   });
 
-  const [showUnstarted, setShowUnstarted] = useState(false);
-  // "least to most amortized" = highest cost-per-unit first.
-  const [sortKey, setSortKey] = useState<SortKey>("amortization");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const {
+    data: providers,
+    isPending: isProvidersPending,
+    error: providersError,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
 
-  function toggleSort(key: SortKey) {
-    if (sortKey !== key) {
-      setSortKey(key);
-      setSortDir(key === "name" || key === "provider" ? "asc" : "desc");
+  const [viewMode, setViewMode] = useState<ViewMode>("courses");
+  const [showUnstarted, setShowUnstarted] = useState(false);
+  const [courseSortKey, setCourseSortKey]
+    = useState<CourseSortKey>("costPerUnit");
+  const [courseSortDir, setCourseSortDir] = useState<SortDir>("desc");
+  const [providerSortKey, setProviderSortKey]
+    = useState<ProviderSortKey>("costPerUnit");
+  const [providerSortDir, setProviderSortDir] = useState<SortDir>("desc");
+
+  function toggleCourseSort(key: CourseSortKey) {
+    if (courseSortKey !== key) {
+      setCourseSortKey(key);
+      setCourseSortDir(key === "name" || key === "provider" ? "asc" : "desc");
       return;
     }
-    setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+    setCourseSortDir(prev => (prev === "asc" ? "desc" : "asc"));
   }
 
-  function sortIcon(key: SortKey) {
-    if (sortKey !== key) {
+  function toggleProviderSort(key: ProviderSortKey) {
+    if (providerSortKey !== key) {
+      setProviderSortKey(key);
+      setProviderSortDir(key === "name" ? "asc" : "desc");
+      return;
+    }
+    setProviderSortDir(prev => (prev === "asc" ? "desc" : "asc"));
+  }
+
+  function courseSortIcon(key: CourseSortKey) {
+    if (courseSortKey !== key) {
       return <ChevronsUpDownIcon className="size-3 opacity-50" />;
     }
-    return sortDir === "asc" ? (
-      <ChevronUpIcon className="size-3" />
-    ) : (
-      <ChevronDownIcon className="size-3" />
-    );
+    return courseSortDir === "asc"
+      ? (
+        <ChevronUpIcon className="size-3" />
+      )
+      : (
+        <ChevronDownIcon className="size-3" />
+      );
   }
 
-  const rows = useMemo(() => {
-    const all = buildRows(courses);
-    const filtered = showUnstarted ? all : all.filter((r) => !r.isUnstarted);
-    return filtered.slice().sort((a, b) => compareRows(a, b, sortKey, sortDir));
-  }, [courses, showUnstarted, sortKey, sortDir]);
+  function providerSortIcon(key: ProviderSortKey) {
+    if (providerSortKey !== key) {
+      return <ChevronsUpDownIcon className="size-3 opacity-50" />;
+    }
+    return providerSortDir === "asc"
+      ? (
+        <ChevronUpIcon className="size-3" />
+      )
+      : (
+        <ChevronDownIcon className="size-3" />
+      );
+  }
+
+  const courseRows = useMemo(() => {
+    const all = buildCourseRows(courses);
+    const filtered = showUnstarted ? all : all.filter(r => !r.isUnstarted);
+    return filtered
+      .slice()
+      .sort((a, b) => compareCourseRows(a, b, courseSortKey, courseSortDir));
+  }, [courses, showUnstarted, courseSortKey, courseSortDir]);
+
+  const providerRows = useMemo(() => {
+    const all = buildProviderRows(providers, courses);
+    return all
+      .slice()
+      .sort((a, b) =>
+        compareProviderRows(a, b, providerSortKey, providerSortDir));
+  }, [providers, courses, providerSortKey, providerSortDir]);
+
+  const isPending
+    = viewMode === "providers"
+      ? isCoursesPending || isProvidersPending
+      : isCoursesPending;
+  const error
+    = viewMode === "providers" ? coursesError ?? providersError : coursesError;
+  const hasData
+    = viewMode === "providers"
+      ? providers !== undefined && courses !== undefined
+      : courses !== undefined;
+  const isEmpty
+    = viewMode === "providers" ? providerRows.length === 0 : courseRows.length === 0;
 
   return (
     <DashboardCard
-      title="Courses by Amortization"
+      title="Cost per Unit"
       action={
-        <div className="flex items-center gap-3">
+        <Link
+          to="/courses"
+          className="
+            text-primary text-sm underline-offset-2
+            hover:underline
+          "
+        >
+          View all
+        </Link>
+      }
+    >
+      <div
+        className="flex flex-row flex-wrap items-center justify-between gap-3"
+      >
+        <Tabs
+          value={viewMode}
+          onValueChange={v => setViewMode(v as ViewMode)}
+        >
+          <TabsList className="h-8">
+            <TabsTrigger
+              value="courses"
+              className="text-xs"
+            >
+              Courses
+            </TabsTrigger>
+            <TabsTrigger
+              value="providers"
+              className="text-xs"
+            >
+              Providers
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {viewMode === "courses" && (
           <button
             type="button"
             role="switch"
             aria-checked={showUnstarted}
-            onClick={() => setShowUnstarted((prev) => !prev)}
+            onClick={() => setShowUnstarted(prev => !prev)}
             className="
               text-muted-foreground
               hover:text-foreground
@@ -194,35 +381,32 @@ export function DashboardCoursesByAmortization() {
             </span>
             Show unstarted
           </button>
-          <Link
-            to="/courses"
-            className="
-              text-primary text-sm underline-offset-2
-              hover:underline
-            "
-          >
-            View all
-          </Link>
-        </div>
-      }
-    >
+        )}
+      </div>
       {isPending && (
-        <p className="text-muted-foreground text-sm">Loading courses...</p>
-      )}
-      {error && (
-        <p className="text-destructive text-sm">Failed to load courses.</p>
-      )}
-      {courses && rows.length === 0 && (
         <p className="text-muted-foreground text-sm">
-          <i>No courses to show.</i>
+          {viewMode === "providers" ? "Loading providers..." : "Loading courses..."}
         </p>
       )}
-      {rows.length > 0 && (
+      {error && (
+        <p className="text-destructive text-sm">
+          {viewMode === "providers"
+            ? "Failed to load providers."
+            : "Failed to load courses."}
+        </p>
+      )}
+      {hasData && isEmpty && (
+        <p className="text-muted-foreground text-sm">
+          <i>
+            {viewMode === "providers"
+              ? "No providers with shared course fees."
+              : "No courses to show."}
+          </i>
+        </p>
+      )}
+      {viewMode === "courses" && courseRows.length > 0 && (
         <div
-          className="
-            max-h-80 w-full overflow-auto
-            [scrollbar-width:thin]
-          "
+          className="max-h-80 w-full overflow-auto [scrollbar-width:thin]"
         >
           <Table className="w-auto min-w-full">
             <TableHeader>
@@ -230,66 +414,66 @@ export function DashboardCoursesByAmortization() {
                 <TableHead className="whitespace-nowrap">
                   <button
                     type="button"
-                    onClick={() => toggleSort("name")}
+                    onClick={() => toggleCourseSort("name")}
                     className="
                       hover:text-foreground
                       inline-flex items-center gap-1
                     "
                   >
                     Course
-                    {sortIcon("name")}
+                    {courseSortIcon("name")}
                   </button>
                 </TableHead>
                 <TableHead className="whitespace-nowrap">
                   <button
                     type="button"
-                    onClick={() => toggleSort("provider")}
+                    onClick={() => toggleCourseSort("provider")}
                     className="
                       hover:text-foreground
                       inline-flex items-center gap-1
                     "
                   >
                     Provider
-                    {sortIcon("provider")}
+                    {courseSortIcon("provider")}
                   </button>
                 </TableHead>
                 <TableHead className="text-right whitespace-nowrap">
                   <button
                     type="button"
-                    onClick={() => toggleSort("cost")}
+                    onClick={() => toggleCourseSort("cost")}
                     className="
                       hover:text-foreground
                       inline-flex items-center gap-1
                     "
                   >
                     Cost
-                    {sortIcon("cost")}
+                    {courseSortIcon("cost")}
                   </button>
                 </TableHead>
                 <TableHead className="text-right whitespace-nowrap">
                   <button
                     type="button"
-                    onClick={() => toggleSort("progress")}
+                    onClick={() => toggleCourseSort("progress")}
                     className="
                       hover:text-foreground
                       inline-flex items-center gap-1
                     "
                   >
                     Progress
-                    {sortIcon("progress")}
+                    {courseSortIcon("progress")}
                   </button>
                 </TableHead>
                 <TableHead className="text-right whitespace-nowrap">
                   <button
                     type="button"
-                    onClick={() => toggleSort("amortization")}
+                    onClick={() => toggleCourseSort("costPerUnit")}
                     className="
                       hover:text-foreground
                       inline-flex items-center gap-1
                     "
                   >
-                    Amortization
-                    {sortIcon("amortization")}
+                    Cost per Unit
+                    {courseSortIcon("costPerUnit")}
                   </button>
                 </TableHead>
                 <TableHead className="text-right whitespace-nowrap">
@@ -298,13 +482,13 @@ export function DashboardCoursesByAmortization() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map(
+              {courseRows.map(
                 ({
                   course,
                   effectiveCost,
                   progressCurrent,
                   progressTotal,
-                  amortization,
+                  costPerUnit,
                   isUnstarted,
                 }) => (
                   <TableRow key={course.id}>
@@ -320,22 +504,24 @@ export function DashboardCoursesByAmortization() {
                       </Link>
                     </TableCell>
                     <TableCell className="whitespace-nowrap">
-                      {course.provider ? (
-                        <Link
-                          to="/providers/$id"
-                          params={{
-                            id: course.provider.id,
-                          }}
-                          className="
-                            text-muted-foreground
-                            hover:text-blue-600
-                          "
-                        >
-                          {course.provider.name}
-                        </Link>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
+                      {course.provider
+                        ? (
+                          <Link
+                            to="/providers/$id"
+                            params={{
+                              id: course.provider.id,
+                            }}
+                            className="
+                              text-muted-foreground
+                              hover:text-blue-600
+                            "
+                          >
+                            {course.provider.name}
+                          </Link>
+                        )
+                        : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
                     </TableCell>
                     <TableCell className="text-right whitespace-nowrap">
                       {formatCurrency(effectiveCost)}
@@ -358,25 +544,171 @@ export function DashboardCoursesByAmortization() {
                         isUnstarted ? "Unstarted — no progress yet" : undefined
                       }
                     >
-                      {amortization === null
+                      {costPerUnit === null
                         ? "—"
-                        : formatCurrency(amortization)}
+                        : formatCurrency(costPerUnit)}
                     </TableCell>
                     <TableCell className="text-right whitespace-nowrap">
-                      {course.url ? (
-                        <Button asChild size="sm" variant="outline">
-                          <a
-                            href={course.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                      {course.url
+                        ? (
+                          <Button
+                            asChild
+                            size="sm"
+                            variant="outline"
                           >
-                            Go
-                            <ExternalLink />
-                          </a>
-                        </Button>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
+                            <a
+                              href={course.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Go
+                              <ExternalLink />
+                            </a>
+                          </Button>
+                        )
+                        : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+      {viewMode === "providers" && providerRows.length > 0 && (
+        <div
+          className="max-h-80 w-full overflow-auto [scrollbar-width:thin]"
+        >
+          <Table className="w-auto min-w-full">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("name")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Provider
+                    {providerSortIcon("name")}
+                  </button>
+                </TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("courseCount")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Courses
+                    {providerSortIcon("courseCount")}
+                  </button>
+                </TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("completedUnits")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Completed Units
+                    {providerSortIcon("completedUnits")}
+                  </button>
+                </TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("totalUnits")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Total Units
+                    {providerSortIcon("totalUnits")}
+                  </button>
+                </TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("cost")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Cost
+                    {providerSortIcon("cost")}
+                  </button>
+                </TableHead>
+                <TableHead className="text-right whitespace-nowrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleProviderSort("costPerUnit")}
+                    className="
+                      hover:text-foreground
+                      inline-flex items-center gap-1
+                    "
+                  >
+                    Cost per Unit
+                    {providerSortIcon("costPerUnit")}
+                  </button>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {providerRows.map(
+                ({
+                  provider,
+                  courseCount,
+                  completedUnits,
+                  totalUnits,
+                  cost,
+                  costPerUnit,
+                }) => (
+                  <TableRow key={provider.id}>
+                    <TableCell className="font-medium whitespace-nowrap">
+                      <Link
+                        to="/providers/$id"
+                        params={{
+                          id: provider.id,
+                        }}
+                        className="hover:text-blue-600"
+                      >
+                        {provider.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {courseCount}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {completedUnits}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {totalUnits}
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {formatCurrency(cost)}
+                    </TableCell>
+                    <TableCell
+                      className="text-right whitespace-nowrap"
+                      title={
+                        costPerUnit === null
+                          ? "No course progress yet"
+                          : undefined
+                      }
+                    >
+                      {costPerUnit === null
+                        ? "—"
+                        : formatCurrency(costPerUnit)}
                     </TableCell>
                   </TableRow>
                 ),

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -318,7 +318,7 @@ export function DashboardCoursesByAmortization() {
         <Link
           to="/courses"
           className="
-            text-primary text-sm underline-offset-2
+            text-sm text-primary underline-offset-2
             hover:underline
           "
         >
@@ -355,9 +355,8 @@ export function DashboardCoursesByAmortization() {
             aria-checked={showUnstarted}
             onClick={() => setShowUnstarted(prev => !prev)}
             className="
-              text-muted-foreground
+              inline-flex items-center gap-2 text-xs text-muted-foreground
               hover:text-foreground
-              inline-flex items-center gap-2 text-xs
             "
           >
             <span
@@ -372,7 +371,7 @@ export function DashboardCoursesByAmortization() {
               <span
                 className={cn(
                   `
-                    bg-background inline-block size-3 rounded-full shadow-sm
+                    inline-block size-3 rounded-full bg-background shadow-sm
                     transition-transform
                   `,
                   showUnstarted ? "translate-x-3.5" : "translate-x-0.5",
@@ -384,19 +383,19 @@ export function DashboardCoursesByAmortization() {
         )}
       </div>
       {isPending && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-sm text-muted-foreground">
           {viewMode === "providers" ? "Loading providers..." : "Loading courses..."}
         </p>
       )}
       {error && (
-        <p className="text-destructive text-sm">
+        <p className="text-sm text-destructive">
           {viewMode === "providers"
             ? "Failed to load providers."
             : "Failed to load courses."}
         </p>
       )}
       {hasData && isEmpty && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-sm text-muted-foreground">
           <i>
             {viewMode === "providers"
               ? "No providers with shared course fees."
@@ -416,8 +415,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleCourseSort("name")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Course
@@ -429,8 +428,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleCourseSort("provider")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Provider
@@ -442,8 +441,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleCourseSort("cost")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Cost
@@ -455,8 +454,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleCourseSort("progress")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Progress
@@ -468,8 +467,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleCourseSort("costPerUnit")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Cost per Unit
@@ -589,8 +588,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("name")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Provider
@@ -602,8 +601,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("courseCount")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Courses
@@ -615,8 +614,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("completedUnits")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Completed Units
@@ -628,8 +627,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("totalUnits")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Total Units
@@ -641,8 +640,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("cost")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Cost
@@ -654,8 +653,8 @@ export function DashboardCoursesByAmortization() {
                     type="button"
                     onClick={() => toggleProviderSort("costPerUnit")}
                     className="
-                      hover:text-foreground
                       inline-flex items-center gap-1
+                      hover:text-foreground
                     "
                   >
                     Cost per Unit

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
@@ -87,7 +87,7 @@ export function DashboardUnderutilizedProviders() {
         <Link
           to="/providers"
           className="
-            text-primary text-sm underline-offset-2
+            text-sm text-primary underline-offset-2
             hover:underline
           "
         >
@@ -96,13 +96,13 @@ export function DashboardUnderutilizedProviders() {
       }
     >
       {isPending && (
-        <p className="text-muted-foreground text-sm">Loading providers...</p>
+        <p className="text-sm text-muted-foreground">Loading providers...</p>
       )}
       {error && (
-        <p className="text-destructive text-sm">Failed to load providers.</p>
+        <p className="text-sm text-destructive">Failed to load providers.</p>
       )}
       {providers && rows.length === 0 && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-sm text-muted-foreground">
           <i>No underutilized providers.</i>
         </p>
       )}

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
@@ -87,7 +87,7 @@ export function DashboardUnderutilizedProviders() {
         <Link
           to="/providers"
           className="
-            text-sm text-primary underline-offset-2
+            text-primary text-sm underline-offset-2
             hover:underline
           "
         >
@@ -96,29 +96,26 @@ export function DashboardUnderutilizedProviders() {
       }
     >
       {isPending && (
-        <p className="text-sm text-muted-foreground">Loading providers...</p>
+        <p className="text-muted-foreground text-sm">Loading providers...</p>
       )}
       {error && (
-        <p className="text-sm text-destructive">Failed to load providers.</p>
+        <p className="text-destructive text-sm">Failed to load providers.</p>
       )}
       {providers && rows.length === 0 && (
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           <i>No underutilized providers.</i>
         </p>
       )}
       {rows.length > 0 && (
         <div
-          className="
-            max-h-80 w-full overflow-auto
-            [scrollbar-width:thin]
-          "
+          className="max-h-80 w-full overflow-auto [scrollbar-width:thin]"
         >
           <Table className="w-auto min-w-full">
             <TableHeader>
               <TableRow>
                 <TableHead className="whitespace-nowrap">Provider</TableHead>
                 <TableHead className="text-right whitespace-nowrap">
-                  Amortization
+                  Cost per Unit
                 </TableHead>
                 <TableHead className="text-right whitespace-nowrap">
                   Inactive
@@ -133,7 +130,9 @@ export function DashboardUnderutilizedProviders() {
             </TableHeader>
             <TableBody>
               {rows.map(
-                ({ provider, amortization, inactiveCount, completeCount }) => (
+                ({
+                  provider, amortization, inactiveCount, completeCount,
+                }) => (
                   <TableRow key={provider.id}>
                     <TableCell className="font-medium whitespace-nowrap">
                       <Link
@@ -165,7 +164,11 @@ export function DashboardUnderutilizedProviders() {
                       {completeCount}
                     </TableCell>
                     <TableCell className="text-right whitespace-nowrap">
-                      <Button variant="outline" size="sm" asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        asChild
+                      >
                         <a
                           href={provider.url}
                           target="_blank"


### PR DESCRIPTION
Renames the "Amortization" label to "Cost per Unit" across the course
detail page and the two relevant dashboard cards. Moves the
"Show unstarted" toggle from the card header into the card body, and
adds a tab toggle to switch between viewing courses and providers (with
shared course fees) on the Cost per Unit card.