### PR TITLE
Remove default className values from form field components

### DIFF
--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -31,7 +31,7 @@ export function ComboboxField({
   label,
   options,
   placeholder,
-  className = "text-2xl",
+  className,
   disabled,
   create,
 }: ComboboxFieldProps) {

--- a/packages/client/src/components/formFields/DatePickerField.tsx
+++ b/packages/client/src/components/formFields/DatePickerField.tsx
@@ -18,7 +18,7 @@ export function DatePickerField({
   label,
   placeholder = "No expiry date",
   clearLabel = "Clear date",
-  className = "text-2xl",
+  className,
 }: DatePickerFieldProps) {
   const field = useFieldContext<Date | null>();
 

--- a/packages/client/src/components/formFields/InputField.tsx
+++ b/packages/client/src/components/formFields/InputField.tsx
@@ -12,9 +12,9 @@ interface InputFieldProps {
 
 export function InputField({
   label,
-  className = "text-2xl",
+  className,
   placeholder,
-  fieldClassName = "h-11 md:text-xl",
+  fieldClassName,
   disabled,
 }: InputFieldProps) {
   const {

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -70,7 +70,7 @@ export function MultiComboboxField({
   label,
   options,
   placeholder,
-  className = "text-2xl",
+  className,
   create,
   groupByPrefix = false,
 }: MultiComboboxFieldProps) {

--- a/packages/client/src/components/formFields/NumberField.tsx
+++ b/packages/client/src/components/formFields/NumberField.tsx
@@ -12,7 +12,7 @@ interface NumberFieldProps {
 
 export function NumberField({
   label,
-  className = "text-2xl",
+  className,
   min,
   step,
   disabled,

--- a/packages/client/src/components/formFields/RadioGroupField.tsx
+++ b/packages/client/src/components/formFields/RadioGroupField.tsx
@@ -14,7 +14,7 @@ interface RadioGroupFieldProps {
 export function RadioGroupField({
   label,
   options,
-  className = "text-2xl",
+  className,
   labelClassName = "capitalize",
 }: RadioGroupFieldProps) {
   const field = useFieldContext<string>();

--- a/packages/client/src/components/formFields/TextareaField.tsx
+++ b/packages/client/src/components/formFields/TextareaField.tsx
@@ -12,7 +12,7 @@ interface TextareaFieldProps {
 
 export function TextareaField({
   label,
-  className = "text-2xl",
+  className,
   placeholder,
   disabled,
   labelIcon,

--- a/packages/client/src/components/forms/CourseFields.tsx
+++ b/packages/client/src/components/forms/CourseFields.tsx
@@ -32,6 +32,8 @@ export function CourseFields({
             <field.InputField
               label="Resource Name"
               placeholder="Memes"
+              className="text-2xl"
+              fieldClassName="h-11 md:text-xl"
             />
           )}
         </form.AppField>
@@ -40,6 +42,8 @@ export function CourseFields({
             <field.InputField
               label="Resource URL"
               placeholder="Memes"
+              className="text-2xl"
+              fieldClassName="h-11 md:text-xl"
             />
           )}
         </form.AppField>

--- a/packages/client/src/routes/onboard.tsx
+++ b/packages/client/src/routes/onboard.tsx
@@ -148,6 +148,8 @@ function Onboard() {
                           <field.InputField
                             label={`Topic ${i + 1}`}
                             placeholder="Memes"
+                            className="text-2xl"
+                            fieldClassName="h-11 md:text-xl"
                           />
                         )}
                       </form.AppField>


### PR DESCRIPTION
## Summary
Removes hardcoded default `className` values from form field components and moves styling responsibility to the call sites. This makes the components more flexible and allows consumers to explicitly control styling rather than relying on implicit defaults.

## Changes
- **InputField, ComboboxField, DatePickerField, MultiComboboxField, NumberField, RadioGroupField, TextareaField:** Removed `className = "text-2xl"` default parameter
- **InputField:** Removed `fieldClassName = "h-11 md:text-xl"` default parameter
- **CourseFields:** Added explicit `className="text-2xl"` and `fieldClassName="h-11 md:text-xl"` to both InputField usages (Resource Name and Resource URL)
- **onboard.tsx:** Added explicit `className="text-2xl"` and `fieldClassName="h-11 md:text-xl"` to Topic InputField

## Implementation Details
This change follows the principle of explicit over implicit configuration. Rather than having form field components apply default styling, consumers now explicitly pass the styling they need. This makes the component contracts clearer and allows for easier customization in different contexts without needing to override defaults.

The styling values being moved (`text-2xl` for labels, `h-11 md:text-xl` for input fields) are preserved at the call sites, so there is no visual change to the application.

https://claude.ai/code/session_01U33gX2z3HHv4LpoCZSM4G1