### PR TITLE
Add optional notes field to weekly routine schedule items

### DIFF
--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -53,6 +53,7 @@ export function WeeklyScheduleField({
             day,
             type: "" as WeeklyRowType,
             id: "",
+            notes: "",
           };
           const itemOptions
             = row.type === "task"
@@ -66,83 +67,102 @@ export function WeeklyScheduleField({
             <li
               key={day}
               className="
-                grid grid-cols-[110px_140px_1fr] items-center gap-2 rounded-md
-                border bg-background px-2 py-1.5
+                flex flex-col gap-1.5 rounded-md border bg-background px-2
+                py-1.5
               "
             >
-              <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
-
-              <select
-                aria-label={`${DAY_LABELS[day]} type`}
-                value={row.type}
-                onChange={(e) => {
-                  // Changing the type clears the chosen item (different
-                  // option set).
-                  update(day, {
-                    type: e.target.value as WeeklyRowType,
-                    id: "",
-                  });
-                }}
-                className="
-                  flex h-9 w-full rounded-md border bg-background px-2 text-sm
-                "
+              <div
+                className="grid grid-cols-[110px_140px_1fr] items-center gap-2"
               >
-                <option value="">— None —</option>
-                <option value="task">Task</option>
-                <option value="resource">Resource</option>
-                <option value="freeform">Freeform</option>
-              </select>
+                <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
 
-              {row.type === "freeform"
-                ? (
-                  <input
-                    aria-label={`${DAY_LABELS[day]} description`}
-                    value={row.id}
-                    onChange={e => update(day, {
-                      id: e.target.value,
-                    })}
-                    placeholder="Describe the activity…"
-                    className="
-                      flex h-9 w-full rounded-md border bg-background px-2
-                      text-sm
-                    "
-                  />
-                )
-                : (
-                  <Combobox
-                    items={itemOptions.map(o => o.value)}
-                    value={row.id || null}
-                    onValueChange={val => update(day, {
-                      id: val ?? "",
-                    })}
-                    itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-                  >
-                    <ComboboxInput
-                      placeholder={
-                        row.type === "task"
-                          ? "Search tasks..."
-                          : row.type === "resource"
-                            ? "Search resources..."
-                            : "Pick a type first"
-                      }
-                      showClear
-                      disabled={!row.type}
+                <select
+                  aria-label={`${DAY_LABELS[day]} type`}
+                  value={row.type}
+                  onChange={(e) => {
+                    // Changing the type clears the chosen item (different
+                    // option set) and any note.
+                    update(day, {
+                      type: e.target.value as WeeklyRowType,
+                      id: "",
+                      notes: "",
+                    });
+                  }}
+                  className="
+                    flex h-9 w-full rounded-md border bg-background px-2 text-sm
+                  "
+                >
+                  <option value="">— None —</option>
+                  <option value="task">Task</option>
+                  <option value="resource">Resource</option>
+                  <option value="freeform">Freeform</option>
+                </select>
+
+                {row.type === "freeform"
+                  ? (
+                    <input
+                      aria-label={`${DAY_LABELS[day]} description`}
+                      value={row.id}
+                      onChange={e => update(day, {
+                        id: e.target.value,
+                      })}
+                      placeholder="Describe the activity…"
+                      className="
+                        flex h-9 w-full rounded-md border bg-background px-2
+                        text-sm
+                      "
                     />
-                    <ComboboxContent>
-                      <ComboboxEmpty>No items found.</ComboboxEmpty>
-                      <ComboboxList>
-                        {(val: string) => (
-                          <ComboboxItem
-                            key={val}
-                            value={val}
-                          >
-                            {optionsMap.get(val) ?? val}
-                          </ComboboxItem>
-                        )}
-                      </ComboboxList>
-                    </ComboboxContent>
-                  </Combobox>
-                )}
+                  )
+                  : (
+                    <Combobox
+                      items={itemOptions.map(o => o.value)}
+                      value={row.id || null}
+                      onValueChange={val => update(day, {
+                        id: val ?? "",
+                      })}
+                      itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+                    >
+                      <ComboboxInput
+                        placeholder={
+                          row.type === "task"
+                            ? "Search tasks..."
+                            : row.type === "resource"
+                              ? "Search resources..."
+                              : "Pick a type first"
+                        }
+                        showClear
+                        disabled={!row.type}
+                      />
+                      <ComboboxContent>
+                        <ComboboxEmpty>No items found.</ComboboxEmpty>
+                        <ComboboxList>
+                          {(val: string) => (
+                            <ComboboxItem
+                              key={val}
+                              value={val}
+                            >
+                              {optionsMap.get(val) ?? val}
+                            </ComboboxItem>
+                          )}
+                        </ComboboxList>
+                      </ComboboxContent>
+                    </Combobox>
+                  )}
+              </div>
+
+              {row.type !== "" && (
+                <input
+                  aria-label={`${DAY_LABELS[day]} notes`}
+                  value={row.notes}
+                  onChange={e => update(day, {
+                    notes: e.target.value,
+                  })}
+                  placeholder="Notes (optional)…"
+                  className="
+                    flex h-9 w-full rounded-md border bg-background px-2 text-sm
+                  "
+                />
+              )}
             </li>
           );
         })}

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -1,0 +1,86 @@
+import type { RoutineWeekly } from "@emstack/types/src";
+
+import { describe, expect, test } from "vitest";
+
+import { rowsToWeekly, weeklyToRows } from "./weekly";
+
+describe("weekly schedule item notes", () => {
+  test("weeklyToRows surfaces an item's notes", () => {
+    const weekly: RoutineWeekly = {
+      1: {
+        type: "task",
+        id: "task-1",
+        notes: "focus on the subjunctive",
+      },
+    };
+    const monday = weeklyToRows(weekly).find(r => r.day === "1");
+    expect(monday?.notes).toBe("focus on the subjunctive");
+  });
+
+  test("weeklyToRows defaults a missing note to an empty string", () => {
+    const weekly: RoutineWeekly = {
+      2: {
+        type: "resource",
+        id: "res-1",
+      },
+    };
+    const tuesday = weeklyToRows(weekly).find(r => r.day === "2");
+    expect(tuesday?.notes).toBe("");
+  });
+
+  test("rowsToWeekly preserves a non-empty note", () => {
+    const weekly: RoutineWeekly = {
+      3: {
+        type: "task",
+        id: "task-9",
+        notes: "do exercises 1-5",
+      },
+    };
+    expect(rowsToWeekly(weeklyToRows(weekly))[3]).toEqual({
+      type: "task",
+      id: "task-9",
+      notes: "do exercises 1-5",
+    });
+  });
+
+  test("rowsToWeekly omits an empty note from the stored item", () => {
+    const weekly: RoutineWeekly = {
+      4: {
+        type: "task",
+        id: "task-2",
+      },
+    };
+    const stored = rowsToWeekly(weeklyToRows(weekly))[4];
+    expect(stored).toEqual({
+      type: "task",
+      id: "task-2",
+    });
+    expect(stored).not.toHaveProperty("notes");
+  });
+
+  test("a weekly grid survives a rows round-trip with notes intact", () => {
+    const original: RoutineWeekly = {
+      1: {
+        type: "task",
+        id: "task-1",
+        notes: "warm up",
+      },
+      5: {
+        type: "freeform",
+        id: "Read a chapter",
+        notes: "",
+      },
+    };
+    const restored = rowsToWeekly(weeklyToRows(original));
+    expect(restored[1]).toEqual({
+      type: "task",
+      id: "task-1",
+      notes: "warm up",
+    });
+    // The empty note is dropped, the freeform item is otherwise intact.
+    expect(restored[5]).toEqual({
+      type: "freeform",
+      id: "Read a chapter",
+    });
+  });
+});

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -7,6 +7,8 @@ export interface WeeklyRow {
   // "" = no entry scheduled for this day.
   type: WeeklyRowType;
   id: string;
+  // Optional free-text note for this day's item. "" = no note.
+  notes: string;
 }
 
 // Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.
