### PR TITLE
Fix task type selection in Daily routine mode

### DIFF
--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -2,7 +2,7 @@ import type { RoutineWeekly } from "@emstack/types/src";
 
 import { describe, expect, test } from "vitest";
 
-import { rowsToWeekly, weeklyToRows } from "./weekly";
+import { fillAllDays, representativeRow, rowsToWeekly, weeklyToRows } from "./weekly";
 
 describe("weekly schedule item notes", () => {
   test("weeklyToRows surfaces an item's notes", () => {
@@ -81,6 +81,44 @@ describe("weekly schedule item notes", () => {
     expect(restored[5]).toEqual({
       type: "freeform",
       id: "Read a chapter",
+    });
+  });
+});
+
+describe("representativeRow (Daily Task mode)", () => {
+  // Regression: picking a type clears the id, so the editor must still surface
+  // the chosen type before an item is picked — otherwise the controlled type
+  // <select> reverts to "None" and the item picker can never be enabled.
+  test("surfaces a type chosen before its item (empty id)", () => {
+    const rows = fillAllDays({
+      type: "task",
+      id: "",
+    });
+    expect(representativeRow(rows)).toEqual({
+      type: "task",
+      id: "",
+      notes: "",
+    });
+  });
+
+  test("surfaces a fully populated entry", () => {
+    const rows = fillAllDays({
+      type: "resource",
+      id: "res-1",
+      notes: "chapter 3",
+    });
+    expect(representativeRow(rows)).toEqual({
+      type: "resource",
+      id: "res-1",
+      notes: "chapter 3",
+    });
+  });
+
+  test("returns a blank entry for an empty grid", () => {
+    expect(representativeRow(weeklyToRows(undefined))).toEqual({
+      type: "",
+      id: "",
+      notes: "",
     });
   });
 });

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -65,14 +65,17 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
 }
 
 // Daily Task mode keeps the same entry on every weekday. `representativeRow`
-// reads that shared entry (the first populated day), and `fillAllDays` writes a
-// single entry across the whole length-7 grid.
+// reads that shared entry (the first day with a type), and `fillAllDays` writes
+// a single entry across the whole length-7 grid. We match on `type` alone — not
+// `type && id` — so a half-chosen entry (a type picked before its item) still
+// surfaces; otherwise the controlled type <select> would snap back to "None" and
+// the item picker would never enable.
 export function representativeRow(rows: WeeklyRow[]): {
   type: WeeklyRowType;
   id: string;
   notes: string;
 } {
-  const found = rows.find(r => r.type !== "" && r.id);
+  const found = rows.find(r => r.type !== "");
   return found
     ? {
       type: found.type,


### PR DESCRIPTION
In Daily Task mode, picking a type (Task/Resource/Freeform) clears the
entry's id, but `representativeRow` only surfaced rows that had both a
type and an id. The controlled type <select> therefore reverted to
"None" on the next render and the item picker stayed disabled, making it
impossible to pick a type at all.

Match on `type` alone so a half-chosen entry (type picked before its
item) still surfaces, keeping the type selected and enabling the item
picker. Saving is unaffected: rowsToWeekly still drops id-less rows and
submit validation still requires an id.

Add representativeRow regression tests covering the type-before-id case.

https://claude.ai/code/session_01MZap5RBoD7Ark84AF7jU1U