### PR TITLE
Simplify @emstack/types import paths

### DIFF
--- a/packages/middleware/src/routes/api/dailies/createDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/createDaily.ts
@@ -8,7 +8,7 @@ import {
   nullableDailyStatusEnum,
   nullableString,
 } from "@/utils/schemas";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
+import type { DailyCompletion, DailyCriteria } from "@emstack/types";
 import { v4 as uuidv4 } from "uuid";
 
 const createSchema = {

--- a/packages/middleware/src/routes/api/dailies/getDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/getDaily.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types/src";
+import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types";
 
 const getSchema = {
   schema: {

--- a/packages/middleware/src/routes/api/dailies/root.ts
+++ b/packages/middleware/src/routes/api/dailies/root.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types/src";
+import type { Daily, DailyCompletion, DailyCriteria } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/routes/api/dailies/upsertDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/upsertDaily.ts
@@ -9,7 +9,7 @@ import {
   nullableDailyStatusEnum,
   nullableString,
 } from "@/utils/schemas";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types/src";
+import type { DailyCompletion, DailyCriteria } from "@emstack/types";
 import { v4 as uuidv4 } from "uuid";
 
 const upsertSchema = {

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Domain } from "@emstack/types/src";
+import type { Domain } from "@emstack/types";
 import { sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
 

--- a/packages/middleware/src/routes/api/domains/getRadar.ts
+++ b/packages/middleware/src/routes/api/domains/getRadar.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { sendNotFound } from "@/utils/errors";
-import type { Radar } from "@emstack/types/src";
+import type { Radar } from "@emstack/types";
 
 const getRadarSchema = {
   schema: {

--- a/packages/middleware/src/routes/api/domains/root.ts
+++ b/packages/middleware/src/routes/api/domains/root.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Domain } from "@emstack/types/src";
+import type { Domain } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/routes/api/providers/root.ts
+++ b/packages/middleware/src/routes/api/providers/root.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { CourseProvider } from "@emstack/types/src";
+import type { CourseProvider } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/routes/api/resources/getResource.ts
+++ b/packages/middleware/src/routes/api/resources/getResource.ts
@@ -4,7 +4,7 @@ import { db } from "@/db";
 import { processCost } from "@/utils/processCost";
 import { processTopics } from "@/utils/processTopics";
 import { idParamSchema } from "@/utils/schemas";
-import type { Resource, ResourceFromServer, DailyCompletion } from "@emstack/types/src";
+import type { Resource, ResourceFromServer, DailyCompletion } from "@emstack/types";
 
 const testSchema = {
   schema: {

--- a/packages/middleware/src/routes/api/resources/root.ts
+++ b/packages/middleware/src/routes/api/resources/root.ts
@@ -3,7 +3,7 @@ import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { processCost } from "@/utils/processCost";
 import { processTopics } from "@/utils/processTopics";
-import type { Resource, ResourceFromServer, DailyCompletion } from "@emstack/types/src";
+import type { Resource, ResourceFromServer, DailyCompletion } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Task } from "@emstack/types/src";
+import type { Task } from "@emstack/types";
 import { idParamSchema } from "@/utils/schemas";
 
 const getSchema = {

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { Task } from "@emstack/types/src";
+import type { Task } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/routes/api/topics/root.ts
+++ b/packages/middleware/src/routes/api/topics/root.ts
@@ -1,7 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
-import type { TopicForTopicsPage } from "@emstack/types/src";
+import type { TopicForTopicsPage } from "@emstack/types";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();

--- a/packages/middleware/src/utils/moduleLength.ts
+++ b/packages/middleware/src/utils/moduleLength.ts
@@ -1,6 +1,6 @@
 import {
   isModuleDurationBucket,
-} from "@emstack/types/src";
+} from "@emstack/types";
 
 // Normalize the incoming module length value to the unified `length` column
 // shape. Accepts the new `length` string OR the legacy `minutesLength`

--- a/packages/middleware/src/utils/processCost.ts
+++ b/packages/middleware/src/utils/processCost.ts
@@ -1,5 +1,5 @@
-import type { CostData } from "@emstack/types/src";
-import { ResourceFromServer } from "@emstack/types/src";
+import type { CostData } from "@emstack/types";
+import { ResourceFromServer } from "@emstack/types";
 
 export function processCost(course: ResourceFromServer): CostData {
   let costData: CostData = {

--- a/packages/middleware/src/utils/processCourses.ts
+++ b/packages/middleware/src/utils/processCourses.ts
@@ -1,4 +1,4 @@
-import { TopicsToResources } from "@emstack/types/src";
+import { TopicsToResources } from "@emstack/types";
 
 export function processCourses(ttc: TopicsToResources[] | null | undefined) {
   if (ttc && ttc.length > 0) {

--- a/packages/middleware/src/utils/processTopics.ts
+++ b/packages/middleware/src/utils/processTopics.ts
@@ -1,4 +1,4 @@
-import { TopicsToResources } from "@emstack/types/src";
+import { TopicsToResources } from "@emstack/types";
 
 export function processTopics(ttc: TopicsToResources[] | null | undefined) {
   if (ttc && ttc.length > 0) {


### PR DESCRIPTION
## Summary
Updated all import statements across the middleware package to use the simplified import path `@emstack/types` instead of the verbose `@emstack/types/src`.

## Changes
- Standardized 18 import statements in the middleware package to use the cleaner import path
- Updated imports in utility files:
  - `processCost.ts`
  - `moduleLength.ts`
  - `processCourses.ts`
  - `processTopics.ts`
- Updated imports in route handlers:
  - Daily routes (createDaily, getDaily, root, upsertDaily)
  - Domain routes (getDomain, getRadar, root)
  - Provider routes (root)
  - Resource routes (getResource, root)
  - Task routes (getTask, root)
  - Topic routes (root)

## Implementation Details
This change assumes the `@emstack/types` package has been configured to properly export types from its entry point (likely via `package.json` exports or TypeScript configuration), eliminating the need to reference the `/src` subdirectory directly. This is a common pattern when packages are properly built and published with their public API clearly defined.

https://claude.ai/code/session_01RjSj8cETkdzFB6X9sVicmE