### PR TITLE
Add routine templates to pre-fill routine weekly schedules

### DIFF
--- a/packages/client/src/components/routines/RoutineTemplateEditModal.tsx
+++ b/packages/client/src/components/routines/RoutineTemplateEditModal.tsx
@@ -1,0 +1,152 @@
+import type { WeeklyRow } from "@/components/routines/weekly";
+import type { SelectOption } from "@/utils";
+import type { RoutineTemplate } from "@emstack/types/src";
+
+import { useEffect, useState } from "react";
+
+import { Loader2, Trash2Icon } from "lucide-react";
+
+import { Input } from "@/components/input";
+import { rowsToWeekly, weeklyToRows } from "@/components/routines/weekly";
+import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface RoutineTemplateEditModalProps {
+  open: boolean;
+  template: RoutineTemplate | null;
+  isNew?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (next: RoutineTemplate) => void;
+  onDelete?: () => void;
+  isSaving?: boolean;
+  deleteDisabled?: boolean;
+  taskOptions: SelectOption[];
+  resourceOptions: SelectOption[];
+}
+
+export function RoutineTemplateEditModal({
+  open,
+  template,
+  isNew = false,
+  onOpenChange,
+  onSave,
+  onDelete,
+  isSaving = false,
+  deleteDisabled = false,
+  taskOptions,
+  resourceOptions,
+}: RoutineTemplateEditModalProps) {
+  const [label, setLabel] = useState(template?.label ?? "");
+  const [rows, setRows] = useState<WeeklyRow[]>(weeklyToRows(template?.weekly));
+
+  useEffect(() => {
+    setLabel(template?.label ?? "");
+    setRows(weeklyToRows(template?.weekly));
+  }, [template]);
+
+  if (!template) {
+    return null;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!template) return;
+    onSave({
+      id: template.id,
+      label,
+      weekly: rowsToWeekly(rows),
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {isNew ? "Add Routine Template" : "Edit Routine Template"}
+          </DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              className="text-xs font-medium text-muted-foreground"
+              htmlFor="routine-template-label"
+            >
+              Label
+            </label>
+            <Input
+              id="routine-template-label"
+              type="text"
+              value={label}
+              onChange={e => setLabel(e.target.value)}
+              required
+              placeholder="Template label (e.g. Summer Japanese)"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-muted-foreground">
+              Weekly Schedule
+            </span>
+            <WeeklyScheduleField
+              value={rows}
+              onChange={setRows}
+              taskOptions={taskOptions}
+              resourceOptions={resourceOptions}
+            />
+          </div>
+          <DialogFooter className="sm:justify-between">
+            {onDelete && !isNew
+              ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={onDelete}
+                  disabled={isSaving || deleteDisabled}
+                >
+                  <Trash2Icon className="size-4" />
+                  Remove
+                </Button>
+              )
+              : (
+                <span />
+              )}
+            <div
+              className="
+                flex flex-col-reverse gap-2
+                sm:flex-row
+              "
+            >
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSaving}
+              >
+                {isSaving && <Loader2 className="animate-spin" />}
+                Save
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef } from "react";
 import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EyeIcon, Loader2 } from "lucide-react";
+import { ChevronDownIcon, EyeIcon, Loader2, WandSparklesIcon } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
@@ -13,11 +13,18 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { rowsToWeekly, weeklyToRows } from "@/components/routines/weekly";
 import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
   createRoutine,
   deleteSingleRoutine,
   fetchResources,
+  fetchRoutineTemplates,
   fetchSingleRoutine,
   fetchTasks,
   fetchTopics,
@@ -116,6 +123,13 @@ function SingleRoutineEdit() {
   } = useQuery({
     queryKey: ["courses"],
     queryFn: () => fetchResources(),
+  });
+
+  const {
+    data: routineTemplates,
+  } = useQuery({
+    queryKey: ["routineTemplates"],
+    queryFn: () => fetchRoutineTemplates(),
   });
 
   const topicOptions = toOptions(topics);
