### PR TITLE
Extract ActionableSentence component for styled routine names

### DIFF
--- a/packages/client/src/components/dailies/ActionableSentence.tsx
+++ b/packages/client/src/components/dailies/ActionableSentence.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+interface ActionableSentenceProps {
+  prependText?: string | null;
+  appendText?: string | null;
+  // The resource/task/freeform name — a plain string on the dashboard, or a
+  // clickable <Link> on the single routine page.
+  name: ReactNode;
+  className?: string;
+}
+
+// Renders a routine's actionable sentence (prepend + name + append) with the
+// name at a heavier weight than its surrounding affixes, so the meaningful core
+// stands out. A routine with no prepend/append simply renders its name.
+export function ActionableSentence({
+  prependText,
+  appendText,
+  name,
+  className,
+}: ActionableSentenceProps) {
+  const prepend = typeof prependText === "string" ? prependText.trim() : "";
+  const append = typeof appendText === "string" ? appendText.trim() : "";
+  return (
+    <span className={className}>
+      {prepend
+        ? (
+          <>
+            <span className="font-normal">{prepend}</span>
+            {" "}
+          </>
+        )
+        : null}
+      <span className="font-medium">{name}</span>
+      {append
+        ? (
+          <>
+            {" "}
+            <span className="font-normal">{append}</span>
+          </>
+        )
+        : null}
+    </span>
+  );
+}

--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -5,6 +5,7 @@ import { Fragment } from "react";
 import { Link } from "@tanstack/react-router";
 import { FlameIcon, LaughIcon } from "lucide-react";
 
+import { ActionableSentence } from "./ActionableSentence";
 import { DailyCommentPopover } from "./DailyCommentPopover";
 import { DailyCourseIndicator } from "./DailyCourseIndicator";
 import { DailyLocationCell } from "./DailyLocationCell";
