### PR TITLE
Add tab navigation to routine and daily detail panels

### DIFF
--- a/packages/client/src/components/dailies/DailyDetailsPanel.tsx
+++ b/packages/client/src/components/dailies/DailyDetailsPanel.tsx
@@ -1,3 +1,5 @@
+import type { DailyDetailTab } from "./dailyStatusMeta";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { DailyCompletionsManager } from "./DailyCompletionsManager";
@@ -16,11 +18,24 @@ interface DailyDetailsPanelProps {
   dailyId: string;
   /** Extra content rendered at the top of the Details tab. */
   detailsContent?: React.ReactNode;
+  /**
+   * Active tab. When provided together with `onTabChange`, the panel is
+   * controlled (e.g. driven by a URL search param); otherwise it manages its
+   * own tab state, defaulting to "details".
+   */
+  tab?: DailyDetailTab;
+  /** Called with the next tab when the user selects a different tab. */
+  onTabChange?: (tab: DailyDetailTab) => void;
+  /** Rendered under the empty state of the Status Criteria tab. */
+  criteriaEmptyAction?: React.ReactNode;
 }
 
 export function DailyDetailsPanel({
   dailyId,
   detailsContent,
+  tab,
+  onTabChange,
+  criteriaEmptyAction,
 }: DailyDetailsPanelProps) {
   const {
     isPending, error, data,
@@ -75,8 +90,19 @@ export function DailyDetailsPanel({
   ];
   const visibleCriteria = criteriaLabels.filter(c => !!criteria[c.key]);
 
+  // Controlled only when both `tab` and `onTabChange` are supplied, so the
+  // panel never passes Radix both `value` and `defaultValue` at once.
+  const tabsProps = tab !== undefined && onTabChange !== undefined
+    ? {
+      value: tab,
+      onValueChange: (v: string) => onTabChange(v as DailyDetailTab),
+    }
+    : {
+      defaultValue: "details" as const,
+    };
+
   return (
-    <Tabs defaultValue="details">
+    <Tabs {...tabsProps}>
       <TabsList>
         <TabsTrigger value="details">Details</TabsTrigger>
         <TabsTrigger value="entries">
@@ -157,9 +183,12 @@ export function DailyDetailsPanel({
             </dl>
           )
           : (
-            <p className="text-sm text-muted-foreground">
-              <i>No status criteria defined.</i>
-            </p>
+            <div className="flex flex-col items-start gap-3">
+              <p className="text-sm text-muted-foreground">
+                <i>No status criteria defined.</i>
+              </p>
+              {criteriaEmptyAction}
+            </div>
           )}
       </TabsContent>
     </Tabs>

--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -8,6 +8,10 @@ import {
   SparklesIcon,
 } from "lucide-react";
 
+/** Tabs shown in the daily / routine detail panel. */
+export const DAILY_DETAIL_TABS = ["details", "entries", "criteria"] as const;
+export type DailyDetailTab = (typeof DAILY_DETAIL_TABS)[number];
+
 export interface DailyStatusOption {
   value: DailyCompletionStatus;
   label: string;

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -1,12 +1,15 @@
+import type { DailyDetailTab } from "@/components/dailies/dailyStatusMeta";
+
 import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, FlameIcon, LaughIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
+import { DAILY_DETAIL_TABS } from "@/components/dailies/dailyStatusMeta";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -24,8 +27,24 @@ import {
   getTotalCompletedDays,
 } from "@/utils";
 
+interface RoutineViewSearch {
+  tab?: DailyDetailTab;
+}
+
 export const Route = createFileRoute("/routines/$id/")({
   component: SingleRoutine,
+  validateSearch: (search: Record<string, unknown>): RoutineViewSearch => {
+    const value = search.tab;
+    if (
+      typeof value === "string"
+      && (DAILY_DETAIL_TABS as readonly string[]).includes(value)
+    ) {
+      return {
+        tab: value as DailyDetailTab,
+      };
+    }
+    return {};
+  },
 });
 
 function RoutinePending() {
@@ -40,6 +59,23 @@ function SingleRoutine() {
   const {
     id,
   } = Route.useParams();
+
+  const navigate = useNavigate();
+  const search = Route.useSearch();
+  const tab: DailyDetailTab = search.tab ?? "details";
+
+  function changeTab(next: DailyDetailTab) {
+    navigate({
+      to: "/routines/$id",
+      params: {
+        id,
+      },
+      search: {
+        tab: next,
+      },
+      replace: true,
+    });
+  }
 
   const {
     isPending, error, data,
@@ -195,6 +231,28 @@ function SingleRoutine() {
         )}
         <DailyDetailsPanel
           dailyId={id}
+          tab={tab}
+          onTabChange={changeTab}
+          criteriaEmptyAction={(
+            <Link
+              to="/routines/$id/edit"
+              params={{
+                id,
+              }}
+              search={{
+                tab: "criteria",
+              }}
+            >
+              <Button
+                variant="secondary"
+                size="sm"
+              >
+                Add Status Criteria
+                {" "}
+                <EditIcon />
+              </Button>
+            </Link>
+          )}
           detailsContent={(
             <div className="flex flex-col gap-12">
               <div


### PR DESCRIPTION
## Summary
Adds URL-driven tab state management to the routine detail view and enhances the `DailyDetailsPanel` component to support both controlled and uncontrolled tab modes. This allows users to navigate between Details, Entries, and Criteria tabs via URL search parameters while maintaining backward compatibility.

## Key Changes

- **Route validation:** Added `validateSearch` to the routine detail route to parse and validate the `tab` query parameter against the `DAILY_DETAIL_TABS` enum
- **Tab state management:** Implemented `changeTab()` function in `SingleRoutine` that updates the URL search param when users switch tabs, using `navigate()` with `replace: true` to avoid polluting browser history
- **DailyDetailsPanel enhancements:**
  - Added `tab`, `onTabChange`, and `criteriaEmptyAction` props to support controlled tab mode
  - Conditionally applies either controlled (`value` + `onValueChange`) or uncontrolled (`defaultValue`) props to the Radix `Tabs` component based on whether both `tab` and `onTabChange` are provided
  - Renders the `criteriaEmptyAction` node (e.g., "Add Status Criteria" button) below the empty state message in the Criteria tab
- **Type exports:** Extracted `DailyDetailTab` type and `DAILY_DETAIL_TABS` constant to `dailyStatusMeta.tsx` for reuse across components
- **Routine view integration:** Passes the active tab and change handler to `DailyDetailsPanel`, along with a link to the edit page (with `tab: "criteria"` search param) as the empty action

## Implementation Details

The tab state is now driven by the URL search parameter when on the routine detail page, allowing users to bookmark or share links to specific tabs. The `DailyDetailsPanel` remains flexible—it can be used standalone (uncontrolled, defaulting to "details") or integrated into a parent component that manages tab state via URL or other means.

https://claude.ai/code/session_014BLKZyDHDNXeF966x6o9E2