### PR TITLE
Fix radar migration to ensure radar_config exists before detection

### DIFF
--- a/packages/middleware/src/db/migrateConsolidateRadar.ts
+++ b/packages/middleware/src/db/migrateConsolidateRadar.ts
@@ -15,11 +15,16 @@ type ConstraintRow = { constraint_name: string } & Record<string, unknown>;
 //   - drops the `topics_to_domains` junction; backfills its rows as blips
 //     with NULL quadrant/ring
 //   - drops the now-empty `radar_quadrants` and `radar_rings` tables
-//
-// Detection: the `domains.has_radar` column existing means we have not run
-// yet. After the migration finishes the column is gone, so subsequent
-// startups short-circuit.
 export async function migrateConsolidateRadar() {
+  // Always ensure radar_config exists — drizzle-kit push in a non-TTY
+  // container can drop has_radar without adding radar_config, leaving the DB
+  // in a state where the has_radar guard below would skip the column add.
+  await db.execute(sql`
+    ALTER TABLE domains
+    ADD COLUMN IF NOT EXISTS radar_config JSONB NOT NULL
+    DEFAULT '{"quadrants":[],"rings":[]}'::jsonb
+  `);
+
   const hasRadarColumn = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
@@ -31,12 +36,6 @@ export async function migrateConsolidateRadar() {
   }
 
   await db.transaction(async (tx) => {
-    await tx.execute(sql`
-      ALTER TABLE domains
-      ADD COLUMN IF NOT EXISTS radar_config JSONB NOT NULL
-      DEFAULT '{"quadrants":[],"rings":[]}'::jsonb
-    `);
-
     const quadrantsTableExists = await tx.execute<ExistsRow>(sql`
       SELECT EXISTS (
         SELECT 1 FROM information_schema.tables


### PR DESCRIPTION
## Summary
Moves the `radar_config` column creation outside of the database transaction in the radar consolidation migration to prevent a race condition where drizzle-kit could drop the `has_radar` column without adding `radar_config`, leaving the database in an inconsistent state.

## Key Changes
- Moved `ALTER TABLE domains ADD COLUMN radar_config` execution before the transaction block
- Added explanatory comment about the drizzle-kit push issue in non-TTY containers
- Ensures `radar_config` exists before the migration detection logic checks for `has_radar`

## Implementation Details
The migration uses the presence of the `has_radar` column as a guard to detect whether the migration has already run. However, in non-TTY container environments, drizzle-kit push can drop `has_radar` without properly adding `radar_config`, leaving the database in an invalid state. By creating `radar_config` before the transaction and detection logic, we ensure the database is always in a valid state regardless of how drizzle-kit executes schema changes.

https://claude.ai/code/session_01SnAkBjrKrTQF5fUp9QiL6k