### PR TITLE
Refactor routine edit page into tabbed interface with component split

### DIFF
--- a/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
@@ -1,0 +1,245 @@
+import type { Routine } from "@emstack/types/src";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDownIcon, Loader2, WandSparklesIcon } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { DAILY_STATUS_OPTIONS } from "@/components/dailies/dailyStatusMeta";
+import { useAppForm } from "@/components/formFields";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  fetchDailyCriteriaTemplates,
+  formHasChanges,
+  upsertRoutine,
+} from "@/utils";
+
+const criteriaSchema = z.object({
+  criteriaIncomplete: z.string().max(500),
+  criteriaTouched: z.string().max(500),
+  criteriaGoal: z.string().max(500),
+  criteriaExceeded: z.string().max(500),
+  criteriaFreeze: z.string().max(500),
+});
+
+interface CriteriaTabProps {
+  routine: Routine;
+  onSaved: () => Promise<void>;
+  onChangeStateChange?: (hasChanges: boolean) => void;
+}
+
+export function CriteriaTab({
+  routine,
+  onSaved,
+  onChangeStateChange,
+}: CriteriaTabProps) {
+  const {
+    data: criteriaTemplates,
+  } = useQuery({
+    queryKey: ["dailyCriteriaTemplates"],
+    queryFn: () => fetchDailyCriteriaTemplates(),
+  });
+
+  const startingValues = useMemo(
+    () => ({
+      criteriaIncomplete: routine.criteria?.incomplete ?? "",
+      criteriaTouched: routine.criteria?.touched ?? "",
+      criteriaGoal: routine.criteria?.goal ?? "",
+      criteriaExceeded: routine.criteria?.exceeded ?? "",
+      criteriaFreeze: routine.criteria?.freeze ?? "",
+    }),
+    [routine],
+  );
+
+  const lastSavedRef = useRef(startingValues);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: criteriaSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      setIsSaving(true);
+      try {
+        const criteria: Record<string, string> = {};
+        if (value.criteriaIncomplete) {
+          criteria.incomplete = value.criteriaIncomplete;
+        }
+        if (value.criteriaTouched) {
+          criteria.touched = value.criteriaTouched;
+        }
+        if (value.criteriaGoal) {
+          criteria.goal = value.criteriaGoal;
+        }
+        if (value.criteriaExceeded) {
+          criteria.exceeded = value.criteriaExceeded;
+        }
+        if (value.criteriaFreeze) {
+          criteria.freeze = value.criteriaFreeze;
+        }
+
+        // Partial save: only `criteria` is sent, so the routine's schedule,
+        // connections and completions are preserved by the backend merge.
+        await upsertRoutine(routine.id, {
+          criteria,
+        });
+        lastSavedRef.current = value;
+        onChangeStateChange?.(false);
+        await onSaved();
+        toast.success("Status criteria saved.");
+      }
+      catch {
+        toast.error("Failed to save status criteria.");
+      }
+      finally {
+        setIsSaving(false);
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const hasChanges = formHasChanges(currentValues, lastSavedRef.current);
+
+  useEffect(() => {
+    onChangeStateChange?.(hasChanges);
+  }, [hasChanges, onChangeStateChange]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex max-w-3xl flex-col gap-8"
+    >
+      <div className="flex flex-col gap-4 rounded-md border bg-card p-4">
+        <div
+          className="flex flex-row flex-wrap items-start justify-between gap-2"
+        >
+          <div className="flex flex-col gap-1">
+            <h2 className="text-2xl">Status Criteria</h2>
+            <p className="text-sm text-muted-foreground">
+              Optional notes describing what each status means for this
+              routine.
+            </p>
+          </div>
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+              >
+                <WandSparklesIcon className="size-4" />
+                Quick Fill
+                <ChevronDownIcon className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {(criteriaTemplates ?? []).length === 0
+                ? (
+                  <DropdownMenuItem disabled>
+                    No templates — add one in Settings
+                  </DropdownMenuItem>
+                )
+                : (criteriaTemplates ?? []).map(template => (
+                  <DropdownMenuItem
+                    key={template.id}
+                    onSelect={() => {
+                      form.setFieldValue(
+                        "criteriaIncomplete",
+                        template.incomplete,
+                      );
+                      form.setFieldValue("criteriaTouched", template.touched);
+                      form.setFieldValue("criteriaGoal", template.goal);
+                      form.setFieldValue(
+                        "criteriaExceeded",
+                        template.exceeded,
+                      );
+                      form.setFieldValue("criteriaFreeze", template.freeze);
+                    }}
+                  >
+                    {template.label}
+                  </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <form.AppField name="criteriaIncomplete">
+          {field => (
+            <field.TextareaField
+              label="Incomplete"
+              placeholder="What does &quot;Incomplete&quot; mean here?"
+              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
+                o.value === "incomplete")?.icon}
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="criteriaTouched">
+          {field => (
+            <field.TextareaField
+              label="Touched"
+              placeholder="What does &quot;Touched&quot; mean here?"
+              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
+                o.value === "touched")?.icon}
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="criteriaGoal">
+          {field => (
+            <field.TextareaField
+              label="Completed (Goal)"
+              placeholder="What does &quot;Completed&quot; (goal) mean here?"
+              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
+                o.value === "goal")?.icon}
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="criteriaExceeded">
+          {field => (
+            <field.TextareaField
+              label="Exceeded"
+              placeholder="What does &quot;Exceeded&quot; mean here?"
+              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
+                o.value === "exceeded")?.icon}
+            />
+          )}
+        </form.AppField>
+        <form.AppField name="criteriaFreeze">
+          {field => (
+            <field.TextareaField
+              label="Freeze"
+              placeholder="What does &quot;Freeze&quot; mean here?"
+              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
+                o.value === "freeze")?.icon}
+            />
+          )}
+        </form.AppField>
+      </div>
+
+      <div>
+        <Button
+          type="submit"
+          disabled={isSaving}
+        >
+          {isSaving && <Loader2 className="animate-spin" />}
+          Save Status Criteria
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
@@ -1,0 +1,349 @@
+import type { Routine } from "@emstack/types/src";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDownIcon, Loader2, WandSparklesIcon } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import {
+  fillAllDays,
+  representativeRow,
+  rowsToWeekly,
+  weeklyToRows,
+} from "@/components/routines/weekly";
+import { WeeklyEntryEditor } from "@/components/routines/WeeklyEntryEditor";
+import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  buildConnectionOptions,
+  decodeConnection,
+  encodeConnection,
+  fetchResources,
+  fetchRoutineTemplates,
+  fetchTasks,
+  fetchTopics,
+  formHasChanges,
+  toOptions,
+  upsertRoutine,
+} from "@/utils";
+
+const STATUS_OPTIONS = [
+  {
+    value: "active",
+    label: "Active",
+  },
+  {
+    value: "inactive",
+    label: "Inactive",
+  },
+  {
+    value: "complete",
+    label: "Complete",
+  },
+  {
+    value: "paused",
+    label: "Paused",
+  },
+];
+
+const MODE_OPTIONS = [
+  {
+    value: "weekly",
+    label: "Weekly Schedule",
+  },
+  {
+    value: "daily",
+    label: "Daily Task",
+  },
+];
+
+const weeklyRowSchema = z
+  .object({
+    day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
+    type: z.enum(["", "task", "resource", "freeform"]),
+    id: z.string(),
+    notes: z.string(),
+  })
+  .refine(row => row.type === "" || row.id.length > 0, {
+    message: "Required",
+    path: ["id"],
+  });
+
+const detailsSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(2000),
+  connections: z.array(z.string()),
+  status: z.enum(["active", "inactive", "complete", "paused"]),
+  mode: z.enum(["weekly", "daily"]),
+  location: z.string().max(255),
+  weekly: z.array(weeklyRowSchema).length(7),
+});
+
+interface DetailsTabProps {
+  routine: Routine;
+  onSaved: () => Promise<void>;
+  onChangeStateChange?: (hasChanges: boolean) => void;
+}
+
+export function DetailsTab({
+  routine,
+  onSaved,
+  onChangeStateChange,
+}: DetailsTabProps) {
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+  });
+
+  const {
+    data: resources,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchResources(),
+  });
+
+  const {
+    data: routineTemplates,
+  } = useQuery({
+    queryKey: ["routineTemplates"],
+    queryFn: () => fetchRoutineTemplates(),
+  });
+
+  const taskOptions = useMemo(() => toOptions(tasks), [tasks]);
+  const resourceOptions = useMemo(() => toOptions(resources), [resources]);
+  const connectionOptions = useMemo(
+    () => buildConnectionOptions(topics, tasks, resources),
+    [topics, tasks, resources],
+  );
+
+  const startingValues = useMemo(
+    () => ({
+      name: routine.name ?? "",
+      description: routine.description ?? "",
+      connections: (routine.connections ?? []).map(encodeConnection),
+      status: routine.status ?? "active",
+      mode: routine.mode ?? "weekly",
+      location: routine.location ?? "",
+      weekly: weeklyToRows(routine.weekly),
+    }),
+    [routine],
+  );
+
+  const lastSavedRef = useRef(startingValues);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: detailsSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      setIsSaving(true);
+      try {
+        const connections = value.connections
+          .map(decodeConnection)
+          .filter((c): c is NonNullable<typeof c> => c !== null);
+
+        await upsertRoutine(routine.id, {
+          name: value.name,
+          description: value.description || null,
+          connections,
+          status: value.status,
+          mode: value.mode,
+          location: value.mode === "daily" ? value.location || null : null,
+          // Daily mode mirrors the single chosen entry onto all 7 days so
+          // "today's item" resolves identically every day.
+          weekly:
+            value.mode === "daily"
+              ? rowsToWeekly(fillAllDays(representativeRow(value.weekly)))
+              : rowsToWeekly(value.weekly),
+        });
+        lastSavedRef.current = value;
+        onChangeStateChange?.(false);
+        await onSaved();
+        toast.success("Details saved.");
+      }
+      catch {
+        toast.error("Failed to save details.");
+      }
+      finally {
+        setIsSaving(false);
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const hasChanges = formHasChanges(currentValues, lastSavedRef.current);
+  const isDaily = currentValues.mode === "daily";
+
+  useEffect(() => {
+    onChangeStateChange?.(hasChanges);
+  }, [hasChanges, onChangeStateChange]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex max-w-3xl flex-col gap-8"
+    >
+      <form.AppField name="name">
+        {field => <field.InputField label="Routine Name" />}
+      </form.AppField>
+
+      <form.AppField name="mode">
+        {field => (
+          <field.RadioGroupField
+            label="Type"
+            options={MODE_OPTIONS}
+          />
+        )}
+      </form.AppField>
+
+      <form.AppField name="connections">
+        {field => (
+          <field.MultiComboboxField
+            label="Connected To"
+            options={connectionOptions}
+            groupByPrefix
+            placeholder="Search topics, tasks, resources..."
+          />
+        )}
+      </form.AppField>
+
+      <form.AppField name="status">
+        {field => (
+          <field.RadioGroupField
+            label="Status"
+            options={STATUS_OPTIONS}
+          />
+        )}
+      </form.AppField>
+
+      <form.AppField name="description">
+        {field => (
+          <field.TextareaField
+            label="Description"
+            placeholder="What is this routine about?"
+          />
+        )}
+      </form.AppField>
+
+      {isDaily && (
+        <form.AppField name="location">
+          {field => (
+            <field.InputField
+              label="Location"
+              placeholder="e.g. Spanish app, gym, journal"
+            />
+          )}
+        </form.AppField>
+      )}
+
+      <form.Field name="weekly">
+        {field =>
+          isDaily
+            ? (
+              <div className="flex flex-col gap-1">
+                <span className="text-2xl">Daily Task</span>
+                <p className="text-sm text-muted-foreground">
+                  Pick what to work on each day — the same item applies to
+                  every day of the week.
+                </p>
+                <div className="mt-1">
+                  <WeeklyEntryEditor
+                    {...representativeRow(field.state.value)}
+                    onChange={next =>
+                      field.handleChange(fillAllDays(next))}
+                    taskOptions={taskOptions}
+                    resourceOptions={resourceOptions}
+                  />
+                </div>
+              </div>
+            )
+            : (
+              <div className="flex flex-col gap-1">
+                <div
+                  className="flex flex-wrap items-center justify-between gap-2"
+                >
+                  <span className="text-2xl">Weekly Schedule</span>
+                  <DropdownMenu modal={false}>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                      >
+                        <WandSparklesIcon className="size-4" />
+                        Quick Fill
+                        <ChevronDownIcon className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {(routineTemplates ?? []).length === 0
+                        ? (
+                          <DropdownMenuItem disabled>
+                            No templates — add one in Settings
+                          </DropdownMenuItem>
+                        )
+                        : (routineTemplates ?? []).map(template => (
+                          <DropdownMenuItem
+                            key={template.id}
+                            onSelect={() => {
+                              field.handleChange(
+                                weeklyToRows(template.weekly),
+                              );
+                            }}
+                          >
+                            {template.label}
+                          </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <WeeklyScheduleField
+                  value={field.state.value}
+                  onChange={next => field.handleChange(next)}
+                  taskOptions={taskOptions}
+                  resourceOptions={resourceOptions}
+                />
+              </div>
+            )}
+      </form.Field>
+
+      <div>
+        <Button
+          type="submit"
+          disabled={isSaving}
+        >
+          {isSaving && <Loader2 className="animate-spin" />}
+          Save Details
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/client/src/routes/routines.$id.edit.-components/-EntriesTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-EntriesTab.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { DailyCompletionsManager } from "@/components/dailies/DailyCompletionsManager";
+import { EntityError, EntityPending } from "@/components/EntityStates";
+import { fetchSingleDaily } from "@/utils";
+
+interface EntriesTabProps {
+  id: string;
+}
+
+/**
+ * A routine and a daily are the same entity by id, so we read the daily
+ * projection and reuse the self-saving completions manager. It persists each
+ * change on its own (no separate Save button), exactly as on the View page.
+ */
+export function EntriesTab({
+  id,
+}: EntriesTabProps) {
+  const {
+    isPending, error, data,
+  } = useQuery({
+    queryKey: ["daily", id],
+    queryFn: () => fetchSingleDaily(id),
+  });
+
+  if (isPending) {
+    return <EntityPending entity="daily" />;
+  }
+
+  if (error || !data) {
+    return <EntityError entity="daily" />;
+  }
+
+  return (
+    <DailyCompletionsManager
+      daily={data}
+      readOnly={data.status !== "active"}
+    />
+  );
+}

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -1,51 +1,39 @@
 import type { RoutineConnectionType, RoutineMode } from "@emstack/types/src";
 
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { ChevronDownIcon, EyeIcon, Loader2, WandSparklesIcon } from "lucide-react";
+import { EyeIcon, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
-import { DAILY_STATUS_OPTIONS } from "@/components/dailies/dailyStatusMeta";
+import { CriteriaTab } from "./routines.$id.edit.-components/-CriteriaTab";
+import { DetailsTab } from "./routines.$id.edit.-components/-DetailsTab";
+import { EntriesTab } from "./routines.$id.edit.-components/-EntriesTab";
+
 import { useAppForm } from "@/components/formFields";
 import { EditPageFooter } from "@/components/layout/EditPageFooter";
 import { PageHeader } from "@/components/layout/PageHeader";
-import {
-  fillAllDays,
-  representativeRow,
-  rowsToWeekly,
-  weeklyToRows,
-} from "@/components/routines/weekly";
-import { WeeklyEntryEditor } from "@/components/routines/WeeklyEntryEditor";
-import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
+import { fillAllDays, rowsToWeekly } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
-  buildConnectionOptions,
   createRoutine,
-  decodeConnection,
   deleteSingleRoutine,
   duplicateRoutine,
-  encodeConnection,
-  fetchDailyCriteriaTemplates,
-  fetchResources,
-  fetchRoutineTemplates,
   fetchSingleRoutine,
-  fetchTasks,
-  fetchTopics,
-  formHasChanges,
-  toOptions,
-  upsertRoutine,
 } from "@/utils";
+
+const TAB_VALUES = ["details", "entries", "criteria"] as const;
+type EditTab = (typeof TAB_VALUES)[number];
 
 interface RoutineEditSearch {
   // Legacy alias: a bare `?topicId=` still prefills a topic connection.
@@ -55,6 +43,7 @@ interface RoutineEditSearch {
   mode?: RoutineMode;
   entryType?: "task" | "resource";
   entryId?: string;
+  tab?: EditTab;
 }
 
 export const Route = createFileRoute("/routines/$id/edit")({
@@ -86,27 +75,13 @@ export const Route = createFileRoute("/routines/$id/edit")({
       typeof search.entryId === "string" && search.entryId
         ? search.entryId
         : undefined,
+    tab:
+      typeof search.tab === "string"
+      && (TAB_VALUES as readonly string[]).includes(search.tab)
+        ? (search.tab as EditTab)
+        : undefined,
   }),
 });
-
-const STATUS_OPTIONS = [
-  {
-    value: "active",
-    label: "Active",
-  },
-  {
-    value: "inactive",
-    label: "Inactive",
-  },
-  {
-    value: "complete",
-    label: "Complete",
-  },
-  {
-    value: "paused",
-    label: "Paused",
-  },
-];
 
 const MODE_OPTIONS = [
   {
@@ -119,289 +94,101 @@ const MODE_OPTIONS = [
   },
 ];
 
-const weeklyRowSchema = z
-  .object({
-    day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
-    type: z.enum(["", "task", "resource", "freeform"]),
-    id: z.string(),
-    notes: z.string(),
-  })
-  .refine(row => row.type === "" || row.id.length > 0, {
-    message: "Required",
-    path: ["id"],
-  });
-
-const formSchema = z.object({
+const newRoutineSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
-  description: z.string().max(2000),
-  connections: z.array(z.string()),
-  status: z.enum(["active", "inactive", "complete", "paused"]),
   mode: z.enum(["weekly", "daily"]),
-  location: z.string().max(255),
-  weekly: z.array(weeklyRowSchema).length(7),
-  criteriaIncomplete: z.string().max(500),
-  criteriaTouched: z.string().max(500),
-  criteriaGoal: z.string().max(500),
-  criteriaExceeded: z.string().max(500),
-  criteriaFreeze: z.string().max(500),
 });
 
 function SingleRoutineEdit() {
   const {
     id,
   } = Route.useParams();
-  const search = Route.useSearch();
-  const isNew = id === "new";
+
+  if (id === "new") {
+    return <NewRoutine />;
+  }
+  return <ExistingRoutineEdit id={id} />;
+}
+
+function NewRoutine() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const search = Route.useSearch();
+  const [isSaving, setIsSaving] = useState(false);
 
-  const skipBlocker = useRef(false);
-
-  const {
-    data,
-  } = useQuery({
-    queryKey: ["routine", id],
-    queryFn: () => fetchSingleRoutine(id),
-    enabled: !isNew,
-  });
-
-  const {
-    data: topics,
-  } = useQuery({
-    queryKey: ["topics"],
-    queryFn: () => fetchTopics(),
-  });
-
-  const {
-    data: tasks,
-  } = useQuery({
-    queryKey: ["tasks"],
-    queryFn: () => fetchTasks(),
-  });
-
-  const {
-    data: resources,
-  } = useQuery({
-    queryKey: ["courses"],
-    queryFn: () => fetchResources(),
-  });
-
-  const {
-    data: routineTemplates,
-  } = useQuery({
-    queryKey: ["routineTemplates"],
-    queryFn: () => fetchRoutineTemplates(),
-  });
-
-  const {
-    data: criteriaTemplates,
-  } = useQuery({
-    queryKey: ["dailyCriteriaTemplates"],
-    queryFn: () => fetchDailyCriteriaTemplates(),
-  });
-
-  const taskOptions = useMemo(() => toOptions(tasks), [tasks]);
-  const resourceOptions = useMemo(() => toOptions(resources), [resources]);
-  const connectionOptions = useMemo(
-    () => buildConnectionOptions(topics, tasks, resources),
-    [topics, tasks, resources],
-  );
-
-  // New routines can be prefilled with a connection via search params: the
-  // generic `?connectedType=&connectedId=` or the legacy `?topicId=` alias.
+  // New routines can be prefilled via search params: the generic
+  // `?connectedType=&connectedId=` or the legacy `?topicId=` alias, plus an
+  // optional `?entryType=&entryId=` that seeds the weekly grid.
   const prefilledConnections = useMemo(() => {
-    const out: string[] = [];
+    const out: { type: RoutineConnectionType;
+      id: string; }[] = [];
     if (search.connectedType && search.connectedId) {
-      out.push(
-        encodeConnection({
-          type: search.connectedType,
-          id: search.connectedId,
-        }),
-      );
+      out.push({
+        type: search.connectedType,
+        id: search.connectedId,
+      });
     }
     if (search.topicId) {
-      out.push(encodeConnection({
+      out.push({
         type: "topic",
         id: search.topicId,
-      }));
+      });
     }
     return out;
   }, [search.connectedType, search.connectedId, search.topicId]);
 
-  const startingValues = useMemo(
-    () => ({
-      name: data?.name ?? "",
-      description: data?.description ?? "",
-      connections: isNew
-        ? prefilledConnections
-        : (data?.connections ?? []).map(encodeConnection),
-      status: data?.status ?? "active",
-      mode: data?.mode ?? (isNew ? (search.mode ?? "weekly") : "weekly"),
-      location: data?.location ?? "",
-      weekly:
-        isNew && search.entryType && search.entryId
-          ? fillAllDays({
-            type: search.entryType,
-            id: search.entryId,
-          })
-          : weeklyToRows(data?.weekly),
-      criteriaIncomplete: data?.criteria?.incomplete ?? "",
-      criteriaTouched: data?.criteria?.touched ?? "",
-      criteriaGoal: data?.criteria?.goal ?? "",
-      criteriaExceeded: data?.criteria?.exceeded ?? "",
-      criteriaFreeze: data?.criteria?.freeze ?? "",
-    }),
-    [data, isNew, prefilledConnections, search.mode, search.entryType, search.entryId],
-  );
-
   const form = useAppForm({
-    defaultValues: startingValues,
+    defaultValues: {
+      name: "",
+      mode: search.mode ?? "weekly",
+    },
     validators: {
-      onSubmit: formSchema,
+      onSubmit: newRoutineSchema,
     },
     onSubmit: async ({
       value,
     }) => {
-      const criteria: Record<string, string> = {};
-      if (value.criteriaIncomplete) {
-        criteria.incomplete = value.criteriaIncomplete;
-      }
-      if (value.criteriaTouched) {
-        criteria.touched = value.criteriaTouched;
-      }
-      if (value.criteriaGoal) {
-        criteria.goal = value.criteriaGoal;
-      }
-      if (value.criteriaExceeded) {
-        criteria.exceeded = value.criteriaExceeded;
-      }
-      if (value.criteriaFreeze) {
-        criteria.freeze = value.criteriaFreeze;
-      }
-
-      const connections = value.connections
-        .map(decodeConnection)
-        .filter((c): c is NonNullable<typeof c> => c !== null);
-
-      const routineData = {
-        name: value.name,
-        description: value.description || null,
-        connections,
-        status: value.status,
-        mode: value.mode,
-        location: value.mode === "daily" ? value.location || null : null,
-        // Daily mode mirrors the single chosen entry onto all 7 days so
-        // "today's item" resolves identically every day.
-        weekly:
-          value.mode === "daily"
-            ? rowsToWeekly(fillAllDays(representativeRow(value.weekly)))
-            : rowsToWeekly(value.weekly),
-        criteria,
-      };
-
+      setIsSaving(true);
       try {
-        let routineId: string;
-        if (isNew) {
-          const result = await createRoutine(routineData);
-          routineId = result.id;
-        }
-        else {
-          await upsertRoutine(id, routineData);
-          routineId = id;
-          await queryClient.invalidateQueries({
-            queryKey: ["routine", id],
-          });
-        }
-        await queryClient.invalidateQueries({
-          queryKey: ["routines"],
+        const weekly
+          = search.entryType && search.entryId
+            ? rowsToWeekly(
+              fillAllDays({
+                type: search.entryType,
+                id: search.entryId,
+              }),
+            )
+            : {};
+        const result = await createRoutine({
+          name: value.name,
+          mode: value.mode,
+          status: "active",
+          connections: prefilledConnections,
+          weekly,
         });
-        await queryClient.invalidateQueries({
-          queryKey: ["dailies"],
-        });
-        skipBlocker.current = true;
         await navigate({
-          to: "/routines/$id",
+          to: "/routines/$id/edit",
           params: {
-            id: routineId,
+            id: result.id,
           },
         });
       }
       catch {
-        toast.error(
-          isNew
-            ? "Failed to create routine. Please try again."
-            : "Failed to save routine. Please try again.",
-        );
+        toast.error("Failed to create routine. Please try again.");
+      }
+      finally {
+        setIsSaving(false);
       }
     },
   });
 
-  const currentValues = useStore(form.store, state => ({
-    ...state.values,
-  }));
   const isSubmitting = useStore(form.store, state => state.isSubmitting);
-  const hasChanges = formHasChanges(currentValues, startingValues);
-  const isDaily = currentValues.mode === "daily";
-
-  async function handleDelete() {
-    try {
-      await deleteSingleRoutine(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["routines"],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ["dailies"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/routines",
-      });
-    }
-    catch {
-      toast.error("Failed to delete routine. Please try again.");
-    }
-  }
-
-  async function handleDuplicate() {
-    try {
-      const result = await duplicateRoutine(id);
-      await queryClient.invalidateQueries({
-        queryKey: ["routines"],
-      });
-      skipBlocker.current = true;
-      await navigate({
-        to: "/routines/$id/edit",
-        params: {
-          id: result.id,
-        },
-      });
-    }
-    catch {
-      toast.error("Failed to duplicate routine. Please try again.");
-    }
-  }
 
   return (
     <div>
       <PageHeader
-        pageTitle={isNew ? "New Routine" : "Edit Routine"}
+        pageTitle="New Routine"
         pageSection="routines"
-      >
-        {!isNew && (
-          <Link
-            to="/routines/$id"
-            params={{
-              id,
-            }}
-          >
-            <Button variant="secondary">
-              View Routine
-              {" "}
-              <EyeIcon />
-            </Button>
-          </Link>
-        )}
-      </PageHeader>
+      />
       <div className="m-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
@@ -423,273 +210,193 @@ function SingleRoutineEdit() {
             )}
           </form.AppField>
 
-          <form.AppField name="connections">
-            {field => (
-              <field.MultiComboboxField
-                label="Connected To"
-                options={connectionOptions}
-                groupByPrefix
-                placeholder="Search topics, tasks, resources..."
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="status">
-            {field => (
-              <field.RadioGroupField
-                label="Status"
-                options={STATUS_OPTIONS}
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="description">
-            {field => (
-              <field.TextareaField
-                label="Description"
-                placeholder="What is this routine about?"
-              />
-            )}
-          </form.AppField>
-
-          {isDaily && (
-            <form.AppField name="location">
-              {field => (
-                <field.InputField
-                  label="Location"
-                  placeholder="e.g. Spanish app, gym, journal"
-                />
-              )}
-            </form.AppField>
-          )}
-
-          <form.Field name="weekly">
-            {field =>
-              isDaily
-                ? (
-                  <div className="flex flex-col gap-1">
-                    <span className="text-2xl">Daily Task</span>
-                    <p className="text-sm text-muted-foreground">
-                      Pick what to work on each day — the same item applies to
-                      every day of the week.
-                    </p>
-                    <div className="mt-1">
-                      <WeeklyEntryEditor
-                        {...representativeRow(field.state.value)}
-                        onChange={next =>
-                          field.handleChange(fillAllDays(next))}
-                        taskOptions={taskOptions}
-                        resourceOptions={resourceOptions}
-                      />
-                    </div>
-                  </div>
-                )
-                : (
-                  <div className="flex flex-col gap-1">
-                    <div
-                      className="
-                        flex flex-wrap items-center justify-between gap-2
-                      "
-                    >
-                      <span className="text-2xl">Weekly Schedule</span>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                          >
-                            <WandSparklesIcon className="size-4" />
-                            Quick Fill
-                            <ChevronDownIcon className="size-4" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          {(routineTemplates ?? []).length === 0
-                            ? (
-                              <DropdownMenuItem disabled>
-                                No templates — add one in Settings
-                              </DropdownMenuItem>
-                            )
-                            : (routineTemplates ?? []).map(template => (
-                              <DropdownMenuItem
-                                key={template.id}
-                                onSelect={() => {
-                                  field.handleChange(
-                                    weeklyToRows(template.weekly),
-                                  );
-                                }}
-                              >
-                                {template.label}
-                              </DropdownMenuItem>
-                            ))}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                    <WeeklyScheduleField
-                      value={field.state.value}
-                      onChange={next => field.handleChange(next)}
-                      taskOptions={taskOptions}
-                      resourceOptions={resourceOptions}
-                    />
-                  </div>
-                )}
-          </form.Field>
-
-          <div className="flex flex-col gap-4 rounded-md border bg-card p-4">
-            <div
-              className="
-                flex flex-row flex-wrap items-start justify-between gap-2
-              "
-            >
-              <div className="flex flex-col gap-1">
-                <h2 className="text-2xl">Status Criteria</h2>
-                <p className="text-sm text-muted-foreground">
-                  Optional notes describing what each status means for this
-                  routine.
-                </p>
-              </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                  >
-                    <WandSparklesIcon className="size-4" />
-                    Quick Fill
-                    <ChevronDownIcon className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {(criteriaTemplates ?? []).length === 0
-                    ? (
-                      <DropdownMenuItem disabled>
-                        No templates — add one in Settings
-                      </DropdownMenuItem>
-                    )
-                    : (criteriaTemplates ?? []).map(template => (
-                      <DropdownMenuItem
-                        key={template.id}
-                        onSelect={() => {
-                          form.setFieldValue(
-                            "criteriaIncomplete",
-                            template.incomplete,
-                          );
-                          form.setFieldValue(
-                            "criteriaTouched",
-                            template.touched,
-                          );
-                          form.setFieldValue("criteriaGoal", template.goal);
-                          form.setFieldValue(
-                            "criteriaExceeded",
-                            template.exceeded,
-                          );
-                          form.setFieldValue(
-                            "criteriaFreeze",
-                            template.freeze,
-                          );
-                        }}
-                      >
-                        {template.label}
-                      </DropdownMenuItem>
-                    ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-            <form.AppField name="criteriaIncomplete">
-              {field => (
-                <field.TextareaField
-                  label="Incomplete"
-                  placeholder="What does &quot;Incomplete&quot; mean here?"
-                  labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                    o.value === "incomplete")?.icon}
-                />
-              )}
-            </form.AppField>
-            <form.AppField name="criteriaTouched">
-              {field => (
-                <field.TextareaField
-                  label="Touched"
-                  placeholder="What does &quot;Touched&quot; mean here?"
-                  labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                    o.value === "touched")?.icon}
-                />
-              )}
-            </form.AppField>
-            <form.AppField name="criteriaGoal">
-              {field => (
-                <field.TextareaField
-                  label="Completed (Goal)"
-                  placeholder="What does &quot;Completed&quot; (goal) mean here?"
-                  labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                    o.value === "goal")?.icon}
-                />
-              )}
-            </form.AppField>
-            <form.AppField name="criteriaExceeded">
-              {field => (
-                <field.TextareaField
-                  label="Exceeded"
-                  placeholder="What does &quot;Exceeded&quot; mean here?"
-                  labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                    o.value === "exceeded")?.icon}
-                />
-              )}
-            </form.AppField>
-            <form.AppField name="criteriaFreeze">
-              {field => (
-                <field.TextareaField
-                  label="Freeze"
-                  placeholder="What does &quot;Freeze&quot; mean here?"
-                  labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                    o.value === "freeze")?.icon}
-                />
-              )}
-            </form.AppField>
-          </div>
-
-          <EditPageFooter
-            isNew={isNew}
-            onDelete={handleDelete}
-            deleteLabel="Delete Routine"
-            onDuplicate={isNew ? undefined : handleDuplicate}
-            duplicateLabel="Duplicate Routine"
-          >
+          <EditPageFooter isNew>
             <Button
               type="submit"
-              disabled={isSubmitting}
+              disabled={isSubmitting || isSaving}
             >
-              {isSubmitting && <Loader2 className="animate-spin" />}
-              {isNew ? "Create Routine" : "Save Changes"}
+              {(isSubmitting || isSaving) && (
+                <Loader2 className="animate-spin" />
+              )}
+              Create Routine
             </Button>
             <Button
               type="button"
               variant="outline"
-              onClick={() => {
-                if (isNew) {
-                  navigate({
-                    to: "/routines",
-                  });
-                }
-                else {
-                  navigate({
-                    to: "/routines/$id",
-                    params: {
-                      id,
-                    },
-                  });
-                }
-              }}
+              onClick={() =>
+                navigate({
+                  to: "/routines",
+                })}
             >
               Cancel
             </Button>
           </EditPageFooter>
         </form>
-        <UnsavedChangesDialog
-          shouldBlockFn={() => hasChanges && !skipBlocker.current}
-        />
       </div>
+    </div>
+  );
+}
+
+interface ExistingRoutineEditProps {
+  id: string;
+}
+
+function ExistingRoutineEdit({
+  id,
+}: ExistingRoutineEditProps) {
+  const navigate = useNavigate();
+  const search = Route.useSearch();
+  const tab: EditTab = search.tab ?? "details";
+
+  const {
+    data: routine,
+    queryClient,
+    skipBlock,
+    invalidateRelated,
+    shouldBlockFn,
+    makeDeleteHandler,
+  } = useEditFormPage({
+    id,
+    isNew: false,
+    queryKey: ["routine", id],
+    queryFn: () => fetchSingleRoutine(id),
+    relatedQueryKeys: [["routines"], ["dailies"]],
+  });
+
+  const [detailsHasChanges, setDetailsHasChanges] = useState(false);
+  const [criteriaHasChanges, setCriteriaHasChanges] = useState(false);
+  // Day Entries autosaves on every change, so it has no "unsaved" state.
+  const anyTabHasChanges = detailsHasChanges || criteriaHasChanges;
+
+  const handleSaved = useCallback(async () => {
+    await invalidateRelated();
+    await queryClient.invalidateQueries({
+      queryKey: ["daily", id],
+    });
+  }, [invalidateRelated, queryClient, id]);
+
+  const handleDelete = makeDeleteHandler({
+    deleteFn: deleteSingleRoutine,
+    entityLabel: "routine",
+    navigateToList: () => navigate({
+      to: "/routines",
+    }),
+  });
+
+  async function handleDuplicate() {
+    try {
+      const result = await duplicateRoutine(id);
+      await invalidateRelated();
+      skipBlock();
+      await navigate({
+        to: "/routines/$id/edit",
+        params: {
+          id: result.id,
+        },
+      });
+    }
+    catch {
+      toast.error("Failed to duplicate routine. Please try again.");
+    }
+  }
+
+  function changeTab(next: EditTab) {
+    navigate({
+      to: "/routines/$id/edit",
+      params: {
+        id,
+      },
+      search: {
+        tab: next,
+      },
+      replace: true,
+    });
+  }
+
+  if (!routine) {
+    return (
+      <div className="p-4">
+        <h1 className="mb-4 text-3xl">Loading routine...</h1>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PageHeader
+        pageTitle="Edit Routine"
+        pageSection="routines"
+      >
+        <Link
+          to="/routines/$id"
+          params={{
+            id,
+          }}
+        >
+          <Button variant="secondary">
+            View Routine
+            {" "}
+            <EyeIcon />
+          </Button>
+        </Link>
+      </PageHeader>
+      <div className="container flex flex-col gap-6">
+        <Tabs
+          value={tab}
+          onValueChange={value => changeTab(value as EditTab)}
+        >
+          <TabsList>
+            <TabsTrigger value="details">Details</TabsTrigger>
+            <TabsTrigger value="entries">Day Entries</TabsTrigger>
+            <TabsTrigger value="criteria">Status Criteria</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="details">
+            <DetailsTab
+              routine={routine}
+              onSaved={handleSaved}
+              onChangeStateChange={setDetailsHasChanges}
+            />
+          </TabsContent>
+
+          <TabsContent value="entries">
+            <EntriesTab id={id} />
+          </TabsContent>
+
+          <TabsContent value="criteria">
+            <CriteriaTab
+              routine={routine}
+              onSaved={handleSaved}
+              onChangeStateChange={setCriteriaHasChanges}
+            />
+          </TabsContent>
+        </Tabs>
+
+        <EditPageFooter
+          isNew={false}
+          onDelete={handleDelete}
+          deleteLabel="Delete Routine"
+          onDuplicate={handleDuplicate}
+          duplicateLabel="Duplicate Routine"
+        >
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              navigate({
+                to: "/routines/$id",
+                params: {
+                  id,
+                },
+              })}
+          >
+            Done
+          </Button>
+        </EditPageFooter>
+      </div>
+      <UnsavedChangesDialog
+        shouldBlockFn={shouldBlockFn(anyTabHasChanges)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the routine edit page to use a tabbed interface, splitting the monolithic form into three focused components: Details, Day Entries, and Status Criteria. This improves code organization, enables independent state management per tab, and allows the Day Entries tab to leverage the existing auto-saving completions manager.

## Key Changes

- **Split edit page into two flows:**
  - `NewRoutine`: Simplified form for creating routines with minimal fields (name, mode, optional prefilled connections/entries)
  - `ExistingRoutineEdit`: Full-featured tabbed interface for editing existing routines

- **Extracted tab components:**
  - `DetailsTab`: Handles routine name, mode, connections, status, description, location, and weekly/daily schedule
  - `CriteriaTab`: Manages status criteria (incomplete, touched, goal, exceeded, freeze) with template quick-fill
  - `EntriesTab`: Reuses `DailyCompletionsManager` for self-saving day entry edits (no separate Save button)

- **Improved state management:**
  - Each tab tracks its own `hasChanges` state independently
  - Day Entries auto-saves on every change (no unsaved state)
  - Details and Criteria tabs show save buttons and track changes via `lastSavedRef`
  - Consolidated unsaved changes blocking logic via `useEditFormPage` hook

- **Enhanced routing:**
  - Added `tab` search parameter to preserve active tab on navigation
  - Tab switching updates URL without full page reload

- **Simplified new routine creation:**
  - Removed unnecessary queries and complex form initialization
  - Directly creates routine with minimal data, then navigates to edit page for full configuration
  - Supports optional prefilling via search params (`connectedType`, `connectedId`, `topicId`, `entryType`, `entryId`)

## Implementation Details

- Reused `useEditFormPage` hook for common edit-page boilerplate (query management, delete handler, invalidation)
- Each tab form independently validates and saves via `upsertRoutine` with partial updates
- Criteria tab performs partial saves (only `criteria` field) to preserve other routine data
- Dropdown menus use `modal={false}` to prevent focus trapping in tabs
- Tab state persists in URL search params for bookmarkability and back-button support

https://claude.ai/code/session_01CDWCdWXJw8rrCjEunJr6uU