### PR TITLE
Refactor daily details into tabbed interface and move stats to routine page

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -180,6 +180,9 @@ export function DailyCompletionsManager({
           queryKey: ["daily", daily.id],
         }),
         queryClient.invalidateQueries({
+          queryKey: ["routine", daily.id],
+        }),
+        queryClient.invalidateQueries({
           queryKey: ["dailies"],
         }),
       ]);

--- a/packages/client/src/components/dailies/DailyDetailsPanel.tsx
+++ b/packages/client/src/components/dailies/DailyDetailsPanel.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { FlameIcon, LaughIcon } from "lucide-react";
 
 import { DailyCompletionsManager } from "./DailyCompletionsManager";
 import { DailyRecentDaysStrip } from "./DailyRecentDaysStrip";
@@ -7,10 +6,9 @@ import { DAILY_STATUS_OPTIONS } from "./dailyStatusMeta";
 
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   fetchSingleDaily,
-  getCurrentChain,
-  getTotalCompletedDays,
   isHttpUrl,
 } from "@/utils";
 
@@ -36,8 +34,6 @@ export function DailyDetailsPanel({
     return <EntityError entity="daily" />;
   }
 
-  const total = getTotalCompletedDays(data);
-  const chain = getCurrentChain(data);
   const locationIsUrl = !!data.location && isHttpUrl(data.location);
   const isComplete = data.status === "complete";
   const criteria = data.criteria ?? {};
@@ -77,104 +73,91 @@ export function DailyDetailsPanel({
   const visibleCriteria = criteriaLabels.filter(c => !!criteria[c.key]);
 
   return (
-    <div className="flex flex-col gap-12">
-      <InfoArea
-        header="Description"
-        condition={!!data.description}
-      >
-        <p>{data.description}</p>
-      </InfoArea>
-      <InfoArea
-        header="Location"
-        condition={!!data.location && !locationIsUrl}
-      >
-        <p>{data.location}</p>
-      </InfoArea>
-      <InfoArea
-        header="Provider"
-        condition={!!data.provider}
-      >
-        <p>{data.provider?.name}</p>
-      </InfoArea>
-      <InfoArea
-        header="Last 14 days"
-        condition={true}
-      >
-        <DailyRecentDaysStrip
-          daily={data}
-          count={14}
-          labelFormat="mmdd"
-        />
-      </InfoArea>
-      <InfoArea
-        header="Stats"
-        condition={true}
-      >
-        <div className="flex flex-row flex-wrap gap-6 text-sm">
-          <span className="inline-flex items-center gap-1">
-            <FlameIcon
-              size={16}
-              className={chain > 0
-                ? "text-orange-600"
-                : "text-muted-foreground"}
+    <Tabs defaultValue="details">
+      <TabsList>
+        <TabsTrigger value="details">Details</TabsTrigger>
+        <TabsTrigger value="entries">
+          {isComplete ? "Day Entries (completed)" : "Day Entries"}
+        </TabsTrigger>
+        <TabsTrigger value="criteria">Status Criteria</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="details">
+        <div className="flex flex-col gap-6">
+          <InfoArea
+            header="Description"
+            condition={!!data.description}
+          >
+            <p>{data.description}</p>
+          </InfoArea>
+          <InfoArea
+            header="Location"
+            condition={!!data.location && !locationIsUrl}
+          >
+            <p>{data.location}</p>
+          </InfoArea>
+          <InfoArea
+            header="Provider"
+            condition={!!data.provider}
+          >
+            <p>{data.provider?.name}</p>
+          </InfoArea>
+          <InfoArea
+            header="Last 14 days"
+            condition={true}
+          >
+            <DailyRecentDaysStrip
+              daily={data}
+              count={14}
+              labelFormat="mmdd"
             />
-            <strong>{chain}</strong>
-            <span className="text-muted-foreground">day chain</span>
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <LaughIcon
-              size={16}
-              className={total > 0
-                ? "text-emerald-600"
-                : "text-muted-foreground"}
-            />
-            <strong>{total}</strong>
-            <span className="text-muted-foreground">total days</span>
-          </span>
+          </InfoArea>
         </div>
-      </InfoArea>
-      {visibleCriteria.length > 0 && (
-        <InfoArea
-          header="Status Criteria"
-          condition={true}
-        >
-          <dl className="flex flex-col gap-2">
-            {visibleCriteria.map(c => (
-              <div
-                key={c.key}
-                className="flex flex-col gap-0.5"
-              >
-                <dt
-                  className="
-                    flex flex-row items-center gap-1.5 text-sm font-bold
-                  "
-                >
-                  <span className="inline-flex shrink-0 items-center">
-                    {c.icon}
-                  </span>
-                  <span>{c.label}</span>
-                </dt>
-                <dd
-                  className="
-                    pl-6 text-sm whitespace-pre-wrap text-muted-foreground
-                  "
-                >
-                  {criteria[c.key]}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </InfoArea>
-      )}
-      <InfoArea
-        header={isComplete ? "Day entries (completed)" : "Day entries"}
-        condition={true}
-      >
+      </TabsContent>
+
+      <TabsContent value="entries">
         <DailyCompletionsManager
           daily={data}
           readOnly={data.status !== "active"}
         />
-      </InfoArea>
-    </div>
+      </TabsContent>
+
+      <TabsContent value="criteria">
+        {visibleCriteria.length > 0
+          ? (
+            <dl className="flex flex-col gap-2">
+              {visibleCriteria.map(c => (
+                <div
+                  key={c.key}
+                  className="flex flex-col gap-0.5"
+                >
+                  <dt
+                    className="
+                      flex flex-row items-center gap-1.5 text-sm font-bold
+                    "
+                  >
+                    <span className="inline-flex shrink-0 items-center">
+                      {c.icon}
+                    </span>
+                    <span>{c.label}</span>
+                  </dt>
+                  <dd
+                    className="
+                      pl-6 text-sm whitespace-pre-wrap text-muted-foreground
+                    "
+                  >
+                    {criteria[c.key]}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )
+          : (
+            <p className="text-sm text-muted-foreground">
+              <i>No status criteria defined.</i>
+            </p>
+          )}
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { EditIcon } from "lucide-react";
+import { EditIcon, FlameIcon, LaughIcon } from "lucide-react";
 
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
 import { EntityError, EntityPending } from "@/components/EntityStates";
@@ -13,7 +13,13 @@ import {
   DAY_ORDER,
 } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
-import { fetchResources, fetchSingleRoutine, fetchTasks } from "@/utils";
+import {
+  fetchResources,
+  fetchSingleRoutine,
+  fetchTasks,
+  getCurrentChain,
+  getTotalCompletedDays,
+} from "@/utils";
 
 export const Route = createFileRoute("/routines/$id/")({
   component: SingleRoutine,
@@ -75,6 +81,13 @@ function SingleRoutine() {
   const dailyEntry = isDaily
     ? Object.values(weekly).find(Boolean) ?? null
     : null;
+  const completions = data.completions ?? [];
+  const chain = getCurrentChain({
+    completions,
+  });
+  const total = getTotalCompletedDays({
+    completions,
+  });
 
   function renderEntryLink(entry: { type: string;
     id: string; }) {
@@ -130,19 +143,61 @@ function SingleRoutine() {
         </Link>
       </PageHeader>
       <div className="container flex flex-col gap-12">
-        <InfoArea
-          header="Type"
-          condition={true}
+        <div
+          className="
+            grid grid-cols-1 gap-12
+            md:grid-cols-4
+          "
         >
-          <span
-            className="
-              inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs
-              font-medium
-            "
+          <InfoArea
+            header="Type"
+            condition={true}
           >
-            {isDaily ? "Daily Task" : "Weekly Schedule"}
-          </span>
-        </InfoArea>
+            <span
+              className="
+                inline-flex items-center rounded-full border px-2.5 py-0.5
+                text-xs font-medium
+              "
+            >
+              {isDaily ? "Daily Task" : "Weekly Schedule"}
+            </span>
+          </InfoArea>
+          <InfoArea
+            header="Status"
+            condition={true}
+          >
+            <span className="capitalize">{data.status ?? "active"}</span>
+          </InfoArea>
+          <div className="md:col-span-2">
+            <InfoArea
+              header="Stats"
+              condition={true}
+            >
+              <div className="flex flex-row flex-wrap gap-6 text-sm">
+                <span className="inline-flex items-center gap-1">
+                  <FlameIcon
+                    size={16}
+                    className={chain > 0
+                      ? "text-orange-600"
+                      : "text-muted-foreground"}
+                  />
+                  <strong>{chain}</strong>
+                  <span className="text-muted-foreground">day chain</span>
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <LaughIcon
+                    size={16}
+                    className={total > 0
+                      ? "text-emerald-600"
+                      : "text-muted-foreground"}
+                  />
+                  <strong>{total}</strong>
+                  <span className="text-muted-foreground">total days</span>
+                </span>
+              </div>
+            </InfoArea>
+          </div>
+        </div>
         <InfoArea
           header="Topic"
           condition={!!data.topic}
@@ -160,12 +215,6 @@ function SingleRoutine() {
           >
             {data.topic?.name}
           </Link>
-        </InfoArea>
-        <InfoArea
-          header="Status"
-          condition={true}
-        >
-          <span className="capitalize">{data.status ?? "active"}</span>
         </InfoArea>
         {isDaily
           ? (


### PR DESCRIPTION
## Summary
Reorganizes the daily details panel into a tabbed interface for better content organization, and moves completion statistics (chain and total days) from the daily details panel to the routine page where they're more contextually relevant.

## Key Changes

- **DailyDetailsPanel.tsx:**
  - Converted linear layout into a tabbed interface with three tabs: "Details", "Day Entries", and "Status Criteria"
  - Removed `FlameIcon` and `LaughIcon` imports and the stats section (chain and total days display)
  - Removed unused utility imports (`getCurrentChain`, `getTotalCompletedDays`)
  - Reduced gap spacing from `gap-12` to `gap-6` within the details tab
  - Added fallback message for criteria tab when no criteria are defined
  - Improved visual hierarchy by separating concerns into distinct tabs

- **routines.$id.index.tsx:**
  - Added `FlameIcon` and `LaughIcon` imports
  - Imported `getCurrentChain` and `getTotalCompletedDays` utilities
  - Calculated chain and total stats from routine completions data
  - Added "Status" info area to the routine header
  - Reorganized header layout into a responsive grid (1 column on mobile, 4 columns on desktop)
  - Moved stats display to a dedicated info area in the routine header for better visibility

- **DailyCompletionsManager.tsx:**
  - Added query invalidation for the routine when daily completions are updated, ensuring stats stay in sync

## Implementation Details

The stats display now lives at the routine level rather than within the daily details panel, making it more prominent and contextually appropriate. The daily details panel is now cleaner and more focused, with content logically grouped into tabs. The responsive grid layout on the routine page ensures the stats display adapts well to different screen sizes.

https://claude.ai/code/session_01FUuDb71zzg37pUZhyNfZNb