@@ -85,7 +86,11 @@ export function DailiesActiveListView({
                     hover:text-blue-600
                   "
                 >
-                  {daily.actionLabel ?? daily.name}
+                  <ActionableSentence
+                    prependText={daily.actionParts?.prependText}
+                    appendText={daily.actionParts?.appendText}
+                    name={daily.actionParts?.name ?? daily.name}
+                  />
                 </Link>
                 {daily.description && (
                   <span

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -1,3 +1,4 @@
+export { ActionableSentence } from "./ActionableSentence";
 export { DailiesActiveListView } from "./DailiesActiveListView";
 export { DailyCriteriaTemplateEditModal } from "./DailyCriteriaTemplateEditModal";
 export { DailiesViewModeToggle } from "./DailiesViewModeToggle";

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -18,6 +18,7 @@ import {
   DashboardSectionStatus,
 } from "@/components/boxes/DashboardCard";
 import {
+  ActionableSentence,
   DailiesActiveListView,
   DailiesViewModeToggle,
   DailyCommentPopover,
@@ -315,7 +316,11 @@ export function DashboardDailies() {
                           hover:text-blue-600
                         "
                       >
-                        {daily.actionLabel ?? daily.name}
+                        <ActionableSentence
+                          prependText={daily.actionParts?.prependText}
+                          appendText={daily.actionParts?.appendText}
+                          name={daily.actionParts?.name ?? daily.name}
+                        />
                       </Link>
                     </td>
                     <td className="p-2">

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -6,6 +6,7 @@ import { EditIcon, FlameIcon, LaughIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
+import { ActionableSentence } from "@/components/dailies/ActionableSentence";
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
@@ -119,19 +120,18 @@ function SingleRoutine() {
   }
 
   // prepend text + linked name + append text, forming the actionable sentence
-  // while keeping the name itself clickable.
+  // while keeping the name itself clickable. The affixes render a notch lighter
+  // than the name so the resource itself stands out.
   function renderActionable(entry: { type: string;
     id: string;
     prependText?: string | null;
     appendText?: string | null; }) {
-    const prepend = entry.prependText?.trim();
-    const append = entry.appendText?.trim();
     return (
-      <>
-        {prepend ? `${prepend} ` : null}
-        {entryNameLink(entry)}
-        {append ? ` ${append}` : null}
-      </>
+      <ActionableSentence
+        prependText={entry.prependText}
+        appendText={entry.appendText}
+        name={entryNameLink(entry)}
+      />
     );
   }
 

--- a/packages/client/src/routes/routines.tracker.tsx
+++ b/packages/client/src/routes/routines.tracker.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import {
+  ActionableSentence,
   DailiesActiveListView,
   DailiesLimitSetting,
   DailiesViewModeToggle,
@@ -434,7 +435,11 @@ function DailyTracker() {
                                 hover:text-blue-600
                               "
                             >
-                              {daily.actionLabel ?? daily.name}
+                              <ActionableSentence
+                                prependText={daily.actionParts?.prependText}
+                                appendText={daily.actionParts?.appendText}
+                                name={daily.actionParts?.name ?? daily.name}
+                              />
                             </Link>
                           </td>
                           <td className="p-2">
@@ -604,7 +609,11 @@ function DailyTracker() {
                                 hover:text-blue-600
                               "
                             >
-                              {daily.actionLabel ?? daily.name}
+                              <ActionableSentence
+                                prependText={daily.actionParts?.prependText}
+                                appendText={daily.actionParts?.appendText}
+                                name={daily.actionParts?.name ?? daily.name}
+                              />
                             </Link>
                             <DailyCourseIndicator daily={daily} />
                             <DailyTaskIndicator daily={daily} />
@@ -669,7 +678,11 @@ function DailyTracker() {
                                 hover:text-blue-600
                               "
                             >
-                              {daily.actionLabel ?? daily.name}
+                              <ActionableSentence
+                                prependText={daily.actionParts?.prependText}
+                                appendText={daily.actionParts?.appendText}
+                                name={daily.actionParts?.name ?? daily.name}
+                              />
                             </Link>
                             <DailyCourseIndicator daily={daily} />
                             <DailyTaskIndicator daily={daily} />

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -105,18 +105,23 @@ export function mapRoutineToDaily(
     = resolved.resource?.name
       ?? resolved.task?.name
       ?? (entry?.type === "freeform" ? entry.id : null);
-  const actionLabel
+  // Structured parts (affixes + name) so consumers can render the name heavier
+  // than the surrounding text; the flat label is derived from them so the two
+  // never drift.
+  const actionParts
     = entry && baseName && (entry.prependText || entry.appendText)
-      ? buildActionableSentence({
-        prependText: entry.prependText,
+      ? {
+        prependText: entry.prependText ?? null,
         name: baseName,
-        appendText: entry.appendText,
-      })
+        appendText: entry.appendText ?? null,
+      }
       : null;
+  const actionLabel = actionParts ? buildActionableSentence(actionParts) : null;
 
   return {
     ...daily,
     actionLabel,
+    actionParts,
     mode: routine.mode,
     weekly: routine.weekly ?? {},
     connections: routine.connections ?? [],

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -32,6 +32,13 @@ export interface Daily {
   // natural sentence (e.g. "Review Spanish flashcards for 10 minutes"). Null
   // unless prepend or append text is set; consumers fall back to `name`.
   actionLabel?: string | null;
+  // Structured form of `actionLabel` for styled rendering (affixes lighter than
+  // the name). Null unless prepend/append text is set; consumers fall back to `name`.
+  actionParts?: {
+    prependText?: string | null;
+    name: string;
+    appendText?: string | null;
+  } | null;
   location?: string | null;
   description?: string | null;
   completions: DailyCompletion[];


### PR DESCRIPTION
## Summary
Extracts a reusable `ActionableSentence` component to render routine/task/resource names with optional prepend/append text, where the name itself is emphasized (font-medium) while affixes remain lighter (font-normal). This replaces inline rendering logic across multiple views and enables consistent, styled presentation of actionable sentences.

## Key Changes
- **New component:** `ActionableSentence.tsx` — renders `prependText + name + appendText` with the name at heavier weight; accepts `name` as a `ReactNode` to support both plain strings (dashboard) and clickable links (single routine page)
- **Type update:** Added `actionParts` field to `Daily` interface (structured form of `actionLabel` for styled rendering)
- **Middleware projection:** Updated `mapRoutineToDaily()` to compute and return `actionParts` alongside the existing flat `actionLabel`
- **Client refactors:** Replaced 5 instances of `{daily.actionLabel ?? daily.name}` with `<ActionableSentence>` across:
  - `DailiesActiveListView.tsx`
  - `routines.tracker.tsx` (3 view modes)
  - `dashboard.-components/-DashboardDailies.tsx`
- **Single routine page:** Refactored `renderActionable()` in `routines.$id.index.tsx` to use `ActionableSentence`, simplifying the logic while preserving clickable entity links
- **Export:** Added `ActionableSentence` to the dailies component barrel export

## Implementation Details
- The component trims prepend/append text and only renders them if non-empty after trimming
- Affixes are wrapped in `<span className="font-normal">` while the name uses `<span className="font-medium">` to create visual hierarchy
- The `name` prop accepts `ReactNode` to support both plain strings and `<Link>` components, enabling reuse across different contexts
- `actionParts` is only computed when prepend or append text exists; consumers fall back to the plain `name` field otherwise, maintaining backward compatibility

https://claude.ai/code/session_01BBNkBNSNMUTYxjKYthgUrA