### PR TITLE
Add freeform type to routine weekly entries (#210)

### DIFF
--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -90,41 +90,59 @@ export function WeeklyScheduleField({
                 <option value="">— None —</option>
                 <option value="task">Task</option>
                 <option value="resource">Resource</option>
+                <option value="freeform">Freeform</option>
               </select>
 
-              <Combobox
-                items={itemOptions.map(o => o.value)}
-                value={row.id || null}
-                onValueChange={val => update(day, {
-                  id: val ?? "",
-                })}
-                itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-              >
-                <ComboboxInput
-                  placeholder={
-                    row.type === "task"
-                      ? "Search tasks..."
-                      : row.type === "resource"
-                        ? "Search resources..."
-                        : "Pick a type first"
-                  }
-                  showClear
-                  disabled={!row.type}
-                />
-                <ComboboxContent>
-                  <ComboboxEmpty>No items found.</ComboboxEmpty>
-                  <ComboboxList>
-                    {(val: string) => (
-                      <ComboboxItem
-                        key={val}
-                        value={val}
-                      >
-                        {optionsMap.get(val) ?? val}
-                      </ComboboxItem>
-                    )}
-                  </ComboboxList>
-                </ComboboxContent>
-              </Combobox>
+              {row.type === "freeform"
+                ? (
+                  <input
+                    aria-label={`${DAY_LABELS[day]} description`}
+                    value={row.id}
+                    onChange={e => update(day, {
+                      id: e.target.value,
+                    })}
+                    placeholder="Describe the activity…"
+                    className="
+                      flex h-9 w-full rounded-md border bg-background px-2
+                      text-sm
+                    "
+                  />
+                )
+                : (
+                  <Combobox
+                    items={itemOptions.map(o => o.value)}
+                    value={row.id || null}
+                    onValueChange={val => update(day, {
+                      id: val ?? "",
+                    })}
+                    itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+                  >
+                    <ComboboxInput
+                      placeholder={
+                        row.type === "task"
+                          ? "Search tasks..."
+                          : row.type === "resource"
+                            ? "Search resources..."
+                            : "Pick a type first"
+                      }
+                      showClear
+                      disabled={!row.type}
+                    />
+                    <ComboboxContent>
+                      <ComboboxEmpty>No items found.</ComboboxEmpty>
+                      <ComboboxList>
+                        {(val: string) => (
+                          <ComboboxItem
+                            key={val}
+                            value={val}
+                          >
+                            {optionsMap.get(val) ?? val}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
+                )}
             </li>
           );
         })}

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -1,6 +1,6 @@
 import type { RoutineWeekday, RoutineWeekly } from "@emstack/types/src";
 
-export type WeeklyRowType = "" | "task" | "resource";
+export type WeeklyRowType = "" | "task" | "resource" | "freeform";
 
 export interface WeeklyRow {
   day: RoutineWeekday;
@@ -45,7 +45,7 @@ export function weeklyToRows(
 export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
   const weekly: RoutineWeekly = {};
   for (const row of rows) {
-    if ((row.type === "task" || row.type === "resource") && row.id) {
+    if ((row.type === "task" || row.type === "resource" || row.type === "freeform") && row.id) {
       weekly[row.day] = {
         type: row.type,
         id: row.id,

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -62,11 +62,11 @@ const STATUS_OPTIONS = [
 const weeklyRowSchema = z
   .object({
     day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
-    type: z.enum(["", "task", "resource"]),
+    type: z.enum(["", "task", "resource", "freeform"]),
     id: z.string(),
   })
   .refine(row => row.type === "" || row.id.length > 0, {
-    message: "Pick an item for this day",
+    message: "Required",
     path: ["id"],
   });
 

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -138,34 +138,47 @@ function SingleRoutine() {
                 >
                   <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
                   {entry
-                    ? (
-                      <Link
-                        to={
-                          entry.type === "task"
-                            ? "/tasks/$id"
-                            : "/resources/$id"
-                        }
-                        params={{
-                          id: entry.id,
-                        }}
-                        className="
-                          text-blue-800
-                          hover:text-blue-600
-                          dark:text-blue-300
-                        "
-                      >
-                        <span
+                    ? entry.type === "freeform"
+                      ? (
+                        <span className="text-sm">
+                          <span
+                            className="
+                              mr-2 text-xs text-muted-foreground uppercase
+                            "
+                          >
+                            freeform
+                          </span>
+                          {entry.id}
+                        </span>
+                      )
+                      : (
+                        <Link
+                          to={
+                            entry.type === "task"
+                              ? "/tasks/$id"
+                              : "/resources/$id"
+                          }
+                          params={{
+                            id: entry.id,
+                          }}
                           className="
-                            mr-2 text-xs text-muted-foreground uppercase
+                            text-blue-800
+                            hover:text-blue-600
+                            dark:text-blue-300
                           "
                         >
-                          {entry.type}
-                        </span>
-                        {entry.type === "task"
-                          ? (taskNames.get(entry.id) ?? entry.id)
-                          : (resourceNames.get(entry.id) ?? entry.id)}
-                      </Link>
-                    )
+                          <span
+                            className="
+                              mr-2 text-xs text-muted-foreground uppercase
+                            "
+                          >
+                            {entry.type}
+                          </span>
+                          {entry.type === "task"
+                            ? (taskNames.get(entry.id) ?? entry.id)
+                            : (resourceNames.get(entry.id) ?? entry.id)}
+                        </Link>
+                      )
                     : (
                       <span className="text-sm text-muted-foreground italic">
                         Nothing scheduled

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -22,7 +22,7 @@ export interface DailyCriteria {
 export type RoutineWeekday = "0" | "1" | "2" | "3" | "4" | "5" | "6";
 
 export interface RoutineReferenceItem {
-  type: "task" | "resource";
+  type: "task" | "resource" | "freeform";
   id: string;
 }
 

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -48,7 +48,7 @@ export const routineReferenceItemSchema = {
   properties: {
     type: {
       type: "string",
-      enum: ["task", "resource"],
+      enum: ["task", "resource", "freeform"],
     },
     id: {
       type: "string",

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -1,6 +1,6 @@
 import type { EntityStatus } from "./EntityStatus";
 
-export type RoutineReferenceType = "task" | "resource";
+export type RoutineReferenceType = "task" | "resource" | "freeform";
 
 export interface RoutineReferenceItem {
   type: RoutineReferenceType;


### PR DESCRIPTION
Extends RoutineReferenceType with a "freeform" option so users can label a day's activity as free text (e.g. "Rest day", "Gym") without linking to a task or resource. When "Freeform" is selected in the type dropdown, the item-picker combobox is replaced by a plain text input; the text is stored in the existing `id` field.

https://claude.ai/code/session_01VgMV4DW9puDyfjM3vA7M8g