### PR TITLE
Fix nested form handling and add missing UUID to resource tags

### DIFF
--- a/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
@@ -70,8 +70,7 @@ export function ComboboxCreatePanel({
     f => !f.required || (values[f.name] ?? "").trim().length > 0,
   );
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  function submit() {
     if (!canSubmit || submitting) return;
     const trimmed: Record<string, unknown> = {};
     for (const f of config.fields) {
@@ -81,21 +80,30 @@ export function ComboboxCreatePanel({
     onSubmit(trimmed);
   }
 
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      // Stop the Enter from bubbling to any outer <form> and submitting it —
+      // this panel is rendered inside edit-page forms, and nested <form>s are
+      // not allowed in HTML, so we can't use one here.
+      e.preventDefault();
+      e.stopPropagation();
+      submit();
+    }
+  }
+
   return (
     <div
       className="
         mt-2 flex flex-col gap-3 rounded-md border border-border bg-muted/30 p-4
       "
+      onKeyDown={handleKeyDown}
     >
       <div className="text-sm font-medium">
         New
         {" "}
         {config.itemLabel}
       </div>
-      <form
-        onSubmit={handleSubmit}
-        className="flex flex-col gap-3"
-      >
+      <div className="flex flex-col gap-3">
         {config.fields.map(f => (
           <div
             key={f.name}
@@ -125,9 +133,10 @@ export function ComboboxCreatePanel({
         ))}
         <div className="flex gap-2">
           <Button
-            type="submit"
+            type="button"
             size="sm"
             disabled={!canSubmit || submitting}
+            onClick={submit}
           >
             {submitting && <Loader2 className="size-4 animate-spin" />}
             Create
@@ -142,7 +151,7 @@ export function ComboboxCreatePanel({
             Cancel
           </Button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/packages/middleware/src/routes/api/resources/upsertResource.ts
+++ b/packages/middleware/src/routes/api/resources/upsertResource.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import { resources, resourceTags, topicsToResources } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import {
@@ -107,6 +108,7 @@ export default createUpsertHandler<CourseBody>({
       buildRows: (body, id) =>
         body.topicId
           ? [{
+            id: uuidv4(),
             topicId: body.topicId,
             resourceId: id,
           }]


### PR DESCRIPTION
## Summary
This PR addresses two issues: refactors the ComboboxCreatePanel to avoid using nested HTML forms (which are invalid), and ensures resource-to-topic associations are assigned unique IDs.

## Key Changes

- **ComboboxCreatePanel form refactoring**: Replaced the nested `<form>` element with a `<div>` to comply with HTML standards, since this component is rendered inside edit-page forms. The form submission logic is now handled via:
  - A new `handleKeyDown` handler that captures Enter key presses and prevents them from bubbling to outer forms
  - Changed the submit button from `type="submit"` to `type="button"` with an explicit `onClick` handler
  - Renamed `handleSubmit` to `submit` to better reflect its new purpose

- **Resource tags UUID generation**: Added `uuidv4()` import and ensured that each topic-to-resource association is assigned a unique ID when created, preventing potential database constraint violations.

## Implementation Details

The ComboboxCreatePanel now uses event delegation on the container div to intercept Enter key presses, preventing them from triggering submission of parent forms while still allowing the panel's own submit logic to execute. This maintains the intended UX without violating HTML nesting rules.

https://claude.ai/code/session_01A8DFYjHr2MxFg5kagmG87E