### PR TITLE
Add horizontal padding to DailyRecentDaysStrip

### DIFF
--- a/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
+++ b/packages/client/src/components/dailies/DailyRecentDaysStrip.tsx
@@ -43,7 +43,10 @@ export function DailyRecentDaysStrip({
   return (
     <div
       className={cn(
-        "flex flex-row items-start overflow-x-auto py-1 [scrollbar-width:thin]",
+        `
+          flex flex-row items-start overflow-x-auto px-2 py-1
+          [scrollbar-width:thin]
+        `,
         className,
       )}
     >


### PR DESCRIPTION
## Summary
Adds horizontal padding (`px-2`) to the `DailyRecentDaysStrip` component to improve spacing and visual balance.

## Changes
- Added `px-2` (horizontal padding) to the component's root container className
- Reformatted the className string to use template literals for better readability with multi-line Tailwind classes

## Details
The change improves the visual presentation of the recent days strip by adding consistent left and right padding, preventing the scrollable content from touching the container edges. The className was also reformatted to span multiple lines for improved maintainability when managing multiple Tailwind utility classes.

https://claude.ai/code/session_01Gx4S7TE2jxct3dJH9mwvn1