### PR TITLE
Add a Routines resource (weekly per-topic plans)

### DIFF
--- a/packages/client/src/components/boxes/RoutineBox.tsx
+++ b/packages/client/src/components/boxes/RoutineBox.tsx
@@ -1,0 +1,142 @@
+import type { Routine, RoutineWeekday } from "@emstack/types/src";
+
+import { Link } from "@tanstack/react-router";
+
+import { Description } from "@/components/boxElements/Description";
+import { EntityLink } from "@/components/boxElements/EntityLink";
+import {
+  ContentBox,
+  ContentBoxBody,
+  ContentBoxFooter,
+  ContentBoxHeader,
+  ContentBoxHeaderBar,
+  ContentBoxTitle,
+} from "@/components/boxes/ContentBox";
+import { cn } from "@/lib/utils";
+
+// Monday-first display order with single-letter labels.
+const DAY_STRIP: { day: RoutineWeekday;
+  letter: string; }[] = [
+  {
+    day: "1",
+    letter: "M",
+  },
+  {
+    day: "2",
+    letter: "T",
+  },
+  {
+    day: "3",
+    letter: "W",
+  },
+  {
+    day: "4",
+    letter: "T",
+  },
+  {
+    day: "5",
+    letter: "F",
+  },
+  {
+    day: "6",
+    letter: "S",
+  },
+  {
+    day: "0",
+    letter: "S",
+  },
+];
+
+export function RoutineBox({
+  id,
+  name,
+  description,
+  topic,
+  status,
+  weekly,
+}: Routine) {
+  const scheduledCount = weekly
+    ? Object.values(weekly).filter(Boolean).length
+    : 0;
+  const isActive = status === "active";
+
+  return (
+    <ContentBox>
+      <ContentBoxHeader>
+        <ContentBoxHeaderBar>
+          <div className="flex flex-row items-center gap-2">
+            {topic
+              ? (
+                <EntityLink
+                  entity="topics"
+                  id={topic.id}
+                  className={`
+                    rounded-sm bg-gray-50 px-2 py-0.5 text-xs
+                    hover:bg-gray-900 hover:text-white
+                  `}
+                >
+                  {topic.name}
+                </EntityLink>
+              )
+              : (
+                <span className="text-xs text-muted-foreground italic">
+                  No topic
+                </span>
+              )}
+          </div>
+          <span
+            className={cn(
+              "rounded-sm px-2 py-0.5 text-xs capitalize",
+              isActive
+                ? "bg-green-600 text-white"
+                : "bg-gray-200 text-gray-700",
+            )}
+          >
+            {status ?? "active"}
+          </span>
+        </ContentBoxHeaderBar>
+        <ContentBoxTitle>
+          <h3 className="text-xl">
+            <Link
+              to="/routines/$id"
+              params={{
+                id,
+              }}
+              className="hover:text-blue-600"
+            >
+              {name}
+            </Link>
+          </h3>
+        </ContentBoxTitle>
+      </ContentBoxHeader>
+      <ContentBoxBody>
+        <Description description={description} />
+      </ContentBoxBody>
+      <ContentBoxFooter>
+        <div
+          className="flex flex-row gap-1"
+          title={`${scheduledCount} day${scheduledCount === 1 ? "" : "s"} scheduled`}
+        >
+          {DAY_STRIP.map(({
+            day, letter,
+          }, index) => {
+            const scheduled = !!weekly?.[day];
+            return (
+              <span
+                key={`${day}-${index}`}
+                className={cn(
+                  "flex size-5 items-center justify-center rounded-full text-xs",
+                  scheduled
+                    ? "bg-blue-600 font-bold text-white"
+                    : "bg-gray-100 text-gray-400",
+                )}
+              >
+                {letter}
+              </span>
+            );
+          })}
+        </div>
+      </ContentBoxFooter>
+    </ContentBox>
+  );
+}

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   pageTitle?: string;
-  pageSection?: "" | "resources" | "topics" | "providers" | "domains" | "dailies" | "tasks";
+  pageSection?: "" | "resources" | "topics" | "providers" | "domains" | "dailies" | "routines" | "tasks";
   children?: React.ReactNode;
   progressCurrent?: number;
   progressTotal?: number;
