### PR TITLE
Refactor routines to support polymorphic connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ If you change `packages/middleware/src/db/schema.ts`, run `pnpm --filter=@emstac
 Defined in `packages/middleware/src/db/schema.ts`.
 
 - **Core tables:** `users`, `topics`, `courseProviders`, `courses`, `dailies`, `tasks`, `resources` (task resources), `task_todos`, `domains`
-- **Junction tables:** `topics_to_courses`, `domain_within_scope_topics`
+- **Junction tables:** `topics_to_courses`, `domain_within_scope_topics`, `routine_connections` (polymorphic many-to-many linking a routine to Topics/Tasks/Resources via `connected_type` + `connected_id`; any number may be active)
 - **Radar tables:** `radar_blips` (a blip's `is_ignored` flag marks an "out of scope" / ignored topic; its `description` holds the ignore reasoning). Quadrants/rings live in the `domains.radar_config` JSONB column.
 - **Enums:** `recurPeriodUnit` (days/months/years), `status` (active/inactive/complete/paused), `dailyCompletionStatus` (incomplete/touched/goal/exceeded/freeze), `resourceLevel` (low/medium/high)
 - Uses `drizzle-kit push` (not migration files) — schema changes pushed directly to database

--- a/packages/client/src/components/boxElements/EntityLink.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.tsx
@@ -2,13 +2,14 @@ import type { ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 
-type EntityKind = "resources" | "topics" | "providers" | "domains";
+type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
 
 const FROM_BY_KIND: Record<EntityKind, string> = {
   resources: "/resources",
   topics: "/topics",
   providers: "/providers",
   domains: "/domains",
+  tasks: "/tasks",
 };
 
 const TO_BY_KIND: Record<EntityKind, string> = {
@@ -16,6 +17,7 @@ const TO_BY_KIND: Record<EntityKind, string> = {
   topics: "/topics/$id",
   providers: "/providers/$id",
   domains: "/domains/$id",
+  tasks: "/tasks/$id",
 };
 
 interface EntityLinkProps {

--- a/packages/client/src/components/boxes/RoutineBox.tsx
+++ b/packages/client/src/components/boxes/RoutineBox.tsx
@@ -14,7 +14,11 @@ import {
   ContentBoxTitle,
 } from "@/components/boxes/ContentBox";
 import { cn } from "@/lib/utils";
-import { getCurrentChain, getTotalCompletedDays } from "@/utils";
+import {
+  connectionEntityKind,
+  getCurrentChain,
+  getTotalCompletedDays,
+} from "@/utils";
 
 // Monday-first display order with single-letter labels.
 const DAY_STRIP: { day: RoutineWeekday;
@@ -53,7 +57,7 @@ export function RoutineBox({
   id,
   name,
   description,
-  topic,
+  connections,
   status,
   weekly,
   mode,
@@ -75,23 +79,26 @@ export function RoutineBox({
     <ContentBox>
       <ContentBoxHeader>
         <ContentBoxHeaderBar>
-          <div className="flex flex-row items-center gap-2">
-            {topic
+          <div className="flex flex-row flex-wrap items-center gap-2">
+            {connections && connections.length > 0
               ? (
-                <EntityLink
-                  entity="topics"
-                  id={topic.id}
-                  className={`
-                    rounded-sm bg-gray-50 px-2 py-0.5 text-xs
-                    hover:bg-gray-900 hover:text-white
-                  `}
-                >
-                  {topic.name}
-                </EntityLink>
+                connections.map(c => (
+                  <EntityLink
+                    key={`${c.type}:${c.id}`}
+                    entity={connectionEntityKind(c.type)}
+                    id={c.id}
+                    className={`
+                      rounded-sm bg-gray-50 px-2 py-0.5 text-xs
+                      hover:bg-gray-900 hover:text-white
+                    `}
+                  >
+                    {c.name ?? c.id}
+                  </EntityLink>
+                ))
               )
               : (
                 <span className="text-xs text-muted-foreground italic">
-                  No topic
+                  No connections
                 </span>
               )}
           </div>

--- a/packages/client/src/routes/resources.$id.index.tsx
+++ b/packages/client/src/routes/resources.$id.index.tsx
@@ -57,11 +57,12 @@ function SingleCourse() {
 
   const topics = data?.topics ?? null;
 
-  // The resource → routine link lives inside each routine's weekly grid.
+  // A resource → routine link is either a weekly-grid entry or a connection.
   const linkedRoutines = (routines ?? []).filter(r =>
     Object.values(r.weekly ?? {}).some(
       e => e?.type === "resource" && e.id === id,
-    ));
+    )
+    || (r.connections ?? []).some(c => c.type === "resource" && c.id === id));
 
   return (
     <div className="container flex-col gap-12">

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -1,4 +1,4 @@
-import type { RoutineMode } from "@emstack/types/src";
+import type { RoutineConnectionType, RoutineMode } from "@emstack/types/src";
 
 import { useMemo, useRef } from "react";
 
@@ -30,9 +30,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import {
+  buildConnectionOptions,
   createRoutine,
+  decodeConnection,
   deleteSingleRoutine,
   duplicateRoutine,
+  encodeConnection,
   fetchDailyCriteriaTemplates,
   fetchResources,
   fetchRoutineTemplates,
@@ -45,7 +48,10 @@ import {
 } from "@/utils";
 
 interface RoutineEditSearch {
+  // Legacy alias: a bare `?topicId=` still prefills a topic connection.
   topicId?: string;
+  connectedType?: RoutineConnectionType;
+  connectedId?: string;
   mode?: RoutineMode;
   entryType?: "task" | "resource";
   entryId?: string;
@@ -57,6 +63,16 @@ export const Route = createFileRoute("/routines/$id/edit")({
     topicId:
       typeof search.topicId === "string" && search.topicId
         ? search.topicId
+        : undefined,
+    connectedType:
+      search.connectedType === "topic"
+      || search.connectedType === "task"
+      || search.connectedType === "resource"
+        ? search.connectedType
+        : undefined,
+    connectedId:
+      typeof search.connectedId === "string" && search.connectedId
+        ? search.connectedId
         : undefined,
     mode:
       search.mode === "weekly" || search.mode === "daily"
@@ -117,7 +133,7 @@ const weeklyRowSchema = z
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   description: z.string().max(2000),
-  topicId: z.string(),
+  connections: z.array(z.string()),
   status: z.enum(["active", "inactive", "complete", "paused"]),
   mode: z.enum(["weekly", "daily"]),
   location: z.string().max(255),
@@ -183,15 +199,41 @@ function SingleRoutineEdit() {
     queryFn: () => fetchDailyCriteriaTemplates(),
   });
 
-  const topicOptions = toOptions(topics);
   const taskOptions = useMemo(() => toOptions(tasks), [tasks]);
   const resourceOptions = useMemo(() => toOptions(resources), [resources]);
+  const connectionOptions = useMemo(
+    () => buildConnectionOptions(topics, tasks, resources),
+    [topics, tasks, resources],
+  );
+
+  // New routines can be prefilled with a connection via search params: the
+  // generic `?connectedType=&connectedId=` or the legacy `?topicId=` alias.
+  const prefilledConnections = useMemo(() => {
+    const out: string[] = [];
+    if (search.connectedType && search.connectedId) {
+      out.push(
+        encodeConnection({
+          type: search.connectedType,
+          id: search.connectedId,
+        }),
+      );
+    }
+    if (search.topicId) {
+      out.push(encodeConnection({
+        type: "topic",
+        id: search.topicId,
+      }));
+    }
+    return out;
+  }, [search.connectedType, search.connectedId, search.topicId]);
 
   const startingValues = useMemo(
     () => ({
       name: data?.name ?? "",
       description: data?.description ?? "",
-      topicId: data?.topicId ?? (isNew ? (search.topicId ?? "") : ""),
+      connections: isNew
+        ? prefilledConnections
+        : (data?.connections ?? []).map(encodeConnection),
       status: data?.status ?? "active",
       mode: data?.mode ?? (isNew ? (search.mode ?? "weekly") : "weekly"),
       location: data?.location ?? "",
@@ -208,7 +250,7 @@ function SingleRoutineEdit() {
       criteriaExceeded: data?.criteria?.exceeded ?? "",
       criteriaFreeze: data?.criteria?.freeze ?? "",
     }),
-    [data, isNew, search.topicId, search.mode, search.entryType, search.entryId],
+    [data, isNew, prefilledConnections, search.mode, search.entryType, search.entryId],
   );
 
   const form = useAppForm({
@@ -236,10 +278,14 @@ function SingleRoutineEdit() {
         criteria.freeze = value.criteriaFreeze;
       }
 
+      const connections = value.connections
+        .map(decodeConnection)
+        .filter((c): c is NonNullable<typeof c> => c !== null);
+
       const routineData = {
         name: value.name,
         description: value.description || null,
-        topicId: value.topicId || null,
+        connections,
         status: value.status,
         mode: value.mode,
         location: value.mode === "daily" ? value.location || null : null,
@@ -376,12 +422,13 @@ function SingleRoutineEdit() {
             )}
           </form.AppField>
 
-          <form.AppField name="topicId">
+          <form.AppField name="connections">
             {field => (
-              <field.ComboboxField
-                label="Topic"
-                options={topicOptions}
-                placeholder="Search topics..."
+              <field.MultiComboboxField
+                label="Connected To"
+                options={connectionOptions}
+                groupByPrefix
+                placeholder="Search topics, tasks, resources..."
               />
             )}
           </form.AppField>

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { EditIcon } from "lucide-react";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
@@ -13,7 +14,12 @@ import {
   DAY_ORDER,
 } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
-import { fetchResources, fetchSingleRoutine, fetchTasks } from "@/utils";
+import {
+  connectionEntityKind,
+  fetchResources,
+  fetchSingleRoutine,
+  fetchTasks,
+} from "@/utils";
 
 export const Route = createFileRoute("/routines/$id/")({
   component: SingleRoutine,
@@ -144,22 +150,29 @@ function SingleRoutine() {
           </span>
         </InfoArea>
         <InfoArea
-          header="Topic"
-          condition={!!data.topic}
+          header="Connected To"
+          condition={(data.connections?.length ?? 0) > 0}
         >
-          <Link
-            to="/topics/$id"
-            params={{
-              id: data.topic?.id ?? "",
-            }}
-            className={`
-              font-bold text-blue-800
-              hover:text-blue-600
-              dark:text-blue-300
-            `}
-          >
-            {data.topic?.name}
-          </Link>
+          <ul className="flex flex-col gap-1">
+            {data.connections?.map(c => (
+              <li key={`${c.type}:${c.id}`}>
+                <EntityLink
+                  entity={connectionEntityKind(c.type)}
+                  id={c.id}
+                  className={`
+                    font-bold text-blue-800
+                    hover:text-blue-600
+                    dark:text-blue-300
+                  `}
+                >
+                  <span className="mr-2 text-xs text-muted-foreground uppercase">
+                    {c.type}
+                  </span>
+                  {c.name ?? c.id}
+                </EntityLink>
+              </li>
+            ))}
+          </ul>
         </InfoArea>
         <InfoArea
           header="Status"

--- a/packages/client/src/routes/routines.index.tsx
+++ b/packages/client/src/routes/routines.index.tsx
@@ -1,4 +1,4 @@
-import type { Routine } from "@emstack/types/src";
+import type { Routine, RoutineConnectionType } from "@emstack/types/src";
 
 import { useMemo, useState } from "react";
 
@@ -18,10 +18,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { fetchRoutines, fetchTopics } from "@/utils";
+import { fetchRoutines } from "@/utils";
 
 interface RoutinesSearch {
+  // Legacy alias: `?topicId=` still prefilters by that topic connection.
   topicId?: string;
+  connectedType?: RoutineConnectionType;
+  connectedId?: string;
 }
 
 export const Route = createFileRoute("/routines/")({
@@ -32,6 +35,16 @@ export const Route = createFileRoute("/routines/")({
     topicId:
       typeof search.topicId === "string" && search.topicId
         ? search.topicId
+        : undefined,
+    connectedType:
+      search.connectedType === "topic"
+      || search.connectedType === "task"
+      || search.connectedType === "resource"
+        ? search.connectedType
+        : undefined,
+    connectedId:
+      typeof search.connectedId === "string" && search.connectedId
+        ? search.connectedId
         : undefined,
   }),
 });
@@ -46,9 +59,15 @@ function RoutinesError() {
 
 function Routines() {
   const urlSearch = Route.useSearch();
+  const initialConnection
+    = urlSearch.connectedType && urlSearch.connectedId
+      ? `${urlSearch.connectedType}:${urlSearch.connectedId}`
+      : urlSearch.topicId
+        ? `topic:${urlSearch.topicId}`
+        : undefined;
   const [search, setSearch] = useState("");
-  const [filterTopic, setFilterTopic] = useState<string | undefined>(
-    urlSearch.topicId,
+  const [filterConnection, setFilterConnection] = useState<string | undefined>(
+    initialConnection,
   );
   const [filterMode, setFilterMode] = useState<"weekly" | "daily" | undefined>(
     undefined,
@@ -59,13 +78,6 @@ function Routines() {
   } = useQuery({
     queryKey: ["routines"],
     queryFn: () => fetchRoutines(),
-  });
-
-  const {
-    data: topics,
-  } = useQuery({
-    queryKey: ["topics"],
-    queryFn: () => fetchTopics(),
   });
 
   const filtered = useMemo(() => {
@@ -80,11 +92,14 @@ function Routines() {
         || (r.description?.toLowerCase().includes(q) ?? false));
     }
 
-    if (filterTopic === "none") {
-      result = result.filter(r => !r.topic);
+    if (filterConnection === "none") {
+      result = result.filter(r => !r.connections || r.connections.length === 0);
     }
-    else if (filterTopic) {
-      result = result.filter(r => r.topic?.id === filterTopic);
+    else if (filterConnection) {
+      result = result.filter(r =>
+        (r.connections ?? []).some(
+          c => `${c.type}:${c.id}` === filterConnection,
+        ));
     }
 
     if (filterMode) {
@@ -93,21 +108,44 @@ function Routines() {
     }
 
     return result;
-  }, [data, search, filterTopic, filterMode]);
+  }, [data, search, filterConnection, filterMode]);
 
-  const hasActiveFilters = !!filterTopic || !!filterMode;
+  const hasActiveFilters = !!filterConnection || !!filterMode;
 
-  const routineCountByTopic = useMemo(() => {
-    const counts = new Map<string, number>();
+  // Distinct connections across all routines, each with its display name and
+  // count, for the filter dropdown.
+  const connectionFilterOptions = useMemo(() => {
+    const map = new Map<string, {
+      value: string;
+      name: string;
+      type: RoutineConnectionType;
+      count: number;
+    }>();
     data?.forEach((r) => {
-      const id = r.topic?.id;
-      if (id) counts.set(id, (counts.get(id) ?? 0) + 1);
+      r.connections?.forEach((c) => {
+        const value = `${c.type}:${c.id}`;
+        const existing = map.get(value);
+        if (existing) {
+          existing.count += 1;
+        }
+        else {
+          map.set(value, {
+            value,
+            name: c.name ?? c.id,
+            type: c.type,
+            count: 1,
+          });
+        }
+      });
     });
-    return counts;
+    return Array.from(map.values()).sort((a, b) =>
+      a.name.localeCompare(b.name));
   }, [data]);
   const totalRoutineCount = data?.length ?? 0;
-  const noTopicCount = useMemo(
-    () => data?.filter(r => !r.topic).length ?? 0,
+  const noConnectionCount = useMemo(
+    () =>
+      data?.filter(r => !r.connections || r.connections.length === 0).length
+      ?? 0,
     [data],
   );
 
@@ -160,37 +198,38 @@ function Routines() {
               />
             </div>
             <Select
-              value={filterTopic ?? "all"}
+              value={filterConnection ?? "all"}
               onValueChange={v =>
-                setFilterTopic(v === "all" ? undefined : v)}
+                setFilterConnection(v === "all" ? undefined : v)}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Topic" />
+                <SelectValue placeholder="Connection" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">
-                  <span>All Topics</span>
+                  <span>All Connections</span>
                   <FilterOptionCount count={totalRoutineCount} />
                 </SelectItem>
-                {noTopicCount > 0 && (
+                {noConnectionCount > 0 && (
                   <SelectItem value="none">
-                    <span>No Topic</span>
-                    <FilterOptionCount count={noTopicCount} />
+                    <span>No Connection</span>
+                    <FilterOptionCount count={noConnectionCount} />
                   </SelectItem>
                 )}
-                {topics
-                  ?.filter(t => (routineCountByTopic.get(t.id) ?? 0) > 0)
-                  .map(t => (
-                    <SelectItem
-                      key={t.id}
-                      value={t.id}
+                {connectionFilterOptions.map(opt => (
+                  <SelectItem
+                    key={opt.value}
+                    value={opt.value}
+                  >
+                    <span
+                      className="mr-1 text-xs text-muted-foreground uppercase"
                     >
-                      <span>{t.name}</span>
-                      <FilterOptionCount
-                        count={routineCountByTopic.get(t.id) ?? 0}
-                      />
-                    </SelectItem>
-                  ))}
+                      {opt.type}
+                    </span>
+                    <span>{opt.name}</span>
+                    <FilterOptionCount count={opt.count} />
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
             <Select
@@ -212,7 +251,7 @@ function Routines() {
                 variant="ghost"
                 size="sm"
                 onClick={() => {
-                  setFilterTopic(undefined);
+                  setFilterConnection(undefined);
                   setFilterMode(undefined);
                 }}
               >

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -49,11 +49,12 @@ function SingleTask() {
     return <TaskError />;
   }
 
-  // The task → routine link lives inside each routine's weekly grid.
+  // A task → routine link is either a weekly-grid entry or a connection.
   const linkedRoutines = (routines ?? []).filter(r =>
     Object.values(r.weekly ?? {}).some(
       e => e?.type === "task" && e.id === id,
-    ));
+    )
+    || (r.connections ?? []).some(c => c.type === "task" && c.id === id));
 
   return (
     <div>

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -6,7 +6,7 @@ import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
-import { fetchSingleTopic } from "@/utils";
+import { fetchRoutines, fetchSingleTopic } from "@/utils";
 
 export const Route = createFileRoute("/topics/$id/")({
   component: SingleTopic,
@@ -24,6 +24,13 @@ function SingleTopic() {
     queryFn: () => fetchSingleTopic(id),
   });
 
+  const {
+    data: routines,
+  } = useQuery({
+    queryKey: ["routines"],
+    queryFn: () => fetchRoutines(),
+  });
+
   if (isPending) {
     return <EntityPending entity="topic" />;
   }
@@ -31,6 +38,9 @@ function SingleTopic() {
   if (error) {
     return <EntityError entity="topic" />;
   }
+
+  const linkedRoutines = (routines ?? []).filter(r =>
+    (r.connections ?? []).some(c => c.type === "topic" && c.id === id));
 
   return (
     <div>
@@ -118,6 +128,31 @@ function SingleTopic() {
                     </Link>
                   </li>
                 ))}
+            </ul>
+          </InfoArea>
+        </div>
+        <div>
+          <InfoArea
+            header="Routines"
+            condition={linkedRoutines.length > 0}
+          >
+            <ul className="ml-5 list-disc">
+              {linkedRoutines.map(r => (
+                <li key={r.id}>
+                  <Link
+                    to="/routines/$id"
+                    params={{
+                      id: r.id,
+                    }}
+                    className={`
+                      font-bold text-blue-800
+                      hover:text-blue-600
+                    `}
+                  >
+                    {r.name}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </InfoArea>
         </div>

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from "./formHasChanges";
 export * from "./isHttpUrl";
 export * from "./makePercentageComplete";
 export * from "./parseCost";
+export * from "./routineConnections";
 export * from "./selectOptions";
 export * from "./stripCodeFence";
 export * from "./useIsFieldInvalid";

--- a/packages/client/src/utils/routineConnections.test.ts
+++ b/packages/client/src/utils/routineConnections.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildConnectionOptions,
+  connectionEntityKind,
+  decodeConnection,
+  encodeConnection,
+} from "./routineConnections.ts";
+
+describe("encode/decode connection", () => {
+  test("round-trips each connection type", () => {
+    for (const type of ["topic", "task", "resource"] as const) {
+      const encoded = encodeConnection({
+        type,
+        id: "abc-123",
+      });
+      expect(decodeConnection(encoded)).toEqual({
+        type,
+        id: "abc-123",
+      });
+    }
+  });
+
+  test("encodes with a capitalized group prefix for nice headers", () => {
+    expect(encodeConnection({
+      type: "topic",
+      id: "t1",
+    })).toBe("Topic:t1");
+  });
+
+  test("decodes an id that itself contains nothing weird", () => {
+    expect(decodeConnection("Resource:uuid-with-no-colon")).toEqual({
+      type: "resource",
+      id: "uuid-with-no-colon",
+    });
+  });
+
+  test("returns null for malformed or unknown values", () => {
+    expect(decodeConnection("")).toBeNull();
+    expect(decodeConnection("nocolon")).toBeNull();
+    expect(decodeConnection("Topic:")).toBeNull();
+    expect(decodeConnection("Bogus:id")).toBeNull();
+    expect(decodeConnection(":id")).toBeNull();
+  });
+});
+
+describe("connectionEntityKind", () => {
+  test("maps connection types to EntityLink kinds", () => {
+    expect(connectionEntityKind("topic")).toBe("topics");
+    expect(connectionEntityKind("task")).toBe("tasks");
+    expect(connectionEntityKind("resource")).toBe("resources");
+  });
+});
+
+describe("buildConnectionOptions", () => {
+  test("prefixes each entity by its group and keeps the bare name as label", () => {
+    const options = buildConnectionOptions(
+      [{
+        id: "t1",
+        name: "React",
+      }],
+      [{
+        id: "k1",
+        name: "Finish module",
+      }],
+      [{
+        id: "r1",
+        name: "Docs site",
+      }],
+    );
+    expect(options).toEqual([
+      {
+        value: "Topic:t1",
+        label: "React",
+      },
+      {
+        value: "Task:k1",
+        label: "Finish module",
+      },
+      {
+        value: "Resource:r1",
+        label: "Docs site",
+      },
+    ]);
+  });
+
+  test("handles missing lists", () => {
+    expect(buildConnectionOptions(null, undefined, [])).toEqual([]);
+  });
+});

--- a/packages/client/src/utils/routineConnections.ts
+++ b/packages/client/src/utils/routineConnections.ts
@@ -1,0 +1,87 @@
+import type { SelectOption } from "./selectOptions";
+import type { RoutineConnectionType } from "@emstack/types";
+
+import { toOptions } from "./selectOptions";
+
+export const ROUTINE_CONNECTION_TYPES: RoutineConnectionType[] = [
+  "topic",
+  "task",
+  "resource",
+];
+
+// EntityLink's entity kind (plural route segment) for each connection type.
+const ENTITY_KIND_BY_TYPE = {
+  topic: "topics",
+  task: "tasks",
+  resource: "resources",
+} as const;
+
+export function connectionEntityKind(type: RoutineConnectionType) {
+  return ENTITY_KIND_BY_TYPE[type];
+}
+
+// MultiComboboxField encodes each connection as "<Group>:<id>" so its
+// groupByPrefix renders Topic / Task / Resource group headers. Entity ids are
+// uuids (no colon), so splitting on the first colon is safe.
+const GROUP_LABEL_BY_TYPE: Record<RoutineConnectionType, string> = {
+  topic: "Topic",
+  task: "Task",
+  resource: "Resource",
+};
+const TYPE_BY_GROUP_LABEL: Record<string, RoutineConnectionType> = {
+  Topic: "topic",
+  Task: "task",
+  Resource: "resource",
+};
+
+export function encodeConnection(c: {
+  type: RoutineConnectionType;
+  id: string;
+}) {
+  return `${GROUP_LABEL_BY_TYPE[c.type]}:${c.id}`;
+}
+
+export function decodeConnection(value: string): {
+  type: RoutineConnectionType;
+  id: string;
+} | null {
+  const idx = value.indexOf(":");
+  if (idx <= 0) {
+    return null;
+  }
+  const type = TYPE_BY_GROUP_LABEL[value.slice(0, idx)];
+  const id = value.slice(idx + 1);
+  if (!type || !id) {
+    return null;
+  }
+  return {
+    type,
+    id,
+  };
+}
+
+// Combined, prefixed option list for the connections multi-select. Labels stay
+// the bare entity name (the group header carries the type).
+export function buildConnectionOptions(
+  topics: { id: string;
+    name: string; }[] | null | undefined,
+  tasks: { id: string;
+    name: string; }[] | null | undefined,
+  resources: { id: string;
+    name: string; }[] | null | undefined,
+): SelectOption[] {
+  return [
+    ...toOptions(topics).map(o => ({
+      value: `Topic:${o.value}`,
+      label: o.label,
+    })),
+    ...toOptions(tasks).map(o => ({
+      value: `Task:${o.value}`,
+      label: o.label,
+    })),
+    ...toOptions(resources).map(o => ({
+      value: `Resource:${o.value}`,
+      label: o.label,
+    })),
+  ];
+}

--- a/packages/middleware/src/db/migrateRoutineConnections.ts
+++ b/packages/middleware/src/db/migrateRoutineConnections.ts
@@ -1,0 +1,81 @@
+import { sql } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+
+import { db } from "@/db/index";
+import { routineConnections } from "@/db/schema";
+
+type ExistsRow = { exists: boolean } & Record<string, unknown>;
+type TopicRoutineRow = { id: string;
+  topic_id: string | null; } & Record<string, unknown>;
+type ConnectionRow = { routine_id: string;
+  connected_id: string; } & Record<string, unknown>;
+
+// Idempotent: create the routine_connections junction (in case drizzle-kit push
+// hasn't run yet) and backfill each routine's legacy `topic_id` as a connection
+// of type "topic". Guards on the `topic_id` column still existing, so re-runs
+// after push drops the column are no-ops. The column is left in place as a
+// dormant backup until a later push removes it.
+export async function migrateRoutineConnections() {
+  const routinesExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines'
+    ) AS exists
+  `);
+  if (!routinesExists.rows[0]?.exists) {
+    return;
+  }
+
+  // Self-apply the junction table so the data copy is independent of whether
+  // `drizzle-kit push` has run yet. A later push sees a matching definition and
+  // is a no-op.
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS routine_connections (
+      id varchar PRIMARY KEY,
+      routine_id varchar NOT NULL,
+      connected_type varchar NOT NULL,
+      connected_id varchar NOT NULL,
+      position integer
+    )
+  `);
+
+  const topicColumnExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'routines' AND column_name = 'topic_id'
+    ) AS exists
+  `);
+  if (!topicColumnExists.rows[0]?.exists) {
+    return;
+  }
+
+  const linked = await db.execute<TopicRoutineRow>(sql`
+    SELECT id, topic_id FROM routines WHERE topic_id IS NOT NULL
+  `);
+  if (linked.rows.length === 0) {
+    return;
+  }
+
+  // Skip routines that already carry their topic connection so re-runs don't
+  // duplicate rows.
+  const existing = await db.execute<ConnectionRow>(sql`
+    SELECT routine_id, connected_id FROM routine_connections
+    WHERE connected_type = 'topic'
+  `);
+  const seen = new Set(
+    existing.rows.map(r => `${r.routine_id}|${r.connected_id}`),
+  );
+
+  const rows = linked.rows
+    .filter(r => r.topic_id && !seen.has(`${r.id}|${r.topic_id}`))
+    .map(r => ({
+      id: uuidv4(),
+      routineId: r.id,
+      connectedType: "topic" as const,
+      connectedId: r.topic_id as string,
+      position: 0,
+    }));
+
+  if (rows.length > 0) {
+    await db.insert(routineConnections).values(rows);
+  }
+}

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -28,6 +28,10 @@ export interface RoutineReferenceItem {
 
 export type RoutineWeekly = Partial<Record<RoutineWeekday, RoutineReferenceItem>>;
 
+// Declared locally (like the types above) to avoid a circular dependency on
+// @emstack/types from the schema layer.
+export type RoutineConnectionType = "topic" | "task" | "resource";
+
 export const usersTable = pgTable("users", {
   id: varchar().primaryKey(),
   name: varchar({
@@ -223,17 +227,17 @@ export const dailies = pgTable("dailies", {
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
 });
 
-// A per-topic plan that also carries daily completion tracking. In "weekly"
-// mode each day of the week optionally points at a Task or Resource; in "daily"
-// mode the same entry is applied to every day. Only one routine per topic should
-// be "active" at a time (enforced in the create/upsert handlers).
+// A plan that also carries daily completion tracking. In "weekly" mode each day
+// of the week optionally points at a Task or Resource; in "daily" mode the same
+// entry is applied to every day. A routine's categorical links live in the
+// `routine_connections` junction (many Topics/Tasks/Resources); any number may
+// be "active" at once.
 export const routines = pgTable("routines", {
   id: varchar().primaryKey(),
   name: varchar({
     length: 255,
   }).notNull(),
   description: varchar(),
-  topicId: varchar("topic_id"),
   status: statusEnum().default("active"),
   weekly: jsonb().$type<RoutineWeekly>().default({}).notNull(),
   mode: routineModeEnum().default("weekly").notNull(),
@@ -242,6 +246,21 @@ export const routines = pgTable("routines", {
   }),
   completions: jsonb().$type<DailyCompletion[]>().default([]).notNull(),
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
+});
+
+// Polymorphic many-to-many link from a routine to Topics, Tasks, and/or
+// Resources. UUID PK so a routine can hold multiple links (mirrors
+// topics_to_resources / tasks_to_resources). `connected_id` has no FK because
+// it points at one of three tables; dangling rows (target deleted) are dropped
+// at read time, exactly like dangling weekly-grid entries.
+export const routineConnections = pgTable("routine_connections", {
+  id: varchar().primaryKey(),
+  routineId: varchar("routine_id")
+    .notNull()
+    .references(() => routines.id),
+  connectedType: varchar("connected_type").$type<RoutineConnectionType>().notNull(),
+  connectedId: varchar("connected_id").notNull(),
+  position: integer(),
 });
 
 export const dailyCriteriaTemplates = pgTable("daily_criteria_templates", {
@@ -624,11 +643,17 @@ export const dailiesRelations = relations(dailies, ({
 }));
 
 export const routinesRelations = relations(routines, ({
+  many,
+}) => ({
+  connections: many(routineConnections),
+}));
+
+export const routineConnectionsRelations = relations(routineConnections, ({
   one,
 }) => ({
-  topic: one(topics, {
-    fields: [routines.topicId],
-    references: [topics.id],
+  routine: one(routines, {
+    fields: [routineConnections.routineId],
+    references: [routines.id],
   }),
 }));
 
@@ -683,7 +708,6 @@ export const topicsRelations = relations(topics, ({
   domainWithinScope: many(domainWithinScopeTopics),
   topicsToTags: many(topicsToTags),
   tasks: many(tasks),
-  routines: many(routines),
 }));
 
 export interface RadarConfigEntry {

--- a/packages/middleware/src/db/startup.ts
+++ b/packages/middleware/src/db/startup.ts
@@ -3,6 +3,7 @@ import { resources } from "@/db/schema";
 import { migrateConsolidateRadar } from "./migrateConsolidateRadar.ts";
 import { migrateCoursesToResources } from "./migrateCoursesToResources.ts";
 import { migrateDailiesToRoutines } from "./migrateDailiesToRoutines.ts";
+import { migrateRoutineConnections } from "./migrateRoutineConnections.ts";
 import { migrateIgnoreBlips } from "./migrateIgnoreBlips.ts";
 import { migrateModuleLength } from "./migrateModuleLength.ts";
 import { migrateRadarBlips } from "./migrateRadarBlips.ts";
@@ -68,6 +69,16 @@ export async function runMigrations() {
   }
   catch (err) {
     console.error("Failed to migrate dailies → routines:", err);
+    throw err;
+  }
+
+  // Backfill each routine's legacy topic_id into the routine_connections
+  // junction. Runs after dailies → routines so every routine row exists first.
+  try {
+    await migrateRoutineConnections();
+  }
+  catch (err) {
+    console.error("Failed to migrate routine topics → connections:", err);
     throw err;
   }
 }

--- a/packages/middleware/src/routes/api/routines/createRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/createRoutine.ts
@@ -1,16 +1,17 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
-import { and, eq, ne } from "drizzle-orm";
 import { db } from "@/db";
-import { routines } from "@/db/schema";
+import { routineConnections, routines } from "@/db/schema";
 import type { RoutineWeekly } from "@/db/schema";
 import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import { buildRoutineConnectionRows } from "@/utils/routineConnectionRows";
 import {
   completionSchema,
   criteriaSchema,
   nullableRoutineModeEnum,
   nullableRoutineStatusEnum,
   nullableString,
+  routineConnectionsSchema,
   weeklySchema,
 } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
@@ -26,7 +27,7 @@ const createSchema = {
           type: "string",
         },
         description: nullableString,
-        topicId: nullableString,
+        connections: routineConnectionsSchema,
         status: nullableRoutineStatusEnum,
         weekly: weeklySchema,
         mode: nullableRoutineModeEnum,
@@ -50,34 +51,23 @@ export default async function (server: FastifyInstance) {
     async function (request) {
       const body = request.body;
       const id = uuidv4();
-      const status = body.status ?? "active";
-      const topicId = body.topicId || null;
 
-      await db.transaction(async (tx) => {
-        await tx.insert(routines).values({
-          id,
-          name: body.name,
-          description: body.description ?? null,
-          topicId,
-          status,
-          weekly: (body.weekly ?? {}) as RoutineWeekly,
-          mode: body.mode ?? "weekly",
-          location: body.location ?? null,
-          completions: (body.completions ?? []) as DailyCompletion[],
-          criteria: (body.criteria ?? {}) as DailyCriteria,
-        });
-
-        // Single-active-per-topic enforcement: a new active routine claims the
-        // topic's active slot, deactivating its siblings.
-        if (status === "active" && topicId) {
-          await tx
-            .update(routines)
-            .set({
-              status: "inactive",
-            })
-            .where(and(eq(routines.topicId, topicId), ne(routines.id, id)));
-        }
+      await db.insert(routines).values({
+        id,
+        name: body.name,
+        description: body.description ?? null,
+        status: body.status ?? "active",
+        weekly: (body.weekly ?? {}) as RoutineWeekly,
+        mode: body.mode ?? "weekly",
+        location: body.location ?? null,
+        completions: (body.completions ?? []) as DailyCompletion[],
+        criteria: (body.criteria ?? {}) as DailyCriteria,
       });
+
+      const connectionRows = buildRoutineConnectionRows(body.connections, id);
+      if (connectionRows.length > 0) {
+        await db.insert(routineConnections).values(connectionRows);
+      }
 
       return {
         status: "ok",

--- a/packages/middleware/src/routes/api/routines/deleteRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/deleteRoutine.ts
@@ -1,8 +1,14 @@
-import { routines } from "@/db/schema";
+import { routineConnections, routines } from "@/db/schema";
 import { createDeleteHandler } from "@/utils/createDeleteHandler";
 
 export default createDeleteHandler({
   description: "Delete a routine by id",
   table: routines,
   idColumn: routines.id,
+  junctions: [
+    {
+      table: routineConnections,
+      foreignKey: routineConnections.routineId,
+    },
+  ],
 });

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -1,7 +1,8 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { routines } from "@/db/schema";
+import { routineConnections, routines } from "@/db/schema";
 import { sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
@@ -35,14 +36,12 @@ export default async function (server: FastifyInstance) {
       }
 
       const newId = uuidv4();
-      // The copy starts "inactive" so duplicating never silently steals the
-      // topic's single active slot, and with an empty completion log so the new
-      // routine begins its own tracking history.
+      // The copy starts "inactive" with an empty completion log so the new
+      // routine begins its own tracking history without inheriting the source's.
       await db.insert(routines).values({
         id: newId,
         name: `${source.name} (Copy)`,
         description: source.description ?? null,
-        topicId: source.topicId ?? null,
         status: "inactive",
         weekly: source.weekly ?? {},
         mode: source.mode,
@@ -50,6 +49,23 @@ export default async function (server: FastifyInstance) {
         completions: [],
         criteria: source.criteria ?? {},
       });
+
+      // Carry the source's connections over to the copy with fresh row ids.
+      const sourceConnections = await db
+        .select()
+        .from(routineConnections)
+        .where(eq(routineConnections.routineId, id));
+      if (sourceConnections.length > 0) {
+        await db.insert(routineConnections).values(
+          sourceConnections.map(c => ({
+            id: uuidv4(),
+            routineId: newId,
+            connectedType: c.connectedType,
+            connectedId: c.connectedId,
+            position: c.position,
+          })),
+        );
+      }
 
       return {
         status: "ok",

--- a/packages/middleware/src/routes/api/routines/getRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/getRoutine.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { idParamSchema } from "@/utils/schemas";
+import { resolveRoutineConnections } from "@/utils/resolveRoutineConnections";
 import {
   mapRoutineToDaily,
   representativeEntry,
@@ -33,25 +34,26 @@ export default async function (server: FastifyInstance) {
           eq,
         }) => eq(routines.id, id),
         with: {
-          topic: {
-            columns: {
-              id: true,
-              name: true,
-            },
-          },
+          connections: true,
         },
       });
 
-      // Weekly-mode routines (and a missing row) are returned raw — they still
-      // carry completions/criteria for the tracking panel; the client resolves
-      // schedule names itself.
-      if (!routine || routine.mode !== "daily") {
+      if (!routine) {
         return routine;
+      }
+
+      const [resolved] = await resolveRoutineConnections([routine]);
+
+      // Weekly-mode routines are returned raw (with resolved connections) — they
+      // still carry completions/criteria for the tracking panel; the client
+      // resolves schedule names itself.
+      if (resolved.mode !== "daily") {
+        return resolved;
       }
 
       // Daily mode: resolve the representative weekly entry so the response is a
       // Daily-compatible shape (task/resource progress) for the tracker UI.
-      const entry = representativeEntry(routine.weekly);
+      const entry = representativeEntry(resolved.weekly);
       let task: ResolvedTask | null = null;
       let resource: ResolvedResource | null = null;
 
@@ -94,7 +96,7 @@ export default async function (server: FastifyInstance) {
         })) ?? null;
       }
 
-      return mapRoutineToDaily(routine as RoutineRow, {
+      return mapRoutineToDaily(resolved as RoutineRow, {
         task,
         resource,
       });

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
 import { nullableRoutineModeEnum } from "@/utils/schemas";
+import { resolveRoutineConnections } from "@/utils/resolveRoutineConnections";
 import {
   mapRoutineToDaily,
   representativeEntry,
@@ -35,26 +36,23 @@ export default async function (server: FastifyInstance) {
         }) => eq(routines.mode, mode)
         : undefined,
       with: {
-        topic: {
-          columns: {
-            id: true,
-            name: true,
-          },
-        },
+        connections: true,
       },
     });
 
+    const withConnections = await resolveRoutineConnections(routinesList);
+
     // Only the daily-mode list is projected into the Daily shape (task/resource
     // progress) for the tracker. Weekly and unfiltered lists return raw routines
-    // plus topic; the client resolves schedule names itself.
+    // plus resolved connections; the client resolves schedule names itself.
     if (mode !== "daily") {
-      return routinesList;
+      return withConnections;
     }
 
     // Batch-resolve every representative task/resource id up front to avoid N+1.
     const taskIds: string[] = [];
     const resourceIds: string[] = [];
-    for (const routine of routinesList) {
+    for (const routine of withConnections) {
       const entry = representativeEntry(routine.weekly);
       if (entry?.type === "task") {
         taskIds.push(entry.id);
@@ -107,7 +105,7 @@ export default async function (server: FastifyInstance) {
     const taskMap = new Map(taskRows.map(t => [t.id, t]));
     const resourceMap = new Map(resourceRows.map(r => [r.id, r]));
 
-    return routinesList.map((routine) => {
+    return withConnections.map((routine) => {
       const entry = representativeEntry(routine.weekly);
       const task = entry?.type === "task"
         ? taskMap.get(entry.id) ?? null

--- a/packages/middleware/src/routes/api/routines/upsertRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/upsertRoutine.ts
@@ -1,10 +1,11 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
-import { and, eq, ne } from "drizzle-orm";
 import { db } from "@/db";
-import { routines } from "@/db/schema";
+import { routineConnections, routines } from "@/db/schema";
 import type { RoutineWeekly } from "@/db/schema";
 import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import { buildRoutineConnectionRows } from "@/utils/routineConnectionRows";
+import { syncJunctionTable } from "@/utils/syncJunctionTable";
 import {
   completionSchema,
   criteriaSchema,
@@ -12,6 +13,7 @@ import {
   nullableRoutineModeEnum,
   nullableRoutineStatusEnum,
   nullableString,
+  routineConnectionsSchema,
   weeklySchema,
 } from "@/utils/schemas";
 import { v4 as uuidv4 } from "uuid";
@@ -28,7 +30,7 @@ const upsertSchema = {
           type: "string",
         },
         description: nullableString,
-        topicId: nullableString,
+        connections: routineConnectionsSchema,
         status: nullableRoutineStatusEnum,
         weekly: weeklySchema,
         mode: nullableRoutineModeEnum,
@@ -59,16 +61,13 @@ export default async function (server: FastifyInstance) {
       // Partial merge: only the columns present in the request body are written
       // on update. The daily tracker / dashboard / comment popover send partial
       // payloads (e.g. just completions), so this preserves the routine's mode,
-      // topic, weekly grid and criteria instead of resetting them to defaults.
+      // weekly grid and criteria instead of resetting them to defaults.
       const set: Partial<typeof routines.$inferInsert> = {};
       if (body.name !== undefined) {
         set.name = body.name;
       }
       if (body.description !== undefined) {
         set.description = body.description ?? null;
-      }
-      if (body.topicId !== undefined) {
-        set.topicId = body.topicId || null;
       }
       if (body.status !== undefined) {
         set.status = body.status ?? "active";
@@ -89,43 +88,34 @@ export default async function (server: FastifyInstance) {
         set.criteria = body.criteria as DailyCriteria;
       }
 
-      await db.transaction(async (tx) => {
-        await tx
-          .insert(routines)
-          .values({
-            id,
-            name: body.name,
-            description: body.description ?? null,
-            topicId: body.topicId || null,
-            status: body.status ?? "active",
-            weekly: (body.weekly ?? {}) as RoutineWeekly,
-            mode: body.mode ?? "weekly",
-            location: body.location ?? null,
-            completions: (body.completions ?? []) as DailyCompletion[],
-            criteria: (body.criteria ?? {}) as DailyCriteria,
-          })
-          .onConflictDoUpdate({
-            target: routines.id,
-            set,
-          });
+      await db
+        .insert(routines)
+        .values({
+          id,
+          name: body.name,
+          description: body.description ?? null,
+          status: body.status ?? "active",
+          weekly: (body.weekly ?? {}) as RoutineWeekly,
+          mode: body.mode ?? "weekly",
+          location: body.location ?? null,
+          completions: (body.completions ?? []) as DailyCompletion[],
+          criteria: (body.criteria ?? {}) as DailyCriteria,
+        })
+        .onConflictDoUpdate({
+          target: routines.id,
+          set,
+        });
 
-        // Single-active-per-topic enforcement only runs when this request both
-        // activates the routine and names its topic, so a partial completion
-        // toggle never reshuffles a topic's active slot.
-        if (set.status === "active" && set.topicId) {
-          await tx
-            .update(routines)
-            .set({
-              status: "inactive",
-            })
-            .where(
-              and(
-                eq(routines.topicId, set.topicId),
-                ne(routines.id, id),
-              ),
-            );
-        }
-      });
+      // Only re-sync connections when the request actually carries them, so a
+      // partial completion toggle never wipes the routine's links.
+      if (body.connections !== undefined) {
+        await syncJunctionTable(
+          routineConnections,
+          routineConnections.routineId,
+          id,
+          buildRoutineConnectionRows(body.connections, id),
+        );
+      }
 
       return {
         status: "ok",

--- a/packages/middleware/src/utils/resolveRoutineConnections.ts
+++ b/packages/middleware/src/utils/resolveRoutineConnections.ts
@@ -1,0 +1,105 @@
+import { db } from "@/db";
+import type { RoutineConnectionType } from "@/db/schema";
+
+export interface RawRoutineConnection {
+  connectedType: RoutineConnectionType;
+  connectedId: string;
+}
+
+export interface ResolvedRoutineConnection {
+  type: RoutineConnectionType;
+  id: string;
+  name: string;
+}
+
+// Batch-resolve display names for the polymorphic connections across a set of
+// routines, querying each target table at most once (avoids N+1). Connections
+// whose target no longer exists are dropped, mirroring how dangling weekly-grid
+// entries are ignored on read.
+export async function resolveRoutineConnections<
+  T extends { connections?: RawRoutineConnection[] | null },
+>(rows: T[]): Promise<(Omit<T, "connections"> & {
+  connections: ResolvedRoutineConnection[];
+})[]> {
+  const topicIds = new Set<string>();
+  const taskIds = new Set<string>();
+  const resourceIds = new Set<string>();
+
+  for (const row of rows) {
+    for (const c of row.connections ?? []) {
+      if (c.connectedType === "topic") {
+        topicIds.add(c.connectedId);
+      }
+      else if (c.connectedType === "task") {
+        taskIds.add(c.connectedId);
+      }
+      else if (c.connectedType === "resource") {
+        resourceIds.add(c.connectedId);
+      }
+    }
+  }
+
+  const [topicRows, taskRows, resourceRows] = await Promise.all([
+    topicIds.size
+      ? db.query.topics.findMany({
+        where: (t, {
+          inArray,
+        }) => inArray(t.id, [...topicIds]),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : Promise.resolve([]),
+    taskIds.size
+      ? db.query.tasks.findMany({
+        where: (t, {
+          inArray,
+        }) => inArray(t.id, [...taskIds]),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : Promise.resolve([]),
+    resourceIds.size
+      ? db.query.resources.findMany({
+        where: (r, {
+          inArray,
+        }) => inArray(r.id, [...resourceIds]),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : Promise.resolve([]),
+  ]);
+
+  const nameByType: Record<RoutineConnectionType, Map<string, string>> = {
+    topic: new Map(topicRows.map(r => [r.id, r.name])),
+    task: new Map(taskRows.map(r => [r.id, r.name])),
+    resource: new Map(resourceRows.map(r => [r.id, r.name])),
+  };
+
+  return rows.map((row) => {
+    const {
+      connections: raw, ...rest
+    } = row;
+    const connections = (raw ?? [])
+      .map((c): ResolvedRoutineConnection | null => {
+        const name = nameByType[c.connectedType].get(c.connectedId);
+        return name
+          ? {
+            type: c.connectedType,
+            id: c.connectedId,
+            name,
+          }
+          : null;
+      })
+      .filter((c): c is ResolvedRoutineConnection => c !== null);
+    return {
+      ...rest,
+      connections,
+    };
+  });
+}

--- a/packages/middleware/src/utils/routineConnectionRows.ts
+++ b/packages/middleware/src/utils/routineConnectionRows.ts
@@ -1,0 +1,45 @@
+import { v4 as uuidv4 } from "uuid";
+
+import type { RoutineConnectionType } from "@/db/schema";
+
+export interface RoutineConnectionInput {
+  type: RoutineConnectionType;
+  id: string;
+}
+
+// Dedupe by (type, id) and produce routine_connections rows with stable
+// positions, matching the junction-build pattern used for topics/tasks links.
+export function buildRoutineConnectionRows(
+  connections: readonly RoutineConnectionInput[] | undefined,
+  routineId: string,
+) {
+  if (!connections) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const rows: {
+    id: string;
+    routineId: string;
+    connectedType: RoutineConnectionType;
+    connectedId: string;
+    position: number;
+  }[] = [];
+  for (const c of connections) {
+    if (!c.id) {
+      continue;
+    }
+    const key = `${c.type}:${c.id}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    rows.push({
+      id: uuidv4(),
+      routineId,
+      connectedType: c.type,
+      connectedId: c.id,
+      position: rows.length,
+    });
+  }
+  return rows;
+}

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -3,6 +3,7 @@ import type {
   DailyCompletion,
   DailyCriteria,
   EntityStatus,
+  RoutineConnection,
   RoutineMode,
   RoutineReferenceItem,
   RoutineWeekly,
@@ -48,31 +49,27 @@ export interface ResolvedResource {
   progressTotal: number | null;
 }
 
-// The raw routine columns (plus optional topic relation) the projection reads.
+// The routine columns (plus its resolved connections) the projection reads.
 export interface RoutineRow {
   id: string;
   name: string;
   description: string | null;
-  topicId: string | null;
   status: EntityStatus | null;
   weekly: RoutineWeekly | null;
   mode: RoutineMode;
   location: string | null;
   completions: DailyCompletion[];
   criteria: DailyCriteria;
-  topic?: { id: string;
-    name: string; } | null;
+  connections?: RoutineConnection[];
 }
 
 // A daily-mode routine projected into the Daily shape (so the existing daily
 // tracker / detail components render unchanged) while still carrying the
-// routine-specific fields (mode, weekly, topic) consumers need.
+// routine-specific fields (mode, weekly, connections) consumers need.
 export type RoutineDaily = Daily & {
   mode: RoutineMode;
   weekly: RoutineWeekly;
-  topicId: string | null;
-  topic?: { id: string;
-    name: string; } | null;
+  connections: RoutineConnection[];
 };
 
 // Build a Daily-compatible object from a daily-mode routine, resolving the
@@ -103,7 +100,6 @@ export function mapRoutineToDaily(
     ...daily,
     mode: routine.mode,
     weekly: routine.weekly ?? {},
-    topicId: routine.topicId,
-    topic: routine.topic ?? null,
+    connections: routine.connections ?? [],
   };
 }

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -35,8 +35,8 @@ export const nullableResourceLevelEnum = {
   enum: ["low", "medium", "high", null],
 } as const;
 
-// Routines use the full lifecycle status set (including "inactive", since the
-// single-active-per-topic rule deactivates siblings).
+// Routines use the full lifecycle status set, including "inactive" as a manual
+// status (any number of routines may be active at once).
 export const nullableRoutineStatusEnum = {
   type: ["string", "null"],
   enum: ["active", "inactive", "complete", "paused", null],
@@ -78,6 +78,30 @@ export const weeklySchema = {
     5: routineReferenceItemSchema,
     6: routineReferenceItemSchema,
   },
+} as const;
+
+// A routine's polymorphic connection to a topic / task / resource. `id` is the
+// connected entity's id; the resolved name is added on read, not accepted here.
+export const routineConnectionTypeEnum = {
+  type: "string",
+  enum: ["topic", "task", "resource"],
+} as const;
+
+export const routineConnectionItemSchema = {
+  type: "object",
+  required: ["type", "id"],
+  additionalProperties: false,
+  properties: {
+    type: routineConnectionTypeEnum,
+    id: {
+      type: "string",
+    },
+  },
+} as const;
+
+export const routineConnectionsSchema = {
+  type: "array",
+  items: routineConnectionItemSchema,
 } as const;
 
 export const dailyCompletionStatusEnum = {

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -3,6 +3,19 @@ import type { EntityStatus } from "./EntityStatus";
 
 export type RoutineReferenceType = "task" | "resource" | "freeform";
 
+// A routine can be connected to any number of these entity kinds. The
+// connection is the routine's categorical link (what it's "about"); it is
+// separate from the weekly grid, which is the per-day activity.
+export type RoutineConnectionType = "topic" | "task" | "resource";
+
+// A single polymorphic connection. `name` is resolved on read for display and
+// omitted on write (the client sends only `type` + `id`).
+export interface RoutineConnection {
+  type: RoutineConnectionType;
+  id: string;
+  name?: string | null;
+}
+
 // A routine is either a weekly schedule (each weekday can differ) or a daily
 // task (the same entry applied to every day). Both modes carry completion
 // tracking; the mode only changes how the weekly grid is edited.
@@ -23,11 +36,7 @@ export interface Routine {
   id: string;
   name: string;
   description?: string | null;
-  topicId?: string | null;
-  topic?: {
-    id: string;
-    name: string;
-  } | null;
+  connections?: RoutineConnection[] | null;
   status?: EntityStatus | null;
   weekly?: RoutineWeekly | null;
   mode?: RoutineMode | null;


### PR DESCRIPTION
## Summary

Refactor routines from a single `topicId` foreign key to a polymorphic many-to-many `routine_connections` junction table, allowing routines to be connected to any number of Topics, Tasks, and/or Resources. This enables more flexible routine organization while maintaining backward compatibility with the legacy `topicId` column.

## Key Changes

### Backend (Middleware)
- **Schema:** Replace `routines.topicId` with a new `routine_connections` junction table (`id`, `routine_id`, `connected_type`, `connected_id`, `position`)
- **Migration:** Add `migrateRoutineConnections.ts` to backfill existing `topicId` entries as topic connections (idempotent, guards on column existence)
- **Connection resolution:** New `resolveRoutineConnections.ts` utility batch-resolves display names for polymorphic connections across routines (avoids N+1 queries)
- **API updates:** 
  - Replace `topicId` parameter with `connections: RoutineConnectionInput[]` in create/upsert handlers
  - Add `buildRoutineConnectionRows()` to deduplicate and build junction rows with stable positions
  - Update `getRoutine.ts` and `root.ts` to resolve connections before returning
  - Remove single-active-per-topic enforcement (any number of routines may now be active)
- **Schemas:** Add `routineConnectionTypeEnum`, `routineConnectionItemSchema`, and `routineConnectionsSchema` for validation
- **Duplicate handler:** Copy routine without inheriting connections (fresh start)
- **Delete handler:** Cascade delete connections via junction table

### Frontend (Client)
- **Types:** Import `RoutineConnectionType` from `@emstack/types`
- **Utilities:** 
  - New `routineConnections.ts` with encode/decode helpers (`encodeConnection`, `decodeConnection` using `"Type:id"` format for group headers)
  - `connectionEntityKind()` maps connection types to EntityLink kinds
  - `buildConnectionOptions()` combines topics/tasks/resources into a prefixed option list
  - Tests in `routineConnections.test.ts` cover round-trip encoding and edge cases
- **Routines index page:**
  - Replace `filterTopic` state with `filterConnection` (supports any connection type)
  - Update filter dropdown to show all connection types with counts
  - Remove `fetchTopics` query (connections are resolved server-side)
  - Support legacy `?topicId=` search param alongside new `?connectedType=&connectedId=`
- **Routine edit page:**
  - Replace `topicId` form field with `connections: string[]` multi-select
  - Support prefilling via legacy `?topicId=` or new `?connectedType=&connectedId=` params
  - Use `buildConnectionOptions()` for combined topic/task/resource dropdown
- **Routine detail pages:**
  - Display connections as a list of EntityLinks (one per connection)
  - Show connection type as a small uppercase label
- **RoutineBox component:** Render multiple connection badges instead of single topic
- **Topic detail page:** Show linked routines (reverse lookup via connections)

### Type Definitions
- Add `RoutineConnectionType = "topic" | "task" | "resource"` to `@emstack/types`
- Add `RoutineConnection` interface with `type`, `id`, and optional `name` (resolved on read)

## Notable Implementation Details

- **Backward compatibility:** Legacy `?topicId=` search params still work; migration backfills existing data
- **Encoding scheme:** Connections use `"Type:id"` format (capitalized type prefix) to enable group headers in multi-select dropdowns
- **Batch resolution:** `resolveRoutineConnections()` queries each target table once, filtering out dangling references (mirrors weekly-grid behavior)
- **Deduplication:** `buildRoutineConnectionRows()` dedupes by `(type, id)` and assigns stable positions
- **No single-active enforcement:** Removed the per-topic active-routine constraint; any number of routines may be active simultaneously

https://claude.ai/code/session_01162VvHsom3AVs2NznQFZMi