### PR TITLE
Add bulk delete functionality to topics table

### DIFF
--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -1,5 +1,7 @@
 import type { TopicForTopicsPage } from "@emstack/types/src";
 
+import { useMemo } from "react";
+
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import {
   Table,
@@ -10,18 +12,52 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+interface TopicsTableSelection {
+  selectedIds: Set<string>;
+  onToggleSelected: (id: string) => void;
+  onToggleAll: (selectAll: boolean) => void;
+}
+
 interface TopicsTableProps {
   topics: TopicForTopicsPage[];
+  selection?: TopicsTableSelection;
 }
 
 export function TopicsTable({
   topics,
+  selection,
 }: TopicsTableProps) {
+  const selectedIds = selection?.selectedIds;
+
+  const allSelected = useMemo(() => {
+    if (!selectedIds || topics.length === 0) return false;
+    return topics.every(t => selectedIds.has(t.id));
+  }, [topics, selectedIds]);
+
+  const someSelected = useMemo(() => {
+    if (!selectedIds) return false;
+    return topics.some(t => selectedIds.has(t.id));
+  }, [topics, selectedIds]);
+
   return (
     <div className="w-full rounded-md border bg-card">
       <Table className="w-auto min-w-full">
         <TableHeader>
           <TableRow>
+            {selection && (
+              <TableHead className="w-10">
+                <input
+                  type="checkbox"
+                  className="size-4"
+                  aria-label="Select all topics"
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = !allSelected && someSelected;
+                  }}
+                  onChange={e => selection.onToggleAll(e.target.checked)}
+                />
+              </TableHead>
+            )}
             <TableHead className="whitespace-nowrap">Name</TableHead>
             <TableHead className="whitespace-nowrap">Domains</TableHead>
             <TableHead>Description</TableHead>
@@ -37,60 +73,77 @@ export function TopicsTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {topics.map(topic => (
-            <TableRow key={topic.id}>
-              <TableCell className="font-medium whitespace-nowrap">
-                <EntityLink
-                  entity="topics"
-                  id={topic.id}
-                  className="hover:text-blue-600"
-                >
-                  {topic.name}
-                </EntityLink>
-              </TableCell>
-              <TableCell className="whitespace-nowrap">
-                {topic.domains && topic.domains.length > 0
-                  ? (
-                    <div className="flex flex-wrap gap-1">
-                      {topic.domains.map(domain => (
-                        <span
-                          key={domain.id}
-                          className="
-                            rounded-sm bg-gray-100 px-2 py-0.5 text-xs
-                            text-gray-700
-                          "
-                        >
-                          {domain.title}
-                        </span>
-                      ))}
-                    </div>
-                  )
-                  : (
-                    <span className="text-muted-foreground">—</span>
-                  )}
-              </TableCell>
-              <TableCell className="max-w-md">
-                {topic.description
-                  ? (
-                    <span className="line-clamp-2 text-sm">
-                      {topic.description}
-                    </span>
-                  )
-                  : (
-                    <span className="text-muted-foreground">—</span>
-                  )}
-              </TableCell>
-              <TableCell className="text-right tabular-nums">
-                {topic.courseCount ?? 0}
-              </TableCell>
-              <TableCell className="text-right tabular-nums">
-                {topic.taskCount ?? 0}
-              </TableCell>
-              <TableCell className="text-right tabular-nums">
-                {topic.dailyCount ?? 0}
-              </TableCell>
-            </TableRow>
-          ))}
+          {topics.map((topic) => {
+            const isSelected = selectedIds?.has(topic.id) ?? false;
+            return (
+              <TableRow
+                key={topic.id}
+                data-state={isSelected ? "selected" : undefined}
+              >
+                {selection && (
+                  <TableCell className="w-10">
+                    <input
+                      type="checkbox"
+                      className="size-4"
+                      aria-label={`Select ${topic.name}`}
+                      checked={isSelected}
+                      onChange={() => selection.onToggleSelected(topic.id)}
+                    />
+                  </TableCell>
+                )}
+                <TableCell className="font-medium whitespace-nowrap">
+                  <EntityLink
+                    entity="topics"
+                    id={topic.id}
+                    className="hover:text-blue-600"
+                  >
+                    {topic.name}
+                  </EntityLink>
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {topic.domains && topic.domains.length > 0
+                    ? (
+                      <div className="flex flex-wrap gap-1">
+                        {topic.domains.map(domain => (
+                          <span
+                            key={domain.id}
+                            className="
+                              rounded-sm bg-gray-100 px-2 py-0.5 text-xs
+                              text-gray-700
+                            "
+                          >
+                            {domain.title}
+                          </span>
+                        ))}
+                      </div>
+                    )
+                    : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                </TableCell>
+                <TableCell className="max-w-md">
+                  {topic.description
+                    ? (
+                      <span className="line-clamp-2 text-sm">
+                        {topic.description}
+                      </span>
+                    )
+                    : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {topic.courseCount ?? 0}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {topic.taskCount ?? 0}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {topic.dailyCount ?? 0}
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </div>

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -1,8 +1,8 @@
 import type { TopicForTopicsPage } from "@emstack/types/src";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ArrowRightIcon,
@@ -10,12 +10,15 @@ import {
   ListIcon,
   PlusIcon,
   SearchIcon,
+  Trash2Icon,
   XIcon,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { TopicBox } from "@/components/boxes/TopicBox";
 import { TopicsTable } from "@/components/boxes/TopicsTable";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { FilterOptionCount } from "@/components/FilterOptionCount";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -27,7 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { fetchDomains, fetchTopics } from "@/utils";
+import { bulkDeleteTopics, fetchDomains, fetchTopics } from "@/utils";
 
 type SortOption = "alpha-asc" | "alpha-desc" | "resources";
 type ViewMode = "grid" | "table";
@@ -75,6 +78,10 @@ function Topics() {
   const [filterDomain, setFilterDomain] = useState<string | undefined>();
   const [sortBy, setSortBy] = useState<SortOption>("alpha-asc");
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const queryClient = useQueryClient();
 
   const updateViewMode = (mode: ViewMode) => {
     setViewMode(mode);
@@ -122,6 +129,74 @@ function Topics() {
 
     return sortTopics(result, sortBy);
   }, [data, search, filterDomain, sortBy]);
+
+  const filteredIds = useMemo(
+    () => filteredAndSorted.map(t => t.id),
+    [filteredAndSorted],
+  );
+
+  useEffect(() => {
+    if (viewMode !== "table" && selectedIds.size > 0) {
+      setSelectedIds(new Set());
+    }
+  }, [viewMode, selectedIds]);
+
+  useEffect(() => {
+    if (selectedIds.size === 0) return;
+    const visible = new Set(filteredIds);
+    let changed = false;
+    const next = new Set<string>();
+    selectedIds.forEach((id) => {
+      if (visible.has(id)) {
+        next.add(id);
+      }
+      else {
+        changed = true;
+      }
+    });
+    if (changed) setSelectedIds(next);
+  }, [filteredIds, selectedIds]);
+
+  const handleToggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleToggleAll = (selectAll: boolean) => {
+    setSelectedIds(selectAll ? new Set(filteredIds) : new Set());
+  };
+
+  const handleBulkDelete = async () => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    setIsDeleting(true);
+    try {
+      await bulkDeleteTopics(ids);
+      await queryClient.invalidateQueries({
+        queryKey: ["topics"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["domains"],
+      });
+      setSelectedIds(new Set());
+      setConfirmOpen(false);
+      toast.success(
+        ids.length === 1
+          ? "1 topic deleted."
+          : `${ids.length} topics deleted.`,
+      );
+    }
+    catch {
+      toast.error("Failed to delete topics. Please try again.");
+    }
+    finally {
+      setIsDeleting(false);
+    }
+  };
 
   const hasActiveFilters = filterDomain;
 
@@ -327,7 +402,48 @@ function Topics() {
         {viewMode === "table" && (
           <div className="flex flex-col gap-4">
             {filteredAndSorted.length > 0 && (
-              <TopicsTable topics={filteredAndSorted} />
+              <>
+                <div
+                  className="
+                    flex min-h-9 flex-wrap items-center justify-between gap-2
+                  "
+                >
+                  <span className="text-sm text-muted-foreground">
+                    {selectedIds.size > 0
+                      ? `${selectedIds.size} selected`
+                      : ""}
+                  </span>
+                  {selectedIds.size > 0 && (
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setSelectedIds(new Set())}
+                      >
+                        Clear selection
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setConfirmOpen(true)}
+                      >
+                        <Trash2Icon className="size-4" />
+                        Delete
+                        {" "}
+                        {selectedIds.size}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                <TopicsTable
+                  topics={filteredAndSorted}
+                  selection={{
+                    selectedIds,
+                    onToggleSelected: handleToggleSelected,
+                    onToggleAll: handleToggleAll,
+                  }}
+                />
+              </>
             )}
             <div>
               <Link
@@ -345,6 +461,21 @@ function Topics() {
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={
+          selectedIds.size === 1
+            ? "Delete 1 topic?"
+            : `Delete ${selectedIds.size} topics?`
+        }
+        description="This will remove the selected topics and any links to courses, domains, and radar blips. This cannot be undone."
+        confirmLabel={isDeleting ? "Deleting..." : "Delete"}
+        cancelLabel="Cancel"
+        onConfirm={handleBulkDelete}
+        onCancel={() => {
+          if (!isDeleting) setConfirmOpen(false);
+        }}
+      />
     </div>
   );
 }

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -195,6 +195,20 @@ export const createDailyCriteriaTemplate = dailyCriteriaTemplatesApi.create;
 
 export const deleteSingleCourse = coursesApi.delete;
 export const deleteSingleTopic = topicsApi.delete;
+
+export async function bulkDeleteTopics(
+  ids: string[],
+): Promise<{ status: string;
+  count: number; }> {
+  return postJson(
+    "/api/topics/bulk-delete",
+    {
+      ids,
+    },
+    "Failed to delete topics",
+  );
+}
+
 export const deleteSinglePlatform = providersApi.delete;
 export const deleteSingleDomain = domainsApi.delete;
 export const deleteSingleDaily = dailiesApi.delete;

--- a/packages/middleware/src/routes/api/topics/bulkDeleteTopics.ts
+++ b/packages/middleware/src/routes/api/topics/bulkDeleteTopics.ts
@@ -1,0 +1,56 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  domainExcludedTopics,
+  domainWithinScopeTopics,
+  radarBlips,
+  topics,
+  topicsToCourses,
+} from "@/db/schema";
+
+const bulkDeleteSchema = {
+  schema: {
+    description: "Delete multiple topics by ID",
+    body: {
+      type: "object",
+      required: ["ids"],
+      properties: {
+        ids: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          minItems: 1,
+        },
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post("/bulk-delete", bulkDeleteSchema, async function (request) {
+    const ids = Array.from(new Set(request.body.ids));
+
+    await db.delete(radarBlips).where(inArray(radarBlips.topicId, ids));
+    await db
+      .delete(topicsToCourses)
+      .where(inArray(topicsToCourses.topicId, ids));
+    await db
+      .delete(domainExcludedTopics)
+      .where(inArray(domainExcludedTopics.topicId, ids));
+    await db
+      .delete(domainWithinScopeTopics)
+      .where(inArray(domainWithinScopeTopics.topicId, ids));
+    await db.delete(topics).where(inArray(topics.id, ids));
+
+    return {
+      status: "ok",
+      count: ids.length,
+    };
+  });
+}

--- a/packages/middleware/src/routes/api/topics/routes.ts
+++ b/packages/middleware/src/routes/api/topics/routes.ts
@@ -5,6 +5,7 @@ import courseRoot from "./root";
 import getTopic from "./getTopic";
 import createTopic from "./createTopic";
 import deleteTopic from "./deleteTopic";
+import bulkDeleteTopics from "./bulkDeleteTopics";
 import upsertTopic from "./upsertTopic";
 
 export default async function (server: FastifyInstance) {
@@ -14,5 +15,6 @@ export default async function (server: FastifyInstance) {
   fastify.register(getTopic);
   fastify.register(createTopic);
   fastify.register(deleteTopic);
+  fastify.register(bulkDeleteTopics);
   fastify.register(upsertTopic);
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to select and bulk delete multiple topics from the topics table view. Users can now select individual topics or all visible topics at once, and delete them with a confirmation dialog.

## Key Changes

- **TopicsTable Component**: Added checkbox column for row selection with support for select-all functionality
  - New `TopicsTableSelection` interface to manage selection state
  - Checkboxes in header (with indeterminate state) and each row
  - Visual indication of selected rows via `data-state` attribute
  - Memoized calculations for `allSelected` and `someSelected` states

- **Topics Index Route**: Implemented selection management and bulk delete workflow
  - Selection state persists only in table view mode (cleared when switching views)
  - Selection automatically filters out topics that no longer match current filters
  - Bulk delete button with confirmation dialog
  - Toast notifications for success/error feedback
  - Query invalidation to refresh topics and domains after deletion

- **Backend API**: New `/api/topics/bulk-delete` endpoint
  - Accepts array of topic IDs
  - Cascading deletes: removes associated radar blips, course links, and domain relationships
  - Returns count of deleted topics

- **Utils**: Added `bulkDeleteTopics` fetch function to call the new API endpoint

## Implementation Details

- Selection uses `Set<string>` for efficient lookups
- Indeterminate checkbox state handled via ref callback for partial selection
- Selection is automatically cleaned up when filters change to prevent orphaned selections
- Confirmation dialog prevents accidental bulk deletions with clear messaging about cascading effects

https://claude.ai/code/session_01V4ZC2vF11qiX3mAqH527dH