### PR TITLE
Add sortable column headers to Topics table

### DIFF
--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -2,6 +2,8 @@ import type { TopicForTopicsPage } from "@emstack/types/src";
 
 import { useMemo } from "react";
 
+import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon } from "lucide-react";
+
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import {
   Table,
@@ -11,6 +13,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+export type TopicsTableSortColumn
+  = | "name"
+    | "domains"
+    | "resources"
+    | "tasks"
+    | "dailies";
+export type TopicsTableSortDirection = "asc" | "desc";
+
+export interface TopicsTableSort {
+  column: TopicsTableSortColumn;
+  direction: TopicsTableSortDirection;
+}
 
 interface TopicsTableSelection {
   selectedIds: Set<string>;
@@ -21,11 +37,103 @@ interface TopicsTableSelection {
 interface TopicsTableProps {
   topics: TopicForTopicsPage[];
   selection?: TopicsTableSelection;
+  sort?: TopicsTableSort;
+  onSortChange?: (sort: TopicsTableSort) => void;
+}
+
+interface SortableHeaderProps {
+  column: TopicsTableSortColumn;
+  label: string;
+  sort?: TopicsTableSort;
+  onSortChange?: (sort: TopicsTableSort) => void;
+  align?: "left" | "right";
+}
+
+function SortableHeader({
+  column,
+  label,
+  sort,
+  onSortChange,
+  align = "left",
+}: SortableHeaderProps) {
+  const headClassName = cn(
+    "whitespace-nowrap",
+    align === "right" ? "text-right" : undefined,
+  );
+
+  if (!onSortChange) {
+    return <TableHead className={headClassName}>{label}</TableHead>;
+  }
+
+  const isActive = sort?.column === column;
+  const direction = isActive ? sort.direction : undefined;
+  const ariaSort = isActive
+    ? direction === "asc" ? "ascending" : "descending"
+    : "none";
+
+  const handleClick = () => {
+    if (isActive) {
+      onSortChange({
+        column,
+        direction: direction === "asc" ? "desc" : "asc",
+      });
+    }
+    else {
+      onSortChange({
+        column,
+        direction: column === "name" || column === "domains" ? "asc" : "desc",
+      });
+    }
+  };
+
+  return (
+    <TableHead
+      aria-sort={ariaSort}
+      className={headClassName}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          `
+            inline-flex items-center gap-1 text-xs font-semibold
+            text-muted-foreground uppercase transition-colors
+            hover:text-foreground
+            focus-visible:rounded-sm focus-visible:outline-2
+            focus-visible:outline-offset-2 focus-visible:outline-ring
+          `,
+          align === "right" ? "justify-end" : "justify-start",
+        )}
+      >
+        <span>{label}</span>
+        {isActive && direction === "asc" && (
+          <ArrowUpIcon
+            className="size-3.5"
+            aria-hidden="true"
+          />
+        )}
+        {isActive && direction === "desc" && (
+          <ArrowDownIcon
+            className="size-3.5"
+            aria-hidden="true"
+          />
+        )}
+        {!isActive && (
+          <ArrowUpDownIcon
+            className="size-3.5 opacity-40"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </TableHead>
+  );
 }
 
 export function TopicsTable({
   topics,
   selection,
+  sort,
+  onSortChange,
 }: TopicsTableProps) {
   const selectedIds = selection?.selectedIds;
 
@@ -58,18 +166,40 @@ export function TopicsTable({
                 />
               </TableHead>
             )}
-            <TableHead className="whitespace-nowrap">Name</TableHead>
-            <TableHead className="whitespace-nowrap">Domains</TableHead>
+            <SortableHeader
+              column="name"
+              label="Name"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
+            <SortableHeader
+              column="domains"
+              label="Domains"
+              sort={sort}
+              onSortChange={onSortChange}
+            />
             <TableHead>Description</TableHead>
-            <TableHead className="text-right whitespace-nowrap">
-              Resources
-            </TableHead>
-            <TableHead className="text-right whitespace-nowrap">
-              Tasks
-            </TableHead>
-            <TableHead className="text-right whitespace-nowrap">
-              Dailies
-            </TableHead>
+            <SortableHeader
+              column="resources"
+              label="Resources"
+              sort={sort}
+              onSortChange={onSortChange}
+              align="right"
+            />
+            <SortableHeader
+              column="tasks"
+              label="Tasks"
+              sort={sort}
+              onSortChange={onSortChange}
+              align="right"
+            />
+            <SortableHeader
+              column="dailies"
+              label="Dailies"
+              sort={sort}
+              onSortChange={onSortChange}
+              align="right"
+            />
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -1,3 +1,4 @@
+import type { TopicsTableSort } from "@/components/boxes/TopicsTable";
 import type { TopicForTopicsPage } from "@emstack/types/src";
 
 import { useEffect, useMemo, useState } from "react";
@@ -33,8 +34,66 @@ import {
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { bulkDeleteTopics, fetchDomains, fetchTopics } from "@/utils";
 
-type SortOption = "alpha-asc" | "alpha-desc" | "resources";
+type SortOption
+  = | "alpha-asc"
+    | "alpha-desc"
+    | "resources-desc"
+    | "tasks-desc"
+    | "dailies-desc"
+    | "custom";
 type ViewMode = "grid" | "table";
+
+const DEFAULT_SORT: TopicsTableSort = {
+  column: "name",
+  direction: "asc",
+};
+
+function sortToOption(sort: TopicsTableSort): SortOption {
+  if (sort.column === "name" && sort.direction === "asc") return "alpha-asc";
+  if (sort.column === "name" && sort.direction === "desc") return "alpha-desc";
+  if (sort.column === "resources" && sort.direction === "desc") {
+    return "resources-desc";
+  }
+  if (sort.column === "tasks" && sort.direction === "desc") {
+    return "tasks-desc";
+  }
+  if (sort.column === "dailies" && sort.direction === "desc") {
+    return "dailies-desc";
+  }
+  return "custom";
+}
+
+function optionToSort(option: SortOption): TopicsTableSort {
+  switch (option) {
+    case "alpha-asc":
+      return {
+        column: "name",
+        direction: "asc",
+      };
+    case "alpha-desc":
+      return {
+        column: "name",
+        direction: "desc",
+      };
+    case "resources-desc":
+      return {
+        column: "resources",
+        direction: "desc",
+      };
+    case "tasks-desc":
+      return {
+        column: "tasks",
+        direction: "desc",
+      };
+    case "dailies-desc":
+      return {
+        column: "dailies",
+        direction: "desc",
+      };
+    case "custom":
+      return DEFAULT_SORT;
+  }
+}
 
 const VIEW_MODE_STORAGE_KEY = "topics:viewMode";
 
@@ -58,18 +117,33 @@ function TopicsError() {
   return <EntityError entity="topics" />;
 }
 
+function firstDomainTitle(topic: TopicForTopicsPage): string {
+  const first = topic.domains?.find(d => d.id !== undefined);
+  return first?.title ?? "";
+}
+
 function sortTopics(
   topics: TopicForTopicsPage[],
-  sortBy: SortOption,
+  sort: TopicsTableSort,
 ): TopicForTopicsPage[] {
+  const dir = sort.direction === "asc" ? 1 : -1;
   return [...topics].sort((a, b) => {
-    switch (sortBy) {
-      case "alpha-asc":
-        return a.name.localeCompare(b.name);
-      case "alpha-desc":
-        return b.name.localeCompare(a.name);
+    switch (sort.column) {
+      case "name":
+        return a.name.localeCompare(b.name) * dir;
+      case "domains": {
+        const cmp = firstDomainTitle(a).localeCompare(firstDomainTitle(b));
+        return cmp !== 0 ? cmp * dir : a.name.localeCompare(b.name);
+      }
       case "resources":
-        return (b.resourceCount ?? 0) - (a.resourceCount ?? 0);
+        return ((a.resourceCount ?? 0) - (b.resourceCount ?? 0)) * dir
+          || a.name.localeCompare(b.name);
+      case "tasks":
+        return ((a.taskCount ?? 0) - (b.taskCount ?? 0)) * dir
+          || a.name.localeCompare(b.name);
+      case "dailies":
+        return ((a.dailyCount ?? 0) - (b.dailyCount ?? 0)) * dir
+          || a.name.localeCompare(b.name);
     }
   });
 }
@@ -77,7 +151,7 @@ function sortTopics(
 function Topics() {
   const [search, setSearch] = useState("");
   const [filterDomain, setFilterDomain] = useState<string | undefined>();
-  const [sortBy, setSortBy] = useState<SortOption>("alpha-asc");
+  const [sort, setSort] = useState<TopicsTableSort>(DEFAULT_SORT);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -128,8 +202,8 @@ function Topics() {
         t.domains?.some(d => d.id === filterDomain));
     }
 
-    return sortTopics(result, sortBy);
-  }, [data, search, filterDomain, sortBy]);
+    return sortTopics(result, sort);
+  }, [data, search, filterDomain, sort]);
 
   const filteredIds = useMemo(
     () => filteredAndSorted.map(t => t.id),
@@ -298,8 +372,12 @@ function Topics() {
               <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground">Sort</span>
                 <Select
-                  value={sortBy}
-                  onValueChange={v => setSortBy(v as SortOption)}
+                  value={sortToOption(sort)}
+                  onValueChange={(v) => {
+                    const option = v as SortOption;
+                    if (option === "custom") return;
+                    setSort(optionToSort(option));
+                  }}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Sort by" />
@@ -307,9 +385,18 @@ function Topics() {
                   <SelectContent>
                     <SelectItem value="alpha-asc">A-Z</SelectItem>
                     <SelectItem value="alpha-desc">Z-A</SelectItem>
-                    <SelectItem value="resources">
+                    <SelectItem value="resources-desc">
                       Number of linked resources
                     </SelectItem>
+                    <SelectItem value="tasks-desc">
+                      Number of linked tasks
+                    </SelectItem>
+                    <SelectItem value="dailies-desc">
+                      Number of linked dailies
+                    </SelectItem>
+                    {sortToOption(sort) === "custom" && (
+                      <SelectItem value="custom">Custom</SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
                 <div
@@ -444,6 +531,8 @@ function Topics() {
                     onToggleSelected: handleToggleSelected,
                     onToggleAll: handleToggleAll,
                   }}
+                  sort={sort}
+                  onSortChange={setSort}
                 />
               </>
             )}


### PR DESCRIPTION
## Summary
Adds interactive column sorting to the Topics table, allowing users to sort by name, domains, resources, tasks, and dailies. The sort state is managed at the page level and reflected in both the table header UI and the sort dropdown menu.

## Key Changes
- **New `SortableHeader` component** in `TopicsTable.tsx`: Renders clickable table headers with visual indicators (up/down/bidirectional arrows) showing the current sort state. Supports left and right alignment.
- **Sort state types**: Exported `TopicsTableSort`, `TopicsTableSortColumn`, and `TopicsTableSortDirection` types for type-safe sort management.
- **Enhanced `TopicsTable` props**: Added `sort` and `onSortChange` props to accept and propagate sort changes.
- **Improved `sortTopics` function**: Refactored to accept a `TopicsTableSort` object instead of a `SortOption` string. Now supports sorting by name, domains (by first domain title), resources, tasks, and dailies in both ascending and descending directions. Secondary sort by name is applied for numeric columns.
- **Sort option conversion helpers**: Added `sortToOption()` and `optionToSort()` functions to bridge between the new `TopicsTableSort` type and the existing `SortOption` dropdown values, with a "Custom" option shown when a non-standard sort is active.
- **Updated sort dropdown**: Extended with new sort options for tasks and dailies; now converts to/from the new sort state format.
- **Accessibility**: Added `aria-sort` attributes to sortable headers and `aria-hidden` to sort indicator icons.

## Implementation Details
- Sort direction defaults to ascending for name/domains columns and descending for numeric columns (resources/tasks/dailies) on first click.
- Clicking an active sort header toggles the direction; clicking an inactive header activates it with the appropriate default direction.
- The sort state is managed in the `Topics` component and passed down to `TopicsTable`, maintaining a single source of truth.

https://claude.ai/code/session_016ipFfdka7NWsAVB5CW4Enm