### PR TITLE
Add an Ignored blip category and surface ignored topics on the radar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,8 @@ If you change `packages/middleware/src/db/schema.ts`, run `pnpm --filter=@emstac
 Defined in `packages/middleware/src/db/schema.ts`.
 
 - **Core tables:** `users`, `topics`, `courseProviders`, `courses`, `dailies`, `tasks`, `resources` (task resources), `task_todos`, `domains`
-- **Junction tables:** `topics_to_courses`, `topics_to_domains`, `domain_excluded_topics`
-- **Radar tables:** `radar_quadrants`, `radar_rings`, `radar_blips`
+- **Junction tables:** `topics_to_courses`, `domain_within_scope_topics`
+- **Radar tables:** `radar_blips` (a blip's `is_ignored` flag marks an "out of scope" / ignored topic; its `description` holds the ignore reasoning). Quadrants/rings live in the `domains.radar_config` JSONB column.
 - **Enums:** `recurPeriodUnit` (days/months/years), `status` (active/inactive/complete/paused), `dailyCompletionStatus` (incomplete/touched/goal/exceeded/freeze), `resourceLevel` (low/medium/high)
 - Uses `drizzle-kit push` (not migration files) — schema changes pushed directly to database
 

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   ChevronsUpDownIcon,
+  EyeOffIcon,
   ListChecksIcon,
   Loader2,
   MoreHorizontalIcon,
@@ -18,6 +19,7 @@ import {
   PlusIcon,
   SunIcon,
   TrashIcon,
+  Undo2Icon,
   XIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -83,9 +85,10 @@ interface BlipTableProps {
   topics: TopicForTopicsPage[];
   onSave: (
     blip: RadarBlip,
-    patch: { quadrantId: string;
-      ringId: string;
-      description: string | null; },
+    patch: { quadrantId: string | null;
+      ringId: string | null;
+      description: string | null;
+      isIgnored: boolean; },
   ) => Promise<void>;
   onRemove: (blip: RadarBlip) => Promise<void>;
   onBulkSave: (ids: string[], patch: BulkPatch) => Promise<void>;
@@ -99,6 +102,7 @@ interface EditDraft {
   quadrantId: string;
   ringId: string;
   description: string;
+  isIgnored: boolean;
 }
 
 export function BlipTable({
@@ -326,6 +330,7 @@ export function BlipTable({
       quadrantId: blip.quadrantId ?? quadrants[0]?.id ?? "",
       ringId: blip.ringId ?? rings[0]?.id ?? "",
       description: blip.description ?? "",
+      isIgnored: blip.isIgnored ?? false,
     });
   }
 
@@ -338,19 +343,38 @@ export function BlipTable({
     if (!editDraft) {
       return;
     }
-    if (!editDraft.quadrantId || !editDraft.ringId) {
+    // Ignored blips carry no slice/ring; everything else needs both.
+    if (!editDraft.isIgnored && (!editDraft.quadrantId || !editDraft.ringId)) {
       toast.error("Pick a slice and ring.");
       return;
     }
     setPendingId(blip.id);
     try {
       await onSave(blip, {
-        quadrantId: editDraft.quadrantId,
-        ringId: editDraft.ringId,
+        quadrantId: editDraft.isIgnored ? null : editDraft.quadrantId,
+        ringId: editDraft.isIgnored ? null : editDraft.ringId,
         description: editDraft.description.trim() || null,
+        isIgnored: editDraft.isIgnored,
       });
       setEditingId(null);
       setEditDraft(null);
+    }
+    finally {
+      setPendingId(null);
+    }
+  }
+
+  // Quick toggle from the row menu: flip a blip in/out of the ignored category.
+  // Moving back to the radar leaves it unassigned for the user to place.
+  async function toggleIgnore(blip: RadarBlip) {
+    setPendingId(blip.id);
+    try {
+      await onSave(blip, {
+        quadrantId: blip.isIgnored ? blip.quadrantId : null,
+        ringId: blip.isIgnored ? blip.ringId : null,
+        description: blip.description ?? null,
+        isIgnored: !blip.isIgnored,
+      });
     }
     finally {
       setPendingId(null);
@@ -692,67 +716,88 @@ export function BlipTable({
                             )}
                         </div>
                         <div className="flex flex-col gap-3">
-                          <div className="flex flex-col gap-1">
-                            <label className="text-xs uppercase">
-                              Slice
-                            </label>
-                            <Select
-                              value={editDraft.quadrantId}
-                              onValueChange={value =>
+                          <label
+                            className="flex flex-row items-center gap-2 text-sm"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={editDraft.isIgnored}
+                              onChange={e =>
                                 setEditDraft(prev =>
                                   prev
                                     ? {
                                       ...prev,
-                                      quadrantId: value,
+                                      isIgnored: e.target.checked,
                                     }
                                     : prev)}
-                            >
-                              <SelectTrigger>
-                                <SelectValue placeholder="Choose slice" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {quadrants.map(q => (
-                                  <SelectItem
-                                    key={q.id}
-                                    value={q.id}
-                                  >
-                                    {q.name}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </div>
-                          <div className="flex flex-col gap-1">
-                            <label className="text-xs uppercase">Ring</label>
-                            <Select
-                              value={editDraft.ringId}
-                              onValueChange={value =>
-                                setEditDraft(prev =>
-                                  prev
-                                    ? {
-                                      ...prev,
-                                      ringId: value,
-                                    }
-                                    : prev)}
-                            >
-                              <SelectTrigger>
-                                <SelectValue placeholder="Choose ring" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {rings.map(r => (
-                                  <SelectItem
-                                    key={r.id}
-                                    value={r.id}
-                                  >
-                                    {r.name}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </div>
+                            />
+                            Ignore (out of scope)
+                          </label>
+                          {!editDraft.isIgnored && (
+                            <>
+                              <div className="flex flex-col gap-1">
+                                <label className="text-xs uppercase">
+                                  Slice
+                                </label>
+                                <Select
+                                  value={editDraft.quadrantId}
+                                  onValueChange={value =>
+                                    setEditDraft(prev =>
+                                      prev
+                                        ? {
+                                          ...prev,
+                                          quadrantId: value,
+                                        }
+                                        : prev)}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Choose slice" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {quadrants.map(q => (
+                                      <SelectItem
+                                        key={q.id}
+                                        value={q.id}
+                                      >
+                                        {q.name}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                              <div className="flex flex-col gap-1">
+                                <label className="text-xs uppercase">Ring</label>
+                                <Select
+                                  value={editDraft.ringId}
+                                  onValueChange={value =>
+                                    setEditDraft(prev =>
+                                      prev
+                                        ? {
+                                          ...prev,
+                                          ringId: value,
+                                        }
+                                        : prev)}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Choose ring" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {rings.map(r => (
+                                      <SelectItem
+                                        key={r.id}
+                                        value={r.id}
+                                      >
+                                        {r.name}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                            </>
+                          )}
                           <div className="flex flex-col gap-1">
                             <label className="text-xs uppercase">
-                              Radar Note
+                              {editDraft.isIgnored ? "Reason" : "Radar Note"}
                             </label>
                             <Textarea
                               value={editDraft.description}
@@ -812,6 +857,13 @@ export function BlipTable({
                     </TableCell>
                     <TableCell>
                       {(() => {
+                        if (blip.isIgnored) {
+                          return (
+                            <Pill className="bg-gray-200 text-gray-700">
+                              Ignored
+                            </Pill>
+                          );
+                        }
                         const q = blip.quadrantId
                           ? quadrantById.get(blip.quadrantId)
                           : undefined;
@@ -838,6 +890,13 @@ export function BlipTable({
                     </TableCell>
                     <TableCell>
                       {(() => {
+                        if (blip.isIgnored) {
+                          return (
+                            <span className="text-xs text-muted-foreground">
+                              —
+                            </span>
+                          );
+                        }
                         const r = blip.ringId
                           ? ringById.get(blip.ringId)
                           : undefined;
@@ -995,6 +1054,25 @@ export function BlipTable({
                                 {" "}
                                 View Topic
                               </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => toggleIgnore(blip)}
+                            >
+                              {blip.isIgnored
+                                ? (
+                                  <>
+                                    <Undo2Icon />
+                                    {" "}
+                                    Move back to radar
+                                  </>
+                                )
+                                : (
+                                  <>
+                                    <EyeOffIcon />
+                                    {" "}
+                                    Mark as Ignored
+                                  </>
+                                )}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               variant="destructive"

--- a/packages/client/src/components/radar/BlipsTab.tsx
+++ b/packages/client/src/components/radar/BlipsTab.tsx
@@ -56,9 +56,10 @@ interface BlipsTabProps {
   onRemoveBlip: (blip: BlipDraft) => void;
   onTableSave: (
     blip: RadarBlip,
-    patch: { quadrantId: string;
-      ringId: string;
-      description: string | null; },
+    patch: { quadrantId: string | null;
+      ringId: string | null;
+      description: string | null;
+      isIgnored: boolean; },
   ) => Promise<void>;
   onTableRemove: (blip: RadarBlip) => Promise<void>;
   onTableBulkSave: (

--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -56,6 +56,17 @@ const ADOPTED_AREA_RIGHT_PAD = 12;
 const ADOPTED_AREA_HEIGHT = 96;
 const ADOPTED_LABEL_GAP = 18;
 
+// Ignored ("out of scope") dots get their own strip beneath the Adopted one.
+// They carry no slice, so they render in a neutral gray.
+const IGNORED_DOT_RADIUS = 8;
+const IGNORED_DOT_SPACING = 22;
+const IGNORED_AREA_BOTTOM_PAD = 12;
+const IGNORED_AREA_RIGHT_PAD = 12;
+const IGNORED_AREA_HEIGHT = 96;
+const IGNORED_LABEL_GAP = 18;
+const IGNORED_DOT_COLOR = "#6b7280";
+const IGNORED_LABEL_COLOR = "#4b5563";
+
 // Deterministic pseudo-random in [0, 1) from a string. Used to keep blip
 // placements stable across renders without storing coordinates in the DB.
 function hashUnit(input: string): number {
@@ -82,6 +93,7 @@ export function RadarChart({
     initialSelectedBlipId,
   );
   const [showAdoptedDots, setShowAdoptedDots] = useState(false);
+  const [showIgnoredDots, setShowIgnoredDots] = useState(false);
   const containerWrapperRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -164,8 +176,15 @@ export function RadarChart({
 
   const adoptedBlips = useMemo(
     () =>
-      blips.filter(b => b.ringId !== null && adoptedRingIds.has(b.ringId)),
+      blips.filter(
+        b => !b.isIgnored && b.ringId !== null && adoptedRingIds.has(b.ringId),
+      ),
     [blips, adoptedRingIds],
+  );
+
+  const ignoredBlips = useMemo(
+    () => blips.filter(b => b.isIgnored),
+    [blips],
   );
 
   const positionedBlips = useMemo<PositionedBlip[]>(() => {
@@ -176,6 +195,9 @@ export function RadarChart({
     let displayIndex = 0;
     return blips
       .map((blip) => {
+        if (blip.isIgnored) {
+          return null;
+        }
         if (blip.ringId !== null && adoptedRingIds.has(blip.ringId)) {
           return null;
         }
@@ -217,7 +239,14 @@ export function RadarChart({
   ]);
 
   const showAdoptedInChart = showAdoptedDots && adoptedBlips.length > 0;
-  const totalHeight = size + (showAdoptedInChart ? ADOPTED_AREA_HEIGHT : 0);
+  const showIgnoredInChart = showIgnoredDots && ignoredBlips.length > 0;
+  const adoptedAreaHeight = showAdoptedInChart ? ADOPTED_AREA_HEIGHT : 0;
+  const ignoredAreaHeight = showIgnoredInChart ? IGNORED_AREA_HEIGHT : 0;
+  const totalHeight = size + adoptedAreaHeight + ignoredAreaHeight;
+  // The Adopted strip sits directly below the circle; the Ignored strip sits
+  // below the Adopted one.
+  const adoptedBandBottom = size + adoptedAreaHeight;
+  const ignoredBandTop = size + adoptedAreaHeight;
 
   const positionedAdoptedBlips = useMemo<PositionedBlip[]>(() => {
     if (!showAdoptedInChart) return [];
@@ -225,7 +254,7 @@ export function RadarChart({
     // radar circle (bottom-right of the radar graphic).
     const startX = size - ADOPTED_AREA_RIGHT_PAD - ADOPTED_DOT_RADIUS;
     const startY
-      = totalHeight - ADOPTED_AREA_BOTTOM_PAD - ADOPTED_DOT_RADIUS;
+      = adoptedBandBottom - ADOPTED_AREA_BOTTOM_PAD - ADOPTED_DOT_RADIUS;
     const cols = Math.max(
       1,
       Math.floor((size / 2) / ADOPTED_DOT_SPACING),
@@ -240,7 +269,34 @@ export function RadarChart({
         index: positionedBlips.length + i + 1,
       };
     });
-  }, [showAdoptedInChart, adoptedBlips, size, totalHeight, positionedBlips]);
+  }, [showAdoptedInChart, adoptedBlips, size, adoptedBandBottom, positionedBlips]);
+
+  const positionedIgnoredBlips = useMemo<PositionedBlip[]>(() => {
+    if (!showIgnoredInChart) return [];
+    const startX = size - IGNORED_AREA_RIGHT_PAD - IGNORED_DOT_RADIUS;
+    const startY = totalHeight - IGNORED_AREA_BOTTOM_PAD - IGNORED_DOT_RADIUS;
+    const cols = Math.max(
+      1,
+      Math.floor((size / 2) / IGNORED_DOT_SPACING),
+    );
+    return ignoredBlips.map((blip, i) => {
+      const row = Math.floor(i / cols);
+      const col = i % cols;
+      return {
+        blip,
+        x: startX - col * IGNORED_DOT_SPACING,
+        y: startY - row * IGNORED_DOT_SPACING,
+        index: positionedBlips.length + adoptedBlips.length + i + 1,
+      };
+    });
+  }, [
+    showIgnoredInChart,
+    ignoredBlips,
+    size,
+    totalHeight,
+    positionedBlips,
+    adoptedBlips,
+  ]);
 
   if (quadrantCount === 0 || ringCount === 0) {
     return (
@@ -269,8 +325,8 @@ export function RadarChart({
     onBlipClick?.(blip);
   };
 
-  const adoptedLabelY
-    = totalHeight - ADOPTED_AREA_HEIGHT + ADOPTED_LABEL_GAP;
+  const adoptedLabelY = size + ADOPTED_LABEL_GAP;
+  const ignoredLabelY = ignoredBandTop + IGNORED_LABEL_GAP;
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -568,6 +624,114 @@ export function RadarChart({
                   })}
               </>
             )}
+            {showIgnoredInChart && (
+              <>
+                <text
+                  x={size - IGNORED_AREA_RIGHT_PAD}
+                  y={ignoredLabelY}
+                  textAnchor="end"
+                  fontSize={11}
+                  fontWeight="600"
+                  fill={IGNORED_LABEL_COLOR}
+                >
+                  Ignored
+                </text>
+                {[...positionedIgnoredBlips]
+                  .sort((a, b) => {
+                    const aActive = activeBlipId === a.blip.id ? 1 : 0;
+                    const bActive = activeBlipId === b.blip.id ? 1 : 0;
+                    return aActive - bActive;
+                  })
+                  .map(({
+                    blip, x, y, index,
+                  }) => {
+                    const isActive = activeBlipId === blip.id;
+                    const isSelected = selectedBlipId === blip.id;
+                    return (
+                      <Tooltip
+                        key={`ignored-${blip.id}`}
+                        open={isActive || undefined}
+                      >
+                        <TooltipTrigger asChild>
+                          <g
+                            onMouseEnter={() => setHoveredBlipId(blip.id)}
+                            onMouseLeave={() => setHoveredBlipId(null)}
+                            onFocus={() => setHoveredBlipId(blip.id)}
+                            onBlur={() => setHoveredBlipId(null)}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleBlipClick(blip);
+                            }}
+                            style={{
+                              cursor: "pointer",
+                            }}
+                            tabIndex={0}
+                          >
+                            {isActive && (
+                              <circle
+                                cx={x}
+                                cy={y}
+                                r={IGNORED_DOT_RADIUS + 5}
+                                fill="none"
+                                stroke={IGNORED_DOT_COLOR}
+                                strokeWidth={isSelected ? 3 : 2}
+                                strokeOpacity={isSelected ? 0.8 : 0.5}
+                              />
+                            )}
+                            <circle
+                              cx={x}
+                              cy={y}
+                              r={
+                                isActive
+                                  ? IGNORED_DOT_RADIUS + 2
+                                  : IGNORED_DOT_RADIUS
+                              }
+                              fill={IGNORED_DOT_COLOR}
+                              stroke="white"
+                              strokeWidth={2}
+                            />
+                            <text
+                              x={x}
+                              y={y}
+                              textAnchor="middle"
+                              dominantBaseline="central"
+                              fontSize={9}
+                              fontWeight="700"
+                              fill="white"
+                              style={{
+                                pointerEvents: "none",
+                              }}
+                            >
+                              {index}
+                            </text>
+                          </g>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          className="max-w-xs"
+                        >
+                          <div className="flex flex-col gap-0.5 text-left">
+                            <div className="font-semibold">
+                              {index}
+                              .
+                              {" "}
+                              {blip.topicName}
+                            </div>
+                            <div className="text-[11px] opacity-80">
+                              Ignored
+                            </div>
+                            {blip.description && (
+                              <div className="text-[11px] opacity-90">
+                                {blip.description}
+                              </div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+              </>
+            )}
           </svg>
         </div>
         {showLegend && (
@@ -593,12 +757,25 @@ export function RadarChart({
                 dots on radar
               </label>
             )}
+            {ignoredBlips.length > 0 && (
+              <label
+                className="flex flex-row items-center gap-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={showIgnoredDots}
+                  onChange={e => setShowIgnoredDots(e.target.checked)}
+                />
+                Show Ignored dots on radar
+              </label>
+            )}
             <RadarLegend
               quadrants={sortedQuadrants}
               positionedBlips={positionedBlips}
               rings={sortedRings}
               adoptedBlips={adoptedBlips}
               adoptedSectionName={adoptedSectionName}
+              ignoredBlips={ignoredBlips}
               onDescriptionChange={handleSetDescription}
               onHover={setHoveredBlipId}
               activeBlipId={activeBlipId}
@@ -618,6 +795,7 @@ interface RadarLegendProps {
   positionedBlips: PositionedBlip[];
   adoptedBlips: RadarBlip[];
   adoptedSectionName: string;
+  ignoredBlips: RadarBlip[];
   onDescriptionChange: (blipId: string, value: string) => void;
   activeBlipId: string | null;
   selectedBlipId: string | null;
@@ -631,6 +809,7 @@ function RadarLegend({
   positionedBlips,
   adoptedBlips,
   adoptedSectionName,
+  ignoredBlips,
   onDescriptionChange,
   activeBlipId,
   selectedBlipId,
@@ -810,6 +989,96 @@ function RadarLegend({
           </h4>
           <ul className="flex flex-col gap-0.5">
             {adoptedBlips.map((blip) => {
+              const isActive = activeBlipId === blip.id;
+              const isSelected = selectedBlipId === blip.id;
+              const description = blip.description ?? "";
+              return (
+                <li
+                  key={blip.id}
+                  ref={(el) => {
+                    if (el) {
+                      itemRefs.current.set(blip.id, el);
+                    }
+                    else {
+                      itemRefs.current.delete(blip.id);
+                    }
+                  }}
+                  onMouseEnter={() => onHover(blip.id)}
+                  onMouseLeave={() => onHover(null)}
+                  className={cn(
+                    `
+                      group flex flex-col rounded-sm px-1 py-0.5 text-sm
+                      transition-colors
+                    `,
+                    isActive && "bg-gray-200",
+                    isSelected && "ring-1 ring-gray-400",
+                  )}
+                >
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onBlipClick(blip);
+                      }}
+                      className="flex-1 cursor-pointer text-left"
+                    >
+                      <span className="font-medium">{blip.topicName}</span>
+                    </button>
+                    <div
+                      className={cn(
+                        `
+                          flex items-center gap-0.5 opacity-0 transition-opacity
+                          group-hover:opacity-100
+                          focus-within:opacity-100
+                        `,
+                        isSelected && "opacity-100",
+                      )}
+                    >
+                      <BlipDescriptionPopover
+                        value={description}
+                        onChange={value => onDescriptionChange(blip.id, value)}
+                      />
+                      <Link
+                        to="/topics/$id"
+                        params={{
+                          id: blip.topicId,
+                        }}
+                        aria-label={`Go to topic ${blip.topicName}`}
+                      >
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="size-6 p-0"
+                        >
+                          <ArrowRightIcon className="size-3.5" />
+                        </Button>
+                      </Link>
+                    </div>
+                  </div>
+                  {description && (
+                    <p
+                      className={`
+                        mt-0.5 ml-4 text-xs text-muted-foreground italic
+                      `}
+                    >
+                      {description}
+                    </p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+      {ignoredBlips.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h4 className="text-sm font-semibold text-gray-600 uppercase">
+            Ignored
+          </h4>
+          <ul className="flex flex-col gap-0.5">
+            {ignoredBlips.map((blip) => {
               const isActive = activeBlipId === blip.id;
               const isSelected = selectedBlipId === blip.id;
               const description = blip.description ?? "";

--- a/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
@@ -215,9 +215,10 @@ export function BlipsTabContainer({
 
   async function handleTableSave(
     blip: RadarBlip,
-    patch: { quadrantId: string;
-      ringId: string;
-      description: string | null; },
+    patch: { quadrantId: string | null;
+      ringId: string | null;
+      description: string | null;
+      isIgnored: boolean; },
   ) {
     try {
       await upsertRadarBlip(domainId, blip.id, {
@@ -225,6 +226,7 @@ export function BlipsTabContainer({
         quadrantId: patch.quadrantId,
         ringId: patch.ringId,
         description: patch.description,
+        isIgnored: patch.isIgnored,
       });
       await onSaved();
       toast.success("Blip saved.");
@@ -269,6 +271,7 @@ export function BlipsTabContainer({
           quadrantId: patch.quadrantId ?? blip.quadrantId,
           ringId: patch.ringId ?? blip.ringId,
           description: blip.description ?? null,
+          isIgnored: blip.isIgnored ?? false,
         });
         updated += 1;
       }

--- a/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.tsx
@@ -1,4 +1,4 @@
-import type { Domain, TopicForTopicsPage } from "@emstack/types/src";
+import type { Domain, Radar, TopicForTopicsPage } from "@emstack/types/src";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -15,37 +15,50 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { upsertDomain } from "@/utils";
+import {
+  createRadarBlip,
+  deleteRadarBlip,
+  upsertDomain,
+  upsertRadarBlip,
+} from "@/utils";
 
 interface ScopeTabProps {
   domain: Domain;
+  radar: Radar | undefined;
   topics: TopicForTopicsPage[];
   onSaved: () => Promise<void>;
   onChangeStateChange?: (hasChanges: boolean) => void;
 }
 
-interface ExcludedRow {
+// An "ignore" row maps to a radar blip with `isIgnored = true`. `blipId` is
+// absent for rows the user just added (created on save).
+interface IgnoreRow {
+  blipId?: string;
   topicId: string;
   reason: string;
   localKey: string;
 }
 
-let exclusionKeyCounter = 0;
-function nextExclusionKey() {
-  exclusionKeyCounter += 1;
-  return `exclusion-${exclusionKeyCounter}`;
+let ignoreKeyCounter = 0;
+function nextIgnoreKey() {
+  ignoreKeyCounter += 1;
+  return `ignore-${ignoreKeyCounter}`;
 }
 
-function buildExcludedFromDomain(domain: Domain): ExcludedRow[] {
-  return (domain.excludedTopics ?? []).map(et => ({
-    topicId: et.id,
-    reason: et.reason ?? "",
-    localKey: nextExclusionKey(),
-  }));
+function buildIgnoreRows(radar: Radar | undefined): IgnoreRow[] {
+  return (radar?.blips ?? [])
+    .filter(b => b.isIgnored)
+    .map(b => ({
+      blipId: b.id,
+      topicId: b.topicId,
+      reason: b.description ?? "",
+      localKey: nextIgnoreKey(),
+    }));
 }
 
 export function ScopeTab({
   domain,
+  radar,
   topics,
   onSaved,
   onChangeStateChange,
@@ -56,26 +69,59 @@ export function ScopeTab({
     () => (domain.withinScopeTopics ?? []).map(t => t.id),
     [domain],
   );
-  const startingExcluded = useMemo(
-    () => buildExcludedFromDomain(domain),
-    [domain],
-  );
 
   const [withinDescription, setWithinDescription] = useState(startingWithinDescription);
   const [outDescription, setOutDescription] = useState(startingOutDescription);
   const [withinTopicIds, setWithinTopicIds] = useState<string[]>(startingWithinTopicIds);
-  const [excludedRows, setExcludedRows] = useState<ExcludedRow[]>(startingExcluded);
+  const [ignoreRows, setIgnoreRows] = useState<IgnoreRow[]>(() =>
+    buildIgnoreRows(radar));
   const [isSaving, setIsSaving] = useState(false);
   const lastSavedRef = useRef({
     withinDescription: startingWithinDescription,
     outDescription: startingOutDescription,
     withinTopicIds: startingWithinTopicIds,
-    excludedRows: startingExcluded,
+    ignoreRows: buildIgnoreRows(radar),
   });
 
-  const usedExclusionTopicIds = useMemo(
-    () => new Set(excludedRows.map(r => r.topicId).filter(Boolean)),
-    [excludedRows],
+  // The ignore rows live on the radar query (separate from the domain query),
+  // which may resolve after this tab mounts and refetches after a save. Re-sync
+  // from the server whenever the set of ignored blips actually changes, so new
+  // rows pick up their server-assigned blip ids.
+  const serverIgnoreSig = useMemo(
+    () =>
+      (radar?.blips ?? [])
+        .filter(b => b.isIgnored)
+        .map(b => `${b.id}:${b.description ?? ""}`)
+        .sort()
+        .join("|"),
+    [radar],
+  );
+  const lastSyncedSigRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastSyncedSigRef.current === serverIgnoreSig) {
+      return;
+    }
+    lastSyncedSigRef.current = serverIgnoreSig;
+    const rows = buildIgnoreRows(radar);
+    setIgnoreRows(rows);
+    lastSavedRef.current.ignoreRows = rows;
+  }, [serverIgnoreSig, radar]);
+
+  const usedIgnoreTopicIds = useMemo(
+    () => new Set(ignoreRows.map(r => r.topicId).filter(Boolean)),
+    [ignoreRows],
+  );
+
+  // Topics already placed on the radar (non-ignored blips) can't also be
+  // ignored — a topic has at most one blip per domain.
+  const onRadarTopicIds = useMemo(
+    () =>
+      new Set(
+        (radar?.blips ?? [])
+          .filter(b => !b.isIgnored)
+          .map(b => b.topicId),
+      ),
+    [radar],
   );
 
   const hasChanges = useMemo(() => {
@@ -86,32 +132,32 @@ export function ScopeTab({
       || withinTopicIds.some((v, i) => v !== last.withinTopicIds[i])) {
       return true;
     }
-    if (excludedRows.length !== last.excludedRows.length) return true;
-    const lastByTopic = new Map(last.excludedRows.map(r => [r.topicId, r.reason]));
-    return excludedRows.some(r => !lastByTopic.has(r.topicId) || lastByTopic.get(r.topicId) !== r.reason);
-  }, [withinDescription, outDescription, withinTopicIds, excludedRows]);
+    if (ignoreRows.length !== last.ignoreRows.length) return true;
+    const lastByTopic = new Map(last.ignoreRows.map(r => [r.topicId, r.reason]));
+    return ignoreRows.some(r => !lastByTopic.has(r.topicId) || lastByTopic.get(r.topicId) !== r.reason);
+  }, [withinDescription, outDescription, withinTopicIds, ignoreRows]);
 
   useEffect(() => {
     onChangeStateChange?.(hasChanges);
   }, [hasChanges, onChangeStateChange]);
 
-  function addExclusion() {
-    setExcludedRows(prev => [
+  function addIgnore() {
+    setIgnoreRows(prev => [
       ...prev,
       {
         topicId: "",
         reason: "",
-        localKey: nextExclusionKey(),
+        localKey: nextIgnoreKey(),
       },
     ]);
   }
 
-  function removeExclusion(localKey: string) {
-    setExcludedRows(prev => prev.filter(r => r.localKey !== localKey));
+  function removeIgnore(localKey: string) {
+    setIgnoreRows(prev => prev.filter(r => r.localKey !== localKey));
   }
 
-  function updateExclusion(localKey: string, patch: Partial<ExcludedRow>) {
-    setExcludedRows(prev =>
+  function updateIgnore(localKey: string, patch: Partial<IgnoreRow>) {
+    setIgnoreRows(prev =>
       prev.map(r =>
         r.localKey === localKey
           ? {
@@ -122,14 +168,9 @@ export function ScopeTab({
   }
 
   async function handleSave() {
-    const cleanedExcluded = excludedRows
-      .filter(r => r.topicId)
-      .map(r => ({
-        topicId: r.topicId,
-        reason: r.reason.trim() || null,
-      }));
+    const cleaned = ignoreRows.filter(r => r.topicId);
     const seen = new Set<string>();
-    const dedupedExcluded = cleanedExcluded.filter((r) => {
+    const deduped = cleaned.filter((r) => {
       if (seen.has(r.topicId)) return false;
       seen.add(r.topicId);
       return true;
@@ -143,13 +184,49 @@ export function ScopeTab({
         withinScopeDescription: withinDescription.trim() || null,
         outOfScopeDescription: outDescription.trim() || null,
         withinScopeTopicIds: withinTopicIds,
-        excludedTopics: dedupedExcluded,
       });
+
+      // Reconcile ignore blips against the server's current ignored blips.
+      const serverIgnore = buildIgnoreRows(radar);
+      const serverById = new Map(serverIgnore.map(b => [b.blipId, b]));
+      const keptBlipIds = new Set(
+        deduped.map(r => r.blipId).filter((x): x is string => Boolean(x)),
+      );
+      for (const b of serverIgnore) {
+        if (b.blipId && !keptBlipIds.has(b.blipId)) {
+          await deleteRadarBlip(domain.id, b.blipId);
+        }
+      }
+      for (const r of deduped) {
+        const reason = r.reason.trim() || null;
+        if (r.blipId) {
+          const prev = serverById.get(r.blipId);
+          const prevReason = prev?.reason.trim() ? prev.reason.trim() : null;
+          if (prev && prevReason === reason) continue;
+          await upsertRadarBlip(domain.id, r.blipId, {
+            topicId: r.topicId,
+            description: reason,
+            quadrantId: null,
+            ringId: null,
+            isIgnored: true,
+          });
+        }
+        else {
+          await createRadarBlip(domain.id, {
+            topicId: r.topicId,
+            description: reason,
+            quadrantId: null,
+            ringId: null,
+            isIgnored: true,
+          });
+        }
+      }
+
       lastSavedRef.current = {
         withinDescription,
         outDescription,
         withinTopicIds,
-        excludedRows: excludedRows.slice(),
+        ignoreRows: deduped.slice(),
       };
       onChangeStateChange?.(false);
       await onSaved();
@@ -191,7 +268,7 @@ export function ScopeTab({
             <label className="text-xs uppercase">Topics</label>
             <TopicMultiSelect
               options={topics
-                .filter(t => !usedExclusionTopicIds.has(t.id))
+                .filter(t => !usedIgnoreTopicIds.has(t.id))
                 .map(t => ({
                   value: t.id,
                   label: t.name,
@@ -205,10 +282,11 @@ export function ScopeTab({
 
         <div className="flex flex-col gap-3 rounded-md border p-4">
           <div className="flex flex-col gap-1">
-            <h3 className="text-xl font-semibold">Out of Scope</h3>
+            <h3 className="text-xl font-semibold">Out of Scope (Ignored)</h3>
             <p className="text-sm text-muted-foreground">
-              Topics listed here are excluded from the radar. Each can include
-              an optional reason explaining why.
+              Topics listed here are ignored — kept off the radar circle and
+              shown in the radar&apos;s Ignored list. Each can include an
+              optional reason explaining why.
             </p>
           </div>
           <div className="flex flex-col gap-1">
@@ -220,7 +298,7 @@ export function ScopeTab({
             />
           </div>
           <ul className="flex flex-col gap-3">
-            {excludedRows.map(row => (
+            {ignoreRows.map(row => (
               <li
                 key={row.localKey}
                 className="flex flex-col gap-2 rounded-sm border p-3"
@@ -238,7 +316,7 @@ export function ScopeTab({
                     <Select
                       value={row.topicId}
                       onValueChange={value =>
-                        updateExclusion(row.localKey, {
+                        updateIgnore(row.localKey, {
                           topicId: value,
                         })}
                     >
@@ -250,8 +328,9 @@ export function ScopeTab({
                           .filter(
                             t =>
                               t.id === row.topicId
-                              || (!usedExclusionTopicIds.has(t.id)
-                                && !withinTopicIds.includes(t.id)),
+                              || (!usedIgnoreTopicIds.has(t.id)
+                                && !withinTopicIds.includes(t.id)
+                                && !onRadarTopicIds.has(t.id)),
                           )
                           .map(t => (
                             <SelectItem
@@ -269,8 +348,8 @@ export function ScopeTab({
                       type="button"
                       variant="ghost"
                       size="icon"
-                      onClick={() => removeExclusion(row.localKey)}
-                      aria-label="Remove excluded topic"
+                      onClick={() => removeIgnore(row.localKey)}
+                      aria-label="Remove ignored topic"
                     >
                       <TrashIcon />
                     </Button>
@@ -283,7 +362,7 @@ export function ScopeTab({
                   <Textarea
                     value={row.reason}
                     onChange={e =>
-                      updateExclusion(row.localKey, {
+                      updateIgnore(row.localKey, {
                         reason: e.target.value,
                       })}
                     placeholder="Why should the radar ignore this topic?"
@@ -296,11 +375,11 @@ export function ScopeTab({
             <Button
               type="button"
               variant="outline"
-              onClick={addExclusion}
+              onClick={addIgnore}
             >
               <PlusIcon />
               {" "}
-              Add Excluded Topic
+              Add Ignored Topic
             </Button>
           </div>
         </div>

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -328,6 +328,7 @@ function ExistingDomainEdit({
           <TabsContent value="scope">
             <ScopeTab
               domain={domain}
+              radar={radar}
               topics={topics ?? []}
               onSaved={handleSaved}
               onChangeStateChange={setScopeHasChanges}

--- a/packages/client/src/routes/domains.$id.radar.index.tsx
+++ b/packages/client/src/routes/domains.$id.radar.index.tsx
@@ -51,6 +51,7 @@ function RadarView() {
         description: description.trim() ? description.trim() : null,
         quadrantId: blip.quadrantId,
         ringId: blip.ringId,
+        isIgnored: blip.isIgnored ?? false,
       });
     },
     onSuccess: async () => {

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -325,6 +325,7 @@ interface BlipPayload {
   description?: string | null;
   quadrantId?: string | null;
   ringId?: string | null;
+  isIgnored?: boolean | null;
 }
 
 export async function createRadarBlip(

--- a/packages/middleware/src/db/clearData.ts
+++ b/packages/middleware/src/db/clearData.ts
@@ -2,7 +2,6 @@ import {
   courseProviders,
   resources,
   resourceTags,
-  domainExcludedTopics,
   domains,
   domainWithinScopeTopics,
   interactions,
@@ -35,7 +34,6 @@ export async function clearData() {
   await db.delete(moduleGroups);
   await db.delete(topicsToResources);
   await db.delete(radarBlips);
-  await db.delete(domainExcludedTopics);
   await db.delete(domainWithinScopeTopics);
   await db.delete(topics);
   await db.delete(resources);

--- a/packages/middleware/src/db/migrateIgnoreBlips.ts
+++ b/packages/middleware/src/db/migrateIgnoreBlips.ts
@@ -1,0 +1,57 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "@/db/index";
+
+type ExistsRow = { exists: boolean } & Record<string, unknown>;
+
+// Idempotent runtime migration that turns "out of scope" topics into ignored
+// radar blips:
+//   - adds `radar_blips.is_ignored` (a blip category, decoupled from rings)
+//   - backfills the legacy `domain_excluded_topics` rows as ignored blips,
+//     carrying the exclusion `reason` over to the blip `description`
+//   - drops the now-empty `domain_excluded_topics` table
+export async function migrateIgnoreBlips() {
+  // Skip on a fresh DB where drizzle-kit push hasn't created tables yet — the
+  // column ships in the schema, so push creates it for us.
+  const blipsTableExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_name = 'radar_blips'
+    ) AS exists
+  `);
+  if (!blipsTableExists.rows[0]?.exists) {
+    return;
+  }
+
+  await db.execute(sql`
+    ALTER TABLE radar_blips
+    ADD COLUMN IF NOT EXISTS is_ignored BOOLEAN NOT NULL DEFAULT false
+  `);
+
+  const excludedTableExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_name = 'domain_excluded_topics'
+    ) AS exists
+  `);
+  if (!excludedTableExists.rows[0]?.exists) {
+    return;
+  }
+
+  await db.transaction(async (tx) => {
+    // Backfill an ignored blip per excluded topic that isn't already a blip.
+    // A topic that is both excluded and already placed on the radar is
+    // contradictory data; keep the existing blip and skip the exclusion.
+    await tx.execute(sql`
+      INSERT INTO radar_blips (id, domain_id, topic_id, quadrant_id, ring_id, description, is_ignored)
+      SELECT gen_random_uuid()::text, det.domain_id, det.topic_id, NULL, NULL, det.reason, true
+      FROM domain_excluded_topics det
+      WHERE NOT EXISTS (
+        SELECT 1 FROM radar_blips b
+        WHERE b.domain_id = det.domain_id AND b.topic_id = det.topic_id
+      )
+    `);
+
+    await tx.execute(sql`DROP TABLE domain_excluded_topics`);
+  });
+}

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -628,7 +628,6 @@ export const topicsRelations = relations(topics, ({
 }) => ({
   topicsToResources: many(topicsToResources),
   radarBlips: many(radarBlips),
-  domainExclusions: many(domainExcludedTopics),
   domainWithinScope: many(domainWithinScopeTopics),
   topicsToTags: many(topicsToTags),
   tasks: many(tasks),
@@ -665,43 +664,8 @@ export const domainsRelations = relations(domains, ({
   many,
 }) => ({
   radarBlips: many(radarBlips),
-  excludedTopics: many(domainExcludedTopics),
   withinScopeTopics: many(domainWithinScopeTopics),
 }));
-
-export const domainExcludedTopics = pgTable(
-  "domain_excluded_topics",
-  {
-    topicId: varchar("topic_id")
-      .notNull()
-      .references(() => topics.id),
-    domainId: varchar("domain_id")
-      .notNull()
-      .references(() => domains.id),
-    reason: varchar(),
-  },
-  t => [
-    primaryKey({
-      columns: [t.topicId, t.domainId],
-    }),
-  ],
-);
-
-export const domainExcludedTopicsRelations = relations(
-  domainExcludedTopics,
-  ({
-    one,
-  }) => ({
-    topic: one(topics, {
-      fields: [domainExcludedTopics.topicId],
-      references: [topics.id],
-    }),
-    domain: one(domains, {
-      fields: [domainExcludedTopics.domainId],
-      references: [domains.id],
-    }),
-  }),
-);
 
 export const domainWithinScopeTopics = pgTable(
   "domain_within_scope_topics",
@@ -833,6 +797,10 @@ export const radarBlips = pgTable(
       .notNull()
       .references(() => topics.id),
     description: varchar(),
+    // Marks the topic as "ignored" / out of scope for this domain. Ignored
+    // blips are kept off the radar circle and listed in their own section.
+    // Their `description` holds the ignore reasoning.
+    isIgnored: boolean("is_ignored").notNull().default(false),
   },
   t => [
     unique("radar_blips_domain_topic_unique").on(t.domainId, t.topicId),

--- a/packages/middleware/src/db/startup.ts
+++ b/packages/middleware/src/db/startup.ts
@@ -2,6 +2,7 @@ import { db } from "@/db/index";
 import { resources } from "@/db/schema";
 import { migrateConsolidateRadar } from "./migrateConsolidateRadar.ts";
 import { migrateCoursesToResources } from "./migrateCoursesToResources.ts";
+import { migrateIgnoreBlips } from "./migrateIgnoreBlips.ts";
 import { migrateModuleLength } from "./migrateModuleLength.ts";
 import { migrateRadarBlips } from "./migrateRadarBlips.ts";
 import { migrateTasksToResources } from "./migrateTasksToResources.ts";
@@ -32,6 +33,14 @@ export async function runMigrations() {
   }
   catch (err) {
     console.error("Failed to consolidate domain/radar:", err);
+    throw err;
+  }
+
+  try {
+    await migrateIgnoreBlips();
+  }
+  catch (err) {
+    console.error("Failed to migrate ignored blips:", err);
     throw err;
   }
 

--- a/packages/middleware/src/routes/api/domains/createBlip.ts
+++ b/packages/middleware/src/routes/api/domains/createBlip.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db";
 import { radarBlips } from "@/db/schema";
 import { sendConflict } from "@/utils/errors";
-import { nullableString } from "@/utils/schemas";
+import { nullableBoolean, nullableString } from "@/utils/schemas";
 
 const createBlipSchema = {
   schema: {
@@ -28,6 +28,7 @@ const createBlipSchema = {
         description: nullableString,
         quadrantId: nullableString,
         ringId: nullableString,
+        isIgnored: nullableBoolean,
       },
     },
   },
@@ -63,6 +64,7 @@ export default async function (server: FastifyInstance) {
         ringId: body.ringId ?? null,
         topicId: body.topicId,
         description: body.description ?? null,
+        isIgnored: body.isIgnored ?? false,
       });
 
       return {

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -2,7 +2,6 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import {
-  domainExcludedTopics,
   domains,
   domainWithinScopeTopics,
 } from "@/db/schema";
@@ -29,19 +28,6 @@ const createSchema = {
           type: "array",
           items: {
             type: "string",
-          },
-        },
-        excludedTopics: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["topicId"],
-            properties: {
-              topicId: {
-                type: "string",
-              },
-              reason: nullableString,
-            },
           },
         },
         withinScopeTopicIds: {
@@ -80,22 +66,6 @@ export default async function (server: FastifyInstance) {
       const uniqueTopicIds = Array.from(new Set(body.topicIds ?? []));
       if (uniqueTopicIds.length > 0) {
         await syncDomainMembershipByDomain(id, uniqueTopicIds);
-      }
-
-      const dedupedExcluded = new Map<string, string | null>();
-      for (const entry of body.excludedTopics ?? []) {
-        if (!dedupedExcluded.has(entry.topicId)) {
-          dedupedExcluded.set(entry.topicId, entry.reason ?? null);
-        }
-      }
-      if (dedupedExcluded.size > 0) {
-        await db.insert(domainExcludedTopics).values(
-          Array.from(dedupedExcluded.entries()).map(([topicId, reason]) => ({
-            topicId,
-            domainId: id,
-            reason,
-          })),
-        );
       }
 
       const uniqueWithinScopeTopicIds = Array.from(

--- a/packages/middleware/src/routes/api/domains/deleteDomain.ts
+++ b/packages/middleware/src/routes/api/domains/deleteDomain.ts
@@ -1,5 +1,4 @@
 import {
-  domainExcludedTopics,
   domains,
   domainWithinScopeTopics,
   radarBlips,
@@ -14,10 +13,6 @@ export default createDeleteHandler({
     {
       table: radarBlips,
       foreignKey: radarBlips.domainId,
-    },
-    {
-      table: domainExcludedTopics,
-      foreignKey: domainExcludedTopics.domainId,
     },
     {
       table: domainWithinScopeTopics,

--- a/packages/middleware/src/routes/api/domains/duplicateDomain.ts
+++ b/packages/middleware/src/routes/api/domains/duplicateDomain.ts
@@ -2,7 +2,6 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import {
-  domainExcludedTopics,
   domains,
   domainWithinScopeTopics,
   radarBlips,
@@ -35,7 +34,6 @@ export default async function (server: FastifyInstance) {
         }) => eq(d.id, id),
         with: {
           radarBlips: true,
-          excludedTopics: true,
           withinScopeTopics: true,
         },
       });
@@ -61,18 +59,10 @@ export default async function (server: FastifyInstance) {
         quadrantId: b.quadrantId,
         ringId: b.ringId,
         description: b.description ?? null,
+        isIgnored: b.isIgnored ?? false,
       }));
       if (blipCopies.length > 0) {
         await db.insert(radarBlips).values(blipCopies);
-      }
-
-      const exclusions = (source.excludedTopics ?? []).map(e => ({
-        topicId: e.topicId,
-        domainId: newId,
-        reason: e.reason ?? null,
-      }));
-      if (exclusions.length > 0) {
-        await db.insert(domainExcludedTopics).values(exclusions);
       }
 
       const withinScopeLinks = (source.withinScopeTopics ?? []).map(w => ({

--- a/packages/middleware/src/routes/api/domains/getDomain.ts
+++ b/packages/middleware/src/routes/api/domains/getDomain.ts
@@ -48,16 +48,6 @@ export default async function (server: FastifyInstance) {
               },
             },
           },
-          excludedTopics: {
-            with: {
-              topic: {
-                columns: {
-                  id: true,
-                  name: true,
-                },
-              },
-            },
-          },
           withinScopeTopics: {
             with: {
               topic: {
@@ -76,7 +66,12 @@ export default async function (server: FastifyInstance) {
         return sendNotFound(reply, "Domain");
       }
 
+      // Ignored blips are "out of scope" topics — keep them out of the
+      // domain's topic list (so they don't surface as "not on radar") and
+      // expose them separately as excludedTopics, with the blip description
+      // serving as the ignore reasoning.
       const topics = (domain.radarBlips ?? [])
+        .filter(blip => !blip.isIgnored)
         .map((blip) => {
           const topic = blip.topic;
           if (!topic) {
@@ -102,15 +97,16 @@ export default async function (server: FastifyInstance) {
         })
         .filter((t): t is NonNullable<typeof t> => Boolean(t));
 
-      const excludedTopics = (domain.excludedTopics ?? [])
-        .map((row) => {
-          if (!row.topic) {
+      const excludedTopics = (domain.radarBlips ?? [])
+        .filter(blip => blip.isIgnored)
+        .map((blip) => {
+          if (!blip.topic) {
             return null;
           }
           return {
-            id: row.topic.id,
-            name: row.topic.name,
-            reason: row.reason ?? null,
+            id: blip.topic.id,
+            name: blip.topic.name,
+            reason: blip.description ?? null,
           };
         })
         .filter((row): row is NonNullable<typeof row> => Boolean(row));

--- a/packages/middleware/src/routes/api/domains/getRadar.ts
+++ b/packages/middleware/src/routes/api/domains/getRadar.ts
@@ -70,6 +70,7 @@ export default async function (server: FastifyInstance) {
           topicId: b.topicId,
           topicName: b.topic?.name ?? "",
           description: b.description,
+          isIgnored: b.isIgnored ?? false,
         })),
       };
 

--- a/packages/middleware/src/routes/api/domains/upsertBlip.ts
+++ b/packages/middleware/src/routes/api/domains/upsertBlip.ts
@@ -2,7 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { radarBlips } from "@/db/schema";
-import { nullableString } from "@/utils/schemas";
+import { nullableBoolean, nullableString } from "@/utils/schemas";
 
 const upsertBlipSchema = {
   schema: {
@@ -29,6 +29,7 @@ const upsertBlipSchema = {
         description: nullableString,
         quadrantId: nullableString,
         ringId: nullableString,
+        isIgnored: nullableBoolean,
       },
     },
   },
@@ -55,6 +56,7 @@ export default async function (server: FastifyInstance) {
           ringId: body.ringId ?? null,
           topicId: body.topicId,
           description: body.description ?? null,
+          isIgnored: body.isIgnored ?? false,
         })
         .onConflictDoUpdate({
           target: radarBlips.id,
@@ -63,6 +65,7 @@ export default async function (server: FastifyInstance) {
             ringId: body.ringId ?? null,
             topicId: body.topicId,
             description: body.description ?? null,
+            isIgnored: body.isIgnored ?? false,
           },
         });
 

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -2,7 +2,6 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import {
-  domainExcludedTopics,
   domains,
   domainWithinScopeTopics,
 } from "@/db/schema";
@@ -30,19 +29,6 @@ const upsertSchema = {
           type: "array",
           items: {
             type: "string",
-          },
-        },
-        excludedTopics: {
-          type: "array",
-          items: {
-            type: "object",
-            required: ["topicId"],
-            properties: {
-              topicId: {
-                type: "string",
-              },
-              reason: nullableString,
-            },
           },
         },
         withinScopeTopicIds: {
@@ -95,25 +81,6 @@ export default async function (server: FastifyInstance) {
 
       if (body.topicIds !== undefined) {
         await syncDomainMembershipByDomain(id, Array.from(new Set(body.topicIds)));
-      }
-
-      if (body.excludedTopics !== undefined) {
-        const dedup = new Map<string, string | null>();
-        for (const entry of body.excludedTopics) {
-          if (!dedup.has(entry.topicId)) {
-            dedup.set(entry.topicId, entry.reason ?? null);
-          }
-        }
-        await syncJunctionTable(
-          domainExcludedTopics,
-          domainExcludedTopics.domainId,
-          id,
-          Array.from(dedup.entries()).map(([topicId, reason]) => ({
-            topicId,
-            domainId: id,
-            reason,
-          })),
-        );
       }
 
       if (body.withinScopeTopicIds !== undefined) {

--- a/packages/middleware/src/routes/api/topics/bulkDeleteTopics.ts
+++ b/packages/middleware/src/routes/api/topics/bulkDeleteTopics.ts
@@ -4,7 +4,6 @@ import { inArray } from "drizzle-orm";
 
 import { db } from "@/db";
 import {
-  domainExcludedTopics,
   domainWithinScopeTopics,
   radarBlips,
   topics,
@@ -40,9 +39,6 @@ export default async function (server: FastifyInstance) {
     await db
       .delete(topicsToResources)
       .where(inArray(topicsToResources.topicId, ids));
-    await db
-      .delete(domainExcludedTopics)
-      .where(inArray(domainExcludedTopics.topicId, ids));
     await db
       .delete(domainWithinScopeTopics)
       .where(inArray(domainWithinScopeTopics.topicId, ids));

--- a/packages/middleware/src/routes/api/topics/deleteTopic.ts
+++ b/packages/middleware/src/routes/api/topics/deleteTopic.ts
@@ -1,5 +1,4 @@
 import {
-  domainExcludedTopics,
   domainWithinScopeTopics,
   radarBlips,
   topics,
@@ -24,10 +23,6 @@ export default createDeleteHandler({
     {
       table: topicsToTags,
       foreignKey: topicsToTags.topicId,
-    },
-    {
-      table: domainExcludedTopics,
-      foreignKey: domainExcludedTopics.topicId,
     },
     {
       table: domainWithinScopeTopics,

--- a/packages/types/src/Radar.ts
+++ b/packages/types/src/Radar.ts
@@ -16,6 +16,7 @@ export interface RadarBlip {
   topicId: string;
   topicName: string;
   description?: string | null;
+  isIgnored?: boolean;
 }
 
 export interface Radar {


### PR DESCRIPTION
Resolves #202.

Makes **"Ignore" a first-class blip category** via a new `radar_blips.is_ignored` flag (decoupled from rings, so it's always available — unlike "Adopted", which is ring-gated). The blip's existing `description` holds the ignore reasoning. This unifies "Ignore" with the old "Out of Scope" list.

## Changes

- **Migration** (`migrateIgnoreBlips.ts`, wired into `startup.ts` after `migrateConsolidateRadar`): backfills the legacy `domain_excluded_topics` rows into ignored blips (reason → blip `description`), then drops the table. A topic already placed on the radar keeps its existing blip (collision skipped). Idempotent, following the existing `migrateConsolidateRadar` pattern.
- **Radar chart**: renders an **Ignored** dot-strip below the Adopted strip, with a "Show Ignored dots on radar" toggle and an **Ignored** legend section listing each topic + its reason (inline-editable).
- **Scope tab**: the "Out of Scope" section now adds/edits/removes ignored blips instead of the old junction table.
- **Blip editor**: an "Ignore (out of scope)" toggle in the row edit form, a "Mark as Ignored" / "Move back to radar" row action, and an "Ignored" pill for ignored rows.
- **Backend**: `getDomain` derives `excludedTopics` from ignored blips (and keeps them out of `topics`), so the Domain shape stays stable for the domain page + LLM tab. Removed all `domain_excluded_topics` references from the create/upsert/duplicate/delete domain and topic-delete handlers, `clearData`, and the schema.

## Verification

- Middleware typecheck clean; client typecheck adds **no** new errors (existing failures are pre-existing — confirmed identical with changes stashed). ESLint clean; client `vite build` succeeds.
- Ran the **real migration** against a local Postgres: excluded topics became ignored blips (with reason/null), the on-radar collision was skipped, the table was dropped, and a second run was a no-op.
- A fresh `drizzle-kit push` produces `radar_blips.is_ignored` (boolean, not null, default false) with no `domain_excluded_topics`.
- Booted the middleware + seeded DB and exercised the API: creating an ignore blip surfaces it in `getRadar` (`isIgnored: true` + reason), in `getDomain.excludedTopics` with its reason, and excluded from `getDomain.topics`.

https://claude.ai/code/session_012DScLiFf32FoRfzXEkNHoh

---
_Generated by [Claude Code](https://claude.ai/code/session_012DScLiFf32FoRfzXEkNHoh)_