@@ -36,6 +38,7 @@ export function weeklyToRows(
       day,
       type: entry?.type ?? "",
       id: entry?.id ?? "",
+      notes: entry?.notes ?? "",
     };
   });
 }
@@ -49,6 +52,12 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
       weekly[row.day] = {
         type: row.type,
         id: row.id,
+        // Only persist a note when present, keeping the stored JSON clean.
+        ...(row.notes
+          ? {
+            notes: row.notes,
+          }
+          : {}),
       };
     }
   }
@@ -61,26 +70,31 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
 export function representativeRow(rows: WeeklyRow[]): {
   type: WeeklyRowType;
   id: string;
+  notes: string;
 } {
   const found = rows.find(r => r.type !== "" && r.id);
   return found
     ? {
       type: found.type,
       id: found.id,
+      notes: found.notes,
     }
     : {
       type: "",
       id: "",
+      notes: "",
     };
 }
 
 export function fillAllDays(entry: {
   type: WeeklyRowType;
   id: string;
+  notes?: string;
 }): WeeklyRow[] {
   return ALL_DAYS.map(day => ({
     day,
     type: entry.type,
     id: entry.id,
+    notes: entry.notes ?? "",
   }));
 }

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -108,6 +108,7 @@ const weeklyRowSchema = z
     day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
     type: z.enum(["", "task", "resource", "freeform"]),
     id: z.string(),
