### PR TITLE
Add adopted ring support and enhance radar blip management UI

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -233,7 +233,10 @@ interface BuildPromptArgs {
   rings: RadarRing[];
   existingBlips: { topicName: string;
     radarNote?: string | null;
-    topicDescription?: string | null; }[];
+    topicDescription?: string | null;
+    currentSliceName?: string | null;
+    currentRingName?: string | null;
+    isAdopted?: boolean; }[];
 }
 
 interface BuildCleanupPromptArgs {
@@ -273,17 +276,32 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
   } = args;
 
   const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
-  const ringList = rings.map(r => `- ${r.name}`).join("\n");
+  const ringList = rings
+    .filter(r => !r.isAdopted)
+    .map(r => `- ${r.name}`)
+    .join("\n");
   const domainLabel = domainTitle.trim() || "(unnamed domain)";
   const descriptionBlock = domainDescription?.trim()
     ? domainDescription.trim()
     : "(no description provided)";
+  const hasAnyAdopted = existingBlips.some(b => b.isAdopted);
   const existingList = existingBlips.length > 0
     ? existingBlips
       .map((b) => {
         const note = b.radarNote?.trim();
         const topicDesc = b.topicDescription?.trim();
-        const lines = [`- ${b.topicName}`];
+        const lines = [
+          b.isAdopted
+            ? `- ${b.topicName} [ADOPTED — leave on the side panel; do not move into a slice/ring]`
+            : `- ${b.topicName}`,
+        ];
+        if (!b.isAdopted) {
+          const slice = b.currentSliceName?.trim();
+          const ring = b.currentRingName?.trim();
+          lines.push(
+            `  - current placement: ${slice || "(no slice)"} / ${ring || "(no ring)"}`,
+          );
+        }
         lines.push(
           topicDesc
             ? `  - general description: ${topicDesc}`
@@ -294,6 +312,14 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
       })
       .join("\n")
     : "- (none yet)";
+  const adoptedClause = hasAnyAdopted
+    ? `\nSome existing blips are marked [ADOPTED]. Those live in a separate
+"Adopted" side panel — they are intentionally OUT of the slice/ring layout.
+Do not propose moving them into a slice/ring or removing them just because
+they look mis-placed. Only suggest changes to adopted blips if you have a
+specific reason (e.g., the topic now belongs in active rotation again);
+in that case use action "update" and supply a slice + ring.`
+    : "";
 
   const withinScopeBlock = withinScopeDescription?.trim()
     ? withinScopeDescription.trim()
@@ -334,11 +360,12 @@ material outside of what's listed, or just not added it to the system yet — so
 treat course progress as a signal, not the full picture:
 ${formatTopicsWithCourses(domainTopics)}
 
-Topics already on the radar, with each topic's general description (if any)
-and its current radar note (if any). If the general description is marked
-missing for a topic you keep in your output, supply a description in the
-result so it gets filled in:
+Topics already on the radar, with each topic's general description (if any),
+current placement, and its current radar note (if any). If the general
+description is marked missing for a topic you keep in your output, supply a
+description in the result so it gets filled in:
 ${existingList}
+${adoptedClause}
 
 Topics I have explicitly EXCLUDED from this radar — do NOT suggest these,
 even with a different note or placement. The reason for each is in
@@ -394,7 +421,10 @@ function buildCleanupPrompt(args: BuildCleanupPromptArgs): string {
   } = args;
 
   const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
-  const ringList = rings.map(r => `- ${r.name}`).join("\n");
+  const ringList = rings
+    .filter(r => !r.isAdopted)
+    .map(r => `- ${r.name}`)
+    .join("\n");
   const domainLabel = domainTitle.trim() || "(unnamed domain)";
   const descriptionBlock = domainDescription?.trim()
     ? domainDescription.trim()
@@ -527,7 +557,11 @@ export function BlipLlmAssist({
       const ringById = new Map(rings.map(r => [r.id, r]));
       if (mode === "cleanup") {
         const unassignedBlips = existingBlips
-          .filter(b => !b.quadrantId || !b.ringId)
+          .filter((b) => {
+            const ring = b.ringId ? ringById.get(b.ringId) : null;
+            if (ring?.isAdopted) return false;
+            return !b.quadrantId || !b.ringId;
+          })
           .map(b => ({
             topicName: b.topicName,
             quadrantName: b.quadrantId
@@ -558,11 +592,18 @@ export function BlipLlmAssist({
         outOfScopeTopicNames,
         quadrants,
         rings,
-        existingBlips: existingBlips.map(b => ({
-          topicName: b.topicName,
-          radarNote: b.description,
-          topicDescription: topicById.get(b.topicId)?.description ?? null,
-        })),
+        existingBlips: existingBlips.map((b) => {
+          const ring = b.ringId ? ringById.get(b.ringId) : null;
+          const quadrant = b.quadrantId ? quadrantById.get(b.quadrantId) : null;
+          return {
+            topicName: b.topicName,
+            radarNote: b.description,
+            topicDescription: topicById.get(b.topicId)?.description ?? null,
+            currentSliceName: quadrant?.name ?? null,
+            currentRingName: ring?.name ?? null,
+            isAdopted: ring?.isAdopted ?? false,
+          };
+        }),
       });
     },
     [
@@ -582,10 +623,14 @@ export function BlipLlmAssist({
     ],
   );
 
-  const unassignedCount = useMemo(
-    () => existingBlips.filter(b => !b.quadrantId || !b.ringId).length,
-    [existingBlips],
-  );
+  const unassignedCount = useMemo(() => {
+    const ringByIdMap = new Map(rings.map(r => [r.id, r]));
+    return existingBlips.filter((b) => {
+      const ring = b.ringId ? ringByIdMap.get(b.ringId) : null;
+      if (ring?.isAdopted) return false;
+      return !b.quadrantId || !b.ringId;
+    }).length;
+  }, [existingBlips, rings]);
 
   const [jsonText, setJsonText] = useState("");
   const [parseError, setParseError] = useState<string | null>(null);

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -218,6 +218,8 @@ function formatExcludedTopics(excluded: DomainExcludedTopic[]): string {
     .join("\n");
 }
 
+type PromptMode = "setup" | "cleanup";
+
 interface BuildPromptArgs {
   domainTitle: string;
   domainDescription?: string | null;
@@ -230,6 +232,20 @@ interface BuildPromptArgs {
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   existingBlips: { topicName: string;
+    radarNote?: string | null;
+    topicDescription?: string | null; }[];
+}
+
+interface BuildCleanupPromptArgs {
+  domainTitle: string;
+  domainDescription?: string | null;
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  unassignedBlips: { topicName: string;
+    quadrantName: string | null;
+    ringName: string | null;
     radarNote?: string | null;
     topicDescription?: string | null; }[];
 }
@@ -366,6 +382,94 @@ from the excluded list above.
 `;
 }
 
+function buildCleanupPrompt(args: BuildCleanupPromptArgs): string {
+  const {
+    domainTitle,
+    domainDescription,
+    withinScopeDescription,
+    outOfScopeDescription,
+    quadrants,
+    rings,
+    unassignedBlips,
+  } = args;
+
+  const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
+  const ringList = rings.map(r => `- ${r.name}`).join("\n");
+  const domainLabel = domainTitle.trim() || "(unnamed domain)";
+  const descriptionBlock = domainDescription?.trim()
+    ? domainDescription.trim()
+    : "(no description provided)";
+  const withinScopeBlock = withinScopeDescription?.trim()
+    ? withinScopeDescription.trim()
+    : "(no within-scope description provided)";
+  const outOfScopeBlock = outOfScopeDescription?.trim()
+    ? outOfScopeDescription.trim()
+    : "(no out-of-scope description provided)";
+
+  const blipList = unassignedBlips.length > 0
+    ? unassignedBlips
+      .map((b) => {
+        const lines = [`- ${b.topicName}`];
+        const desc = b.topicDescription?.trim();
+        const note = b.radarNote?.trim();
+        if (desc) {
+          lines.push(`  - description: ${desc}`);
+        }
+        if (note) {
+          lines.push(`  - radar note: ${note}`);
+        }
+        const status: string[] = [];
+        if (!b.quadrantName) status.push("missing slice");
+        if (!b.ringName) status.push("missing ring");
+        if (b.quadrantName) status.push(`current slice: ${b.quadrantName}`);
+        if (b.ringName) status.push(`current ring: ${b.ringName}`);
+        lines.push(`  - status: ${status.join(", ")}`);
+        return lines.join("\n");
+      })
+      .join("\n")
+    : "- (none — all blips already have slice and ring assigned)";
+
+  return `I'm cleaning up the "${domainLabel}" tech radar — assigning slices and
+rings to blips that are missing one or both. Use the existing topic
+description and radar note (if any) to decide where each belongs.
+
+Domain description:
+${descriptionBlock}
+
+Within-scope description:
+${withinScopeBlock}
+
+Out-of-scope description:
+${outOfScopeBlock}
+
+The radar has these slices:
+${quadrantList || "- (none defined)"}
+
+And these rings (innermost first):
+${ringList || "- (none defined)"}
+
+Blips that need a slice and/or ring assigned:
+${blipList}
+
+Please return ONLY a JSON array of entries assigning a slice and ring to
+each blip above, using this exact shape (no other keys, no commentary):
+
+[
+  {
+    "topic": "Topic name (must match exactly from the list above)",
+    "action": "update",
+    "radarNote": "Optional updated note explaining the placement, or null to keep the existing one",
+    "quadrant": "One of the slice names above (exact match)",
+    "ring": "One of the ring names above (exact match)"
+  }
+]
+
+Only include the topics from the list above. The "action" field must be
+"update" so I overwrite their slice/ring placement. If a blip already has a
+slice OR ring set (but not both), still include both in your response.
+`;
+}
+
 function valuesEqual(a: string | null, b: string | null): boolean {
   return (a ?? "") === (b ?? "");
 }
@@ -414,9 +518,35 @@ export function BlipLlmAssist({
   existingBlips,
   onComplete,
 }: BlipLlmAssistProps) {
+  const [mode, setMode] = useState<PromptMode>("setup");
+
   const prompt = useMemo(
     () => {
       const topicById = new Map(topics.map(t => [t.id, t]));
+      const quadrantById = new Map(quadrants.map(q => [q.id, q]));
+      const ringById = new Map(rings.map(r => [r.id, r]));
+      if (mode === "cleanup") {
+        const unassignedBlips = existingBlips
+          .filter(b => !b.quadrantId || !b.ringId)
+          .map(b => ({
+            topicName: b.topicName,
+            quadrantName: b.quadrantId
+              ? quadrantById.get(b.quadrantId)?.name ?? null
+              : null,
+            ringName: b.ringId ? ringById.get(b.ringId)?.name ?? null : null,
+            radarNote: b.description,
+            topicDescription: topicById.get(b.topicId)?.description ?? null,
+          }));
+        return buildCleanupPrompt({
+          domainTitle,
+          domainDescription,
+          withinScopeDescription,
+          outOfScopeDescription,
+          quadrants,
+          rings,
+          unassignedBlips,
+        });
+      }
       return buildLlmPrompt({
         domainTitle,
         domainDescription,
@@ -436,6 +566,7 @@ export function BlipLlmAssist({
       });
     },
     [
+      mode,
       domainTitle,
       domainDescription,
       domainTopics,
@@ -449,6 +580,11 @@ export function BlipLlmAssist({
       existingBlips,
       topics,
     ],
+  );
+
+  const unassignedCount = useMemo(
+    () => existingBlips.filter(b => !b.quadrantId || !b.ringId).length,
+    [existingBlips],
   );
 
   const [jsonText, setJsonText] = useState("");
@@ -914,6 +1050,34 @@ export function BlipLlmAssist({
     <div className="flex flex-col gap-4 rounded-sm border p-4">
       {!resolved && (
         <>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Prompt mode</span>
+            <div className="flex flex-row flex-wrap gap-4">
+              <label className="flex flex-row items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="llm-prompt-mode"
+                  value="setup"
+                  checked={mode === "setup"}
+                  onChange={() => setMode("setup")}
+                />
+                Setup / Update — propose new and updated blips
+              </label>
+              <label className="flex flex-row items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="llm-prompt-mode"
+                  value="cleanup"
+                  checked={mode === "cleanup"}
+                  onChange={() => setMode("cleanup")}
+                  disabled={unassignedCount === 0}
+                />
+                Clean up — assign slice/ring to unassigned blips (
+                {unassignedCount}
+                )
+              </label>
+            </div>
+          </div>
           <div
             className={`
               grid grid-cols-1 gap-4

--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -235,8 +235,7 @@ interface BuildPromptArgs {
     radarNote?: string | null;
     topicDescription?: string | null;
     currentSliceName?: string | null;
-    currentRingName?: string | null;
-    isAdopted?: boolean; }[];
+    currentRingName?: string | null; }[];
 }
 
 interface BuildCleanupPromptArgs {
@@ -275,33 +274,29 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
     existingBlips,
   } = args;
 
+  const adoptedRing = rings.find(r => r.isAdopted);
   const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
-  const ringList = rings
-    .filter(r => !r.isAdopted)
-    .map(r => `- ${r.name}`)
-    .join("\n");
+  const ringList = rings.map((r) => {
+    if (r.isAdopted) {
+      return `- ${r.name} (use for foundational topics that are fully established and no longer being actively evaluated; a slice is still meaningful for grouping)`;
+    }
+    return `- ${r.name}`;
+  }).join("\n");
   const domainLabel = domainTitle.trim() || "(unnamed domain)";
   const descriptionBlock = domainDescription?.trim()
     ? domainDescription.trim()
     : "(no description provided)";
-  const hasAnyAdopted = existingBlips.some(b => b.isAdopted);
   const existingList = existingBlips.length > 0
     ? existingBlips
       .map((b) => {
         const note = b.radarNote?.trim();
         const topicDesc = b.topicDescription?.trim();
-        const lines = [
-          b.isAdopted
-            ? `- ${b.topicName} [ADOPTED — leave on the side panel; do not move into a slice/ring]`
-            : `- ${b.topicName}`,
-        ];
-        if (!b.isAdopted) {
-          const slice = b.currentSliceName?.trim();
-          const ring = b.currentRingName?.trim();
-          lines.push(
-            `  - current placement: ${slice || "(no slice)"} / ${ring || "(no ring)"}`,
-          );
-        }
+        const slice = b.currentSliceName?.trim();
+        const ring = b.currentRingName?.trim();
+        const lines = [`- ${b.topicName}`];
+        lines.push(
+          `  - current placement: ${slice || "(no slice)"} / ${ring || "(no ring)"}`,
+        );
         lines.push(
           topicDesc
             ? `  - general description: ${topicDesc}`
@@ -312,13 +307,12 @@ function buildLlmPrompt(args: BuildPromptArgs): string {
       })
       .join("\n")
     : "- (none yet)";
-  const adoptedClause = hasAnyAdopted
-    ? `\nSome existing blips are marked [ADOPTED]. Those live in a separate
-"Adopted" side panel — they are intentionally OUT of the slice/ring layout.
-Do not propose moving them into a slice/ring or removing them just because
-they look mis-placed. Only suggest changes to adopted blips if you have a
-specific reason (e.g., the topic now belongs in active rotation again);
-in that case use action "update" and supply a slice + ring.`
+  const adoptedClause = adoptedRing
+    ? `\nThe "${adoptedRing.name}" ring is for topics that are fully established
+and no longer under active evaluation — graduated from the trial/assess flow.
+You may suggest moving topics into or out of "${adoptedRing.name}" when that
+matches the topic's maturity. A slice is still meaningful for "${adoptedRing.name}"
+topics (it groups them by category), so include both quadrant and ring.`
     : "";
 
   const withinScopeBlock = withinScopeDescription?.trim()
@@ -420,11 +414,14 @@ function buildCleanupPrompt(args: BuildCleanupPromptArgs): string {
     unassignedBlips,
   } = args;
 
+  const adoptedRing = rings.find(r => r.isAdopted);
   const quadrantList = quadrants.map(q => `- ${q.name}`).join("\n");
-  const ringList = rings
-    .filter(r => !r.isAdopted)
-    .map(r => `- ${r.name}`)
-    .join("\n");
+  const ringList = rings.map((r) => {
+    if (r.isAdopted) {
+      return `- ${r.name} (use for foundational topics that are fully established and no longer being actively evaluated; a slice is still meaningful for grouping)`;
+    }
+    return `- ${r.name}`;
+  }).join("\n");
   const domainLabel = domainTitle.trim() || "(unnamed domain)";
   const descriptionBlock = domainDescription?.trim()
     ? domainDescription.trim()
@@ -458,10 +455,16 @@ function buildCleanupPrompt(args: BuildCleanupPromptArgs): string {
       })
       .join("\n")
     : "- (none — all blips already have slice and ring assigned)";
+  const adoptedClause = adoptedRing
+    ? `\nNote: "${adoptedRing.name}" is a valid ring for foundational topics that
+are fully established. A blip already in "${adoptedRing.name}" but missing a
+slice should keep its ring and just have the slice filled in.`
+    : "";
 
   return `I'm cleaning up the "${domainLabel}" tech radar — assigning slices and
 rings to blips that are missing one or both. Use the existing topic
-description and radar note (if any) to decide where each belongs.
+description, radar note (if any), and current placement to decide where
+each belongs.
 
 Domain description:
 ${descriptionBlock}
@@ -477,6 +480,7 @@ ${quadrantList || "- (none defined)"}
 
 And these rings (innermost first):
 ${ringList || "- (none defined)"}
+${adoptedClause}
 
 Blips that need a slice and/or ring assigned:
 ${blipList}
@@ -496,7 +500,8 @@ each blip above, using this exact shape (no other keys, no commentary):
 
 Only include the topics from the list above. The "action" field must be
 "update" so I overwrite their slice/ring placement. If a blip already has a
-slice OR ring set (but not both), still include both in your response.
+slice OR ring set (but not both), still include both in your response —
+preserve the existing one unless you have a specific reason to change it.
 `;
 }
 
@@ -557,11 +562,7 @@ export function BlipLlmAssist({
       const ringById = new Map(rings.map(r => [r.id, r]));
       if (mode === "cleanup") {
         const unassignedBlips = existingBlips
-          .filter((b) => {
-            const ring = b.ringId ? ringById.get(b.ringId) : null;
-            if (ring?.isAdopted) return false;
-            return !b.quadrantId || !b.ringId;
-          })
+          .filter(b => !b.quadrantId || !b.ringId)
           .map(b => ({
             topicName: b.topicName,
             quadrantName: b.quadrantId
@@ -601,7 +602,6 @@ export function BlipLlmAssist({
             topicDescription: topicById.get(b.topicId)?.description ?? null,
             currentSliceName: quadrant?.name ?? null,
             currentRingName: ring?.name ?? null,
-            isAdopted: ring?.isAdopted ?? false,
           };
         }),
       });
@@ -623,14 +623,10 @@ export function BlipLlmAssist({
     ],
   );
 
-  const unassignedCount = useMemo(() => {
-    const ringByIdMap = new Map(rings.map(r => [r.id, r]));
-    return existingBlips.filter((b) => {
-      const ring = b.ringId ? ringByIdMap.get(b.ringId) : null;
-      if (ring?.isAdopted) return false;
-      return !b.quadrantId || !b.ringId;
-    }).length;
-  }, [existingBlips, rings]);
+  const unassignedCount = useMemo(
+    () => existingBlips.filter(b => !b.quadrantId || !b.ringId).length,
+    [existingBlips],
+  );
 
   const [jsonText, setJsonText] = useState("");
   const [parseError, setParseError] = useState<string | null>(null);

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -5,12 +5,18 @@ import type {
 
 import { useMemo, useState } from "react";
 
+import { Link } from "@tanstack/react-router";
 import {
+  BookOpenIcon,
   ChevronDownIcon,
   ChevronUpIcon,
   ChevronsUpDownIcon,
+  ListChecksIcon,
   Loader2,
+  MoreHorizontalIcon,
   PencilIcon,
+  PlusIcon,
+  SunIcon,
   TrashIcon,
   XIcon,
 } from "lucide-react";
@@ -25,6 +31,14 @@ import {
 } from "@/components/radar/radarColors";
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Select,
   SelectContent,
@@ -51,9 +65,10 @@ interface RingInfo {
   id: string;
   name: string;
   position: number;
+  isAdopted?: boolean;
 }
 
-type SortKey = "topic" | "slice" | "ring";
+type SortKey = "topic" | "slice" | "ring" | "items";
 type SortDir = "asc" | "desc";
 
 interface BlipTableProps {
@@ -71,6 +86,7 @@ interface BlipTableProps {
 }
 
 const ALL = "__all__";
+const UNASSIGNED = "__unassigned__";
 
 interface EditDraft {
   quadrantId: string;
@@ -94,6 +110,7 @@ export function BlipTable({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [showItemsColumn, setShowItemsColumn] = useState(false);
 
   function toggleSort(key: SortKey) {
     if (sortKey !== key) {
@@ -124,31 +141,57 @@ export function BlipTable({
 
   const sliceCounts = useMemo(() => {
     const counts = new Map<string, number>();
+    let unassigned = 0;
     blips.forEach((b) => {
       if (b.quadrantId) {
         counts.set(b.quadrantId, (counts.get(b.quadrantId) ?? 0) + 1);
       }
+      else {
+        unassigned += 1;
+      }
     });
-    return counts;
+    return {
+      counts,
+      unassigned,
+    };
   }, [blips]);
 
   const ringCounts = useMemo(() => {
     const counts = new Map<string, number>();
+    let unassigned = 0;
     blips.forEach((b) => {
       if (b.ringId) {
         counts.set(b.ringId, (counts.get(b.ringId) ?? 0) + 1);
       }
+      else {
+        unassigned += 1;
+      }
     });
-    return counts;
+    return {
+      counts,
+      unassigned,
+    };
   }, [blips]);
+
+  function topicItemCount(topicId: string): number {
+    const t = topicById.get(topicId);
+    if (!t) return 0;
+    return (t.courseCount ?? 0) + (t.taskCount ?? 0) + (t.dailyCount ?? 0);
+  }
 
   const filteredBlips = useMemo(() => {
     const query = search.trim().toLowerCase();
     const filtered = blips.filter((b) => {
-      if (filterQuadrant !== ALL && b.quadrantId !== filterQuadrant) {
+      if (filterQuadrant === UNASSIGNED) {
+        if (b.quadrantId !== null) return false;
+      }
+      else if (filterQuadrant !== ALL && b.quadrantId !== filterQuadrant) {
         return false;
       }
-      if (filterRing !== ALL && b.ringId !== filterRing) {
+      if (filterRing === UNASSIGNED) {
+        if (b.ringId !== null) return false;
+      }
+      else if (filterRing !== ALL && b.ringId !== filterRing) {
         return false;
       }
       if (query) {
@@ -172,6 +215,10 @@ export function BlipTable({
         av = quadrantById.get(a.quadrantId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
         bv = quadrantById.get(b.quadrantId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
       }
+      else if (sortKey === "items") {
+        av = topicItemCount(a.topicId);
+        bv = topicItemCount(b.topicId);
+      }
       else {
         av = ringById.get(a.ringId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
         bv = ringById.get(b.ringId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
@@ -185,6 +232,7 @@ export function BlipTable({
       return (a.topicName ?? "").localeCompare(b.topicName ?? "");
     });
     return sorted;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     blips,
     search,
@@ -194,6 +242,7 @@ export function BlipTable({
     sortDir,
     quadrantById,
     ringById,
+    topicById,
   ]);
 
   function sortIcon(key: SortKey) {
@@ -261,7 +310,7 @@ export function BlipTable({
       <div
         className={`
           grid grid-cols-1 gap-2
-          sm:grid-cols-[1fr_auto_auto]
+          sm:grid-cols-[1fr_auto_auto_auto]
         `}
       >
         <Input
@@ -282,6 +331,11 @@ export function BlipTable({
               {blips.length}
               )
             </SelectItem>
+            <SelectItem value={UNASSIGNED}>
+              Unassigned (
+              {sliceCounts.unassigned}
+              )
+            </SelectItem>
             {quadrants.map(q => (
               <SelectItem
                 key={q.id}
@@ -289,7 +343,7 @@ export function BlipTable({
               >
                 {q.name}
                 {" ("}
-                {sliceCounts.get(q.id) ?? 0}
+                {sliceCounts.counts.get(q.id) ?? 0}
                 )
               </SelectItem>
             ))}
@@ -308,6 +362,11 @@ export function BlipTable({
               {blips.length}
               )
             </SelectItem>
+            <SelectItem value={UNASSIGNED}>
+              Unassigned (
+              {ringCounts.unassigned}
+              )
+            </SelectItem>
             {rings.map(r => (
               <SelectItem
                 key={r.id}
@@ -315,12 +374,22 @@ export function BlipTable({
               >
                 {r.name}
                 {" ("}
-                {ringCounts.get(r.id) ?? 0}
+                {ringCounts.counts.get(r.id) ?? 0}
                 )
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
+        <label
+          className="flex flex-row items-center gap-2 text-sm"
+        >
+          <input
+            type="checkbox"
+            checked={showItemsColumn}
+            onChange={e => setShowItemsColumn(e.target.checked)}
+          />
+          Topic Items
+        </label>
       </div>
 
       <div className="rounded-sm border">
@@ -367,6 +436,21 @@ export function BlipTable({
                 </button>
               </TableHead>
               <TableHead>Radar Note</TableHead>
+              {showItemsColumn && (
+                <TableHead>
+                  <button
+                    type="button"
+                    onClick={() => toggleSort("items")}
+                    className={`
+                      inline-flex items-center gap-1
+                      hover:text-foreground
+                    `}
+                  >
+                    Topic Items
+                    {sortIcon("items")}
+                  </button>
+                </TableHead>
+              )}
               <TableHead className="w-1 text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -374,7 +458,7 @@ export function BlipTable({
             {filteredBlips.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={5}
+                  colSpan={showItemsColumn ? 6 : 5}
                   className="text-center text-muted-foreground"
                 >
                   {blips.length === 0
@@ -391,7 +475,7 @@ export function BlipTable({
               return isEditing
                 ? (
                   <TableRow key={blip.id}>
-                    <TableCell colSpan={5}>
+                    <TableCell colSpan={showItemsColumn ? 6 : 5}>
                       <div
                         className={`
                           grid grid-cols-1 gap-4
@@ -536,7 +620,13 @@ export function BlipTable({
                           ? quadrantById.get(blip.quadrantId)
                           : undefined;
                         if (!q) {
-                          return "—";
+                          return (
+                            <span
+                              className="text-xs text-muted-foreground italic"
+                            >
+                              unassigned
+                            </span>
+                          );
                         }
                         return (
                           <Pill
@@ -556,7 +646,13 @@ export function BlipTable({
                           ? ringById.get(blip.ringId)
                           : undefined;
                         if (!r) {
-                          return "—";
+                          return (
+                            <span
+                              className="text-xs text-muted-foreground italic"
+                            >
+                              unassigned
+                            </span>
+                          );
                         }
                         return (
                           <Pill
@@ -578,33 +674,120 @@ export function BlipTable({
                     >
                       {blip.description?.trim() || "—"}
                     </TableCell>
+                    {showItemsColumn && (
+                      <TableCell className="text-sm text-muted-foreground">
+                        {topic
+                          ? (
+                            <div className="flex flex-row flex-wrap gap-2">
+                              <span title="Courses">
+                                C:
+                                {" "}
+                                {topic.courseCount ?? 0}
+                              </span>
+                              <span title="Tasks">
+                                T:
+                                {" "}
+                                {topic.taskCount ?? 0}
+                              </span>
+                              <span title="Dailies">
+                                D:
+                                {" "}
+                                {topic.dailyCount ?? 0}
+                              </span>
+                            </div>
+                          )
+                          : "—"}
+                      </TableCell>
+                    )}
                     <TableCell className="text-right">
-                      <div className="flex flex-row justify-end gap-2">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => startEdit(blip)}
-                          disabled={isPending || editingId !== null}
-                        >
-                          <PencilIcon />
-                          {" "}
-                          Edit
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleRemove(blip)}
-                          disabled={isPending || editingId !== null}
-                        >
-                          {isPending
-                            ? <Loader2 className="animate-spin" />
-                            : <TrashIcon />}
-                          {" "}
-                          Remove
-                        </Button>
-                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled={isPending || editingId !== null}
+                            aria-label="More actions"
+                          >
+                            {isPending
+                              ? <Loader2 className="animate-spin" />
+                              : <MoreHorizontalIcon />}
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => startEdit(blip)}>
+                            <PencilIcon />
+                            {" "}
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleRemove(blip)}>
+                            <TrashIcon />
+                            {" "}
+                            Remove
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel className="text-xs">
+                            Quick Create
+                          </DropdownMenuLabel>
+                          <DropdownMenuItem asChild>
+                            <Link
+                              to="/dailies/$id/edit"
+                              params={{
+                                id: "new",
+                              }}
+                              search={{
+                                topicId: blip.topicId,
+                              }}
+                            >
+                              <SunIcon />
+                              {" "}
+                              Daily Item
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link
+                              to="/tasks/$id/edit"
+                              params={{
+                                id: "new",
+                              }}
+                              search={{
+                                topicId: blip.topicId,
+                              }}
+                            >
+                              <ListChecksIcon />
+                              {" "}
+                              Task
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link
+                              to="/courses/$id/edit"
+                              params={{
+                                id: "new",
+                              }}
+                              search={{
+                                topicId: blip.topicId,
+                              }}
+                            >
+                              <BookOpenIcon />
+                              {" "}
+                              Course
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link
+                              to="/topics/$id"
+                              params={{
+                                id: blip.topicId,
+                              }}
+                            >
+                              <PlusIcon />
+                              {" "}
+                              View Topic
+                            </Link>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </TableCell>
                   </TableRow>
                 );

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -679,21 +679,24 @@ export function BlipTable({
                         {topic
                           ? (
                             <div className="flex flex-row flex-wrap gap-2">
-                              <span title="Courses">
-                                C:
-                                {" "}
-                                {topic.courseCount ?? 0}
-                              </span>
-                              <span title="Tasks">
-                                T:
-                                {" "}
-                                {topic.taskCount ?? 0}
-                              </span>
-                              <span title="Dailies">
-                                D:
-                                {" "}
-                                {topic.dailyCount ?? 0}
-                              </span>
+                              <TopicItemLink
+                                label="C"
+                                title="Courses"
+                                count={topic.courseCount ?? 0}
+                                topicId={blip.topicId}
+                              />
+                              <TopicItemLink
+                                label="T"
+                                title="Tasks"
+                                count={topic.taskCount ?? 0}
+                                topicId={blip.topicId}
+                              />
+                              <TopicItemLink
+                                label="D"
+                                title="Dailies"
+                                count={topic.dailyCount ?? 0}
+                                topicId={blip.topicId}
+                              />
                             </div>
                           )
                           : "—"}
@@ -796,5 +799,51 @@ export function BlipTable({
         </Table>
       </div>
     </div>
+  );
+}
+
+interface TopicItemLinkProps {
+  label: string;
+  title: string;
+  count: number;
+  topicId: string;
+}
+
+function TopicItemLink({
+  label,
+  title,
+  count,
+  topicId,
+}: TopicItemLinkProps) {
+  if (count === 0) {
+    return (
+      <span
+        title={title}
+        className="text-muted-foreground/60"
+      >
+        {label}
+        :
+        {" "}
+        0
+      </span>
+    );
+  }
+  return (
+    <Link
+      to="/topics/$id"
+      params={{
+        id: topicId,
+      }}
+      title={title}
+      className={`
+        font-medium text-blue-700
+        hover:text-blue-500 hover:underline
+      `}
+    >
+      {label}
+      :
+      {" "}
+      {count}
+    </Link>
   );
 }

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -681,20 +681,23 @@ export function BlipTable({
                             <div className="flex flex-row flex-wrap gap-2">
                               <TopicItemLink
                                 label="C"
-                                title="Courses"
+                                title="Courses for this topic"
                                 count={topic.courseCount ?? 0}
+                                to="/courses"
                                 topicId={blip.topicId}
                               />
                               <TopicItemLink
                                 label="T"
-                                title="Tasks"
+                                title="Tasks for this topic"
                                 count={topic.taskCount ?? 0}
+                                to="/tasks"
                                 topicId={blip.topicId}
                               />
                               <TopicItemLink
                                 label="D"
-                                title="Dailies"
+                                title="Dailies for this topic"
                                 count={topic.dailyCount ?? 0}
+                                to="/dailies"
                                 topicId={blip.topicId}
                               />
                             </div>
@@ -806,6 +809,7 @@ interface TopicItemLinkProps {
   label: string;
   title: string;
   count: number;
+  to: "/courses" | "/tasks" | "/dailies";
   topicId: string;
 }
 
@@ -813,6 +817,7 @@ function TopicItemLink({
   label,
   title,
   count,
+  to,
   topicId,
 }: TopicItemLinkProps) {
   if (count === 0) {
@@ -830,9 +835,9 @@ function TopicItemLink({
   }
   return (
     <Link
-      to="/topics/$id"
-      params={{
-        id: topicId,
+      to={to}
+      search={{
+        topicId,
       }}
       title={title}
       className={`

--- a/packages/client/src/components/radar/BlipsTab.tsx
+++ b/packages/client/src/components/radar/BlipsTab.tsx
@@ -23,6 +23,7 @@ interface PersistedRing {
   id: string;
   name: string;
   position: number;
+  isAdopted?: boolean;
 }
 
 interface BlipDraft {

--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -119,9 +119,19 @@ export function RadarChart({
     [quadrants],
   );
   const sortedRings = useMemo(
-    () => [...rings].sort((a, b) => a.position - b.position),
+    () =>
+      [...rings]
+        .filter(r => !r.isAdopted)
+        .sort((a, b) => a.position - b.position),
     [rings],
   );
+  const adoptedRingIds = useMemo(() => {
+    const set = new Set<string>();
+    rings.forEach((r) => {
+      if (r.isAdopted) set.add(r.id);
+    });
+    return set;
+  }, [rings]);
 
   const quadrantCount = sortedQuadrants.length;
   const ringCount = sortedRings.length;
@@ -135,11 +145,17 @@ export function RadarChart({
 
   const ringNameById = useMemo(() => {
     const map: Record<string, string> = {};
-    sortedRings.forEach((r) => {
+    [...rings].forEach((r) => {
       map[r.id] = r.name;
     });
     return map;
-  }, [sortedRings]);
+  }, [rings]);
+
+  const adoptedBlips = useMemo(
+    () =>
+      blips.filter(b => b.ringId !== null && adoptedRingIds.has(b.ringId)),
+    [blips, adoptedRingIds],
+  );
 
   const positionedBlips = useMemo<PositionedBlip[]>(() => {
     if (quadrantCount === 0 || ringCount === 0) {
@@ -149,6 +165,9 @@ export function RadarChart({
     let displayIndex = 0;
     return blips
       .map((blip) => {
+        if (blip.ringId !== null && adoptedRingIds.has(blip.ringId)) {
+          return null;
+        }
         const quadrantIndex = sortedQuadrants.findIndex(
           q => q.id === blip.quadrantId,
         );
@@ -183,6 +202,7 @@ export function RadarChart({
     ringCount,
     cx,
     cy,
+    adoptedRingIds,
   ]);
 
   if (quadrantCount === 0 || ringCount === 0) {
@@ -398,6 +418,7 @@ export function RadarChart({
             quadrants={sortedQuadrants}
             positionedBlips={positionedBlips}
             rings={sortedRings}
+            adoptedBlips={adoptedBlips}
             onDescriptionChange={handleSetDescription}
             onHover={setHoveredBlipId}
             activeBlipId={activeBlipId}
@@ -414,6 +435,7 @@ interface RadarLegendProps {
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   positionedBlips: PositionedBlip[];
+  adoptedBlips: RadarBlip[];
   onDescriptionChange: (blipId: string, value: string) => void;
   activeBlipId: string | null;
   selectedBlipId: string | null;
@@ -425,6 +447,7 @@ function RadarLegend({
   quadrants,
   rings,
   positionedBlips,
+  adoptedBlips,
   onDescriptionChange,
   activeBlipId,
   selectedBlipId,
@@ -598,6 +621,96 @@ function RadarLegend({
           </div>
         );
       })}
+      {adoptedBlips.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm font-semibold text-amber-700 uppercase">
+            Adopted
+          </h4>
+          <ul className="flex flex-col gap-0.5">
+            {adoptedBlips.map((blip) => {
+              const isActive = activeBlipId === blip.id;
+              const isSelected = selectedBlipId === blip.id;
+              const description = blip.description ?? "";
+              return (
+                <li
+                  key={blip.id}
+                  ref={(el) => {
+                    if (el) {
+                      itemRefs.current.set(blip.id, el);
+                    }
+                    else {
+                      itemRefs.current.delete(blip.id);
+                    }
+                  }}
+                  onMouseEnter={() => onHover(blip.id)}
+                  onMouseLeave={() => onHover(null)}
+                  className={cn(
+                    `
+                      group flex flex-col rounded-sm px-1 py-0.5 text-sm
+                      transition-colors
+                    `,
+                    isActive && "bg-gray-200",
+                    isSelected && "ring-1 ring-gray-400",
+                  )}
+                >
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onBlipClick(blip);
+                      }}
+                      className="flex-1 cursor-pointer text-left"
+                    >
+                      <span className="font-medium">{blip.topicName}</span>
+                    </button>
+                    <div
+                      className={cn(
+                        `
+                          flex items-center gap-0.5 opacity-0 transition-opacity
+                          group-hover:opacity-100
+                          focus-within:opacity-100
+                        `,
+                        isSelected && "opacity-100",
+                      )}
+                    >
+                      <BlipDescriptionPopover
+                        value={description}
+                        onChange={value => onDescriptionChange(blip.id, value)}
+                      />
+                      <Link
+                        to="/topics/$id"
+                        params={{
+                          id: blip.topicId,
+                        }}
+                        aria-label={`Go to topic ${blip.topicName}`}
+                      >
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="size-6 p-0"
+                        >
+                          <ArrowRightIcon className="size-3.5" />
+                        </Button>
+                      </Link>
+                    </div>
+                  </div>
+                  {description && (
+                    <p
+                      className={`
+                        mt-0.5 ml-4 text-xs text-muted-foreground italic
+                      `}
+                    >
+                      {description}
+                    </p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/radar/RadarConfigTab.tsx
+++ b/packages/client/src/components/radar/RadarConfigTab.tsx
@@ -19,6 +19,7 @@ export interface RingDraft {
   name: string;
   position: number;
   localKey: string;
+  isAdopted?: boolean;
 }
 
 interface RadarConfigTabProps {
@@ -27,10 +28,12 @@ interface RadarConfigTabProps {
   quadrantCount: number;
   maxRings: number;
   isSaving: boolean;
+  hasAdoptedSection: boolean;
   onChangeQuadrant: (localKey: string, name: string) => void;
   onChangeRing: (localKey: string, name: string) => void;
   onAddRing: () => void;
   onRemoveRing: (localKey: string) => void;
+  onToggleAdoptedSection: (enabled: boolean) => void;
   onSave: () => void;
 }
 
@@ -40,12 +43,15 @@ export function RadarConfigTab({
   quadrantCount,
   maxRings,
   isSaving,
+  hasAdoptedSection,
   onChangeQuadrant,
   onChangeRing,
   onAddRing,
   onRemoveRing,
+  onToggleAdoptedSection,
   onSave,
 }: RadarConfigTabProps) {
+  const nonAdoptedCount = rings.filter(r => !r.isAdopted).length;
   return (
     <div className="flex flex-col gap-8">
       <div
@@ -98,13 +104,18 @@ export function RadarConfigTab({
             Rings represent levels of adoption.
           </p>
           <div className="flex justify-center">
-            <RingsIllustration names={rings.map(r => r.name)} />
+            <RingsIllustration
+              names={rings.filter(r => !r.isAdopted).map(r => r.name)}
+            />
           </div>
           <ul className="flex flex-col gap-2">
             {rings.map((r, idx) => (
               <li
                 key={r.localKey}
-                className="flex flex-row items-center gap-2"
+                className={`
+                  flex flex-row items-center gap-2
+                  ${r.isAdopted ? "opacity-80" : ""}
+                `}
               >
                 <span className="w-6 text-sm text-muted-foreground">
                   {idx + 1}
@@ -114,30 +125,55 @@ export function RadarConfigTab({
                   value={r.name}
                   onChange={e => onChangeRing(r.localKey, e.target.value)}
                   placeholder="Ring name"
+                  disabled={r.isAdopted}
                 />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => onRemoveRing(r.localKey)}
-                  aria-label="Remove ring"
-                >
-                  <TrashIcon />
-                </Button>
+                {r.isAdopted
+                  ? (
+                    <span
+                      className={`
+                        rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px]
+                        text-amber-900
+                      `}
+                      title="Hidden from radar chart, listed on the side"
+                    >
+                      Side panel
+                    </span>
+                  )
+                  : (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onRemoveRing(r.localKey)}
+                      aria-label="Remove ring"
+                    >
+                      <TrashIcon />
+                    </Button>
+                  )}
               </li>
             ))}
           </ul>
-          <div>
+          <div className="flex flex-row items-center gap-4">
             <Button
               type="button"
               variant="outline"
               onClick={onAddRing}
-              disabled={rings.length >= maxRings}
+              disabled={nonAdoptedCount >= maxRings}
             >
               <PlusIcon />
               {" "}
               Add Ring
             </Button>
+            <label
+              className="flex flex-row items-center gap-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={hasAdoptedSection}
+                onChange={e => onToggleAdoptedSection(e.target.checked)}
+              />
+              Have Adopted Section
+            </label>
           </div>
         </section>
       </div>

--- a/packages/client/src/routes/courses.$id.edit.tsx
+++ b/packages/client/src/routes/courses.$id.edit.tsx
@@ -27,8 +27,18 @@ import {
   uuidv4,
 } from "@/utils";
 
+interface CourseEditSearch {
+  topicId?: string;
+}
+
 export const Route = createFileRoute("/courses/$id/edit")({
   component: SingleCourseEdit,
+  validateSearch: (search: Record<string, unknown>): CourseEditSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
 });
 
 const formSchema = z.object({
@@ -48,6 +58,7 @@ function SingleCourseEdit() {
   const {
     id,
   } = Route.useParams();
+  const search = Route.useSearch();
   const isNew = id === "new";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -100,10 +111,13 @@ function SingleCourseEdit() {
       progressTotal: data?.progressTotal ?? null,
       cost: data?.cost?.cost != null ? Number(data.cost.cost) : null,
       dateExpires: data?.dateExpires ? new Date(data.dateExpires) : null,
-      topicId: (Array.isArray(data?.topics) && data.topics[0]?.id) || "",
+      topicId:
+        (Array.isArray(data?.topics) && data.topics[0]?.id)
+        || (isNew ? search.topicId ?? "" : "")
+        || "",
       courseProviderId: data?.provider?.id ?? "",
     }),
-    [data],
+    [data, isNew, search.topicId],
   );
 
   const form = useAppForm({

--- a/packages/client/src/routes/courses.index.tsx
+++ b/packages/client/src/routes/courses.index.tsx
@@ -42,10 +42,20 @@ function getInitialViewMode(): ViewMode {
   return stored === "table" ? "table" : "grid";
 }
 
+interface CoursesSearch {
+  topicId?: string;
+}
+
 export const Route = createFileRoute("/courses/")({
   component: Courses,
   errorComponent: CoursesError,
   pendingComponent: CoursesPending,
+  validateSearch: (search: Record<string, unknown>): CoursesSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
 });
 
 function CoursesPending() {
@@ -82,9 +92,12 @@ function sortCourses(
 }
 
 function Courses() {
+  const urlSearch = Route.useSearch();
   const [search, setSearch] = useState("");
   const [filterProvider, setFilterProvider] = useState<string | undefined>();
-  const [filterTopic, setFilterTopic] = useState<string | undefined>();
+  const [filterTopic, setFilterTopic] = useState<string | undefined>(
+    urlSearch.topicId,
+  );
   const [sortBy, setSortBy] = useState<SortOption>("alpha");
   const [sortAsc, setSortAsc] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);

--- a/packages/client/src/routes/dailies.$id.edit.tsx
+++ b/packages/client/src/routes/dailies.$id.edit.tsx
@@ -51,12 +51,14 @@ import {
   fetchProviders,
   fetchSingleDaily,
   fetchTasks,
+  fetchTopics,
   formHasChanges,
   upsertDaily,
 } from "@/utils";
 
 interface DailyEditSearch {
   newCourseId?: string;
+  topicId?: string;
 }
 
 export const Route = createFileRoute("/dailies/$id/edit")({
@@ -65,6 +67,10 @@ export const Route = createFileRoute("/dailies/$id/edit")({
     newCourseId:
       typeof search.newCourseId === "string" && search.newCourseId
         ? search.newCourseId
+        : undefined,
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
         : undefined,
   }),
 });
@@ -143,6 +149,20 @@ function SingleDailyEdit() {
     queryFn: () => fetchDailyCriteriaTemplates(),
   });
 
+  const {
+    data: topicsForPrefill,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+    enabled: isNew && !!search.topicId,
+  });
+
+  const prefillTopicName = useMemo(() => {
+    if (!isNew || !search.topicId || !topicsForPrefill) return "";
+    const t = topicsForPrefill.find(top => top.id === search.topicId);
+    return t?.name ?? "";
+  }, [isNew, search.topicId, topicsForPrefill]);
+
   const activeDailiesCount
     = existingDailies?.filter(
       d => d.status !== "complete" && d.status !== "paused",
@@ -176,7 +196,7 @@ function SingleDailyEdit() {
 
   const startingValues = useMemo(
     () => ({
-      name: data?.name ?? "",
+      name: data?.name ?? prefillTopicName ?? "",
       location: data?.location ?? "",
       description: data?.description ?? "",
       courseProviderId: data?.provider?.id ?? "",
@@ -196,7 +216,7 @@ function SingleDailyEdit() {
       criteriaExceeded: data?.criteria?.exceeded ?? "",
       criteriaFreeze: data?.criteria?.freeze ?? "",
     }),
-    [data, isNew, search.newCourseId, initialLinked],
+    [data, isNew, search.newCourseId, initialLinked, prefillTopicName],
   );
 
   const [linkBoxCollapsed, setLinkBoxCollapsed] = useState(false);

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -1,6 +1,6 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types/src";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
@@ -36,7 +36,9 @@ import { useDailiesViewMode } from "@/hooks/useDailiesViewMode";
 import { useSettings } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
 import {
+  fetchCourses,
   fetchDailies,
+  fetchTasks,
   findStatusForDate,
   getCurrentChain,
   getDailyProgressPercent,
@@ -51,10 +53,20 @@ import {
   withCompletionNote,
 } from "@/utils";
 
+interface DailiesSearch {
+  topicId?: string;
+}
+
 export const Route = createFileRoute("/dailies/")({
   component: Dailies,
   errorComponent: DailiesError,
   pendingComponent: DailiesPending,
+  validateSearch: (search: Record<string, unknown>): DailiesSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
 });
 
 const RECENT_DAYS_COUNT = 6;
@@ -77,16 +89,23 @@ type SortDir = "asc" | "desc";
 
 function Dailies() {
   const queryClient = useQueryClient();
+  const urlSearch = Route.useSearch();
+  const filterTopicId = urlSearch.topicId;
   const todayKey = getTodayKey();
-  const { settings } = useSettings();
-  const { mode, setMode } = useDailiesViewMode();
+  const {
+    settings,
+  } = useSettings();
+  const {
+    mode, setMode,
+  } = useDailiesViewMode();
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
-      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
+      setSortDir(prev => (prev === "asc" ? "desc" : "asc"));
+    }
+    else {
       setSortKey(key);
       setSortDir(key === "progress" ? "desc" : "asc");
     }
@@ -96,17 +115,72 @@ function Dailies() {
     if (sortKey !== key) {
       return <ArrowUpDownIcon className="size-3 opacity-40" />;
     }
-    return sortDir === "asc" ? (
-      <ArrowUpIcon className="size-3" />
-    ) : (
-      <ArrowDownIcon className="size-3" />
-    );
+    return sortDir === "asc"
+      ? (
+        <ArrowUpIcon className="size-3" />
+      )
+      : (
+        <ArrowDownIcon className="size-3" />
+      );
   }
 
-  const { data: dailies } = useQuery({
+  const {
+    data: dailies,
+  } = useQuery({
     queryKey: ["dailies"],
     queryFn: () => fetchDailies(),
   });
+
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+    enabled: !!filterTopicId,
+  });
+
+  const {
+    data: courses,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchCourses(),
+    enabled: !!filterTopicId,
+  });
+
+  const topicMatchedTaskIds = useMemo(() => {
+    if (!filterTopicId || !tasks) return null;
+    const set = new Set<string>();
+    tasks.forEach((t) => {
+      if (t.topicId === filterTopicId) set.add(t.id);
+    });
+    return set;
+  }, [filterTopicId, tasks]);
+
+  const topicMatchedCourseIds = useMemo(() => {
+    if (!filterTopicId || !courses) return null;
+    const set = new Set<string>();
+    courses.forEach((c) => {
+      if (c.topics?.some(t => t.id === filterTopicId)) set.add(c.id);
+    });
+    return set;
+  }, [filterTopicId, courses]);
+
+  const topicFilteredDailies = useMemo(() => {
+    if (!dailies) return undefined;
+    if (!filterTopicId) return dailies;
+    if (!topicMatchedTaskIds || !topicMatchedCourseIds) return undefined;
+    return dailies.filter((d) => {
+      const taskHit = d.taskId
+        ? topicMatchedTaskIds.has(d.taskId)
+        : d.task?.id
+          ? topicMatchedTaskIds.has(d.task.id)
+          : false;
+      const courseHit = d.course?.id
+        ? topicMatchedCourseIds.has(d.course.id)
+        : false;
+      return taskHit || courseHit;
+    });
+  }, [dailies, filterTopicId, topicMatchedTaskIds, topicMatchedCourseIds]);
 
   const mutation = useMutation({
     mutationFn: ({
@@ -119,17 +193,17 @@ function Dailies() {
       note?: string | null;
     }) => {
       const withStatus = withCompletion(daily, todayKey, status);
-      const completions =
-        note === undefined
+      const completions
+        = note === undefined
           ? withStatus
           : withCompletionNote(
-              {
-                ...daily,
-                completions: withStatus,
-              },
-              todayKey,
-              note,
-            );
+            {
+              ...daily,
+              completions: withStatus,
+            },
+            todayKey,
+            note,
+          );
       return upsertDaily(daily.id, {
         name: daily.name,
         location: daily.location ?? null,
@@ -149,17 +223,16 @@ function Dailies() {
     },
   });
 
-  const baseSorted = dailies
-    ? [...dailies].sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, {
-          sensitivity: "base",
-        }),
-      )
+  const baseSorted = topicFilteredDailies
+    ? [...topicFilteredDailies].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, {
+        sensitivity: "base",
+      }))
     : undefined;
 
   const activeDailies = (
     baseSorted?.filter(
-      (d) => d.status !== "complete" && d.status !== "paused",
+      d => d.status !== "complete" && d.status !== "paused",
     ) ?? []
   )
     .slice()
@@ -173,25 +246,28 @@ function Dailies() {
       });
       return sortKey === "name" && sortDir === "desc" ? -cmp : cmp;
     });
-  const pausedDailies = baseSorted?.filter((d) => d.status === "paused") ?? [];
-  const completedDailies =
-    baseSorted?.filter((d) => d.status === "complete") ?? [];
+  const pausedDailies = baseSorted?.filter(d => d.status === "paused") ?? [];
+  const completedDailies
+    = baseSorted?.filter(d => d.status === "complete") ?? [];
 
-  const dayHeaders =
-    activeDailies.length > 0
+  const dayHeaders
+    = activeDailies.length > 0
       ? getRecentDays(activeDailies[0], RECENT_DAYS_COUNT + 1, todayKey, "mmdd")
-          .slice(0, -1)
-          .reverse()
-          .map((d) => ({
-            dateKey: d.dateKey,
-            label: formatMmDd(d.dateKey),
-            isToday: d.isToday,
-          }))
+        .slice(0, -1)
+        .reverse()
+        .map(d => ({
+          dateKey: d.dateKey,
+          label: formatMmDd(d.dateKey),
+          isToday: d.isToday,
+        }))
       : [];
 
   return (
     <div>
-      <PageHeader pageTitle="Dailies" pageSection="">
+      <PageHeader
+        pageTitle="Dailies"
+        pageSection=""
+      >
         <Link
           to="/dailies/$id/edit"
           params={{
@@ -225,7 +301,10 @@ function Dailies() {
             }
             action={
               <>
-                <DailiesViewModeToggle mode={mode} onChange={setMode} />
+                <DailiesViewModeToggle
+                  mode={mode}
+                  onChange={setMode}
+                />
                 <DailiesLimitSetting />
               </>
             }
@@ -241,8 +320,7 @@ function Dailies() {
                     daily,
                     status,
                     note,
-                  })
-                }
+                  })}
               />
             )}
             {mode === "table" && (
@@ -292,7 +370,7 @@ function Dailies() {
                       <th className="w-36 p-2 font-medium whitespace-nowrap">
                         Today&apos;s Status
                       </th>
-                      {dayHeaders.map((d) => (
+                      {dayHeaders.map(d => (
                         <th
                           key={d.dateKey}
                           className={cn(
@@ -354,27 +432,29 @@ function Dailies() {
                             </span>
                           </td>
                           <td className="max-w-xs p-2">
-                            {daily.description ? (
-                              <span
-                                className="
+                            {daily.description
+                              ? (
+                                <span
+                                  className="
                                     block truncate text-muted-foreground
                                   "
-                                title={daily.description}
-                              >
-                                {daily.description}
-                              </span>
-                            ) : (
-                              <span className="text-muted-foreground/60">
-                                <i>No description</i>
-                              </span>
-                            )}
+                                  title={daily.description}
+                                >
+                                  {daily.description}
+                                </span>
+                              )
+                              : (
+                                <span className="text-muted-foreground/60">
+                                  <i>No description</i>
+                                </span>
+                              )}
                           </td>
                           <td className="p-2">
                             <span
                               className={cn(
                                 "inline-flex items-center gap-1 text-xs",
-                                currentStatus === null ||
-                                  currentStatus === "incomplete"
+                                currentStatus === null
+                                || currentStatus === "incomplete"
                                   ? "text-muted-foreground"
                                   : chain > 0
                                     ? "text-orange-600"
@@ -414,12 +494,11 @@ function Dailies() {
                               daily={daily}
                               currentStatus={currentStatus}
                               disabled={mutation.isPending}
-                              onChange={(status) =>
+                              onChange={status =>
                                 mutation.mutate({
                                   daily,
                                   status,
-                                })
-                              }
+                                })}
                             />
                           </td>
                           {days.map((day, i) => {
@@ -449,7 +528,9 @@ function Dailies() {
                                     "
                                   />
                                 )}
-                                <div className="relative z-10 flex justify-center">
+                                <div
+                                  className="relative z-10 flex justify-center"
+                                >
                                   <DailyStatusCircle
                                     status={day.status}
                                     size="sm"

--- a/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
@@ -66,6 +66,7 @@ export function BlipsTabContainer({
       id: r.id,
       name: r.name,
       position: r.position,
+      isAdopted: r.isAdopted ?? false,
     })),
     [radar],
   );

--- a/packages/client/src/routes/domains.$id.edit.-components/-ConfigTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ConfigTab.tsx
@@ -29,6 +29,7 @@ const DEFAULT_RINGS = ["Adopt", "Trial", "Assess", "Hold"];
 
 const QUADRANT_COUNT = 5;
 const MAX_RINGS = 6;
+const ADOPTED_RING_NAME = "Adopted";
 
 let localKeyCounter = 0;
 function nextLocalKey() {
@@ -63,7 +64,8 @@ function quadrantsFromServer(items: { id: string;
 
 function ringsFromServer(items: { id: string;
   name: string;
-  position: number; }[]): RingDraft[] {
+  position: number;
+  isAdopted?: boolean; }[]): RingDraft[] {
   return items
     .slice()
     .sort((a, b) => a.position - b.position)
@@ -72,6 +74,7 @@ function ringsFromServer(items: { id: string;
       name: r.name,
       position: r.position,
       localKey: r.id,
+      isAdopted: r.isAdopted ?? false,
     }));
 }
 
@@ -98,6 +101,7 @@ export function ConfigTab({
 }: ConfigTabProps) {
   const [quadrants, setQuadrants] = useState<QuadrantDraft[]>([]);
   const [rings, setRings] = useState<RingDraft[]>([]);
+  const [hasAdoptedSection, setHasAdoptedSection] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -111,6 +115,7 @@ export function ConfigTab({
     setRings(
       radar.rings.length > 0 ? ringsFromServer(radar.rings) : defaultRings(),
     );
+    setHasAdoptedSection(radar.hasAdoptedSection ?? false);
     setHydrated(true);
   }, [radar, hydrated]);
 
@@ -138,15 +143,22 @@ export function ConfigTab({
 
   function addRing() {
     setRings((prev) => {
-      if (prev.length >= MAX_RINGS) return prev;
-      return [
-        ...prev,
+      const nonAdopted = prev.filter(r => !r.isAdopted);
+      if (nonAdopted.length >= MAX_RINGS) return prev;
+      const adopted = prev.filter(r => r.isAdopted);
+      const next = [
+        ...nonAdopted,
         {
           name: "",
-          position: prev.length,
+          position: nonAdopted.length,
           localKey: nextLocalKey(),
         },
+        ...adopted,
       ];
+      return next.map((r, idx) => ({
+        ...r,
+        position: idx,
+      }));
     });
   }
 
@@ -158,6 +170,32 @@ export function ConfigTab({
           ...r,
           position: idx,
         })));
+  }
+
+  function toggleAdoptedSection(enabled: boolean) {
+    setHasAdoptedSection(enabled);
+    setRings((prev) => {
+      const withoutAdopted = prev.filter(r => !r.isAdopted);
+      if (!enabled) {
+        return withoutAdopted.map((r, idx) => ({
+          ...r,
+          position: idx,
+        }));
+      }
+      const next = [
+        ...withoutAdopted,
+        {
+          name: ADOPTED_RING_NAME,
+          position: withoutAdopted.length,
+          localKey: nextLocalKey(),
+          isAdopted: true,
+        },
+      ];
+      return next.map((r, idx) => ({
+        ...r,
+        position: idx,
+      }));
+    });
   }
 
   async function handleSave() {
@@ -177,7 +215,8 @@ export function ConfigTab({
       toast.error("Every ring needs a name.");
       return;
     }
-    if (rings.length > MAX_RINGS) {
+    const nonAdoptedRings = rings.filter(r => !r.isAdopted);
+    if (nonAdoptedRings.length > MAX_RINGS) {
       toast.error(`At most ${MAX_RINGS} rings are allowed.`);
       return;
     }
@@ -189,14 +228,16 @@ export function ConfigTab({
           name: q.name.trim(),
           position: idx,
         })),
-        rings: rings.map(r => ({
+        rings: rings.map((r, idx) => ({
           id: r.id,
           name: r.name.trim(),
-          position: r.position,
+          position: idx,
+          isAdopted: r.isAdopted ?? false,
         })),
+        hasAdoptedSection,
       });
-      setHydrated(false);
       await onSaved();
+      setHydrated(false);
       toast.success("Radar configuration saved.");
     }
     catch {
@@ -214,10 +255,12 @@ export function ConfigTab({
       quadrantCount={QUADRANT_COUNT}
       maxRings={MAX_RINGS}
       isSaving={isSaving}
+      hasAdoptedSection={hasAdoptedSection}
       onChangeQuadrant={changeQuadrant}
       onChangeRing={changeRing}
       onAddRing={addRing}
       onRemoveRing={removeRing}
+      onToggleAdoptedSection={toggleAdoptedSection}
       onSave={handleSave}
     />
   );

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -22,8 +22,18 @@ import {
   upsertTask,
 } from "@/utils";
 
+interface TaskEditSearch {
+  topicId?: string;
+}
+
 export const Route = createFileRoute("/tasks/$id/edit")({
   component: SingleTaskEdit,
+  validateSearch: (search: Record<string, unknown>): TaskEditSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
 });
 
 const formSchema = z.object({
@@ -37,6 +47,7 @@ function SingleTaskEdit() {
   const {
     id,
   } = Route.useParams();
+  const search = Route.useSearch();
   const isNew = id === "new";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -79,10 +90,10 @@ function SingleTaskEdit() {
     () => ({
       name: data?.name ?? "",
       description: data?.description ?? "",
-      topicId: data?.topicId ?? "",
+      topicId: data?.topicId ?? (isNew ? search.topicId ?? "" : ""),
       taskTypeId: data?.taskTypeId ?? "",
     }),
-    [data],
+    [data, isNew, search.topicId],
   );
 
   const form = useAppForm({

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -20,10 +20,20 @@ import {
 } from "@/components/ui/select";
 import { fetchTasks, fetchTopics } from "@/utils";
 
+interface TasksSearch {
+  topicId?: string;
+}
+
 export const Route = createFileRoute("/tasks/")({
   component: Tasks,
   errorComponent: TasksError,
   pendingComponent: TasksPending,
+  validateSearch: (search: Record<string, unknown>): TasksSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
 });
 
 function TasksPending() {
@@ -35,8 +45,11 @@ function TasksError() {
 }
 
 function Tasks() {
+  const urlSearch = Route.useSearch();
   const [search, setSearch] = useState("");
-  const [filterTopic, setFilterTopic] = useState<string | undefined>();
+  const [filterTopic, setFilterTopic] = useState<string | undefined>(
+    urlSearch.topicId,
+  );
 
   const {
     data,

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -265,7 +265,9 @@ interface RadarConfigPayload {
     position: number; }[];
   rings: { id?: string;
     name: string;
-    position: number; }[];
+    position: number;
+    isAdopted?: boolean; }[];
+  hasAdoptedSection?: boolean;
 }
 
 export async function upsertRadarConfig(

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -243,11 +243,13 @@ export interface RadarConfigEntry {
   id: string;
   name: string;
   position: number;
+  isAdopted?: boolean;
 }
 
 export interface RadarConfig {
   quadrants: RadarConfigEntry[];
   rings: RadarConfigEntry[];
+  hasAdoptedSection?: boolean;
 }
 
 export const domains = pgTable("domains", {

--- a/packages/middleware/src/routes/api/domains/getRadar.ts
+++ b/packages/middleware/src/routes/api/domains/getRadar.ts
@@ -55,6 +55,7 @@ export default async function (server: FastifyInstance) {
       const radar: Radar = {
         domainId: domain.id,
         domainTitle: domain.title,
+        hasAdoptedSection: domain.radarConfig.hasAdoptedSection ?? false,
         quadrants: [...(domain.radarConfig.quadrants ?? [])].sort(
           (a, b) => a.position - b.position,
         ),

--- a/packages/middleware/src/routes/api/domains/upsertRadarConfig.ts
+++ b/packages/middleware/src/routes/api/domains/upsertRadarConfig.ts
@@ -45,7 +45,7 @@ const upsertConfigSchema = {
         },
         rings: {
           type: "array",
-          maxItems: 6,
+          maxItems: 7,
           items: {
             type: "object",
             required: ["name", "position"],
@@ -59,8 +59,14 @@ const upsertConfigSchema = {
               position: {
                 type: "integer",
               },
+              isAdopted: {
+                type: "boolean",
+              },
             },
           },
+        },
+        hasAdoptedSection: {
+          type: "boolean",
         },
       },
     },
@@ -78,7 +84,7 @@ export default async function (server: FastifyInstance) {
         domainId,
       } = request.params;
       const {
-        quadrants, rings,
+        quadrants, rings, hasAdoptedSection,
       } = request.body;
 
       const domain = await db.query.domains.findFirst({
@@ -104,7 +110,9 @@ export default async function (server: FastifyInstance) {
           id: r.id ?? uuidv4(),
           name: r.name,
           position: r.position ?? idx,
+          isAdopted: r.isAdopted ?? false,
         })),
+        hasAdoptedSection: hasAdoptedSection ?? false,
       };
 
       await db

--- a/packages/types/src/Radar.ts
+++ b/packages/types/src/Radar.ts
@@ -2,6 +2,7 @@ export interface RadarConfigEntry {
   id: string;
   name: string;
   position: number;
+  isAdopted?: boolean;
 }
 
 export type RadarQuadrant = RadarConfigEntry;
@@ -20,6 +21,7 @@ export interface RadarBlip {
 export interface Radar {
   domainId: string;
   domainTitle: string;
+  hasAdoptedSection?: boolean;
   quadrants: RadarQuadrant[];
   rings: RadarRing[];
   blips: RadarBlip[];


### PR DESCRIPTION
## Summary
This PR introduces support for an "Adopted" ring in tech radars—a special side panel for items that are intentionally outside the main slice/ring layout. It also enhances the blip table UI with a dropdown menu for actions, topic item counts, and quick-create links.

## Key Changes

### Adopted Ring Support
- Added `isAdopted` flag to `RadarConfigEntry` and related types
- Added `hasAdoptedSection` boolean to radar configuration
- Adopted rings are hidden from the radar chart visualization and displayed in a separate "Adopted" section in the legend
- Updated LLM prompt generation to handle adopted blips specially—they are marked as intentionally out of the slice/ring layout and should not be moved without specific reason
- Added "cleanup" mode to LLM assist for assigning slice/ring to unassigned blips (those missing either quadrant or ring, excluding adopted items)
- Increased max rings from 6 to 7 to accommodate the adopted ring

### Blip Table Enhancements
- Replaced inline Edit/Remove buttons with a dropdown menu (DropdownMenu component)
- Added "Topic Items" optional column showing course, task, and daily counts with links to the topic
- Added "Quick Create" section in dropdown menu with links to create new dailies, tasks, or courses pre-filled with the current topic
- Added "View Topic" link in dropdown menu
- Added support for filtering by "Unassigned" quadrants and rings
- Added "items" as a sortable column (sorts by topic item count)
- Updated unassigned quadrant/ring display to show "unassigned" label instead of "—"

### LLM Prompt Improvements
- Enhanced setup prompt to include current slice/ring placement for existing blips
- Added special handling for adopted blips in prompts with explanation that they should not be moved without reason
- New cleanup prompt specifically for assigning slice/ring to unassigned blips
- Added mode selector (Setup/Update vs. Cleanup) in the LLM assist UI

### Quick Create Integration
- Added `topicId` search parameter support to daily, task, and course edit routes
- Pre-fills topic name when creating new items from the blip table dropdown
- Enables seamless workflow from radar view to creating related learning items

### UI/UX Improvements
- Updated grid layout in blip table controls to accommodate new checkbox
- Adjusted table column spans to account for optional items column
- Added visual distinction for adopted rings in config tab (disabled input, "Side panel" badge)
- Improved filter dropdowns to show unassigned counts alongside quadrant/ring counts

## Implementation Details
- Adopted rings are filtered out from `sortedRings` in RadarChart but included in `ringNameById` for reference
- Blips assigned to adopted rings are collected separately and rendered in a dedicated legend section
- The LLM assist mode state is managed separately from the prompt generation, allowing users to switch between setup and cleanup modes
- Topic item counts are computed from `courseCount`, `taskCount`, and `dailyCount` on the topic object

https://claude.ai/code/session_01CXGd9CXYJsr9G64HJrmuYp