### PR TITLE
Add bulk edit and adopted section visualization to radar

### DIFF
--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -3,7 +3,7 @@ import type {
   TopicForTopicsPage,
 } from "@emstack/types/src";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Link } from "@tanstack/react-router";
 import {
@@ -71,6 +71,11 @@ interface RingInfo {
 type SortKey = "topic" | "slice" | "ring" | "items";
 type SortDir = "asc" | "desc";
 
+interface BulkPatch {
+  quadrantId?: string;
+  ringId?: string;
+}
+
 interface BlipTableProps {
   blips: RadarBlip[];
   quadrants: QuadrantInfo[];
@@ -83,10 +88,12 @@ interface BlipTableProps {
       description: string | null; },
   ) => Promise<void>;
   onRemove: (blip: RadarBlip) => Promise<void>;
+  onBulkSave: (ids: string[], patch: BulkPatch) => Promise<void>;
 }
 
 const ALL = "__all__";
 const UNASSIGNED = "__unassigned__";
+const NO_CHANGE = "__no_change__";
 
 interface EditDraft {
   quadrantId: string;
@@ -101,6 +108,7 @@ export function BlipTable({
   topics,
   onSave,
   onRemove,
+  onBulkSave,
 }: BlipTableProps) {
   const [search, setSearch] = useState("");
   const [filterQuadrant, setFilterQuadrant] = useState<string>(ALL);
@@ -111,6 +119,10 @@ export function BlipTable({
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [showItemsColumn, setShowItemsColumn] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkQuadrantId, setBulkQuadrantId] = useState<string>(NO_CHANGE);
+  const [bulkRingId, setBulkRingId] = useState<string>(NO_CHANGE);
+  const [bulkPending, setBulkPending] = useState(false);
 
   function toggleSort(key: SortKey) {
     if (sortKey !== key) {
@@ -245,6 +257,60 @@ export function BlipTable({
     topicById,
   ]);
 
+  // Drop selections that are no longer visible (after filter changes or
+  // server-side deletion).
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      const visible = new Set(filteredBlips.map(b => b.id));
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (visible.has(id)) {
+          next.add(id);
+        }
+        else {
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [filteredBlips]);
+
+  const allVisibleSelected
+    = filteredBlips.length > 0
+      && filteredBlips.every(b => selectedIds.has(b.id));
+  const someVisibleSelected
+    = !allVisibleSelected && filteredBlips.some(b => selectedIds.has(b.id));
+
+  function toggleSelected(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAllVisible() {
+    setSelectedIds((prev) => {
+      if (allVisibleSelected) {
+        const next = new Set(prev);
+        filteredBlips.forEach(b => next.delete(b.id));
+        return next;
+      }
+      const next = new Set(prev);
+      filteredBlips.forEach(b => next.add(b.id));
+      return next;
+    });
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+    setBulkQuadrantId(NO_CHANGE);
+    setBulkRingId(NO_CHANGE);
+  }
+
   function sortIcon(key: SortKey) {
     if (sortKey !== key) {
       return <ChevronsUpDownIcon className="size-3 opacity-50" />;
@@ -299,11 +365,40 @@ export function BlipTable({
         setEditingId(null);
         setEditDraft(null);
       }
+      setSelectedIds((prev) => {
+        if (!prev.has(blip.id)) return prev;
+        const next = new Set(prev);
+        next.delete(blip.id);
+        return next;
+      });
     }
     finally {
       setPendingId(null);
     }
   }
+
+  async function applyBulk() {
+    if (selectedIds.size === 0) return;
+    if (bulkQuadrantId === NO_CHANGE && bulkRingId === NO_CHANGE) {
+      toast.error("Pick a slice or ring to apply.");
+      return;
+    }
+    const patch: BulkPatch = {};
+    if (bulkQuadrantId !== NO_CHANGE) patch.quadrantId = bulkQuadrantId;
+    if (bulkRingId !== NO_CHANGE) patch.ringId = bulkRingId;
+    setBulkPending(true);
+    try {
+      await onBulkSave(Array.from(selectedIds), patch);
+      setBulkQuadrantId(NO_CHANGE);
+      setBulkRingId(NO_CHANGE);
+      setSelectedIds(new Set());
+    }
+    finally {
+      setBulkPending(false);
+    }
+  }
+
+  const colCount = (showItemsColumn ? 6 : 5) + 1;
 
   return (
     <div className="flex flex-col gap-3">
@@ -392,10 +487,98 @@ export function BlipTable({
         </label>
       </div>
 
+      {selectedIds.size > 0 && (
+        <div
+          className={`
+            flex flex-row flex-wrap items-center gap-2 rounded-sm border
+            border-primary/40 bg-primary/5 p-2
+          `}
+        >
+          <span className="text-sm font-medium">
+            {selectedIds.size}
+            {" "}
+            selected
+          </span>
+          <Select
+            value={bulkQuadrantId}
+            onValueChange={setBulkQuadrantId}
+          >
+            <SelectTrigger className="min-w-40">
+              <SelectValue placeholder="Slice" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_CHANGE}>(don&apos;t change slice)</SelectItem>
+              {quadrants.map(q => (
+                <SelectItem
+                  key={q.id}
+                  value={q.id}
+                >
+                  {q.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={bulkRingId}
+            onValueChange={setBulkRingId}
+          >
+            <SelectTrigger className="min-w-32">
+              <SelectValue placeholder="Ring" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_CHANGE}>(don&apos;t change ring)</SelectItem>
+              {rings.map(r => (
+                <SelectItem
+                  key={r.id}
+                  value={r.id}
+                >
+                  {r.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            size="sm"
+            onClick={applyBulk}
+            disabled={
+              bulkPending
+              || (bulkQuadrantId === NO_CHANGE && bulkRingId === NO_CHANGE)
+            }
+          >
+            {bulkPending && <Loader2 className="animate-spin" />}
+            Apply to
+            {" "}
+            {selectedIds.size}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={clearSelection}
+            disabled={bulkPending}
+          >
+            Clear
+          </Button>
+        </div>
+      )}
+
       <div className="rounded-sm border">
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-1">
+                <input
+                  type="checkbox"
+                  aria-label="Select all visible"
+                  checked={allVisibleSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someVisibleSelected;
+                  }}
+                  onChange={toggleSelectAllVisible}
+                  disabled={filteredBlips.length === 0}
+                />
+              </TableHead>
               <TableHead>
                 <button
                   type="button"
@@ -458,7 +641,7 @@ export function BlipTable({
             {filteredBlips.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={showItemsColumn ? 6 : 5}
+                  colSpan={colCount}
                   className="text-center text-muted-foreground"
                 >
                   {blips.length === 0
@@ -470,12 +653,13 @@ export function BlipTable({
             {filteredBlips.map((blip) => {
               const isEditing = editingId === blip.id && editDraft !== null;
               const isPending = pendingId === blip.id;
+              const isSelected = selectedIds.has(blip.id);
               const topic = topicById.get(blip.topicId);
               const topicDescription = topic?.description ?? null;
               return isEditing
                 ? (
                   <TableRow key={blip.id}>
-                    <TableCell colSpan={showItemsColumn ? 6 : 5}>
+                    <TableCell colSpan={colCount}>
                       <div
                         className={`
                           grid grid-cols-1 gap-4
@@ -610,7 +794,19 @@ export function BlipTable({
                   </TableRow>
                 )
                 : (
-                  <TableRow key={blip.id}>
+                  <TableRow
+                    key={blip.id}
+                    className="group"
+                    data-state={isSelected ? "selected" : undefined}
+                  >
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        aria-label={`Select ${blip.topicName}`}
+                        checked={isSelected}
+                        onChange={() => toggleSelected(blip.id)}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium">
                       {blip.topicName}
                     </TableCell>
@@ -706,94 +902,111 @@ export function BlipTable({
                       </TableCell>
                     )}
                     <TableCell className="text-right">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            disabled={isPending || editingId !== null}
-                            aria-label="More actions"
-                          >
-                            {isPending
-                              ? <Loader2 className="animate-spin" />
-                              : <MoreHorizontalIcon />}
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => startEdit(blip)}>
-                            <PencilIcon />
-                            {" "}
-                            Edit
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => handleRemove(blip)}>
-                            <TrashIcon />
-                            {" "}
-                            Remove
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuLabel className="text-xs">
-                            Quick Create
-                          </DropdownMenuLabel>
-                          <DropdownMenuItem asChild>
-                            <Link
-                              to="/dailies/$id/edit"
-                              params={{
-                                id: "new",
-                              }}
-                              search={{
-                                topicId: blip.topicId,
-                              }}
+                      <div
+                        className={`
+                          flex flex-row items-center justify-end gap-1 opacity-0
+                          transition-opacity
+                          group-focus-within:opacity-100
+                          group-hover:opacity-100
+                        `}
+                      >
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={isPending || editingId !== null}
+                          aria-label="Edit blip"
+                          onClick={() => startEdit(blip)}
+                        >
+                          <PencilIcon />
+                        </Button>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              disabled={isPending || editingId !== null}
+                              aria-label="More actions"
                             >
-                              <SunIcon />
-                              {" "}
-                              Daily Item
-                            </Link>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem asChild>
-                            <Link
-                              to="/tasks/$id/edit"
-                              params={{
-                                id: "new",
-                              }}
-                              search={{
-                                topicId: blip.topicId,
-                              }}
+                              {isPending
+                                ? <Loader2 className="animate-spin" />
+                                : <MoreHorizontalIcon />}
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuLabel className="text-xs">
+                              Quick Create
+                            </DropdownMenuLabel>
+                            <DropdownMenuItem asChild>
+                              <Link
+                                to="/dailies/$id/edit"
+                                params={{
+                                  id: "new",
+                                }}
+                                search={{
+                                  topicId: blip.topicId,
+                                }}
+                              >
+                                <SunIcon />
+                                {" "}
+                                Daily Item
+                              </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                              <Link
+                                to="/tasks/$id/edit"
+                                params={{
+                                  id: "new",
+                                }}
+                                search={{
+                                  topicId: blip.topicId,
+                                }}
+                              >
+                                <ListChecksIcon />
+                                {" "}
+                                Task
+                              </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                              <Link
+                                to="/courses/$id/edit"
+                                params={{
+                                  id: "new",
+                                }}
+                                search={{
+                                  topicId: blip.topicId,
+                                }}
+                              >
+                                <BookOpenIcon />
+                                {" "}
+                                Course
+                              </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem asChild>
+                              <Link
+                                to="/topics/$id"
+                                params={{
+                                  id: blip.topicId,
+                                }}
+                              >
+                                <PlusIcon />
+                                {" "}
+                                View Topic
+                              </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={() => handleRemove(blip)}
                             >
-                              <ListChecksIcon />
+                              <TrashIcon />
                               {" "}
-                              Task
-                            </Link>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem asChild>
-                            <Link
-                              to="/courses/$id/edit"
-                              params={{
-                                id: "new",
-                              }}
-                              search={{
-                                topicId: blip.topicId,
-                              }}
-                            >
-                              <BookOpenIcon />
-                              {" "}
-                              Course
-                            </Link>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem asChild>
-                            <Link
-                              to="/topics/$id"
-                              params={{
-                                id: blip.topicId,
-                              }}
-                            >
-                              <PlusIcon />
-                              {" "}
-                              View Topic
-                            </Link>
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                              Remove
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
                     </TableCell>
                   </TableRow>
                 );

--- a/packages/client/src/components/radar/BlipsTab.tsx
+++ b/packages/client/src/components/radar/BlipsTab.tsx
@@ -61,6 +61,11 @@ interface BlipsTabProps {
       description: string | null; },
   ) => Promise<void>;
   onTableRemove: (blip: RadarBlip) => Promise<void>;
+  onTableBulkSave: (
+    ids: string[],
+    patch: { quadrantId?: string;
+      ringId?: string; },
+  ) => Promise<void>;
 }
 
 export function BlipsTab({
@@ -83,6 +88,7 @@ export function BlipsTab({
   onRemoveBlip,
   onTableSave,
   onTableRemove,
+  onTableBulkSave,
 }: BlipsTabProps) {
   return (
     <section className="flex flex-col gap-4">
@@ -112,6 +118,7 @@ export function BlipsTab({
           topics={topics}
           onSave={onTableSave}
           onRemove={onTableRemove}
+          onBulkSave={onTableBulkSave}
         />
       )}
 

--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -49,6 +49,13 @@ const QUADRANT_PALETTE = [
   "#db2777",
 ];
 
+const ADOPTED_DOT_RADIUS = 8;
+const ADOPTED_DOT_SPACING = 22;
+const ADOPTED_AREA_BOTTOM_PAD = 12;
+const ADOPTED_AREA_RIGHT_PAD = 12;
+const ADOPTED_AREA_HEIGHT = 96;
+const ADOPTED_LABEL_GAP = 18;
+
 // Deterministic pseudo-random in [0, 1) from a string. Used to keep blip
 // placements stable across renders without storing coordinates in the DB.
 function hashUnit(input: string): number {
@@ -74,6 +81,7 @@ export function RadarChart({
   const [selectedBlipId, setSelectedBlipId] = useState<string | null>(
     initialSelectedBlipId,
   );
+  const [showAdoptedDots, setShowAdoptedDots] = useState(false);
   const containerWrapperRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -125,13 +133,16 @@ export function RadarChart({
         .sort((a, b) => a.position - b.position),
     [rings],
   );
+  const adoptedRings = useMemo(
+    () => rings.filter(r => r.isAdopted),
+    [rings],
+  );
   const adoptedRingIds = useMemo(() => {
     const set = new Set<string>();
-    rings.forEach((r) => {
-      if (r.isAdopted) set.add(r.id);
-    });
+    adoptedRings.forEach(r => set.add(r.id));
     return set;
-  }, [rings]);
+  }, [adoptedRings]);
+  const adoptedSectionName = adoptedRings[0]?.name ?? "Adopted";
 
   const quadrantCount = sortedQuadrants.length;
   const ringCount = sortedRings.length;
@@ -205,6 +216,32 @@ export function RadarChart({
     adoptedRingIds,
   ]);
 
+  const showAdoptedInChart = showAdoptedDots && adoptedBlips.length > 0;
+  const totalHeight = size + (showAdoptedInChart ? ADOPTED_AREA_HEIGHT : 0);
+
+  const positionedAdoptedBlips = useMemo<PositionedBlip[]>(() => {
+    if (!showAdoptedInChart) return [];
+    // Lay out adopted dots right-to-left, bottom-up in the strip below the
+    // radar circle (bottom-right of the radar graphic).
+    const startX = size - ADOPTED_AREA_RIGHT_PAD - ADOPTED_DOT_RADIUS;
+    const startY
+      = totalHeight - ADOPTED_AREA_BOTTOM_PAD - ADOPTED_DOT_RADIUS;
+    const cols = Math.max(
+      1,
+      Math.floor((size / 2) / ADOPTED_DOT_SPACING),
+    );
+    return adoptedBlips.map((blip, i) => {
+      const row = Math.floor(i / cols);
+      const col = i % cols;
+      return {
+        blip,
+        x: startX - col * ADOPTED_DOT_SPACING,
+        y: startY - row * ADOPTED_DOT_SPACING,
+        index: positionedBlips.length + i + 1,
+      };
+    });
+  }, [showAdoptedInChart, adoptedBlips, size, totalHeight, positionedBlips]);
+
   if (quadrantCount === 0 || ringCount === 0) {
     return (
       <div
@@ -232,6 +269,9 @@ export function RadarChart({
     onBlipClick?.(blip);
   };
 
+  const adoptedLabelY
+    = totalHeight - ADOPTED_AREA_HEIGHT + ADOPTED_LABEL_GAP;
+
   return (
     <TooltipProvider delayDuration={200}>
       <div
@@ -243,7 +283,7 @@ export function RadarChart({
       >
         <div className="flex-1">
           <svg
-            viewBox={`0 0 ${size} ${size}`}
+            viewBox={`0 0 ${size} ${totalHeight}`}
             width="100%"
             style={{
               maxWidth: size,
@@ -411,20 +451,161 @@ export function RadarChart({
                   </Tooltip>
                 );
               })}
+            {showAdoptedInChart && (
+              <>
+                <text
+                  x={size - ADOPTED_AREA_RIGHT_PAD}
+                  y={adoptedLabelY}
+                  textAnchor="end"
+                  fontSize={11}
+                  fontWeight="600"
+                  fill="#b45309"
+                >
+                  {adoptedSectionName}
+                </text>
+                {[...positionedAdoptedBlips]
+                  .sort((a, b) => {
+                    const aActive = activeBlipId === a.blip.id ? 1 : 0;
+                    const bActive = activeBlipId === b.blip.id ? 1 : 0;
+                    return aActive - bActive;
+                  })
+                  .map(({
+                    blip, x, y, index,
+                  }) => {
+                    const quadrantIndex = sortedQuadrants.findIndex(
+                      q => q.id === blip.quadrantId,
+                    );
+                    const color
+                      = QUADRANT_PALETTE[
+                        Math.max(0, quadrantIndex) % QUADRANT_PALETTE.length
+                      ];
+                    const isActive = activeBlipId === blip.id;
+                    const isSelected = selectedBlipId === blip.id;
+                    return (
+                      <Tooltip
+                        key={`adopted-${blip.id}`}
+                        open={isActive || undefined}
+                      >
+                        <TooltipTrigger asChild>
+                          <g
+                            onMouseEnter={() => setHoveredBlipId(blip.id)}
+                            onMouseLeave={() => setHoveredBlipId(null)}
+                            onFocus={() => setHoveredBlipId(blip.id)}
+                            onBlur={() => setHoveredBlipId(null)}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleBlipClick(blip);
+                            }}
+                            style={{
+                              cursor: "pointer",
+                            }}
+                            tabIndex={0}
+                          >
+                            {isActive && (
+                              <circle
+                                cx={x}
+                                cy={y}
+                                r={ADOPTED_DOT_RADIUS + 5}
+                                fill="none"
+                                stroke={color}
+                                strokeWidth={isSelected ? 3 : 2}
+                                strokeOpacity={isSelected ? 0.8 : 0.5}
+                              />
+                            )}
+                            <circle
+                              cx={x}
+                              cy={y}
+                              r={
+                                isActive
+                                  ? ADOPTED_DOT_RADIUS + 2
+                                  : ADOPTED_DOT_RADIUS
+                              }
+                              fill={color}
+                              stroke="white"
+                              strokeWidth={2}
+                            />
+                            <text
+                              x={x}
+                              y={y}
+                              textAnchor="middle"
+                              dominantBaseline="central"
+                              fontSize={9}
+                              fontWeight="700"
+                              fill="white"
+                              style={{
+                                pointerEvents: "none",
+                              }}
+                            >
+                              {index}
+                            </text>
+                          </g>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          className="max-w-xs"
+                        >
+                          <div className="flex flex-col gap-0.5 text-left">
+                            <div className="font-semibold">
+                              {index}
+                              .
+                              {" "}
+                              {blip.topicName}
+                            </div>
+                            <div className="text-[11px] opacity-80">
+                              {sortedQuadrants[quadrantIndex]?.name}
+                              {" · "}
+                              {adoptedSectionName}
+                            </div>
+                            {blip.description && (
+                              <div className="text-[11px] opacity-90">
+                                {blip.description}
+                              </div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+              </>
+            )}
           </svg>
         </div>
         {showLegend && (
-          <RadarLegend
-            quadrants={sortedQuadrants}
-            positionedBlips={positionedBlips}
-            rings={sortedRings}
-            adoptedBlips={adoptedBlips}
-            onDescriptionChange={handleSetDescription}
-            onHover={setHoveredBlipId}
-            activeBlipId={activeBlipId}
-            selectedBlipId={selectedBlipId}
-            onBlipClick={handleBlipClick}
-          />
+          <div
+            className={`
+              flex flex-col gap-2
+              lg:w-80
+            `}
+          >
+            {adoptedBlips.length > 0 && (
+              <label
+                className="flex flex-row items-center gap-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={showAdoptedDots}
+                  onChange={e => setShowAdoptedDots(e.target.checked)}
+                />
+                Show
+                {" "}
+                {adoptedSectionName}
+                {" "}
+                dots on radar
+              </label>
+            )}
+            <RadarLegend
+              quadrants={sortedQuadrants}
+              positionedBlips={positionedBlips}
+              rings={sortedRings}
+              adoptedBlips={adoptedBlips}
+              adoptedSectionName={adoptedSectionName}
+              onDescriptionChange={handleSetDescription}
+              onHover={setHoveredBlipId}
+              activeBlipId={activeBlipId}
+              selectedBlipId={selectedBlipId}
+              onBlipClick={handleBlipClick}
+            />
+          </div>
         )}
       </div>
     </TooltipProvider>
@@ -436,6 +617,7 @@ interface RadarLegendProps {
   rings: RadarRing[];
   positionedBlips: PositionedBlip[];
   adoptedBlips: RadarBlip[];
+  adoptedSectionName: string;
   onDescriptionChange: (blipId: string, value: string) => void;
   activeBlipId: string | null;
   selectedBlipId: string | null;
@@ -448,6 +630,7 @@ function RadarLegend({
   rings,
   positionedBlips,
   adoptedBlips,
+  adoptedSectionName,
   onDescriptionChange,
   activeBlipId,
   selectedBlipId,
@@ -491,8 +674,7 @@ function RadarLegend({
       className={`
         grid grid-cols-1 gap-4
         sm:grid-cols-2
-        lg:grid lg:max-h-[600px] lg:w-80 lg:grid-cols-1 lg:overflow-y-auto
-        lg:pr-1
+        lg:grid lg:max-h-[600px] lg:grid-cols-1 lg:overflow-y-auto lg:pr-1
       `}
     >
       {quadrants.map((q, idx) => {
@@ -624,7 +806,7 @@ function RadarLegend({
       {adoptedBlips.length > 0 && (
         <div className="flex flex-col gap-1">
           <h4 className="text-sm font-semibold text-amber-700 uppercase">
-            Adopted
+            {adoptedSectionName}
           </h4>
           <ul className="flex flex-col gap-0.5">
             {adoptedBlips.map((blip) => {

--- a/packages/client/src/components/radar/RadarConfigTab.tsx
+++ b/packages/client/src/components/radar/RadarConfigTab.tsx
@@ -124,8 +124,7 @@ export function RadarConfigTab({
                 <Input
                   value={r.name}
                   onChange={e => onChangeRing(r.localKey, e.target.value)}
-                  placeholder="Ring name"
-                  disabled={r.isAdopted}
+                  placeholder={r.isAdopted ? "Adopted section name" : "Ring name"}
                 />
                 {r.isAdopted
                   ? (

--- a/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
@@ -246,6 +246,48 @@ export function BlipsTabContainer({
     }
   }
 
+  async function handleTableBulkSave(
+    ids: string[],
+    patch: { quadrantId?: string;
+      ringId?: string; },
+  ) {
+    if (ids.length === 0) return;
+    if (patch.quadrantId === undefined && patch.ringId === undefined) return;
+    const blipById = new Map<string, RadarBlip>();
+    (radar?.blips ?? []).forEach(b => blipById.set(b.id, b));
+    let updated = 0;
+    let failed = 0;
+    for (const id of ids) {
+      const blip = blipById.get(id);
+      if (!blip) {
+        failed += 1;
+        continue;
+      }
+      try {
+        await upsertRadarBlip(domainId, id, {
+          topicId: blip.topicId,
+          quadrantId: patch.quadrantId ?? blip.quadrantId,
+          ringId: patch.ringId ?? blip.ringId,
+          description: blip.description ?? null,
+        });
+        updated += 1;
+      }
+      catch {
+        failed += 1;
+      }
+    }
+    await onSaved();
+    if (updated > 0 && failed === 0) {
+      toast.success(`Updated ${updated} blip${updated === 1 ? "" : "s"}.`);
+    }
+    else if (updated > 0 && failed > 0) {
+      toast.error(`Updated ${updated}, failed ${failed}.`);
+    }
+    else {
+      toast.error("Failed to update blips.");
+    }
+  }
+
   return (
     <BlipsPanel
       allConfigPersisted={allConfigPersisted}
@@ -267,6 +309,7 @@ export function BlipsTabContainer({
       onRemoveBlip={removeBlip}
       onTableSave={handleTableSave}
       onTableRemove={handleTableRemove}
+      onTableBulkSave={handleTableBulkSave}
     />
   );
 }


### PR DESCRIPTION
## Summary
This PR adds two major features to the radar chart component: bulk editing capabilities for blips and visualization of adopted items in a dedicated section below the main radar.

## Key Changes

### Bulk Edit Feature (BlipTable)
- Added checkbox selection for individual blips and a "select all visible" header checkbox
- Implemented bulk action UI with dropdowns to change slice (quadrant) and/or ring for multiple selected blips
- Added `onBulkSave` callback to handle batch updates of blip properties
- Selection state is automatically cleaned up when blips are filtered or deleted
- Bulk operations show loading state and provide user feedback via toast notifications

### Adopted Section Visualization (RadarChart)
- Added toggle to show/hide adopted items in a dedicated section below the radar circle
- Adopted blips are displayed as numbered dots in a grid layout (right-to-left, bottom-up)
- Adopted dots maintain the same color coding by quadrant as main radar blips
- Added hover/focus states and tooltips for adopted blips matching main radar interaction patterns
- Extracted adopted ring filtering logic for reuse and clarity
- Dynamically adjusts SVG viewBox height based on whether adopted section is visible

### UI/UX Improvements
- Refactored row action buttons to use a hidden-by-default layout that appears on hover/focus
- Moved "Edit" action to a dedicated button separate from the dropdown menu
- Reorganized dropdown menu to prioritize "Quick Create" actions with "Remove" as destructive action at bottom
- Added visual feedback for selected rows with `data-state` attribute
- Improved accessibility with proper ARIA labels for checkboxes

### Integration
- Updated `BlipsTab` and `BlipsTabContainer` to wire up bulk save functionality
- Bulk save handler in `BlipsTabContainer` updates multiple blips and provides aggregated success/error feedback

https://claude.ai/code/session_01JPFLcVtc97ndqfU8Y9u5iV