### PR TITLE
Refactor combobox grouping to use explicit `group` field

### DIFF
--- a/packages/client/src/components/boxElements/EntityLink.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.tsx
@@ -4,14 +4,6 @@ import { Link } from "@tanstack/react-router";
 
 type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
 
-const FROM_BY_KIND: Record<EntityKind, string> = {
-  resources: "/resources",
-  topics: "/topics",
-  providers: "/providers",
-  domains: "/domains",
-  tasks: "/tasks",
-};
-
 const TO_BY_KIND: Record<EntityKind, string> = {
   resources: "/resources/$id",
   topics: "/topics/$id",
@@ -23,7 +15,6 @@ const TO_BY_KIND: Record<EntityKind, string> = {
 interface EntityLinkProps {
   entity: EntityKind;
   id: string | number;
-  from?: string;
   className?: string;
   children: ReactNode;
 }
@@ -31,14 +22,12 @@ interface EntityLinkProps {
 export function EntityLink({
   entity,
   id,
-  from,
   className = "hover:text-blue-600",
   children,
 }: EntityLinkProps) {
   return (
     <Link
       to={TO_BY_KIND[entity]}
-      from={from ?? FROM_BY_KIND[entity]}
       params={{
         id: String(id),
       }}

--- a/packages/client/src/components/boxes/CourseBox.tsx
+++ b/packages/client/src/components/boxes/CourseBox.tsx
@@ -87,7 +87,6 @@ export function CourseBox({
             <EntityLink
               entity="providers"
               id={provider.id}
-              from="/resources/$id"
               className={`
                 text-blue-800
                 hover:text-blue-600

--- a/packages/client/src/components/boxes/CoursesTable.tsx
+++ b/packages/client/src/components/boxes/CoursesTable.tsx
@@ -80,7 +80,6 @@ export function CoursesTable({
                     <EntityLink
                       entity="providers"
                       id={course.provider.id}
-                      from="/resources"
                       className="
                         text-blue-800
                         hover:text-blue-600

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -10,6 +10,7 @@ import {
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
+  ComboboxCollection,
   ComboboxContent,
   ComboboxEmpty,
   ComboboxGroup,
@@ -24,35 +25,49 @@ import { cn } from "@/lib/utils";
 import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
+interface ComboboxOption {
+  value: string;
+  label: string;
+  group?: string;
+}
+
 interface MultiComboboxFieldProps {
   label: string;
-  options: { value: string;
-    label: string; }[];
+  options: ComboboxOption[];
   placeholder?: string;
   className?: string;
   create?: CreateConfig;
   /**
-   * When true, options whose value matches `group:value` are partitioned by
-   * the substring before the first `:` and rendered under a group header.
-   * Options without a colon fall under an "Other" group rendered last.
+   * When true, options are rendered under group headers (and the dropdown filters
+   * per group, hiding empty ones). An option's group comes from its explicit
+   * `group` field, falling back to the substring before the first `:` in its
+   * value; options with neither fall under an "Other" group rendered last.
    */
   groupByPrefix?: boolean;
 }
 
-function partitionOptions(options: { value: string;
-  label: string; }[]) {
-  const groups = new Map<string, { value: string;
-    label: string; }[]>();
+// Group option values into Base UI's grouped-items shape (`{ value, items }[]`,
+// where `value` is the header label and `items` are the option values). Passing
+// this as the combobox `items` lets Base UI filter within each group and hide
+// empty ones. Groups keep first-appearance order, with "Other" forced last.
+function partitionOptions(
+  options: ComboboxOption[],
+): { value: string;
+  items: string[]; }[] {
+  const groups = new Map<string, string[]>();
   const otherKey = "Other";
   for (const opt of options) {
-    const idx = opt.value.indexOf(":");
-    const groupName = idx > 0 ? opt.value.slice(0, idx) : otherKey;
+    let groupName = opt.group;
+    if (!groupName) {
+      const idx = opt.value.indexOf(":");
+      groupName = idx > 0 ? opt.value.slice(0, idx) : otherKey;
+    }
     const bucket = groups.get(groupName);
     if (bucket) {
-      bucket.push(opt);
+      bucket.push(opt.value);
     }
     else {
-      groups.set(groupName, [opt]);
+      groups.set(groupName, [opt.value]);
     }
   }
   const others = groups.get(otherKey);
@@ -60,7 +75,10 @@ function partitionOptions(options: { value: string;
     groups.delete(otherKey);
     groups.set(otherKey, others);
   }
-  return groups;
+  return Array.from(groups.entries()).map(([value, items]) => ({
+    value,
+    items,
+  }));
 }
 
 function stripGroup(label: string) {
@@ -128,11 +146,9 @@ export function MultiComboboxField({
       <FieldLabel className={className}>{label}</FieldLabel>
       <Combobox
         multiple
-        {...(groupByPrefix
-          ? {}
-          : {
-            items: options.map(o => o.value),
-          })}
+        items={
+          groupByPrefix ? partitionOptions(options) : options.map(o => o.value)
+        }
         value={field.state.value || []}
         onValueChange={val => field.handleChange(val)}
         onInputValueChange={val => setInputValue(val)}
@@ -180,20 +196,24 @@ export function MultiComboboxField({
           <ComboboxEmpty>No items found.</ComboboxEmpty>
           <ComboboxList>
             {groupByPrefix
-              ? Array.from(partitionOptions(options).entries()).map(
-                ([groupName, groupOptions]) => (
-                  <ComboboxGroup key={groupName}>
-                    <ComboboxLabel>{groupName}</ComboboxLabel>
-                    {groupOptions.map(o => (
+              ? (group: { value: string;
+                items: string[]; }) => (
+                <ComboboxGroup
+                  key={group.value}
+                  items={group.items}
+                >
+                  <ComboboxLabel>{group.value}</ComboboxLabel>
+                  <ComboboxCollection>
+                    {(value: string) => (
                       <ComboboxItem
-                        key={o.value}
-                        value={o.value}
+                        key={value}
+                        value={value}
                       >
-                        {stripGroup(o.label)}
+                        {stripGroup(optionsMap.get(value) ?? value)}
                       </ComboboxItem>
-                    ))}
-                  </ComboboxGroup>
-                ),
+                    )}
+                  </ComboboxCollection>
+                </ComboboxGroup>
               )
               : (value: string) => (
                 <ComboboxItem

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -156,10 +156,7 @@ export function MultiComboboxField({
       >
         <ComboboxChips ref={anchor}>
           {(field.state.value || []).map(val => (
-            <ComboboxChip
-              key={val}
-              value={val}
-            >
+            <ComboboxChip key={val}>
               {optionsMap.get(val) ?? val}
             </ComboboxChip>
           ))}

--- a/packages/client/src/components/radar/TopicMultiSelect.tsx
+++ b/packages/client/src/components/radar/TopicMultiSelect.tsx
@@ -37,10 +37,7 @@ export function TopicMultiSelect({
     >
       <ComboboxChips ref={anchor}>
         {value.map(val => (
-          <ComboboxChip
-            key={val}
-            value={val}
-          >
+          <ComboboxChip key={val}>
             {optionsMap.get(val) ?? val}
           </ComboboxChip>
         ))}

--- a/packages/client/src/components/tasks/TagPicker.tsx
+++ b/packages/client/src/components/tasks/TagPicker.tsx
@@ -7,6 +7,7 @@ import {
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
+  ComboboxCollection,
   ComboboxContent,
   ComboboxEmpty,
   ComboboxGroup,
@@ -40,9 +41,19 @@ export function TagPicker({
     }
   }
 
+  // Base UI grouped-items shape: `items` lets the dropdown filter within each
+  // group and hide empty ones (`value` is the header label, kept alongside the
+  // group `id` so both survive filtering).
+  const groupedItems = tagGroups.map(group => ({
+    id: group.id,
+    value: group.name,
+    items: (group.tags ?? []).map(tag => tag.id),
+  }));
+
   return (
     <Combobox
       multiple
+      items={groupedItems}
       value={value}
       onValueChange={(next: string[]) => onChange(next)}
       inputValue={inputValue}
@@ -53,10 +64,7 @@ export function TagPicker({
         {value.map((id) => {
           const tag = tagsById.get(id);
           return (
-            <ComboboxChip
-              key={id}
-              value={id}
-            >
+            <ComboboxChip key={id}>
               {tag?.name ?? id}
             </ComboboxChip>
           );
@@ -66,19 +74,26 @@ export function TagPicker({
       <ComboboxContent anchor={anchor}>
         <ComboboxEmpty>No tags found.</ComboboxEmpty>
         <ComboboxList>
-          {tagGroups.map(group => (
-            <ComboboxGroup key={group.id}>
-              <ComboboxLabel>{group.name}</ComboboxLabel>
-              {(group.tags ?? []).map(tag => (
-                <ComboboxItem
-                  key={tag.id}
-                  value={tag.id}
-                >
-                  {tag.name}
-                </ComboboxItem>
-              ))}
+          {(group: { id: string;
+            value: string;
+            items: string[]; }) => (
+            <ComboboxGroup
+              key={group.id}
+              items={group.items}
+            >
+              <ComboboxLabel>{group.value}</ComboboxLabel>
+              <ComboboxCollection>
+                {(id: string) => (
+                  <ComboboxItem
+                    key={id}
+                    value={id}
+                  >
+                    {tagsById.get(id)?.name ?? id}
+                  </ComboboxItem>
+                )}
+              </ComboboxCollection>
             </ComboboxGroup>
-          ))}
+          )}
         </ComboboxList>
       </ComboboxContent>
     </Combobox>

--- a/packages/client/src/components/tasks/TagsInput.tsx
+++ b/packages/client/src/components/tasks/TagsInput.tsx
@@ -7,6 +7,7 @@ import {
   ComboboxChip,
   ComboboxChips,
   ComboboxChipsInput,
+  ComboboxCollection,
   ComboboxContent,
   ComboboxEmpty,
   ComboboxGroup,
@@ -25,7 +26,11 @@ interface TagsInputProps {
   groupByPrefix?: boolean;
 }
 
-function partitionTags(tags: string[]) {
+// Group tags into Base UI's grouped-items shape (`{ value, items }[]`, where
+// `value` is the header label and `items` are the tag values) so the dropdown
+// filters within each group and hides empty ones. "Other" is forced last.
+function partitionTags(tags: string[]): { value: string;
+  items: string[]; }[] {
   const groups = new Map<string, string[]>();
   const otherKey = "Other";
   for (const tag of tags) {
@@ -44,7 +49,10 @@ function partitionTags(tags: string[]) {
     groups.delete(otherKey);
     groups.set(otherKey, others);
   }
-  return groups;
+  return Array.from(groups.entries()).map(([value, items]) => ({
+    value,
+    items,
+  }));
 }
 
 function stripGroup(tag: string) {
@@ -80,11 +88,7 @@ export function TagsInput({
   return (
     <Combobox
       multiple
-      {...(groupByPrefix
-        ? {}
-        : {
-          items: allOptionValues,
-        })}
+      items={groupByPrefix ? partitionTags(allOptionValues) : allOptionValues}
       value={value}
       onValueChange={(next: string[]) => onChange(next)}
       inputValue={inputValue}
@@ -93,10 +97,7 @@ export function TagsInput({
     >
       <ComboboxChips ref={anchor}>
         {value.map(tag => (
-          <ComboboxChip
-            key={tag}
-            value={tag}
-          >
+          <ComboboxChip key={tag}>
             {tag}
           </ComboboxChip>
         ))}
@@ -137,20 +138,24 @@ export function TagsInput({
         <ComboboxEmpty>No tags found.</ComboboxEmpty>
         <ComboboxList>
           {groupByPrefix
-            ? Array.from(partitionTags(allOptionValues).entries()).map(
-              ([groupName, groupTags]) => (
-                <ComboboxGroup key={groupName}>
-                  <ComboboxLabel>{groupName}</ComboboxLabel>
-                  {groupTags.map(tag => (
+            ? (group: { value: string;
+              items: string[]; }) => (
+              <ComboboxGroup
+                key={group.value}
+                items={group.items}
+              >
+                <ComboboxLabel>{group.value}</ComboboxLabel>
+                <ComboboxCollection>
+                  {(tag: string) => (
                     <ComboboxItem
                       key={tag}
                       value={tag}
                     >
                       {stripGroup(tag)}
                     </ComboboxItem>
-                  ))}
-                </ComboboxGroup>
-              ),
+                  )}
+                </ComboboxCollection>
+              </ComboboxGroup>
             )
             : (val: string) => (
               <ComboboxItem

--- a/packages/client/src/context/SettingsProviderContext.ts
+++ b/packages/client/src/context/SettingsProviderContext.ts
@@ -14,7 +14,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   dailiesViewMode: null,
 };
 
-interface SettingsProviderState {
+export interface SettingsProviderState {
   settings: AppSettings;
   setMaxActiveDailies: (value: number) => void;
   setDailiesViewMode: (value: DailiesViewMode | null) => void;

--- a/packages/client/src/context/ThemeProviderContext.ts
+++ b/packages/client/src/context/ThemeProviderContext.ts
@@ -2,7 +2,7 @@ import { createContext } from "react";
 
 export type Theme = "dark" | "light" | "system";
 
-interface ThemeProviderState {
+export interface ThemeProviderState {
   theme: Theme;
   setTheme: (theme: Theme) => void;
 }

--- a/packages/client/src/routes/domains.$id.edit.tsx
+++ b/packages/client/src/routes/domains.$id.edit.tsx
@@ -37,7 +37,7 @@ import {
 const TAB_VALUES = ["details", "scope", "config", "blips", "llm"] as const;
 type EditTab = (typeof TAB_VALUES)[number];
 
-interface EditSearch {
+export interface EditSearch {
   tab?: EditTab;
 }
 

--- a/packages/client/src/routes/domains.$id.radar.index.tsx
+++ b/packages/client/src/routes/domains.$id.radar.index.tsx
@@ -9,7 +9,7 @@ import { RadarChart } from "@/components/radar/RadarChart";
 import { Button } from "@/components/ui/button";
 import { fetchRadar, upsertRadarBlip } from "@/utils";
 
-interface RadarSearch {
+export interface RadarSearch {
   blipId?: string;
 }
 

--- a/packages/client/src/routes/onboard.tsx
+++ b/packages/client/src/routes/onboard.tsx
@@ -180,7 +180,11 @@ function Onboard() {
               {FIELD_INDICES.map(i => (
                 <CourseFields
                   key={`course${i}`}
-                  form={form}
+                  // CourseFields is form-data-agnostic (it only renders
+                  // dynamically-named string fields). Bridge TanStack Form's
+                  // invariant generics: this form's data is Record<string,string>
+                  // while the prop defaults to the unknown-data form type.
+                  form={form as unknown as ReturnType<typeof useAppForm>}
                   condition={i === 0 || !!topics[i]}
                   name={`course${i}`}
                   label={topics[i]}

--- a/packages/client/src/routes/resources.$id.edit.tsx
+++ b/packages/client/src/routes/resources.$id.edit.tsx
@@ -34,7 +34,7 @@ import {
   uuidv4,
 } from "@/utils";
 
-interface ResourceEditSearch {
+export interface ResourceEditSearch {
   topicId?: string;
 }
 

--- a/packages/client/src/routes/resources.$id.index.tsx
+++ b/packages/client/src/routes/resources.$id.index.tsx
@@ -13,7 +13,7 @@ import { InfoRow } from "@/components/layout/InfoRow";
 import { Button } from "@/components/ui/button";
 import { fetchRoutines, fetchSingleResource, makePercentageComplete } from "@/utils";
 
-interface CourseSearch {
+export interface CourseSearch {
   promptDaily?: 1;
 }
 

--- a/packages/client/src/routes/resources.index.tsx
+++ b/packages/client/src/routes/resources.index.tsx
@@ -43,7 +43,7 @@ function getInitialViewMode(): ViewMode {
   return stored === "table" ? "table" : "grid";
 }
 
-interface ResourcesSearch {
+export interface ResourcesSearch {
   topicId?: string;
 }
 

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -47,7 +47,7 @@ import {
   upsertRoutine,
 } from "@/utils";
 
-interface RoutineEditSearch {
+export interface RoutineEditSearch {
   // Legacy alias: a bare `?topicId=` still prefills a topic connection.
   topicId?: string;
   connectedType?: RoutineConnectionType;

--- a/packages/client/src/routes/routines.index.tsx
+++ b/packages/client/src/routes/routines.index.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/select";
 import { fetchRoutines } from "@/utils";
 
-interface RoutinesSearch {
+export interface RoutinesSearch {
   // Legacy alias: `?topicId=` still prefilters by that topic connection.
   topicId?: string;
   connectedType?: RoutineConnectionType;

--- a/packages/client/src/routes/routines.tracker.tsx
+++ b/packages/client/src/routes/routines.tracker.tsx
@@ -54,7 +54,7 @@ import {
   withCompletionNote,
 } from "@/utils";
 
-interface TrackerSearch {
+export interface TrackerSearch {
   topicId?: string;
 }
 

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -25,7 +25,7 @@ import {
   upsertTask,
 } from "@/utils";
 
-interface TaskEditSearch {
+export interface TaskEditSearch {
   topicId?: string;
 }
 

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -21,7 +21,7 @@ import {
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchTasks, fetchTopics } from "@/utils";
 
-interface TasksSearch {
+export interface TasksSearch {
   topicId?: string;
 }
 

--- a/packages/client/src/utils/routineConnections.test.ts
+++ b/packages/client/src/utils/routineConnections.test.ts
@@ -53,7 +53,7 @@ describe("connectionEntityKind", () => {
 });
 
 describe("buildConnectionOptions", () => {
-  test("prefixes each entity by its group and keeps the bare name as label", () => {
+  test("prefixes each entity value by type and tags it with a dropdown group", () => {
     const options = buildConnectionOptions(
       [{
         id: "t1",
@@ -72,14 +72,110 @@ describe("buildConnectionOptions", () => {
       {
         value: "Topic:t1",
         label: "React",
+        group: "Topics · No domain",
       },
       {
         value: "Task:k1",
         label: "Finish module",
+        group: "Tasks",
       },
       {
         value: "Resource:r1",
         label: "Docs site",
+        group: "Resources",
+      },
+    ]);
+  });
+
+  test("groups topics by domain, sorted with No domain last and names sorted", () => {
+    const options = buildConnectionOptions(
+      [
+        {
+          id: "t1",
+          name: "Zebra",
+          domains: [{
+            id: "d2",
+            title: "Tooling",
+          }],
+        },
+        {
+          id: "t2",
+          name: "Apple",
+          domains: [{
+            id: "d1",
+            title: "Frontend",
+          }],
+        },
+        {
+          id: "t3",
+          name: "Mango",
+          domains: [],
+        },
+        {
+          id: "t4",
+          name: "Bravo",
+          domains: [{
+            id: "d1",
+            title: "Frontend",
+          }],
+        },
+      ],
+      [],
+      [],
+    );
+    expect(options).toEqual([
+      {
+        value: "Topic:t2",
+        label: "Apple",
+        group: "Topics · Frontend",
+      },
+      {
+        value: "Topic:t4",
+        label: "Bravo",
+        group: "Topics · Frontend",
+      },
+      {
+        value: "Topic:t1",
+        label: "Zebra",
+        group: "Topics · Tooling",
+      },
+      {
+        value: "Topic:t3",
+        label: "Mango",
+        group: "Topics · No domain",
+      },
+    ]);
+  });
+
+  test("lists a multi-domain topic once under each of its domains", () => {
+    const options = buildConnectionOptions(
+      [{
+        id: "t1",
+        name: "React",
+        domains: [
+          {
+            id: "d1",
+            title: "Frontend",
+          },
+          {
+            id: "d2",
+            title: "Tooling",
+          },
+        ],
+      }],
+      [],
+      [],
+    );
+    expect(options).toEqual([
+      {
+        value: "Topic:t1",
+        label: "React",
+        group: "Topics · Frontend",
+      },
+      {
+        value: "Topic:t1",
+        label: "React",
+        group: "Topics · Tooling",
       },
     ]);
   });

--- a/packages/client/src/utils/routineConnections.ts
+++ b/packages/client/src/utils/routineConnections.ts
@@ -20,9 +20,10 @@ export function connectionEntityKind(type: RoutineConnectionType) {
   return ENTITY_KIND_BY_TYPE[type];
 }
 
-// MultiComboboxField encodes each connection as "<Group>:<id>" so its
-// groupByPrefix renders Topic / Task / Resource group headers. Entity ids are
-// uuids (no colon), so splitting on the first colon is safe.
+// Each connection value is encoded as "<Group>:<id>" purely so encode/decode can
+// round-trip the entity type. Entity ids are uuids (no colon), so splitting on
+// the first colon is safe. Dropdown grouping is driven by each option's explicit
+// `group` field (see buildConnectionOptions), not by this value prefix.
 const GROUP_LABEL_BY_TYPE: Record<RoutineConnectionType, string> = {
   topic: "Topic",
   task: "Task",
@@ -60,28 +61,76 @@ export function decodeConnection(value: string): {
   };
 }
 
-// Combined, prefixed option list for the connections multi-select. Labels stay
-// the bare entity name (the group header carries the type).
+const NO_DOMAIN_GROUP = "Topics · No domain";
+
+function topicGroupLabel(domainTitle: string) {
+  return `Topics · ${domainTitle}`;
+}
+
+// Combined option list for the connections multi-select. Labels stay the bare
+// entity name; each option carries an explicit `group` for the dropdown header.
+// Topics are grouped under "Topics · <domain>" (one entry per domain a topic
+// belongs to, so a multi-domain topic appears under each), with topics that have
+// no domain bucketed under "Topics · No domain". Tasks and Resources get their
+// own groups. Domain groups sort alphabetically by title with "No domain" last;
+// entities sort by name within a group.
 export function buildConnectionOptions(
-  topics: { id: string;
-    name: string; }[] | null | undefined,
+  topics: {
+    id: string;
+    name: string;
+    domains?: { id: string;
+      title: string; }[] | null;
+  }[] | null | undefined,
   tasks: { id: string;
     name: string; }[] | null | undefined,
   resources: { id: string;
     name: string; }[] | null | undefined,
 ): SelectOption[] {
+  const byDomainTitle = new Map<string, SelectOption[]>();
+  const noDomain: SelectOption[] = [];
+
+  for (const topic of topics ?? []) {
+    const domains = topic.domains ?? [];
+    if (domains.length === 0) {
+      noDomain.push({
+        value: `Topic:${topic.id}`,
+        label: topic.name,
+        group: NO_DOMAIN_GROUP,
+      });
+      continue;
+    }
+    for (const domain of domains) {
+      const bucket = byDomainTitle.get(domain.title) ?? [];
+      bucket.push({
+        value: `Topic:${topic.id}`,
+        label: topic.name,
+        group: topicGroupLabel(domain.title),
+      });
+      byDomainTitle.set(domain.title, bucket);
+    }
+  }
+
+  const byLabel = (a: SelectOption, b: SelectOption) =>
+    a.label.localeCompare(b.label);
+
+  const topicOptions: SelectOption[] = [
+    ...Array.from(byDomainTitle.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .flatMap(([, bucket]) => bucket.sort(byLabel)),
+    ...noDomain.sort(byLabel),
+  ];
+
   return [
-    ...toOptions(topics).map(o => ({
-      value: `Topic:${o.value}`,
-      label: o.label,
-    })),
+    ...topicOptions,
     ...toOptions(tasks).map(o => ({
       value: `Task:${o.value}`,
       label: o.label,
+      group: "Tasks",
     })),
     ...toOptions(resources).map(o => ({
       value: `Resource:${o.value}`,
       label: o.label,
+      group: "Resources",
     })),
   ];
 }

--- a/packages/client/src/utils/selectOptions.ts
+++ b/packages/client/src/utils/selectOptions.ts
@@ -3,6 +3,9 @@ import type { TagGroup } from "@emstack/types";
 export interface SelectOption {
   value: string;
   label: string;
+  // Optional explicit dropdown group. When set, a grouped combobox buckets the
+  // option under this label instead of deriving one from the value prefix.
+  group?: string;
 }
 
 // Map a list of {id, name} entities to combobox/select options.


### PR DESCRIPTION
## Summary

Refactors dropdown grouping across combobox components to use an explicit `group` field on options instead of deriving groups from value prefixes. This enables more flexible grouping strategies (e.g., domain-based grouping for topics) while simplifying the Base UI integration.

## Key Changes

- **SelectOption interface:** Added optional `group` field to `SelectOption` to carry explicit dropdown group labels
- **buildConnectionOptions:** 
  - Topics now group by domain (one entry per domain for multi-domain topics), with "Topics · No domain" for undomained topics
  - Domain groups sort alphabetically with "No domain" last; entities sort by name within groups
  - Tasks and Resources get explicit `group` fields ("Tasks", "Resources")
- **MultiComboboxField, TagsInput, TagPicker:** Updated to use Base UI's grouped-items shape (`{ value, items }[]`) for the `items` prop, enabling per-group filtering and hiding empty groups
  - `partitionOptions` and `partitionTags` now return the grouped-items shape
  - Combobox groups use `ComboboxCollection` to render items within each group
  - Group derivation falls back to value prefix only if no explicit `group` is set
- **ComboboxChip:** Removed unused `value` prop (Base UI no longer requires it)
- **EntityLink:** Removed unused `from` prop and `FROM_BY_KIND` constant (TanStack Router infers source route)
- **Minor exports:** Made several route search interfaces public (`EditSearch`, `RadarSearch`, `ResourceEditSearch`, etc.) and provider context interfaces (`SettingsProviderState`, `ThemeProviderState`)
- **Test updates:** Updated `buildConnectionOptions` tests to verify explicit `group` fields and added tests for domain-based grouping and multi-domain topic handling

## Implementation Details

- Topics with multiple domains now appear once under each domain in the dropdown (matching the UI requirement for domain-scoped topic selection)
- Grouping is now driven by the `group` field first, with value-prefix fallback only for backward compatibility
- Base UI's grouped-items filtering automatically hides empty groups when search narrows results

https://claude.ai/code/session_01FAPDGuf4Ayz3P8BXtYRzve