### PR TITLE
Add proper package exports configuration to types package

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,15 @@
     "@types/node": "24.10.1",
     "typescript": "5.9.3"
   },
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "packageManager": "pnpm@10.13.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Updated the `packages/types` package.json to include proper CommonJS and ESM export configurations, improving compatibility and clarity for package consumers.

## Key Changes
- Added `"main"` field pointing to `dist/index.js` for CommonJS compatibility
- Added `"exports"` field with conditional exports that specify:
  - TypeScript type definitions via `"types"` condition
  - ESM import via `"import"` condition
  - Default fallback to `dist/index.js`

## Details
These changes follow modern Node.js package standards and ensure that:
- TypeScript consumers can properly resolve type definitions
- Both CommonJS and ESM consumers can import the package correctly
- The package has explicit, well-defined entry points

https://claude.ai/code/session_01S9hiBn55h5PVPBLEPiZ1oq