+    notes: z.string(),
   })
   .refine(row => row.type === "" || row.id.length > 0, {
     message: "Required",

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -77,36 +77,47 @@ function SingleRoutine() {
     : null;
 
   function renderEntryLink(entry: { type: string;
-    id: string; }) {
-    if (entry.type === "freeform") {
-      return (
+    id: string;
+    notes?: string | null; }) {
+    const main = entry.type === "freeform"
+      ? (
         <span className="text-sm">
           <span className="mr-2 text-xs text-muted-foreground uppercase">
             freeform
           </span>
           {entry.id}
         </span>
+      )
+      : (
+        <Link
+          to={entry.type === "task" ? "/tasks/$id" : "/resources/$id"}
+          params={{
+            id: entry.id,
+          }}
+          className="
+            text-blue-800
+            hover:text-blue-600
+            dark:text-blue-300
+          "
+        >
+          <span className="mr-2 text-xs text-muted-foreground uppercase">
+            {entry.type}
+          </span>
+          {entry.type === "task"
+            ? (taskNames.get(entry.id) ?? entry.id)
+            : (resourceNames.get(entry.id) ?? entry.id)}
+        </Link>
       );
+
+    if (!entry.notes) {
+      return main;
     }
+
     return (
-      <Link
-        to={entry.type === "task" ? "/tasks/$id" : "/resources/$id"}
-        params={{
-          id: entry.id,
-        }}
-        className="
-          text-blue-800
-          hover:text-blue-600
-          dark:text-blue-300
-        "
-      >
-        <span className="mr-2 text-xs text-muted-foreground uppercase">
-          {entry.type}
-        </span>
-        {entry.type === "task"
-          ? (taskNames.get(entry.id) ?? entry.id)
-          : (resourceNames.get(entry.id) ?? entry.id)}
-      </Link>
+      <span className="flex flex-col gap-0.5">
+        {main}
+        <span className="text-sm text-muted-foreground">{entry.notes}</span>
+      </span>
     );
   }
 

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -24,6 +24,7 @@ export type RoutineWeekday = "0" | "1" | "2" | "3" | "4" | "5" | "6";
 export interface RoutineReferenceItem {
   type: "task" | "resource" | "freeform";
   id: string;
+  notes?: string | null;
 }
 
 export type RoutineWeekly = Partial<Record<RoutineWeekday, RoutineReferenceItem>>;

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -60,6 +60,7 @@ export const routineReferenceItemSchema = {
     id: {
       type: "string",
     },
+    notes: nullableString,
   },
 } as const;
 

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -11,6 +11,9 @@ export type RoutineMode = "weekly" | "daily";
 export interface RoutineReferenceItem {
   type: RoutineReferenceType;
   id: string;
+  // Optional free-text annotation for this day's scheduled item (e.g. "focus
+  // on the subjunctive"). Empty/absent means no note.
+  notes?: string | null;
 }
 
 // Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.


### PR DESCRIPTION
## Summary
Adds support for optional free-text notes on weekly routine schedule items, allowing users to annotate scheduled tasks, resources, and freeform activities with contextual information (e.g., "focus on the subjunctive" for a language task).

## Key Changes

- **Type definitions** (`packages/types/src/Routine.ts`, `packages/middleware/src/db/schema.ts`): Added optional `notes?: string | null` field to `RoutineReferenceItem` interface
- **Weekly schedule UI** (`packages/client/src/components/routines/WeeklyScheduleField.tsx`):
  - Restructured layout from single-row grid to flex column to accommodate notes input
  - Added conditional notes input field that appears when a day has a scheduled item
  - Updated type-change handler to clear notes when switching item types
  - Notes field is optional and only shown when `row.type !== ""`
- **Weekly schedule logic** (`packages/client/src/components/routines/weekly.ts`):
  - Updated `WeeklyRow` interface to include `notes: string` field
  - Modified `weeklyToRows()` to surface notes from stored items (defaults to empty string)
  - Modified `rowsToWeekly()` to persist notes only when non-empty, keeping stored JSON clean
  - Updated helper functions (`representativeRow`, `fillAllDays`) to handle notes
- **Routine display** (`packages/client/src/routes/routines.$id.index.tsx`): Refactored `renderEntryLink()` to display notes below the main item link when present
- **Form validation** (`packages/client/src/routes/routines.$id.edit.tsx`): Added `notes: z.string()` to weekly row schema
- **Database schema** (`packages/middleware/src/utils/schemas.ts`): Added `notes: nullableString` to `routineReferenceItemSchema`
- **Tests** (`packages/client/src/components/routines/weekly.test.ts`): Added comprehensive test suite covering notes persistence, round-trip conversion, and empty note handling

## Implementation Details

- Notes are stored only when non-empty to keep the persisted JSON clean
- Empty notes default to `""` in the UI layer but are omitted from the stored `RoutineReferenceItem`
- Notes field is conditionally rendered only when an item type is selected, improving UX
- The feature integrates seamlessly with existing weekly schedule logic without breaking changes

https://claude.ai/code/session_01DFW3fUZbneCJkxs6efTWt7