### PR TITLE
Drop strict exports from @emstack/types to unbreak client build

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,13 +8,6 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
   "packageManager": "pnpm@10.13.1",
   "private": true,
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,15 @@
     "@types/node": "24.10.1",
     "typescript": "5.9.3"
   },
+  "main": "dist/index.js",
   "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "packageManager": "pnpm@10.13.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

PR #190 added an `exports` map to `@emstack/types` so Node could resolve the package at runtime. But `exports` is restrictive — it blocks any subpath that isn't explicitly listed. The client still imports from `@emstack/types/src/...` in ~50 files, so the Coolify deploy started failing with:

```
[rolldown:vite-resolve] "./src" is not exported under the conditions
["module", "browser", "production", "import"]
from package /app/packages/client/node_modules/@emstack/types
```

This drops the `exports` block. `"main": "dist/index.js"` (added in #190 and kept here) is enough for Node to resolve the package root to the built entry, which is what the middleware needs. Without `exports`, bundlers (Vite/rolldown) fall back to legacy resolution, so the client's existing `@emstack/types/src/...` imports keep working unchanged.

## Test plan

- [ ] Coolify deploy succeeds (both `db-push` and `gateway` services build)
- [ ] Middleware container stays up (no `Cannot find package @emstack/types/index.js` crash loop)
- [ ] Client app loads in browser

## Follow-up (not in this PR)

`packages/middleware/Dockerfile`'s `db-push` target runs `pnpm run -r build`, which builds the entire monorepo (including the React client) just to push schema. Worth slimming so a client build hiccup can't block schema migrations.

https://claude.ai/code/session_01S9hiBn55h5PVPBLEPiZ1oq

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hiBn55h5PVPBLEPiZ1oq)_