### PR TITLE
Remove explicit container names from docker-compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   db:
     image: postgres:16-alpine
-    container_name: coursetracker-db
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
@@ -20,7 +19,6 @@ services:
       context: ./
       dockerfile: ./packages/middleware/Dockerfile
       target: db-push
-    container_name: coursetracker-db-push
     restart: "no"
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-coursetracker}
@@ -31,7 +29,6 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    container_name: coursetracker-gateway
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
## Summary
Removed hardcoded `container_name` specifications from three services in the docker-compose configuration. This allows Docker Compose to automatically generate container names based on the project name and service name, improving flexibility and reducing naming conflicts.

## Changes
- Removed `container_name: coursetracker-db` from the `db` service
- Removed `container_name: coursetracker-db-push` from the `db-push` service
- Removed `container_name: coursetracker-gateway` from the `gateway` service

## Benefits
- Container names will now be automatically generated as `{project-name}_{service-name}_{instance-number}`, making them more predictable and avoiding hardcoded naming conventions
- Improves portability when running multiple instances or in different environments
- Reduces potential naming conflicts when the same compose file is used in different contexts

https://claude.ai/code/session_01LqgTWGfAbEodW9rHQgSz74