### PR TITLE
Add entity descriptions to list page headers

### DIFF
--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 interface PageHeaderProps {
   pageTitle?: string;
   pageSection?: "" | "resources" | "topics" | "providers" | "domains" | "dailies" | "tasks";
+  description?: React.ReactNode;
   children?: React.ReactNode;
   progressCurrent?: number;
   progressTotal?: number;
@@ -17,6 +18,7 @@ interface PageHeaderProps {
 export function PageHeader({
   pageTitle = "",
   pageSection = "",
+  description,
   children,
   progressCurrent = 0,
   progressTotal = 0,
@@ -91,6 +93,11 @@ export function PageHeader({
           >
             <div>
               <h1 className="text-3xl">{pageTitle}</h1>
+              {description && (
+                <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                  {description}
+                </p>
+              )}
             </div>
             {children && <div>{children}</div>}
           </div>

--- a/packages/client/src/lib/entityDescriptions.ts
+++ b/packages/client/src/lib/entityDescriptions.ts
@@ -1,0 +1,11 @@
+// Short, plain-language blurbs shown under the title on each entity's list
+// page (see PageHeader's `description` prop). One source of truth so the copy
+// is easy to tweak and can be reused on detail pages / the dashboard later.
+export const ENTITY_DESCRIPTIONS = {
+  resources: "Courses, videos, books — anything you learn from. Each resource tracks its provider, progress, cost, and the modules inside it.",
+  topics: "The subjects and skills you want to learn. Topics are concepts in their own right, independent of any one resource, and link to the resources, domains, and tasks that cover them.",
+  tasks: "Discrete pieces of work to do. Each task can carry a checklist, linked resources, and an optional daily habit.",
+  dailies: "Recurring habits you track day by day. Each daily logs a status per day and measures your streak against its own goal criteria.",
+  domains: "Big-picture areas of expertise that group related topics. Each domain defines what's in and out of scope and powers a tech-radar view.",
+  providers: "The platforms and vendors your resources come from. Providers track cost, subscriptions, and which resources belong to them.",
+} as const;

--- a/packages/client/src/routes/dailies.index.tsx
+++ b/packages/client/src/routes/dailies.index.tsx
@@ -34,6 +34,7 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { useDailiesViewMode } from "@/hooks/useDailiesViewMode";
 import { useSettings } from "@/hooks/useSettings";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { cn } from "@/lib/utils";
 import {
   fetchResources,
@@ -267,6 +268,7 @@ function Dailies() {
       <PageHeader
         pageTitle="Dailies"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.dailies}
       >
         <Link
           to="/dailies/$id/edit"

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -9,6 +9,7 @@ import { DomainBox } from "@/components/boxes/DomainBox";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchDomains } from "@/utils";
 
 export const Route = createFileRoute("/domains/")({
@@ -38,6 +39,7 @@ function DomainsIndex() {
       <PageHeader
         pageTitle="Domains"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.domains}
       >
         <Link
           to="/domains/$id/edit"

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -9,6 +9,7 @@ import { ProviderBox } from "@/components/boxes/ProviderBox";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchProviders } from "@/utils";
 
 export const Route = createFileRoute("/providers/")({
@@ -38,6 +39,7 @@ function Providers() {
       <PageHeader
         pageTitle="Providers"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.providers}
       >
         <Link
           to="/providers/$id/edit"

--- a/packages/client/src/routes/resources.index.tsx
+++ b/packages/client/src/routes/resources.index.tsx
@@ -29,6 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchResources, fetchProviders, fetchTopics } from "@/utils";
 
 type SortOption = "alpha" | "progress" | "provider" | "topic";
@@ -176,6 +177,7 @@ function Courses() {
       <PageHeader
         pageTitle="Your Resources"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.resources}
       >
         <Link
           to="/resources/$id/edit"

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchTasks, fetchTopics } from "@/utils";
 
 interface TasksSearch {
@@ -108,6 +109,7 @@ function Tasks() {
       <PageHeader
         pageTitle="Tasks"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.tasks}
       >
         <Link
           to="/tasks/$id/edit"

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -30,6 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { bulkDeleteTopics, fetchDomains, fetchTopics } from "@/utils";
 
 type SortOption = "alpha-asc" | "alpha-desc" | "resources";
@@ -217,6 +218,7 @@ function Topics() {
       <PageHeader
         pageTitle="Topics"
         pageSection=""
+        description={ENTITY_DESCRIPTIONS.topics}
       />
       <div className="container flex flex-col gap-4">
         <div>


### PR DESCRIPTION
## Summary
Adds plain-language descriptions under the title on each entity's list page, providing users with a quick reference for what each entity type represents and its key features.

## Changes
- **New file:** `packages/client/src/lib/entityDescriptions.ts`
  - Centralized source of truth for entity descriptions (resources, topics, tasks, dailies, domains, providers)
  - Exported as a const object for easy reuse across pages and future features (detail pages, dashboard)

- **Updated:** `packages/client/src/components/layout/PageHeader.tsx`
  - Added optional `description` prop to `PageHeaderProps`
  - Renders description as a small, muted-foreground paragraph below the page title when provided

- **Updated entity list routes:** All six entity index routes now import and pass their description:
  - `packages/client/src/routes/resources.index.tsx`
  - `packages/client/src/routes/topics.index.tsx`
  - `packages/client/src/routes/tasks.index.tsx`
  - `packages/client/src/routes/dailies.index.tsx`
  - `packages/client/src/routes/domains.index.tsx`
  - `packages/client/src/routes/providers.index.tsx`

## Implementation Details
- Descriptions are styled with `text-sm text-muted-foreground` and capped at `max-w-2xl` for readability
- The `description` prop is optional, maintaining backward compatibility with existing `PageHeader` usage
- Descriptions are concise, action-oriented, and highlight the key purpose and features of each entity type

https://claude.ai/code/session_01F8kFk5mQC987TBVBdWQMSS