@@ -71,6 +71,14 @@ export function PageHeader({
                   className="text-sm uppercase"
                 >
                   Dailies
+                </Link>
+              )}
+              {pageSection === "routines" && (
+                <Link
+                  to="/routines"
+                  className="text-sm uppercase"
+                >
+                  Routines
                 </Link>
               )}
               {pageSection === "tasks" && (

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -1,0 +1,134 @@
+import type { WeeklyRow, WeeklyRowType } from "@/components/routines/weekly";
+import type { RoutineWeekday } from "@emstack/types/src";
+
+import { useMemo } from "react";
+
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/combobox";
+import { DAY_LABELS, DAY_ORDER } from "@/components/routines/weekly";
+
+interface ItemOption {
+  value: string;
+  label: string;
+}
+
+interface WeeklyScheduleFieldProps {
+  value: WeeklyRow[];
+  onChange: (next: WeeklyRow[]) => void;
+  taskOptions: ItemOption[];
+  resourceOptions: ItemOption[];
+}
+
+export function WeeklyScheduleField({
+  value,
+  onChange,
+  taskOptions,
+  resourceOptions,
+}: WeeklyScheduleFieldProps) {
+  const rowsByDay = useMemo(
+    () => new Map(value.map(r => [r.day, r])),
+    [value],
+  );
+
+  function update(day: RoutineWeekday, patch: Partial<WeeklyRow>) {
+    onChange(value.map(r => (r.day === day
+      ? {
+        ...r,
+        ...patch,
+      }
+      : r)));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ul className="flex flex-col gap-2">
+        {DAY_ORDER.map((day) => {
+          const row = rowsByDay.get(day) ?? {
+            day,
+            type: "" as WeeklyRowType,
+            id: "",
+          };
+          const itemOptions
+            = row.type === "task"
+              ? taskOptions
+              : row.type === "resource"
+                ? resourceOptions
+                : [];
+          const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
+
+          return (
+            <li
+              key={day}
+              className="
+                grid grid-cols-[110px_140px_1fr] items-center gap-2 rounded-md
+                border bg-background px-2 py-1.5
+              "
+            >
+              <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
+
+              <select
+                aria-label={`${DAY_LABELS[day]} type`}
+                value={row.type}
+                onChange={(e) => {
+                  // Changing the type clears the chosen item (different
+                  // option set).
+                  update(day, {
+                    type: e.target.value as WeeklyRowType,
+                    id: "",
+                  });
+                }}
+                className="
+                  flex h-9 w-full rounded-md border bg-background px-2 text-sm
+                "
+              >
+                <option value="">— None —</option>
+                <option value="task">Task</option>
+                <option value="resource">Resource</option>
+              </select>
+
+              <Combobox
+                items={itemOptions.map(o => o.value)}
+                value={row.id || null}
+                onValueChange={val => update(day, {
+                  id: val ?? "",
+                })}
+                itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+              >
+                <ComboboxInput
+                  placeholder={
+                    row.type === "task"
+                      ? "Search tasks..."
+                      : row.type === "resource"
+                        ? "Search resources..."
+                        : "Pick a type first"
+                  }
+                  showClear
+                  disabled={!row.type}
+                />
+                <ComboboxContent>
+                  <ComboboxEmpty>No items found.</ComboboxEmpty>
+                  <ComboboxList>
+                    {(val: string) => (
+                      <ComboboxItem
+                        key={val}
+                        value={val}
+                      >
+                        {optionsMap.get(val) ?? val}
+                      </ComboboxItem>
+                    )}
+                  </ComboboxList>
+                </ComboboxContent>
+              </Combobox>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -1,0 +1,56 @@
+import type { RoutineWeekday, RoutineWeekly } from "@emstack/types/src";
+
+export type WeeklyRowType = "" | "task" | "resource";
+
+export interface WeeklyRow {
+  day: RoutineWeekday;
+  // "" = no entry scheduled for this day.
+  type: WeeklyRowType;
+  id: string;
+}
+
+// Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.
+const ALL_DAYS: RoutineWeekday[] = ["0", "1", "2", "3", "4", "5", "6"];
+
+// Display order is Monday-first; storage stays keyed by getDay() number.
+export const DAY_ORDER: RoutineWeekday[] = ["1", "2", "3", "4", "5", "6", "0"];
+
+export const DAY_LABELS: Record<RoutineWeekday, string> = {
+  0: "Sunday",
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+};
+
+// Build the fixed length-7 row array the form holds, defaulting from an
+// existing routine's weekly object (empty days become blank rows).
+export function weeklyToRows(
+  weekly: RoutineWeekly | null | undefined,
+): WeeklyRow[] {
+  return ALL_DAYS.map((day) => {
+    const entry = weekly?.[day];
+    return {
+      day,
+      type: entry?.type ?? "",
+      id: entry?.id ?? "",
+    };
+  });
+}
+
+// Serialize rows back to the weekly object, dropping days without a complete
+// {type, id} pair.
+export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
+  const weekly: RoutineWeekly = {};
+  for (const row of rows) {
+    if ((row.type === "task" || row.type === "resource") && row.id) {
+      weekly[row.day] = {
+        type: row.type,
+        id: row.id,
+      };
+    }
+  }
+  return weekly;
+}

--- a/packages/client/src/routeTree.gen.ts
+++ b/packages/client/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as TopicsRouteImport } from './routes/topics'
 import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RoutinesRouteImport } from './routes/routines'
 import { Route as ResourcesRouteImport } from './routes/resources'
 import { Route as ProvidersRouteImport } from './routes/providers'
 import { Route as OnboardRouteImport } from './routes/onboard'
@@ -21,24 +22,28 @@ import { Route as DailiesRouteImport } from './routes/dailies'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsIndexRouteImport } from './routes/topics.index'
 import { Route as TasksIndexRouteImport } from './routes/tasks.index'
+import { Route as RoutinesIndexRouteImport } from './routes/routines.index'
 import { Route as ResourcesIndexRouteImport } from './routes/resources.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as DomainsIndexRouteImport } from './routes/domains.index'
 import { Route as DailiesIndexRouteImport } from './routes/dailies.index'
 import { Route as TopicsIdRouteImport } from './routes/topics.$id'
 import { Route as TasksIdRouteImport } from './routes/tasks.$id'
+import { Route as RoutinesIdRouteImport } from './routes/routines.$id'
 import { Route as ResourcesIdRouteImport } from './routes/resources.$id'
 import { Route as ProvidersIdRouteImport } from './routes/providers.$id'
 import { Route as DomainsIdRouteImport } from './routes/domains.$id'
 import { Route as DailiesIdRouteImport } from './routes/dailies.$id'
 import { Route as TopicsIdIndexRouteImport } from './routes/topics.$id.index'
 import { Route as TasksIdIndexRouteImport } from './routes/tasks.$id.index'
+import { Route as RoutinesIdIndexRouteImport } from './routes/routines.$id.index'
 import { Route as ResourcesIdIndexRouteImport } from './routes/resources.$id.index'
 import { Route as ProvidersIdIndexRouteImport } from './routes/providers.$id.index'
 import { Route as DomainsIdIndexRouteImport } from './routes/domains.$id.index'
 import { Route as DailiesIdIndexRouteImport } from './routes/dailies.$id.index'
 import { Route as TopicsIdEditRouteImport } from './routes/topics.$id.edit'
 import { Route as TasksIdEditRouteImport } from './routes/tasks.$id.edit'
+import { Route as RoutinesIdEditRouteImport } from './routes/routines.$id.edit'
 import { Route as ResourcesIdEditRouteImport } from './routes/resources.$id.edit'
 import { Route as ProvidersIdEditRouteImport } from './routes/providers.$id.edit'
 import { Route as DomainsIdRadarRouteImport } from './routes/domains.$id.radar'
@@ -60,6 +65,11 @@ const TasksRoute = TasksRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RoutinesRoute = RoutinesRouteImport.update({
+  id: '/routines',
+  path: '/routines',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ResourcesRoute = ResourcesRouteImport.update({
@@ -107,6 +117,11 @@ const TasksIndexRoute = TasksIndexRouteImport.update({
   path: '/',
   getParentRoute: () => TasksRoute,
 } as any)
+const RoutinesIndexRoute = RoutinesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => RoutinesRoute,
+} as any)
 const ResourcesIndexRoute = ResourcesIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -136,6 +151,11 @@ const TasksIdRoute = TasksIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => TasksRoute,
+} as any)
+const RoutinesIdRoute = RoutinesIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => RoutinesRoute,
 } as any)
 const ResourcesIdRoute = ResourcesIdRouteImport.update({
   id: '/$id',
@@ -167,6 +187,11 @@ const TasksIdIndexRoute = TasksIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => TasksIdRoute,
 } as any)
+const RoutinesIdIndexRoute = RoutinesIdIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => RoutinesIdRoute,
+} as any)
 const ResourcesIdIndexRoute = ResourcesIdIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -196,6 +221,11 @@ const TasksIdEditRoute = TasksIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
   getParentRoute: () => TasksIdRoute,
