### PR TITLE
Fix client build: correct Textarea import path in ScopeTab

### DIFF
--- a/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, PlusIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
 
-import { Textarea } from "@/components/forms/textarea";
+import { Textarea } from "@/components/textarea";
 import { TopicMultiSelect } from "@/components/radar/TopicMultiSelect";
 import { Button } from "@/components/ui/button";
 import {

--- a/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
@@ -5,8 +5,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, PlusIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
 
-import { Textarea } from "@/components/textarea";
 import { TopicMultiSelect } from "@/components/radar/TopicMultiSelect";
+import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
 import {
   Select,

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -16,7 +16,6 @@ import { ScopeTab } from "./domains.$id.edit.-components/-ScopeTab";
 import { useAppForm } from "@/components/formFields";
 import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
-import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
 import {
   Tabs,


### PR DESCRIPTION
The Domain/Radar consolidation PR (#175) imported Textarea from
@/components/forms/textarea, which doesn't exist — the component lives
at @/components/textarea. Also drop the now-unused Textarea import from
domains.$id.edit.tsx.

https://claude.ai/code/session_016uNTpeAWXra8bykBVP5QXp