### PR TITLE
Refactor database startup logic into separate module

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -40,8 +40,10 @@
     "dev": "nodemon --exec tsx src/app.ts",
     "test": "node --test",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "push:prod": "dotenv -e .env.production -- drizzle-kit push",
-    "push:dev": "dotenv -e .env -- drizzle-kit push",
+    "migrate:prod": "dotenv -e .env.production -- tsx src/db/migrate.ts",
+    "migrate:dev": "dotenv -e .env -- tsx src/db/migrate.ts",
+    "push:prod": "pnpm run migrate:prod && dotenv -e .env.production -- drizzle-kit push",
+    "push:dev": "pnpm run migrate:dev && dotenv -e .env -- drizzle-kit push",
     "push": "pnpm run push:prod && pnpm run push:dev",
     "db:push": "drizzle-kit push",
     "studio": "pnpm drizzle-kit studio"

--- a/packages/middleware/src/app.ts
+++ b/packages/middleware/src/app.ts
@@ -5,6 +5,7 @@ import fastifySwaggerUi from "@fastify/swagger-ui";
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import Fastify from "fastify";
 
+import { runMigrations, seedIfEmpty } from "./db/startup";
 import routes from "./routes/routes";
 import { makeEnvOptions } from "./services/env";
 import swaggerOptions from "./services/swaggerOptions";
@@ -56,6 +57,16 @@ const start = async () => {
     process.exit(1);
   }
 };
+
+(async () => {
+  try {
+    await runMigrations();
+    await seedIfEmpty();
+  }
+  catch (err) {
+    console.error("Startup migrations/seed failed:", err);
+  }
+})();
 
 start();
 

--- a/packages/middleware/src/db/index.ts
+++ b/packages/middleware/src/db/index.ts
@@ -1,35 +1,7 @@
 import "dotenv/config";
 import * as schema from "@/db/schema";
 import { drizzle as LocalDrizzle } from "drizzle-orm/node-postgres";
-import { seed } from "./seed.ts";
-import { migrateRadarBlips } from "./migrateRadarBlips.ts";
-import { migrateConsolidateRadar } from "./migrateConsolidateRadar.ts";
-import { courses } from "@/db/schema";
 
 export const db = LocalDrizzle(process.env.DATABASE_URL!, {
   schema,
 });
-
-async function main() {
-  try {
-    await migrateRadarBlips();
-  }
-  catch (err) {
-    console.error("Failed to migrate radar blips:", err);
-  }
-
-  try {
-    await migrateConsolidateRadar();
-  }
-  catch (err) {
-    console.error("Failed to consolidate domain/radar:", err);
-  }
-
-  const currentCourses = await db.select().from(courses);
-  const isCourses = currentCourses.length > 0;
-  if (!isCourses) {
-    await seed();
-  }
-}
-
-main();

--- a/packages/middleware/src/db/migrate.ts
+++ b/packages/middleware/src/db/migrate.ts
@@ -1,0 +1,10 @@
+import "dotenv/config";
+
+import { runMigrations } from "./startup.ts";
+
+runMigrations()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/middleware/src/db/migrateConsolidateRadar.ts
+++ b/packages/middleware/src/db/migrateConsolidateRadar.ts
@@ -16,6 +16,17 @@ type ConstraintRow = { constraint_name: string } & Record<string, unknown>;
 //     with NULL quadrant/ring
 //   - drops the now-empty `radar_quadrants` and `radar_rings` tables
 export async function migrateConsolidateRadar() {
+  // Skip on a fresh DB where drizzle-kit push hasn't created tables yet.
+  const domainsTableExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_name = 'domains'
+    ) AS exists
+  `);
+  if (!domainsTableExists.rows[0]?.exists) {
+    return;
+  }
+
   // Always ensure radar_config exists — drizzle-kit push in a non-TTY
   // container can drop has_radar without adding radar_config, leaving the DB
   // in a state where the has_radar guard below would skip the column add.

--- a/packages/middleware/src/db/startup.ts
+++ b/packages/middleware/src/db/startup.ts
@@ -1,0 +1,30 @@
+import { db } from "@/db/index";
+import { courses } from "@/db/schema";
+import { migrateConsolidateRadar } from "./migrateConsolidateRadar.ts";
+import { migrateRadarBlips } from "./migrateRadarBlips.ts";
+import { seed } from "./seed.ts";
+
+export async function runMigrations() {
+  try {
+    await migrateRadarBlips();
+  }
+  catch (err) {
+    console.error("Failed to migrate radar blips:", err);
+    throw err;
+  }
+
+  try {
+    await migrateConsolidateRadar();
+  }
+  catch (err) {
+    console.error("Failed to consolidate domain/radar:", err);
+    throw err;
+  }
+}
+
+export async function seedIfEmpty() {
+  const currentCourses = await db.select().from(courses);
+  if (currentCourses.length === 0) {
+    await seed();
+  }
+}


### PR DESCRIPTION
## Summary
Extracted database initialization logic from `db/index.ts` into a dedicated `db/startup.ts` module and integrated it into the application startup flow. This improves separation of concerns and allows migrations to be run independently via CLI.

## Key Changes
- **New `db/startup.ts` module**: Exports `runMigrations()` and `seedIfEmpty()` functions that were previously embedded in `db/index.ts`
- **New `db/migrate.ts` CLI script**: Standalone script for running migrations outside the application startup
- **Updated `db/index.ts`**: Removed all initialization logic, now only exports the database instance
- **Updated `app.ts`**: Integrated startup migrations and seeding into the application initialization flow
- **Enhanced `migrateConsolidateRadar()`**: Added table existence check to gracefully handle fresh databases where schema hasn't been created yet
- **Updated npm scripts**: Added `migrate:dev` and `migrate:prod` scripts; `push:dev` and `push:prod` now run migrations before drizzle-kit push

## Notable Implementation Details
- Migrations are now run asynchronously during application startup with error handling
- The `seedIfEmpty()` function checks if the courses table is populated before seeding
- The `migrateConsolidateRadar()` function now safely skips execution on fresh databases where the `domains` table doesn't exist yet, preventing errors during initial schema creation
- Migrations can be triggered independently via the new CLI scripts without starting the full application

https://claude.ai/code/session_01FhEqDUmo1ATr9w6xxxHDUh