+} as any)
+const RoutinesIdEditRoute = RoutinesIdEditRouteImport.update({
+  id: '/edit',
+  path: '/edit',
+  getParentRoute: () => RoutinesIdRoute,
 } as any)
 const ResourcesIdEditRoute = ResourcesIdEditRouteImport.update({
   id: '/edit',
@@ -241,6 +271,7 @@ export interface FileRoutesByFullPath {
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/resources': typeof ResourcesRouteWithChildren
+  '/routines': typeof RoutinesRouteWithChildren
   '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
@@ -248,12 +279,14 @@ export interface FileRoutesByFullPath {
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/resources/$id': typeof ResourcesIdRouteWithChildren
+  '/routines/$id': typeof RoutinesIdRouteWithChildren
   '/tasks/$id': typeof TasksIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/resources/': typeof ResourcesIndexRoute
+  '/routines/': typeof RoutinesIndexRoute
   '/tasks/': typeof TasksIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
@@ -261,12 +294,14 @@ export interface FileRoutesByFullPath {
   '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/resources/$id/edit': typeof ResourcesIdEditRoute
+  '/routines/$id/edit': typeof RoutinesIdEditRoute
   '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/resources/$id/': typeof ResourcesIdIndexRoute
+  '/routines/$id/': typeof RoutinesIdIndexRoute
   '/tasks/$id/': typeof TasksIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
@@ -281,18 +316,21 @@ export interface FileRoutesByTo {
   '/domains': typeof DomainsIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/resources': typeof ResourcesIndexRoute
+  '/routines': typeof RoutinesIndexRoute
   '/tasks': typeof TasksIndexRoute
   '/topics': typeof TopicsIndexRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
   '/domains/$id/edit': typeof DomainsIdEditRoute
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/resources/$id/edit': typeof ResourcesIdEditRoute
+  '/routines/$id/edit': typeof RoutinesIdEditRoute
   '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/dailies/$id': typeof DailiesIdIndexRoute
   '/domains/$id': typeof DomainsIdIndexRoute
   '/providers/$id': typeof ProvidersIdIndexRoute
   '/resources/$id': typeof ResourcesIdIndexRoute
+  '/routines/$id': typeof RoutinesIdIndexRoute
   '/tasks/$id': typeof TasksIdIndexRoute
   '/topics/$id': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
@@ -307,6 +345,7 @@ export interface FileRoutesById {
   '/onboard': typeof OnboardRoute
   '/providers': typeof ProvidersRouteWithChildren
   '/resources': typeof ResourcesRouteWithChildren
+  '/routines': typeof RoutinesRouteWithChildren
   '/settings': typeof SettingsRoute
   '/tasks': typeof TasksRouteWithChildren
   '/topics': typeof TopicsRouteWithChildren
@@ -314,12 +353,14 @@ export interface FileRoutesById {
   '/domains/$id': typeof DomainsIdRouteWithChildren
   '/providers/$id': typeof ProvidersIdRouteWithChildren
   '/resources/$id': typeof ResourcesIdRouteWithChildren
+  '/routines/$id': typeof RoutinesIdRouteWithChildren
   '/tasks/$id': typeof TasksIdRouteWithChildren
   '/topics/$id': typeof TopicsIdRouteWithChildren
   '/dailies/': typeof DailiesIndexRoute
   '/domains/': typeof DomainsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/resources/': typeof ResourcesIndexRoute
+  '/routines/': typeof RoutinesIndexRoute
   '/tasks/': typeof TasksIndexRoute
   '/topics/': typeof TopicsIndexRoute
   '/dailies/$id/edit': typeof DailiesIdEditRoute
@@ -327,12 +368,14 @@ export interface FileRoutesById {
   '/domains/$id/radar': typeof DomainsIdRadarRouteWithChildren
   '/providers/$id/edit': typeof ProvidersIdEditRoute
   '/resources/$id/edit': typeof ResourcesIdEditRoute
+  '/routines/$id/edit': typeof RoutinesIdEditRoute
   '/tasks/$id/edit': typeof TasksIdEditRoute
   '/topics/$id/edit': typeof TopicsIdEditRoute
   '/dailies/$id/': typeof DailiesIdIndexRoute
   '/domains/$id/': typeof DomainsIdIndexRoute
   '/providers/$id/': typeof ProvidersIdIndexRoute
   '/resources/$id/': typeof ResourcesIdIndexRoute
+  '/routines/$id/': typeof RoutinesIdIndexRoute
   '/tasks/$id/': typeof TasksIdIndexRoute
   '/topics/$id/': typeof TopicsIdIndexRoute
   '/domains/$id/radar/edit': typeof DomainsIdRadarEditRoute
@@ -348,6 +391,7 @@ export interface FileRouteTypes {
     | '/onboard'
     | '/providers'
     | '/resources'
+    | '/routines'
     | '/settings'
     | '/tasks'
     | '/topics'
@@ -355,12 +399,14 @@ export interface FileRouteTypes {
     | '/domains/$id'
     | '/providers/$id'
     | '/resources/$id'
+    | '/routines/$id'
     | '/tasks/$id'
     | '/topics/$id'
     | '/dailies/'
     | '/domains/'
     | '/providers/'
     | '/resources/'
+    | '/routines/'
     | '/tasks/'
     | '/topics/'
     | '/dailies/$id/edit'
@@ -368,12 +414,14 @@ export interface FileRouteTypes {
     | '/domains/$id/radar'
     | '/providers/$id/edit'
     | '/resources/$id/edit'
+    | '/routines/$id/edit'
     | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
     | '/resources/$id/'
+    | '/routines/$id/'
     | '/tasks/$id/'
     | '/topics/$id/'
     | '/domains/$id/radar/edit'
@@ -388,18 +436,21 @@ export interface FileRouteTypes {
     | '/domains'
     | '/providers'
     | '/resources'
+    | '/routines'
     | '/tasks'
     | '/topics'
     | '/dailies/$id/edit'
     | '/domains/$id/edit'
     | '/providers/$id/edit'
     | '/resources/$id/edit'
+    | '/routines/$id/edit'
     | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/dailies/$id'
     | '/domains/$id'
     | '/providers/$id'
     | '/resources/$id'
+    | '/routines/$id'
     | '/tasks/$id'
     | '/topics/$id'
     | '/domains/$id/radar/edit'
@@ -413,6 +464,7 @@ export interface FileRouteTypes {
     | '/onboard'
     | '/providers'
     | '/resources'
+    | '/routines'
     | '/settings'
     | '/tasks'
     | '/topics'
@@ -420,12 +472,14 @@ export interface FileRouteTypes {
     | '/domains/$id'
     | '/providers/$id'
     | '/resources/$id'
+    | '/routines/$id'
     | '/tasks/$id'
     | '/topics/$id'
     | '/dailies/'
     | '/domains/'
     | '/providers/'
     | '/resources/'
+    | '/routines/'
     | '/tasks/'
     | '/topics/'
     | '/dailies/$id/edit'
@@ -433,12 +487,14 @@ export interface FileRouteTypes {
     | '/domains/$id/radar'
     | '/providers/$id/edit'
     | '/resources/$id/edit'
+    | '/routines/$id/edit'
     | '/tasks/$id/edit'
     | '/topics/$id/edit'
     | '/dailies/$id/'
     | '/domains/$id/'
     | '/providers/$id/'
     | '/resources/$id/'
+    | '/routines/$id/'
     | '/tasks/$id/'
     | '/topics/$id/'
     | '/domains/$id/radar/edit'
@@ -453,6 +509,7 @@ export interface RootRouteChildren {
   OnboardRoute: typeof OnboardRoute
   ProvidersRoute: typeof ProvidersRouteWithChildren
   ResourcesRoute: typeof ResourcesRouteWithChildren
+  RoutinesRoute: typeof RoutinesRouteWithChildren
   SettingsRoute: typeof SettingsRoute
   TasksRoute: typeof TasksRouteWithChildren
   TopicsRoute: typeof TopicsRouteWithChildren
@@ -479,6 +536,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/routines': {
+      id: '/routines'
+      path: '/routines'
+      fullPath: '/routines'
+      preLoaderRoute: typeof RoutinesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/resources': {
@@ -544,6 +608,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TasksIndexRouteImport
       parentRoute: typeof TasksRoute
     }
+    '/routines/': {
+      id: '/routines/'
+      path: '/'
+      fullPath: '/routines/'
+      preLoaderRoute: typeof RoutinesIndexRouteImport
+      parentRoute: typeof RoutinesRoute
+    }
     '/resources/': {
       id: '/resources/'
       path: '/'
@@ -585,6 +656,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/tasks/$id'
       preLoaderRoute: typeof TasksIdRouteImport
       parentRoute: typeof TasksRoute
+    }
+    '/routines/$id': {
+      id: '/routines/$id'
+      path: '/$id'
+      fullPath: '/routines/$id'
+      preLoaderRoute: typeof RoutinesIdRouteImport
+      parentRoute: typeof RoutinesRoute
     }
     '/resources/$id': {
       id: '/resources/$id'
@@ -628,6 +706,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TasksIdIndexRouteImport
       parentRoute: typeof TasksIdRoute
     }
+    '/routines/$id/': {
+      id: '/routines/$id/'
+      path: '/'
+      fullPath: '/routines/$id/'
+      preLoaderRoute: typeof RoutinesIdIndexRouteImport
+      parentRoute: typeof RoutinesIdRoute
+    }
     '/resources/$id/': {
       id: '/resources/$id/'
       path: '/'
@@ -669,6 +754,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/tasks/$id/edit'
       preLoaderRoute: typeof TasksIdEditRouteImport
       parentRoute: typeof TasksIdRoute
+    }
+    '/routines/$id/edit': {
+      id: '/routines/$id/edit'
+      path: '/edit'
+      fullPath: '/routines/$id/edit'
+      preLoaderRoute: typeof RoutinesIdEditRouteImport
+      parentRoute: typeof RoutinesIdRoute
     }
     '/resources/$id/edit': {
       id: '/resources/$id/edit'
@@ -848,6 +940,34 @@ const ResourcesRouteWithChildren = ResourcesRoute._addFileChildren(
   ResourcesRouteChildren,
 )
 
+interface RoutinesIdRouteChildren {
+  RoutinesIdEditRoute: typeof RoutinesIdEditRoute
+  RoutinesIdIndexRoute: typeof RoutinesIdIndexRoute
+}
+
+const RoutinesIdRouteChildren: RoutinesIdRouteChildren = {
+  RoutinesIdEditRoute: RoutinesIdEditRoute,
+  RoutinesIdIndexRoute: RoutinesIdIndexRoute,
+}
+
+const RoutinesIdRouteWithChildren = RoutinesIdRoute._addFileChildren(
+  RoutinesIdRouteChildren,
+)
+
+interface RoutinesRouteChildren {
+  RoutinesIdRoute: typeof RoutinesIdRouteWithChildren
+  RoutinesIndexRoute: typeof RoutinesIndexRoute
+}
+
+const RoutinesRouteChildren: RoutinesRouteChildren = {
+  RoutinesIdRoute: RoutinesIdRouteWithChildren,
+  RoutinesIndexRoute: RoutinesIndexRoute,
+}
+
+const RoutinesRouteWithChildren = RoutinesRoute._addFileChildren(
+  RoutinesRouteChildren,
+)
+
 interface TasksIdRouteChildren {
   TasksIdEditRoute: typeof TasksIdEditRoute
   TasksIdIndexRoute: typeof TasksIdIndexRoute
@@ -908,6 +1028,7 @@ const rootRouteChildren: RootRouteChildren = {
   OnboardRoute: OnboardRoute,
   ProvidersRoute: ProvidersRouteWithChildren,
   ResourcesRoute: ResourcesRouteWithChildren,
+  RoutinesRoute: RoutinesRouteWithChildren,
   SettingsRoute: SettingsRoute,
   TasksRoute: TasksRouteWithChildren,
   TopicsRoute: TopicsRouteWithChildren,

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -134,6 +134,13 @@ const RootComponent: React.FunctionComponent = () => {
           >
             Tasks
           </Link>
+
+          <Link
+            to="/routines"
+            className={navLinkClass}
+          >
+            Routines
+          </Link>
         </div>
         <div
           className={`
@@ -222,6 +229,12 @@ const RootComponent: React.FunctionComponent = () => {
                   className="cursor-pointer"
                 >
                   <Link to="/tasks">Tasks</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  asChild
+                  className="cursor-pointer"
+                >
+                  <Link to="/routines">Routines</Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   asChild

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -1,0 +1,324 @@
+import { useMemo, useRef } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { EyeIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { EditPageFooter } from "@/components/layout/EditPageFooter";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { rowsToWeekly, weeklyToRows } from "@/components/routines/weekly";
+import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
+import { Button } from "@/components/ui/button";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import {
+  createRoutine,
+  deleteSingleRoutine,
+  fetchResources,
+  fetchSingleRoutine,
+  fetchTasks,
+  fetchTopics,
+  formHasChanges,
+  toOptions,
+  upsertRoutine,
+} from "@/utils";
+
+interface RoutineEditSearch {
+  topicId?: string;
+}
+
+export const Route = createFileRoute("/routines/$id/edit")({
+  component: SingleRoutineEdit,
+  validateSearch: (search: Record<string, unknown>): RoutineEditSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
+});
+
+const STATUS_OPTIONS = [
+  {
+    value: "active",
+    label: "Active",
+  },
+  {
+    value: "inactive",
+    label: "Inactive",
+  },
+  {
+    value: "complete",
+    label: "Complete",
+  },
+  {
+    value: "paused",
+    label: "Paused",
+  },
+];
+
+const weeklyRowSchema = z
+  .object({
+    day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
+    type: z.enum(["", "task", "resource"]),
+    id: z.string(),
+  })
+  .refine(row => row.type === "" || row.id.length > 0, {
+    message: "Pick an item for this day",
+    path: ["id"],
+  });
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(2000),
+  topicId: z.string(),
+  status: z.enum(["active", "inactive", "complete", "paused"]),
+  weekly: z.array(weeklyRowSchema).length(7),
+});
+
+function SingleRoutineEdit() {
+  const {
+    id,
+  } = Route.useParams();
+  const search = Route.useSearch();
+  const isNew = id === "new";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const skipBlocker = useRef(false);
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["routine", id],
+    queryFn: () => fetchSingleRoutine(id),
+    enabled: !isNew,
+  });
+
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
+  const {
+    data: resources,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchResources(),
+  });
+
+  const topicOptions = toOptions(topics);
+  const taskOptions = useMemo(() => toOptions(tasks), [tasks]);
+  const resourceOptions = useMemo(() => toOptions(resources), [resources]);
+
+  const startingValues = useMemo(
+    () => ({
+      name: data?.name ?? "",
+      description: data?.description ?? "",
+      topicId: data?.topicId ?? (isNew ? (search.topicId ?? "") : ""),
+      status: data?.status ?? "active",
+      weekly: weeklyToRows(data?.weekly),
+    }),
+    [data, isNew, search.topicId],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      const routineData = {
+        name: value.name,
+        description: value.description || null,
+        topicId: value.topicId || null,
+        status: value.status,
+        weekly: rowsToWeekly(value.weekly),
+      };
+
+      try {
+        let routineId: string;
+        if (isNew) {
+          const result = await createRoutine(routineData);
+          routineId = result.id;
+        }
+        else {
+          await upsertRoutine(id, routineData);
+          routineId = id;
+          await queryClient.invalidateQueries({
+            queryKey: ["routine", id],
+          });
+        }
+        await queryClient.invalidateQueries({
+          queryKey: ["routines"],
+        });
+        skipBlocker.current = true;
+        await navigate({
+          to: "/routines/$id",
+          params: {
+            id: routineId,
+          },
+        });
+      }
+      catch {
+        toast.error(
+          isNew
+            ? "Failed to create routine. Please try again."
+            : "Failed to save routine. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  async function handleDelete() {
+    try {
+      await deleteSingleRoutine(id);
+      await queryClient.invalidateQueries({
+        queryKey: ["routines"],
+      });
+      skipBlocker.current = true;
+      await navigate({
+        to: "/routines",
+      });
+    }
+    catch {
+      toast.error("Failed to delete routine. Please try again.");
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={isNew ? "New Routine" : "Edit Routine"}
+        pageSection="routines"
+      >
+        {!isNew && (
+          <Link
+            to="/routines/$id"
+            params={{
+              id,
+            }}
+          >
+            <Button variant="secondary">
+              View Routine
+              {" "}
+              <EyeIcon />
+            </Button>
+          </Link>
+        )}
+      </PageHeader>
+      <div className="m-auto w-full max-w-[1200px] px-4">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex max-w-3xl flex-col gap-8"
+        >
+          <form.AppField name="name">
+            {field => <field.InputField label="Routine Name" />}
+          </form.AppField>
+
+          <form.AppField name="topicId">
+            {field => (
+              <field.ComboboxField
+                label="Topic"
+                options={topicOptions}
+                placeholder="Search topics..."
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="status">
+            {field => (
+              <field.RadioGroupField
+                label="Status"
+                options={STATUS_OPTIONS}
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="description">
+            {field => (
+              <field.TextareaField
+                label="Description"
+                placeholder="What is this routine about?"
+              />
+            )}
+          </form.AppField>
+
+          <form.Field name="weekly">
+            {field => (
+              <div className="flex flex-col gap-1">
+                <span className="text-2xl">Weekly Schedule</span>
+                <WeeklyScheduleField
+                  value={field.state.value}
+                  onChange={next => field.handleChange(next)}
+                  taskOptions={taskOptions}
+                  resourceOptions={resourceOptions}
+                />
+              </div>
+            )}
+          </form.Field>
+
+          <EditPageFooter
+            isNew={isNew}
+            onDelete={handleDelete}
+            deleteLabel="Delete Routine"
+          >
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+            >
+              {isSubmitting && <Loader2 className="animate-spin" />}
+              {isNew ? "Create Routine" : "Save Changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (isNew) {
+                  navigate({
+                    to: "/routines",
+                  });
+                }
+                else {
+                  navigate({
+                    to: "/routines/$id",
+                    params: {
+                      id,
+                    },
+                  });
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </EditPageFooter>
+        </form>
+        <UnsavedChangesDialog
+          shouldBlockFn={() => hasChanges && !skipBlocker.current}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -1,0 +1,182 @@
+import { useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { EditIcon } from "lucide-react";
+
+import { EntityError, EntityPending } from "@/components/EntityStates";
+import { InfoArea } from "@/components/layout/InfoArea";
+import { PageHeader } from "@/components/layout/PageHeader";
+import {
+  DAY_LABELS,
+  DAY_ORDER,
+} from "@/components/routines/weekly";
+import { Button } from "@/components/ui/button";
+import { fetchResources, fetchSingleRoutine, fetchTasks } from "@/utils";
+
+export const Route = createFileRoute("/routines/$id/")({
+  component: SingleRoutine,
+});
+
+function RoutinePending() {
+  return <EntityPending entity="routine" />;
+}
+
+function RoutineError() {
+  return <EntityError entity="routine" />;
+}
+
+function SingleRoutine() {
+  const {
+    id,
+  } = Route.useParams();
+
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["routine", id],
+    queryFn: () => fetchSingleRoutine(id),
+  });
+
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
+  const {
+    data: resources,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchResources(),
+  });
+
+  const taskNames = useMemo(
+    () => new Map((tasks ?? []).map(t => [t.id, t.name])),
+    [tasks],
+  );
+  const resourceNames = useMemo(
+    () => new Map((resources ?? []).map(r => [r.id, r.name])),
+    [resources],
+  );
+
+  if (isPending) {
+    return <RoutinePending />;
+  }
+
+  if (error || !data) {
+    return <RoutineError />;
+  }
+
+  const weekly = data.weekly ?? {};
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle={data.name}
+        pageSection="routines"
+      >
+        <Link
+          to="/routines/$id/edit"
+          params={{
+            id: data.id,
+          }}
+        >
+          <Button variant="secondary">
+            Edit Routine
+            {" "}
+            <EditIcon />
+          </Button>
+        </Link>
+      </PageHeader>
+      <div className="container flex flex-col gap-12">
+        <InfoArea
+          header="Topic"
+          condition={!!data.topic}
+        >
+          <Link
+            to="/topics/$id"
+            params={{
+              id: data.topic?.id ?? "",
+            }}
+            className={`
+              font-bold text-blue-800
+              hover:text-blue-600
+              dark:text-blue-300
+            `}
+          >
+            {data.topic?.name}
+          </Link>
+        </InfoArea>
+        <InfoArea
+          header="Status"
+          condition={true}
+        >
+          <span className="capitalize">{data.status ?? "active"}</span>
+        </InfoArea>
+        <InfoArea
+          header="Description"
+          condition={!!data.description}
+        >
+          <p>{data.description}</p>
+        </InfoArea>
+        <InfoArea
+          header="Weekly Schedule"
+          condition={true}
+        >
+          <ul className="flex flex-col gap-1">
+            {DAY_ORDER.map((day) => {
+              const entry = weekly[day];
+              return (
+                <li
+                  key={day}
+                  className="
+                    grid grid-cols-[120px_1fr] items-center gap-2 border-b
+                    border-border/60 py-1
+                  "
+                >
+                  <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
+                  {entry
+                    ? (
+                      <Link
+                        to={
+                          entry.type === "task"
+                            ? "/tasks/$id"
+                            : "/resources/$id"
+                        }
+                        params={{
+                          id: entry.id,
+                        }}
+                        className="
+                          text-blue-800
+                          hover:text-blue-600
+                          dark:text-blue-300
+                        "
+                      >
+                        <span
+                          className="
+                            mr-2 text-xs text-muted-foreground uppercase
+                          "
+                        >
+                          {entry.type}
+                        </span>
+                        {entry.type === "task"
+                          ? (taskNames.get(entry.id) ?? entry.id)
+                          : (resourceNames.get(entry.id) ?? entry.id)}
+                      </Link>
+                    )
+                    : (
+                      <span className="text-sm text-muted-foreground italic">
+                        Nothing scheduled
+                      </span>
+                    )}
+                </li>
+              );
+            })}
+          </ul>
+        </InfoArea>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/routines.$id.tsx
+++ b/packages/client/src/routes/routines.$id.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/routines/$id")({
+  component: SingleRoutineIndex,
+});
+
+function SingleRoutineIndex() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/routes/routines.index.tsx
+++ b/packages/client/src/routes/routines.index.tsx
@@ -1,0 +1,222 @@
+import type { Routine } from "@emstack/types/src";
+
+import { useMemo, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
+
+import { RoutineBox } from "@/components/boxes/RoutineBox";
+import { EntityError, EntityPending } from "@/components/EntityStates";
+import { FilterOptionCount } from "@/components/FilterOptionCount";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { fetchRoutines, fetchTopics } from "@/utils";
+
+interface RoutinesSearch {
+  topicId?: string;
+}
+
+export const Route = createFileRoute("/routines/")({
+  component: Routines,
+  errorComponent: RoutinesError,
+  pendingComponent: RoutinesPending,
+  validateSearch: (search: Record<string, unknown>): RoutinesSearch => ({
+    topicId:
+      typeof search.topicId === "string" && search.topicId
+        ? search.topicId
+        : undefined,
+  }),
+});
+
+function RoutinesPending() {
+  return <EntityPending entity="routines" />;
+}
+
+function RoutinesError() {
+  return <EntityError entity="routines" />;
+}
+
+function Routines() {
+  const urlSearch = Route.useSearch();
+  const [search, setSearch] = useState("");
+  const [filterTopic, setFilterTopic] = useState<string | undefined>(
+    urlSearch.topicId,
+  );
+
+  const {
+    data,
+  } = useQuery({
+    queryKey: ["routines"],
+    queryFn: () => fetchRoutines(),
+  });
+
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+
+    let result = data;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(r =>
+        r.name.toLowerCase().includes(q)
+        || (r.description?.toLowerCase().includes(q) ?? false));
+    }
+
+    if (filterTopic === "none") {
+      result = result.filter(r => !r.topic);
+    }
+    else if (filterTopic) {
+      result = result.filter(r => r.topic?.id === filterTopic);
+    }
+
+    return result;
+  }, [data, search, filterTopic]);
+
+  const hasActiveFilters = !!filterTopic;
+
+  const routineCountByTopic = useMemo(() => {
+    const counts = new Map<string, number>();
+    data?.forEach((r) => {
+      const id = r.topic?.id;
+      if (id) counts.set(id, (counts.get(id) ?? 0) + 1);
+    });
+    return counts;
+  }, [data]);
+  const totalRoutineCount = data?.length ?? 0;
+  const noTopicCount = useMemo(
+    () => data?.filter(r => !r.topic).length ?? 0,
+    [data],
+  );
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Routines"
+        pageSection=""
+      >
+        <Link
+          to="/routines/$id/edit"
+          params={{
+            id: "new",
+          }}
+        >
+          <Button variant="outline">
+            <PlusIcon className="size-4" />
+            New Routine
+          </Button>
+        </Link>
+      </PageHeader>
+      <div className="container flex flex-col gap-4">
+        {data && data.length > 0 && (
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <div className="relative">
+              <SearchIcon
+                className="
+                  absolute top-1/2 left-2.5 size-4 -translate-y-1/2
+                  text-muted-foreground
+                "
+              />
+              <input
+                type="text"
+                placeholder="Search routines..."
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                className="
+                  h-9 rounded-md border border-input bg-transparent pr-3 pl-8
+                  text-sm shadow-xs transition-[color,box-shadow] outline-none
+                  placeholder:text-muted-foreground
+                  focus-visible:border-ring focus-visible:ring-[3px]
+                  focus-visible:ring-ring/50
+                "
+              />
+            </div>
+            <Select
+              value={filterTopic ?? "all"}
+              onValueChange={v =>
+                setFilterTopic(v === "all" ? undefined : v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Topic" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  <span>All Topics</span>
+                  <FilterOptionCount count={totalRoutineCount} />
+                </SelectItem>
+                {noTopicCount > 0 && (
+                  <SelectItem value="none">
+                    <span>No Topic</span>
+                    <FilterOptionCount count={noTopicCount} />
+                  </SelectItem>
+                )}
+                {topics
+                  ?.filter(t => (routineCountByTopic.get(t.id) ?? 0) > 0)
+                  .map(t => (
+                    <SelectItem
+                      key={t.id}
+                      value={t.id}
+                    >
+                      <span>{t.name}</span>
+                      <FilterOptionCount
+                        count={routineCountByTopic.get(t.id) ?? 0}
+                      />
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            {hasActiveFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setFilterTopic(undefined);
+                }}
+              >
+                <XIcon className="size-4" />
+                Clear filters
+              </Button>
+            )}
+          </div>
+        )}
+
+        {(!data || data.length === 0) && (
+          <p className="text-sm text-muted-foreground">
+            <i>No routines yet!</i>
+          </p>
+        )}
+
+        {data && data.length > 0 && filtered.length === 0 && (
+          <div className="text-muted-foreground">
+            <i>No routines match your filters.</i>
+          </div>
+        )}
+
+        {filtered.length > 0 && (
+          <div className="card-grid">
+            {filtered.map((routine: Routine) => (
+              <RoutineBox
+                key={routine.id}
+                {...routine}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/routes/routines.tsx
+++ b/packages/client/src/routes/routines.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/routines")({
+  component: Routines,
+});
+
+function Routines() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -10,6 +10,7 @@ import type {
   Module,
   ModuleGroup,
   Radar,
+  Routine,
   Tag,
   TagGroup,
   Task,
@@ -155,6 +156,7 @@ export const providersApi = createEntityClient<CourseProvider>(
 );
 export const domainsApi = createEntityClient<Domain>("domains", "domain");
 export const dailiesApi = createEntityClient<Daily>("dailies", "daily");
+export const routinesApi = createEntityClient<Routine>("routines", "routine");
 export const tasksApi = createEntityClient<Task>("tasks", "task");
 export const taskTypesApi = createEntityClient<TaskType>(
   "task-types",
@@ -184,6 +186,7 @@ export const fetchProviders = providersApi.list;
 export const fetchResources = resourcesApi.list;
 export const fetchDomains = domainsApi.list;
 export const fetchDailies = dailiesApi.list;
+export const fetchRoutines = routinesApi.list;
 export const fetchTasks = tasksApi.list;
 export const fetchTaskTypes = taskTypesApi.list;
 export const fetchTagGroups = tagGroupsApi.list;
@@ -198,6 +201,7 @@ export const fetchSingleTopic = topicsApi.get;
 export const fetchSingleProvider = providersApi.get;
 export const fetchSingleDomain = domainsApi.get;
 export const fetchSingleDaily = dailiesApi.get;
+export const fetchSingleRoutine = routinesApi.get;
 export const fetchSingleTask = tasksApi.get;
 
 export const upsertResource = resourcesApi.upsert;
@@ -205,6 +209,7 @@ export const upsertTopic = topicsApi.upsert;
 export const upsertProvider = providersApi.upsert;
 export const upsertDomain = domainsApi.upsert;
 export const upsertDaily = dailiesApi.upsert;
+export const upsertRoutine = routinesApi.upsert;
 export const upsertTask = tasksApi.upsert;
 export const upsertTaskType = taskTypesApi.upsert;
 export const upsertTagGroup = tagGroupsApi.upsert;
@@ -218,6 +223,7 @@ export const createTopic = topicsApi.create;
 export const createProvider = providersApi.create;
 export const createDomain = domainsApi.create;
 export const createDaily = dailiesApi.create;
+export const createRoutine = routinesApi.create;
 export const createTask = tasksApi.create;
 export const createTaskType = taskTypesApi.create;
 export const createTagGroup = tagGroupsApi.create;
@@ -246,6 +252,7 @@ export async function bulkDeleteTopics(
 export const deleteSinglePlatform = providersApi.delete;
 export const deleteSingleDomain = domainsApi.delete;
 export const deleteSingleDaily = dailiesApi.delete;
+export const deleteSingleRoutine = routinesApi.delete;
 export const deleteSingleTask = tasksApi.delete;
 export const deleteSingleTaskType = taskTypesApi.delete;
 export const deleteSingleTagGroup = tagGroupsApi.delete;
@@ -258,6 +265,7 @@ export const deleteSingleDailyCriteriaTemplate = dailyCriteriaTemplatesApi.delet
 export const duplicateResource = resourcesApi.duplicate;
 export const duplicateDomain = domainsApi.duplicate;
 export const duplicateDaily = dailiesApi.duplicate;
+export const duplicateRoutine = routinesApi.duplicate;
 
 export async function fetchSeed(): Promise<SuccessObj> {
   return await fetch("/api/seed").then(res => res.json());

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -16,6 +16,18 @@ export interface DailyCriteria {
   exceeded?: string;
 }
 
+// Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.
+// Declared locally (mirroring DailyCompletion/DailyCriteria) to avoid a
+// circular dependency on @emstack/types from the schema layer.
+export type RoutineWeekday = "0" | "1" | "2" | "3" | "4" | "5" | "6";
+
+export interface RoutineReferenceItem {
+  type: "task" | "resource";
+  id: string;
+}
+
+export type RoutineWeekly = Partial<Record<RoutineWeekday, RoutineReferenceItem>>;
+
 export const usersTable = pgTable("users", {
   id: varchar().primaryKey(),
   name: varchar({
@@ -208,6 +220,20 @@ export const dailies = pgTable("dailies", {
   taskId: varchar("task_id").unique(),
   status: statusEnum().default("active"),
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
+});
+
+// A per-topic weekly plan: each day of the week optionally points at a Task
+// or a Resource to work on. Only one routine per topic should be "active" at a
+// time (enforced in the create/upsert handlers).
+export const routines = pgTable("routines", {
+  id: varchar().primaryKey(),
+  name: varchar({
+    length: 255,
+  }).notNull(),
+  description: varchar(),
+  topicId: varchar("topic_id"),
+  status: statusEnum().default("active"),
+  weekly: jsonb().$type<RoutineWeekly>().default({}).notNull(),
 });
 
 export const dailyCriteriaTemplates = pgTable("daily_criteria_templates", {
@@ -580,6 +606,15 @@ export const dailiesRelations = relations(dailies, ({
   }),
 }));
 
+export const routinesRelations = relations(routines, ({
+  one,
+}) => ({
+  topic: one(topics, {
+    fields: [routines.topicId],
+    references: [topics.id],
+  }),
+}));
+
 export const resourcesRelations = relations(resources, ({
   one, many,
 }) => ({
@@ -632,6 +667,7 @@ export const topicsRelations = relations(topics, ({
   domainWithinScope: many(domainWithinScopeTopics),
   topicsToTags: many(topicsToTags),
   tasks: many(tasks),
+  routines: many(routines),
 }));
 
 export interface RadarConfigEntry {

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -9,6 +9,7 @@ import topics from "./topics/routes";
 import providers from "./providers/routes";
 import domains from "./domains/routes";
 import dailies from "./dailies/routes";
+import routines from "./routines/routes";
 import tasks from "./tasks/routes";
 import taskTypes from "./task-types/routes";
 import tagGroups from "./tag-groups/routes";
@@ -38,6 +39,9 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(dailies, {
     prefix: "/dailies",
+  });
+  fastify.register(routines, {
+    prefix: "/routines",
   });
   fastify.register(tasks, {
     prefix: "/tasks",

--- a/packages/middleware/src/routes/api/routines/createRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/createRoutine.ts
@@ -1,0 +1,73 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { and, eq, ne } from "drizzle-orm";
+import { db } from "@/db";
+import { routines } from "@/db/schema";
+import type { RoutineWeekly } from "@/db/schema";
+import {
+  nullableRoutineStatusEnum,
+  nullableString,
+  weeklySchema,
+} from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const createSchema = {
+  schema: {
+    description: "Create a new routine",
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        topicId: nullableString,
+        status: nullableRoutineStatusEnum,
+        weekly: weeklySchema,
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request) {
+      const body = request.body;
+      const id = uuidv4();
+      const status = body.status ?? "active";
+      const topicId = body.topicId || null;
+
+      await db.transaction(async (tx) => {
+        await tx.insert(routines).values({
+          id,
+          name: body.name,
+          description: body.description ?? null,
+          topicId,
+          status,
+          weekly: (body.weekly ?? {}) as RoutineWeekly,
+        });
+
+        // Single-active-per-topic enforcement: a new active routine claims the
+        // topic's active slot, deactivating its siblings.
+        if (status === "active" && topicId) {
+          await tx
+            .update(routines)
+            .set({
+              status: "inactive",
+            })
+            .where(and(eq(routines.topicId, topicId), ne(routines.id, id)));
+        }
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routines/deleteRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/deleteRoutine.ts
@@ -1,0 +1,8 @@
+import { routines } from "@/db/schema";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
+
+export default createDeleteHandler({
+  description: "Delete a routine by id",
+  table: routines,
+  idColumn: routines.id,
+});

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -1,0 +1,55 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { routines } from "@/db/schema";
+import { sendNotFound } from "@/utils/errors";
+import { idParamSchema } from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const duplicateSchema = {
+  schema: {
+    description: "Duplicate a routine by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:id/duplicate",
+    duplicateSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const source = await db.query.routines.findFirst({
+        where: (r, {
+          eq,
+        }) => eq(r.id, id),
+      });
+
+      if (!source) {
+        return sendNotFound(reply, "Routine");
+      }
+
+      const newId = uuidv4();
+      // The copy starts "inactive" so duplicating never silently steals the
+      // topic's single active slot.
+      await db.insert(routines).values({
+        id: newId,
+        name: `${source.name} (Copy)`,
+        description: source.description ?? null,
+        topicId: source.topicId ?? null,
+        status: "inactive",
+        weekly: source.weekly ?? {},
+      });
+
+      return {
+        status: "ok",
+        id: newId,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routines/getRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/getRoutine.ts
@@ -1,0 +1,39 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { idParamSchema } from "@/utils/schemas";
+
+const getSchema = {
+  schema: {
+    description: "Get a routine by id",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id",
+    getSchema,
+    async function (request) {
+      const {
+        id,
+      } = request.params;
+
+      return await db.query.routines.findFirst({
+        where: (routines, {
+          eq,
+        }) => eq(routines.id, id),
+        with: {
+          topic: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -1,0 +1,20 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get("/", async () => {
+    return await db.query.routines.findMany({
+      with: {
+        topic: {
+          columns: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+  });
+}

--- a/packages/middleware/src/routes/api/routines/routes.ts
+++ b/packages/middleware/src/routes/api/routines/routes.ts
@@ -1,0 +1,20 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import routineRoot from "./root";
+import getRoutine from "./getRoutine";
+import createRoutine from "./createRoutine";
+import upsertRoutine from "./upsertRoutine";
+import deleteRoutine from "./deleteRoutine";
+import duplicateRoutine from "./duplicateRoutine";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(routineRoot);
+  fastify.register(getRoutine);
+  fastify.register(createRoutine);
+  fastify.register(upsertRoutine);
+  fastify.register(deleteRoutine);
+  fastify.register(duplicateRoutine);
+}

--- a/packages/middleware/src/routes/api/routines/upsertRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/upsertRoutine.ts
@@ -1,0 +1,94 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { and, eq, ne } from "drizzle-orm";
+import { db } from "@/db";
+import { routines } from "@/db/schema";
+import type { RoutineWeekly } from "@/db/schema";
+import {
+  idParamSchema,
+  nullableRoutineStatusEnum,
+  nullableString,
+  weeklySchema,
+} from "@/utils/schemas";
+import { v4 as uuidv4 } from "uuid";
+
+const upsertSchema = {
+  schema: {
+    description: "Create or update a routine",
+    params: idParamSchema,
+    body: {
+      type: "object",
+      required: ["name"],
+      properties: {
+        name: {
+          type: "string",
+        },
+        description: nullableString,
+        topicId: nullableString,
+        status: nullableRoutineStatusEnum,
+        weekly: weeklySchema,
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.put(
+    "/:id",
+    upsertSchema,
+    async function (request) {
+      const {
+        id,
+      } = request.params;
+      const body = request.body;
+
+      const routineData = {
+        id: id || uuidv4(),
+        name: body.name,
+        description: body.description ?? null,
+        topicId: body.topicId || null,
+        status: body.status ?? "active",
+        weekly: (body.weekly ?? {}) as RoutineWeekly,
+      };
+
+      await db.transaction(async (tx) => {
+        await tx
+          .insert(routines)
+          .values(routineData)
+          .onConflictDoUpdate({
+            target: routines.id,
+            set: {
+              name: routineData.name,
+              description: routineData.description,
+              topicId: routineData.topicId,
+              status: routineData.status,
+              weekly: routineData.weekly,
+            },
+          });
+
+        // Single-active-per-topic enforcement: activating this routine
+        // deactivates its siblings on the same topic.
+        if (routineData.status === "active" && routineData.topicId) {
+          await tx
+            .update(routines)
+            .set({
+              status: "inactive",
+            })
+            .where(
+              and(
+                eq(routines.topicId, routineData.topicId),
+                ne(routines.id, routineData.id),
+              ),
+            );
+        }
+      });
+
+      return {
+        status: "ok",
+        id: routineData.id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -35,6 +35,44 @@ export const nullableResourceLevelEnum = {
   enum: ["low", "medium", "high", null],
 } as const;
 
+// Routines use the full lifecycle status set (including "inactive", since the
+// single-active-per-topic rule deactivates siblings).
+export const nullableRoutineStatusEnum = {
+  type: ["string", "null"],
+  enum: ["active", "inactive", "complete", "paused", null],
+} as const;
+
+export const routineReferenceItemSchema = {
+  type: "object",
+  required: ["type", "id"],
+  properties: {
+    type: {
+      type: "string",
+      enum: ["task", "resource"],
+    },
+    id: {
+      type: "string",
+    },
+  },
+} as const;
+
+// Optional properties "0".."6" (Date.getDay() order), each a {type, id}. No
+// `required`, so every day is optional; additionalProperties:false keeps stray
+// keys out.
+export const weeklySchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    0: routineReferenceItemSchema,
+    1: routineReferenceItemSchema,
+    2: routineReferenceItemSchema,
+    3: routineReferenceItemSchema,
+    4: routineReferenceItemSchema,
+    5: routineReferenceItemSchema,
+    6: routineReferenceItemSchema,
+  },
+} as const;
+
 export const dailyCompletionStatusEnum = {
   type: "string",
   enum: ["incomplete", "touched", "goal", "exceeded", "freeze"],

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -1,0 +1,27 @@
+import type { EntityStatus } from "./EntityStatus";
+
+export type RoutineReferenceType = "task" | "resource";
+
+export interface RoutineReferenceItem {
+  type: RoutineReferenceType;
+  id: string;
+}
+
+// Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.
+export type RoutineWeekday = "0" | "1" | "2" | "3" | "4" | "5" | "6";
+
+// Each day is optional — a routine may have no entry for some days.
+export type RoutineWeekly = Partial<Record<RoutineWeekday, RoutineReferenceItem>>;
+
+export interface Routine {
+  id: string;
+  name: string;
+  description?: string | null;
+  topicId?: string | null;
+  topic?: {
+    id: string;
+    name: string;
+  } | null;
+  status?: EntityStatus | null;
+  weekly?: RoutineWeekly | null;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,6 +17,7 @@ export * from "./Module.js";
 export * from "./ModuleGroup.js";
 export * from "./OnboardData.js";
 export * from "./Radar.js";
+export * from "./Routine.js";
 export * from "./Tag.js";
 export * from "./TagGroup.js";
 export * from "./Task.js";


### PR DESCRIPTION
Closes #93.

Adds a per-topic **Routines** resource: each routine maps days of the week to a Task or Resource to work on, with one active routine per topic.

## Data model
- `@emstack/types` → `Routine` with `weekly: Partial<Record<"0".."6", { type: "task" | "resource"; id: string }>>` (day keys follow `Date.getDay()`, 0 = Sunday).
- `routines` table: `id`, `name`, `description`, `topicId` (nullable FK), `status` (reuses `statusEnum`, default `active`), `weekly` (jsonb, default `{}`). Relations: `routine → topic` and `topic → many(routines)`. Schema uses `drizzle-kit push` (no migration file).

## API (`/api/routines`)
list · get · create · upsert · delete · duplicate — mirroring the `dailies` handlers.
- **Single-active-per-topic**: creating/saving an `active` routine deactivates its sibling routines on the same topic, wrapped in a `db.transaction` (idiomatic here — used in the repo's migrations).
- Duplicates are created `inactive` so they never steal the active slot.

## Client
- `routinesApi` + fetch helpers in `fetchFunctions`.
- Archive (list) page with search + topic filter, single detail page (resolves `weekly` IDs → task/resource names with links), and edit/create page.
- `WeeklyScheduleField`: a Monday-first per-day editor (None / Task / Resource toggle + searchable combobox), wrapped in a single `form.Field` like the existing `ResourceLinksPicker`. Helpers split into `weekly.ts` to satisfy the fast-refresh lint rule.
- `RoutineBox` list card (weekday strip + status badge); nav links (desktop + mobile); `PageHeader` section.

## Decisions
- Used `name` (not the issue's `title`) to match every other entity and the shared UI infra — confirmed with the author.
- "Only one active at once" modeled as a `status` enum with **per-topic** auto-enforcement.

## Verification
- ✅ Types build, middleware typecheck, route tree regenerated, lint clean.
- ✅ Client typecheck holds at the pre-existing baseline errors (none in new files).
- ✅ **Live end-to-end against PostgreSQL 16**: schema push, CRUD, single-active enforcement on both create and upsert, per-topic scoping, topic projection, duplicate-as-inactive, delete, and schema validation all verified.

## Follow-ups (filed, reference #93)
- #205 — Routines dashboard tile
- #204 — Show Routines on Topic single pages
- #206 — Routine templates to pre-fill new routines

https://claude.ai/code/session_01WSjRvr4Uk36EoULng7LTxp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSjRvr4Uk36EoULng7LTxp)_