### PR TITLE
Refactor combobox create panel to capture input at open time

### DIFF
--- a/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { Loader2 } from "lucide-react";
 
@@ -58,13 +58,6 @@ export function ComboboxCreatePanel({
     }
     return initial;
   });
-
-  useEffect(() => {
-    setValues(prev => ({
-      ...prev,
-      [primaryFieldName]: initialPrimaryValue,
-    }));
-  }, [initialPrimaryValue, primaryFieldName]);
 
   const canSubmit = config.fields.every(
     f => !f.required || (values[f.name] ?? "").trim().length > 0,

--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/components/combobox";
 import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
-import { Button } from "@/components/ui/button";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
 interface ComboboxFieldProps {
@@ -42,6 +41,7 @@ export function ComboboxField({
 
   const [inputValue, setInputValue] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  const [createInitialValue, setCreateInitialValue] = useState("");
   const [creating, setCreating] = useState(false);
 
   const optionsMap = new Map(options.map(o => [o.value, o.label]));
@@ -53,6 +53,7 @@ export function ComboboxField({
   const showAddRow = !!create && trimmedInput.length > 0 && !hasExactMatch;
 
   function openCreate() {
+    setCreateInitialValue(trimmedInput);
     setCreateOpen(true);
   }
 
@@ -115,33 +116,7 @@ export function ComboboxField({
               </span>
             </button>
           )}
-          <ComboboxEmpty>
-            {create
-              ? (
-                <div className="flex w-full flex-col items-center gap-2 py-3">
-                  <span>No items found.</span>
-                  {trimmedInput && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        openCreate();
-                      }}
-                    >
-                      <PlusIcon className="size-4" />
-                      Add new
-                      {" "}
-                      {create.itemLabel}
-                    </Button>
-                  )}
-                </div>
-              )
-              : (
-                "No items found."
-              )}
-          </ComboboxEmpty>
+          <ComboboxEmpty>No items found.</ComboboxEmpty>
           <ComboboxList>
             {(value: string) => (
               <ComboboxItem
@@ -157,7 +132,7 @@ export function ComboboxField({
       {create && createOpen && (
         <ComboboxCreatePanel
           config={create}
-          initialPrimaryValue={trimmedInput}
+          initialPrimaryValue={createInitialValue}
           submitting={creating}
           onCancel={() => setCreateOpen(false)}
           onSubmit={handleCreateSubmit}

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/components/combobox";
 import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
-import { Button } from "@/components/ui/button";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
 interface MultiComboboxFieldProps {
@@ -82,6 +81,7 @@ export function MultiComboboxField({
 
   const [inputValue, setInputValue] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  const [createInitialValue, setCreateInitialValue] = useState("");
   const [creating, setCreating] = useState(false);
 
   const optionsMap = new Map(options.map(o => [o.value, o.label]));
@@ -92,6 +92,7 @@ export function MultiComboboxField({
   const showAddRow = !!create && trimmedInput.length > 0 && !hasExactMatch;
 
   function openCreate() {
+    setCreateInitialValue(trimmedInput);
     setCreateOpen(true);
   }
 
@@ -170,33 +171,7 @@ export function MultiComboboxField({
               </span>
             </button>
           )}
-          <ComboboxEmpty>
-            {create
-              ? (
-                <div className="flex w-full flex-col items-center gap-2 py-3">
-                  <span>No items found.</span>
-                  {trimmedInput && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        openCreate();
-                      }}
-                    >
-                      <PlusIcon className="size-4" />
-                      Add new
-                      {" "}
-                      {create.itemLabel}
-                    </Button>
-                  )}
-                </div>
-              )
-              : (
-                "No items found."
-              )}
-          </ComboboxEmpty>
+          <ComboboxEmpty>No items found.</ComboboxEmpty>
           <ComboboxList>
             {groupByPrefix
               ? Array.from(partitionOptions(options).entries()).map(
@@ -228,7 +203,7 @@ export function MultiComboboxField({
       {create && createOpen && (
         <ComboboxCreatePanel
           config={create}
-          initialPrimaryValue={trimmedInput}
+          initialPrimaryValue={createInitialValue}
           submitting={creating}
           onCancel={() => setCreateOpen(false)}
           onSubmit={handleCreateSubmit}


### PR DESCRIPTION
## Summary
Refactored the combobox create flow to capture the user's input value when the create panel is opened, rather than relying on reactive updates. This simplifies state management and removes unnecessary UI duplication.

## Key Changes
- **Removed inline "Add new" button** from `ComboboxEmpty` in both `ComboboxField` and `MultiComboboxField`. The create action is now triggered only via the existing "Add row" button in the combobox list.
- **Introduced `createInitialValue` state** in both field components to store the trimmed input at the moment `openCreate()` is called, ensuring the value is captured before the panel opens.
- **Updated `ComboboxCreatePanel`** to remove the `useEffect` that was syncing `initialPrimaryValue` prop changes into form state. The initial value is now set once when the panel mounts via the form's initialization logic.
- **Removed unused `Button` import** from both field components.

## Implementation Details
- The `createInitialValue` state is set in the `openCreate()` function before `setCreateOpen(true)`, ensuring the captured value is available when the panel renders.
- This change eliminates the reactive dependency on `initialPrimaryValue` changes in `ComboboxCreatePanel`, making the data flow more explicit and predictable.
- The "Add row" button (which was already present in the combobox list) remains the sole UI entry point for creating new items.

https://claude.ai/code/session_01SLCfY6yE4zXDARRDb7tX3c