@@ -269,7 +283,42 @@ function SingleRoutineEdit() {
           <form.Field name="weekly">
             {field => (
               <div className="flex flex-col gap-1">
-                <span className="text-2xl">Weekly Schedule</span>
+                <div
+                  className="flex flex-wrap items-center justify-between gap-2"
+                >
+                  <span className="text-2xl">Weekly Schedule</span>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                      >
+                        <WandSparklesIcon className="size-4" />
+                        Quick Fill
+                        <ChevronDownIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {(routineTemplates ?? []).length === 0
+                        ? (
+                          <DropdownMenuItem disabled>
+                            No templates — add one in Settings
+                          </DropdownMenuItem>
+                        )
+                        : (routineTemplates ?? []).map(template => (
+                          <DropdownMenuItem
+                            key={template.id}
+                            onSelect={() => {
+                              field.handleChange(weeklyToRows(template.weekly));
+                            }}
+                          >
+                            {template.label}
+                          </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
                 <WeeklyScheduleField
                   value={field.state.value}
                   onChange={next => field.handleChange(next)}

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -1,4 +1,8 @@
-import type { DailyCriteriaTemplate, TaskType } from "@emstack/types/src";
+import type {
+  DailyCriteriaTemplate,
+  RoutineTemplate,
+  TaskType,
+} from "@emstack/types/src";
 
 import { useState } from "react";
 
@@ -17,6 +21,7 @@ import { toast } from "sonner";
 
 import { DailyCriteriaTemplateEditModal } from "@/components/dailies";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { RoutineTemplateEditModal } from "@/components/routines/RoutineTemplateEditModal";
 import { TagGroupsAdmin } from "@/components/TagGroupsAdmin";
 import { TagChip } from "@/components/tasks/TagChip";
 import { TaskTypeEditRow } from "@/components/TaskTypeEditRow";
@@ -24,14 +29,21 @@ import { Button } from "@/components/ui/button";
 import { useTheme } from "@/hooks/useTheme.ts";
 import {
   createDailyCriteriaTemplate,
+  createRoutineTemplate,
   createTaskType,
   deleteSingleDailyCriteriaTemplate,
+  deleteSingleRoutineTemplate,
   deleteSingleTaskType,
   fetchClear,
   fetchDailyCriteriaTemplates,
+  fetchResources,
+  fetchRoutineTemplates,
   fetchSeed,
+  fetchTasks,
   fetchTaskTypes,
+  toOptions,
   upsertDailyCriteriaTemplate,
+  upsertRoutineTemplate,
   upsertTaskType,
 } from "@/utils";
 
@@ -41,6 +53,7 @@ export const Route = createFileRoute("/settings")({
 
 const NEW_TASK_TYPE_ID = "__new__";
 const NEW_CRITERIA_TEMPLATE_ID = "__new__";
+const NEW_ROUTINE_TEMPLATE_ID = "__new__";
 
 function makeEmptyTaskType(): TaskType {
   return {
@@ -63,6 +76,14 @@ function makeEmptyCriteriaTemplate(): DailyCriteriaTemplate {
   };
 }
 
+function makeEmptyRoutineTemplate(): RoutineTemplate {
+  return {
+    id: NEW_ROUTINE_TEMPLATE_ID,
+    label: "",
+    weekly: {},
+  };
+}
+
 function Settings() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -74,6 +95,10 @@ function Settings() {
   const [creatingNew, setCreatingNew] = useState(false);
   const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
   const [creatingNewTemplate, setCreatingNewTemplate] = useState(false);
+  const [editingRoutineTemplateId, setEditingRoutineTemplateId]
+    = useState<string | null>(null);
+  const [creatingNewRoutineTemplate, setCreatingNewRoutineTemplate]
+    = useState(false);
 
   const {
     isFetching: isSeedFetching,
@@ -155,6 +180,21 @@ function Settings() {
     queryFn: () => fetchDailyCriteriaTemplates(),
   });
 
+  const routineTemplatesQuery = useQuery({
+    queryKey: ["routineTemplates"],
+    queryFn: () => fetchRoutineTemplates(),
+  });
+
+  const tasksQuery = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
+  const resourcesQuery = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchResources(),
+  });
+
   const upsertTemplateMutation = useMutation({
     mutationFn: (template: DailyCriteriaTemplate) =>
       upsertDailyCriteriaTemplate(template.id, {
@@ -213,6 +253,56 @@ function Settings() {
     },
   });
 
+  const upsertRoutineTemplateMutation = useMutation({
+    mutationFn: (template: RoutineTemplate) =>
+      upsertRoutineTemplate(template.id, {
+        label: template.label,
+        weekly: template.weekly,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["routineTemplates"],
+      });
+      setEditingRoutineTemplateId(null);
+      toast.success("Routine template saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const createRoutineTemplateMutation = useMutation({
+    mutationFn: (template: RoutineTemplate) =>
+      createRoutineTemplate({
+        label: template.label,
+        weekly: template.weekly,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["routineTemplates"],
+      });
+      setCreatingNewRoutineTemplate(false);
+      toast.success("Routine template created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteRoutineTemplateMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleRoutineTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["routineTemplates"],
+      });
+      setEditingRoutineTemplateId(null);
+      toast.success("Routine template deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
   async function handleClearLocal() {
     const clearRefetchResult = await clearRefetch();
 
@@ -244,6 +334,13 @@ function Settings() {
   const editingCriteriaTemplate = editingTemplateId
     ? criteriaTemplates.find(t => t.id === editingTemplateId) ?? null
     : null;
+
+  const routineTemplates = routineTemplatesQuery.data ?? [];
+  const editingRoutineTemplate = editingRoutineTemplateId
+    ? routineTemplates.find(t => t.id === editingRoutineTemplateId) ?? null
+    : null;
+  const taskOptions = toOptions(tasksQuery.data);
+  const resourceOptions = toOptions(resourcesQuery.data);
 
   return (
     <div>
@@ -439,6 +536,75 @@ function Settings() {
         </section>
 
         <section className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-xl font-semibold">
+              Routine Templates
+            </h2>
+            <Button
+              variant="outline"
+              onClick={() => setCreatingNewRoutineTemplate(true)}
+            >
+              <PlusIcon />
+              New Template
+            </Button>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Prefill options for the Weekly Schedule Quick Fill on a routine.
+          </p>
+          {routineTemplatesQuery.isPending
+            ? <p className="text-sm text-muted-foreground">Loading...</p>
+            : routineTemplates.length === 0
+              ? (
+                <p className="text-sm text-muted-foreground">
+                  No templates yet. Create one to use it as a Quick Fill option.
+                </p>
+              )
+              : (
+                <ul className="flex flex-col divide-y rounded-md border">
+                  {routineTemplates.map(t => (
+                    <li
+                      key={t.id}
+                      className="
+                        flex flex-wrap items-center justify-between gap-2 p-3
+                      "
+                    >
+                      <div className="flex flex-col gap-1">
+                        <span className="font-medium">{t.label}</span>
+                        <span
+                          className="line-clamp-1 text-xs text-muted-foreground"
+                        >
+                          {Object.keys(t.weekly ?? {}).length}
+                          {" "}
+                          day(s) scheduled
+                        </span>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setEditingRoutineTemplateId(t.id)}
+                        >
+                          <PencilIcon className="size-4" />
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() =>
+                            deleteRoutineTemplateMutation.mutate(t.id)}
+                          disabled={deleteRoutineTemplateMutation.isPending}
+                        >
+                          <Trash2Icon className="size-4" />
+                          Delete
+                        </Button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+        </section>
+
+        <section className="flex flex-col gap-3">
           <h2 className="text-xl font-semibold">Appearance</h2>
           <div className="flex flex-col items-start gap-2">
             {theme === "dark"
@@ -491,6 +657,38 @@ function Settings() {
         }}
         onSave={t => createTemplateMutation.mutate(t)}
         isSaving={createTemplateMutation.isPending}
+      />
+
+      <RoutineTemplateEditModal
+        open={editingRoutineTemplateId !== null}
+        template={editingRoutineTemplate}
+        taskOptions={taskOptions}
+        resourceOptions={resourceOptions}
+        onOpenChange={(open) => {
+          if (!open) setEditingRoutineTemplateId(null);
+        }}
+        onSave={t => upsertRoutineTemplateMutation.mutate(t)}
+        onDelete={editingRoutineTemplate
+          ? () =>
+            deleteRoutineTemplateMutation.mutate(editingRoutineTemplate.id)
+          : undefined}
+        isSaving={upsertRoutineTemplateMutation.isPending
+          || deleteRoutineTemplateMutation.isPending}
+      />
+
+      <RoutineTemplateEditModal
+        open={creatingNewRoutineTemplate}
+        template={creatingNewRoutineTemplate
+          ? makeEmptyRoutineTemplate()
+          : null}
+        isNew
+        taskOptions={taskOptions}
+        resourceOptions={resourceOptions}
+        onOpenChange={(open) => {
+          if (!open) setCreatingNewRoutineTemplate(false);
+        }}
+        onSave={t => createRoutineTemplateMutation.mutate(t)}
+        isSaving={createRoutineTemplateMutation.isPending}
       />
     </div>
   );

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -11,6 +11,7 @@ import type {
   ModuleGroup,
   Radar,
   Routine,
+  RoutineTemplate,
   Tag,
   TagGroup,
   Task,
@@ -180,6 +181,10 @@ export const dailyCriteriaTemplatesApi = createEntityClient<DailyCriteriaTemplat
   "daily-criteria-templates",
   "criteria template",
 );
+export const routineTemplatesApi = createEntityClient<RoutineTemplate>(
+  "routine-templates",
+  "routine template",
+);
 
 export const fetchTopics = topicsApi.list;
 export const fetchProviders = providersApi.list;
@@ -195,6 +200,7 @@ export const fetchModuleGroups = moduleGroupsApi.list;
 export const fetchModules = modulesApi.list;
 export const fetchInteractions = interactionsApi.list;
 export const fetchDailyCriteriaTemplates = dailyCriteriaTemplatesApi.list;
+export const fetchRoutineTemplates = routineTemplatesApi.list;
 
 export const fetchSingleResource = resourcesApi.get;
 export const fetchSingleTopic = topicsApi.get;
@@ -218,6 +224,7 @@ export const upsertModuleGroup = moduleGroupsApi.upsert;
 export const upsertModule = modulesApi.upsert;
 export const upsertInteraction = interactionsApi.upsert;
 export const upsertDailyCriteriaTemplate = dailyCriteriaTemplatesApi.upsert;
+export const upsertRoutineTemplate = routineTemplatesApi.upsert;
 
 export const createTopic = topicsApi.create;
 export const createProvider = providersApi.create;
@@ -232,6 +239,7 @@ export const createModuleGroup = moduleGroupsApi.create;
 export const createModule = modulesApi.create;
 export const createInteraction = interactionsApi.create;
 export const createDailyCriteriaTemplate = dailyCriteriaTemplatesApi.create;
+export const createRoutineTemplate = routineTemplatesApi.create;
 
 export const deleteSingleResource = resourcesApi.delete;
 export const deleteSingleTopic = topicsApi.delete;
@@ -261,6 +269,7 @@ export const deleteSingleModuleGroup = moduleGroupsApi.delete;
 export const deleteSingleModule = modulesApi.delete;
 export const deleteSingleInteraction = interactionsApi.delete;
 export const deleteSingleDailyCriteriaTemplate = dailyCriteriaTemplatesApi.delete;
+export const deleteSingleRoutineTemplate = routineTemplatesApi.delete;
 
 export const duplicateResource = resourcesApi.duplicate;
 export const duplicateDomain = domainsApi.duplicate;

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -248,6 +248,15 @@ export const dailyCriteriaTemplates = pgTable("daily_criteria_templates", {
   freeze: varchar().notNull().default(""),
 });
 
+// Reusable weekly layouts that pre-fill a routine's weekly schedule.
+export const routineTemplates = pgTable("routine_templates", {
+  id: varchar().primaryKey(),
+  label: varchar({
+    length: 255,
+  }).notNull(),
+  weekly: jsonb().$type<RoutineWeekly>().default({}).notNull(),
+});
+
 // TODO(tag-reform-followup): drop this table once the Tag Groups + Tags system
 // (tagGroups, tags, tasksToTags) has fully replaced the Task Type concept on
 // tasks. Keep in place during the additive migration.

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -18,6 +18,7 @@ import moduleGroups from "./module-groups/routes";
 import modules from "./modules/routes";
 import interactions from "./interactions/routes";
 import dailyCriteriaTemplates from "./daily-criteria-templates/routes";
+import routineTemplates from "./routine-templates/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -66,5 +67,8 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(dailyCriteriaTemplates, {
     prefix: "/daily-criteria-templates",
+  });
+  fastify.register(routineTemplates, {
+    prefix: "/routine-templates",
   });
 }

--- a/packages/middleware/src/routes/api/routine-templates/deleteRoutineTemplate.ts
+++ b/packages/middleware/src/routes/api/routine-templates/deleteRoutineTemplate.ts
@@ -1,0 +1,8 @@
+import { routineTemplates } from "@/db/schema";
+import { createDeleteHandler } from "@/utils/createDeleteHandler";
+
+export default createDeleteHandler({
+  description: "Delete a routine template by ID",
+  table: routineTemplates,
+  idColumn: routineTemplates.id,
+});

--- a/packages/middleware/src/routes/api/routine-templates/getRoutineTemplate.ts
+++ b/packages/middleware/src/routes/api/routine-templates/getRoutineTemplate.ts
@@ -1,0 +1,37 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { idParamSchema } from "@/utils/schemas";
+import { sendNotFound } from "@/utils/errors";
+
+const schema = {
+  schema: {
+    description: "Get a single routine template by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id",
+    schema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+      const template = await db.query.routineTemplates.findFirst({
+        where: (t, {
+          eq,
+        }) => eq(t.id, id),
+      });
+
+      if (!template) {
+        return sendNotFound(reply, "Routine template");
+      }
+
+      return template;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routine-templates/root.ts
+++ b/packages/middleware/src/routes/api/routine-templates/root.ts
@@ -1,0 +1,59 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { routineTemplates } from "@/db/schema";
+import type { RoutineWeekly } from "@/db/schema";
+import { weeklySchema } from "@/utils/schemas";
+
+const createSchema = {
+  schema: {
+    description: "Create a new routine template",
+    body: {
+      type: "object",
+      required: ["label"],
+      properties: {
+        label: {
+          type: "string",
+        },
+        weekly: weeklySchema,
+      },
+    },
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/",
+    async () => {
+      const rows = await db.query.routineTemplates.findMany({
+        orderBy: (t, {
+          asc,
+        }) => asc(t.label),
+      });
+      return rows;
+    },
+  );
+
+  fastify.post(
+    "/",
+    createSchema,
+    async function (request) {
+      const body = request.body;
+      const id = uuidv4();
+
+      await db.insert(routineTemplates).values({
+        id,
+        label: body.label,
+        weekly: (body.weekly ?? {}) as RoutineWeekly,
+      });
+
+      return {
+        status: "ok",
+        id,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/routine-templates/routes.ts
+++ b/packages/middleware/src/routes/api/routine-templates/routes.ts
@@ -1,0 +1,16 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import root from "./root";
+import getRoutineTemplate from "./getRoutineTemplate";
+import upsertRoutineTemplate from "./upsertRoutineTemplate";
+import deleteRoutineTemplate from "./deleteRoutineTemplate";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(root);
+  fastify.register(getRoutineTemplate);
+  fastify.register(upsertRoutineTemplate);
+  fastify.register(deleteRoutineTemplate);
+}

--- a/packages/middleware/src/routes/api/routine-templates/upsertRoutineTemplate.ts
+++ b/packages/middleware/src/routes/api/routine-templates/upsertRoutineTemplate.ts
@@ -1,0 +1,35 @@
+import { routineTemplates } from "@/db/schema";
+import type { RoutineWeekly } from "@/db/schema";
+import { createUpsertHandler } from "@/utils/createUpsertHandler";
+import { weeklySchema } from "@/utils/schemas";
+
+interface RoutineTemplateBody {
+  label: string;
+  weekly?: RoutineWeekly;
+}
+
+const updateableColumns = [
+  "label",
+  "weekly",
+] as const;
+
+export default createUpsertHandler<RoutineTemplateBody>({
+  description: "Create or update a routine template",
+  table: routineTemplates,
+  bodySchema: {
+    type: "object",
+    required: ["label"],
+    properties: {
+      label: {
+        type: "string",
+      },
+      weekly: weeklySchema,
+    },
+  },
+  buildRow: (body, id) => ({
+    id,
+    label: body.label,
+    weekly: (body.weekly ?? {}) as RoutineWeekly,
+  }),
+  updateableColumns,
+});

--- a/packages/types/src/RoutineTemplate.ts
+++ b/packages/types/src/RoutineTemplate.ts
@@ -1,0 +1,7 @@
+import type { RoutineWeekly } from "./Routine";
+
+export interface RoutineTemplate {
+  id: string;
+  label: string;
+  weekly: RoutineWeekly;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export * from "./ModuleGroup.js";
 export * from "./OnboardData.js";
 export * from "./Radar.js";
 export * from "./Routine.js";
+export * from "./RoutineTemplate.js";
 export * from "./Tag.js";
 export * from "./TagGroup.js";
 export * from "./Task.js";


### PR DESCRIPTION
Resolves #206.

Adds a **`routine-templates`** resource that mirrors the existing `daily-criteria-templates` pattern, letting you capture a reusable **weekly layout** and apply it when building a routine.

## Scope decisions
- A template stores the **weekly layout only** (plus a `label`). The issue mentioned "status descriptions and/or a default weekly layout"; routines have no status descriptions, so this was scoped to the weekly layout (confirmed during planning).
- Templates are **created/edited/deleted in a Settings section**, mirroring the "Dailies Status Criteria Templates" section.
- The **apply-template picker appears on both new and existing** routine edit pages, overwriting the weekly grid (like the dailies "Quick Fill" dropdown).

## Changes

**Backend** (`packages/middleware`)
- New `routine_templates` table in `db/schema.ts` (`id`, `label`, `weekly` jsonb default `{}`), reusing the exported `RoutineWeekly` type.
- New `routes/api/routine-templates/` — `root` (list + create), `getRoutineTemplate`, `upsertRoutineTemplate`, `deleteRoutineTemplate` — reusing the shared `weeklySchema`, `createUpsertHandler`, and `createDeleteHandler`. Registered at `/routine-templates`.

**Shared types** (`packages/types`)
- `RoutineTemplate.ts` (`{ id, label, weekly }`), re-exported from the index.

**Client** (`packages/client`)
- `routineTemplatesApi` + named fetch re-exports in `utils/fetchFunctions.ts` (via `createEntityClient`).
- `components/routines/RoutineTemplateEditModal.tsx` — a label input plus the existing `WeeklyScheduleField`.
- Settings: a new **"Routine Templates"** management section (list + create/edit/delete modals).
- Routine edit page: a **"Quick Fill"** dropdown beside the Weekly Schedule that applies a template via `weeklyToRows(...)`.

## Verification
- `pnpm --filter=@emstack/types build`, `pnpm typecheck`, `pnpm lint` (0 errors), and `pnpm test` all pass. The client typecheck surfaces 6 errors, but they are **pre-existing** and identical on the untouched baseline (confirmed by stashing these changes) — none are in touched files.
- **End-to-end smoke test against a live Postgres:** full CRUD round-trip (the `weekly` JSONB persists and upsert-replaces correctly), plus validation — missing `label` → 400, invalid reference `type` → 400, and stray day keys are stripped (matching the existing `/routines` endpoint behavior, since both share `weeklySchema`).

## Notes
- No new client routes, so no `routeTree.gen.ts` regeneration was needed.
- Routine templates are not seeded (a template's `weekly` references concrete task/resource ids, so seeding would be fragile).

https://claude.ai/code/session_013au83uhEdcCvDKjHo2NuAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013au83uhEdcCvDKjHo2NuAZ)_