### PR TITLE
Move @emstack/types to dependencies in middleware package

### DIFF
--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -3,6 +3,7 @@
   "description": "",
   "version": "1.0.0",
   "dependencies": {
+    "@emstack/types": "workspace:*",
     "@fastify/cors": "11.1.0",
     "@fastify/env": "5.0.3",
     "@fastify/swagger": "9.7.0",
@@ -17,7 +18,6 @@
     "uuid": "14.0.0"
   },
   "devDependencies": {
-    "@emstack/types": "workspace:*",
     "@fastify/type-provider-json-schema-to-ts": "5.0.0",
     "@types/node": "24.10.1",
     "@types/pg": "8.15.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
 
   packages/middleware:
     dependencies:
+      '@emstack/types':
+        specifier: workspace:*
+        version: link:../types
       '@fastify/cors':
         specifier: 11.1.0
         version: 11.1.0
@@ -289,9 +292,6 @@ importers:
         specifier: 14.0.0
         version: 14.0.0
     devDependencies:
-      '@emstack/types':
-        specifier: workspace:*
-        version: link:../types
       '@fastify/type-provider-json-schema-to-ts':
         specifier: 5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary
Moved the `@emstack/types` package from devDependencies to dependencies in the middleware package, indicating it's required at runtime rather than just for development.

## Changes
- Moved `@emstack/types` workspace dependency from `devDependencies` to `dependencies`

## Rationale
This change reflects that `@emstack/types` is a runtime dependency for the middleware package and should be included in production builds, not just during development.

https://claude.ai/code/session_01SCaNy7931EMAoLJKpzJthw