### PR TITLE
Actually remove exports from @emstack/types

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,13 +8,6 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  },
   "packageManager": "pnpm@10.13.1",
   "private": true,
   "scripts": {


### PR DESCRIPTION
PR #191 was meant to remove the strict `exports` map but the squash-merge performed a 3-way merge that kept `exports` because PR #190 had also added it on the master side. Net diff was zero, so the client build keeps failing:

    "./src" is not exported under the conditions ["module", "browser",
    "production", "import"] from package @emstack/types

This is a fresh branch off current master that simply deletes the `exports` block. `main: "dist/index.js"` (from #190) stays — that's all Node needs to resolve the package root at runtime. Without `exports`, bundlers fall back to legacy resolution, so the client's existing `@emstack/types/src/...` imports keep working.

https://claude.ai/code/session_01S9hiBn55h5PVPBLEPiZ1oq