### PR TITLE
Move routine location from routine to per-item weekly entries

### DIFF
--- a/packages/client/src/components/routines/WeeklyEntryEditor.tsx
+++ b/packages/client/src/components/routines/WeeklyEntryEditor.tsx
@@ -22,6 +22,7 @@ interface EntryValue {
   type: WeeklyRowType;
   id: string;
   notes: string;
+  location: string;
   prependText: string;
   appendText: string;
 }
@@ -40,6 +41,7 @@ export function WeeklyEntryEditor({
   type,
   id,
   notes,
+  location,
   prependText,
   appendText,
   onChange,
@@ -62,6 +64,7 @@ export function WeeklyEntryEditor({
       type,
       id,
       notes,
+      location,
       prependText,
       appendText,
       ...patch,
@@ -89,11 +92,12 @@ export function WeeklyEntryEditor({
           value={type}
           onChange={e =>
             // Changing the type clears the chosen item (different option set)
-            // and any note/prepend/append.
+            // and any note/location/prepend/append.
             emit({
               type: e.target.value as WeeklyRowType,
               id: "",
               notes: "",
+              location: "",
               prependText: "",
               appendText: "",
             })}
@@ -170,6 +174,18 @@ export function WeeklyEntryEditor({
                 notes: e.target.value,
               })}
             placeholder="Notes (optional)…"
+            className="
+              flex h-9 w-full rounded-md border bg-background px-2 text-sm
+            "
+          />
+          <input
+            aria-label="Daily task location"
+            value={location}
+            onChange={e =>
+              emit({
+                location: e.target.value,
+              })}
+            placeholder="Location (e.g. gym, Spanish app, or a URL)…"
             className="
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -56,6 +56,7 @@ export function WeeklyScheduleField({
             type: "" as WeeklyRowType,
             id: "",
             notes: "",
+            location: "",
             prependText: "",
             appendText: "",
           };
@@ -95,11 +96,12 @@ export function WeeklyScheduleField({
                   value={row.type}
                   onChange={(e) => {
                     // Changing the type clears the chosen item (different
-                    // option set) and any note.
+                    // option set) and any note/location.
                     update(day, {
                       type: e.target.value as WeeklyRowType,
                       id: "",
                       notes: "",
+                      location: "",
                     });
                   }}
                   className="
@@ -173,6 +175,18 @@ export function WeeklyScheduleField({
                       notes: e.target.value,
                     })}
                     placeholder="Notes (optional)…"
+                    className="
+                      flex h-9 w-full rounded-md border bg-background px-2
+                      text-sm
+                    "
+                  />
+                  <input
+                    aria-label={`${DAY_LABELS[day]} location`}
+                    value={row.location}
+                    onChange={e => update(day, {
+                      location: e.target.value,
+                    })}
+                    placeholder="Location (e.g. gym, Spanish app, or a URL)…"
                     className="
                       flex h-9 w-full rounded-md border bg-background px-2
                       text-sm

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -137,6 +137,52 @@ describe("weekly schedule prepend/append text", () => {
   });
 });
 
+describe("weekly schedule item location", () => {
+  test("weeklyToRows surfaces an item's location", () => {
+    const weekly: RoutineWeekly = {
+      1: {
+        type: "task",
+        id: "task-1",
+        location: "the gym",
+      },
+    };
+    const monday = weeklyToRows(weekly).find(r => r.day === "1");
+    expect(monday?.location).toBe("the gym");
+  });
+
+  test("weeklyToRows defaults a missing location to an empty string", () => {
+    const weekly: RoutineWeekly = {
+      2: {
+        type: "resource",
+        id: "res-1",
+      },
+    };
+    const tuesday = weeklyToRows(weekly).find(r => r.day === "2");
+    expect(tuesday?.location).toBe("");
+  });
+
+  test("rowsToWeekly preserves a non-empty location and omits an empty one", () => {
+    const original: RoutineWeekly = {
+      3: {
+        type: "task",
+        id: "task-9",
+        location: "https://example.com/app",
+      },
+      4: {
+        type: "task",
+        id: "task-2",
+      },
+    };
+    const restored = rowsToWeekly(weeklyToRows(original));
+    expect(restored[3]).toEqual({
+      type: "task",
+      id: "task-9",
+      location: "https://example.com/app",
+    });
+    expect(restored[4]).not.toHaveProperty("location");
+  });
+});
+
 describe("representativeRow (Daily Task mode)", () => {
   // Regression: picking a type clears the id, so the editor must still surface
   // the chosen type before an item is picked — otherwise the controlled type
@@ -150,6 +196,7 @@ describe("representativeRow (Daily Task mode)", () => {
       type: "task",
       id: "",
       notes: "",
+      location: "",
       prependText: "",
       appendText: "",
     });
@@ -160,6 +207,7 @@ describe("representativeRow (Daily Task mode)", () => {
       type: "resource",
       id: "res-1",
       notes: "chapter 3",
+      location: "the gym",
       prependText: "Review",
       appendText: "for 10 minutes",
     });
@@ -167,6 +215,7 @@ describe("representativeRow (Daily Task mode)", () => {
       type: "resource",
       id: "res-1",
       notes: "chapter 3",
+      location: "the gym",
       prependText: "Review",
       appendText: "for 10 minutes",
     });
@@ -177,6 +226,7 @@ describe("representativeRow (Daily Task mode)", () => {
       type: "",
       id: "",
       notes: "",
+      location: "",
       prependText: "",
       appendText: "",
     });

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -9,6 +9,8 @@ export interface WeeklyRow {
   id: string;
   // Optional free-text note for this day's item. "" = no note.
   notes: string;
+  // Optional place/link where this day's item happens. "" = no location.
+  location: string;
   // Optional text wrapped around the item's name to form an actionable
   // sentence. "" = nothing to prepend/append.
   prependText: string;
@@ -43,6 +45,7 @@ export function weeklyToRows(
       type: entry?.type ?? "",
       id: entry?.id ?? "",
       notes: entry?.notes ?? "",
+      location: entry?.location ?? "",
       prependText: entry?.prependText ?? "",
       appendText: entry?.appendText ?? "",
     };
@@ -62,6 +65,11 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
         ...(row.notes
           ? {
             notes: row.notes,
+          }
+          : {}),
+        ...(row.location
+          ? {
+            location: row.location,
           }
           : {}),
         ...(row.prependText
@@ -90,6 +98,7 @@ export function representativeRow(rows: WeeklyRow[]): {
   type: WeeklyRowType;
   id: string;
   notes: string;
+  location: string;
   prependText: string;
   appendText: string;
 } {
@@ -99,6 +108,7 @@ export function representativeRow(rows: WeeklyRow[]): {
       type: found.type,
       id: found.id,
       notes: found.notes,
+      location: found.location,
       prependText: found.prependText,
       appendText: found.appendText,
     }
@@ -106,6 +116,7 @@ export function representativeRow(rows: WeeklyRow[]): {
       type: "",
       id: "",
       notes: "",
+      location: "",
       prependText: "",
       appendText: "",
     };
@@ -115,6 +126,7 @@ export function fillAllDays(entry: {
   type: WeeklyRowType;
   id: string;
   notes?: string;
+  location?: string;
   prependText?: string;
   appendText?: string;
 }): WeeklyRow[] {
@@ -123,6 +135,7 @@ export function fillAllDays(entry: {
     type: entry.type,
     id: entry.id,
     notes: entry.notes ?? "",
+    location: entry.location ?? "",
     prependText: entry.prependText ?? "",
     appendText: entry.appendText ?? "",
   }));

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
@@ -73,6 +73,9 @@ const weeklyRowSchema = z
     type: z.enum(["", "task", "resource", "freeform"]),
     id: z.string(),
     notes: z.string(),
+    location: z.string(),
+    prependText: z.string(),
+    appendText: z.string(),
   })
   .refine(row => row.type === "" || row.id.length > 0, {
     message: "Required",
@@ -85,7 +88,6 @@ const detailsSchema = z.object({
   connections: z.array(z.string()),
   status: z.enum(["active", "inactive", "complete", "paused"]),
   mode: z.enum(["weekly", "daily"]),
-  location: z.string().max(255),
   weekly: z.array(weeklyRowSchema).length(7),
 });
 
@@ -142,7 +144,6 @@ export function DetailsTab({
       connections: (routine.connections ?? []).map(encodeConnection),
       status: routine.status ?? "active",
       mode: routine.mode ?? "weekly",
-      location: routine.location ?? "",
       weekly: weeklyToRows(routine.weekly),
     }),
     [routine],
@@ -171,7 +172,6 @@ export function DetailsTab({
           connections,
           status: value.status,
           mode: value.mode,
-          location: value.mode === "daily" ? value.location || null : null,
           // Daily mode mirrors the single chosen entry onto all 7 days so
           // "today's item" resolves identically every day.
           weekly:
@@ -252,17 +252,6 @@ export function DetailsTab({
           />
         )}
       </form.AppField>
-
-      {isDaily && (
-        <form.AppField name="location">
-          {field => (
-            <field.InputField
-              label="Location"
-              placeholder="e.g. Spanish app, gym, journal"
-            />
-          )}
-        </form.AppField>
-      )}
 
       <form.Field name="weekly">
         {field =>

--- a/packages/client/src/routes/routines.$id.edit.tsx
+++ b/packages/client/src/routes/routines.$id.edit.tsx
@@ -94,20 +94,6 @@ const MODE_OPTIONS = [
   },
 ];
 
-const weeklyRowSchema = z
-  .object({
-    day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
-    type: z.enum(["", "task", "resource", "freeform"]),
-    id: z.string(),
-    notes: z.string(),
-    prependText: z.string(),
-    appendText: z.string(),
-  })
-  .refine(row => row.type === "" || row.id.length > 0, {
-    message: "Required",
-    path: ["id"],
-  });
-
 const newRoutineSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
   mode: z.enum(["weekly", "daily"]),

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, FlameIcon, LaughIcon } from "lucide-react";
+import { EditIcon, FlameIcon, LaughIcon, MapPinIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
@@ -28,7 +28,7 @@ import {
   getTotalCompletedDays,
 } from "@/utils";
 
-interface RoutineViewSearch {
+export interface RoutineViewSearch {
   tab?: DailyDetailTab;
 }
 
@@ -174,6 +174,7 @@ function SingleRoutine() {
   function renderEntryLink(entry: { type: string;
     id: string;
     notes?: string | null;
+    location?: string | null;
     prependText?: string | null;
     appendText?: string | null; }) {
     const main = (
@@ -185,14 +186,26 @@ function SingleRoutine() {
       </span>
     );
 
-    if (!entry.notes) {
+    if (!entry.notes && !entry.location) {
       return main;
     }
 
     return (
       <span className="flex flex-col gap-0.5">
         {main}
-        <span className="text-sm text-muted-foreground">{entry.notes}</span>
+        {entry.notes && (
+          <span className="text-sm text-muted-foreground">{entry.notes}</span>
+        )}
+        {entry.location && (
+          <span
+            className="
+              inline-flex items-center gap-1 text-xs text-muted-foreground
+            "
+          >
+            <MapPinIcon className="size-3.5 shrink-0" />
+            {entry.location}
+          </span>
+        )}
       </span>
     );
   }

--- a/packages/middleware/src/db/migrateDailiesToRoutines.ts
+++ b/packages/middleware/src/db/migrateDailiesToRoutines.ts
@@ -9,10 +9,12 @@ type ExistsRow = { exists: boolean } & Record<string, unknown>;
 const DAY_KEYS = ["0", "1", "2", "3", "4", "5", "6"] as const;
 
 // In the unified model the same entry is applied to every weekday, so a daily's
-// single task/resource link becomes a 7-day grid pointing at it.
+// single task/resource link becomes a 7-day grid pointing at it. The daily's
+// location is now a per-item field, so it rides along on every entry.
 function buildWeekly(
   entry: { type: "task" | "resource";
     id: string; } | null,
+  location: string | null,
 ): RoutineWeekly {
   if (!entry) {
     return {};
@@ -22,6 +24,11 @@ function buildWeekly(
     weekly[key] = {
       type: entry.type,
       id: entry.id,
+      ...(location
+        ? {
+          location,
+        }
+        : {}),
     };
   }
   return weekly;
@@ -61,7 +68,6 @@ export async function migrateDailiesToRoutines() {
     END $$;
   `);
   await db.execute(sql`ALTER TABLE routines ADD COLUMN IF NOT EXISTS mode routine_mode NOT NULL DEFAULT 'weekly'`);
-  await db.execute(sql`ALTER TABLE routines ADD COLUMN IF NOT EXISTS location varchar(255)`);
   await db.execute(sql`ALTER TABLE routines ADD COLUMN IF NOT EXISTS completions jsonb NOT NULL DEFAULT '[]'::jsonb`);
   await db.execute(sql`ALTER TABLE routines ADD COLUMN IF NOT EXISTS criteria jsonb NOT NULL DEFAULT '{}'::jsonb`);
 
@@ -89,9 +95,8 @@ export async function migrateDailiesToRoutines() {
       description: daily.description ?? null,
       topicId: null,
       status: daily.status ?? "active",
-      weekly: buildWeekly(entry),
+      weekly: buildWeekly(entry, daily.location ?? null),
       mode: "daily" as const,
-      location: daily.location ?? null,
       completions: daily.completions ?? [],
       criteria: daily.criteria ?? {},
     };

--- a/packages/middleware/src/db/migrateRoutineLocationToWeekly.ts
+++ b/packages/middleware/src/db/migrateRoutineLocationToWeekly.ts
@@ -1,0 +1,72 @@
+import { eq, sql } from "drizzle-orm";
+
+import { db } from "@/db/index";
+import { routines } from "@/db/schema";
+import type { RoutineWeekly } from "@emstack/types";
+
+type ExistsRow = { exists: boolean } & Record<string, unknown>;
+type RoutineLocationRow = {
+  id: string;
+  location: string | null;
+  weekly: RoutineWeekly | null;
+} & Record<string, unknown>;
+
+// Idempotent: `location` used to live on the routine itself; it now lives on
+// each per-day weekly entry. Fold every routine's legacy `location` into its
+// populated weekly entries, then drop the column. Guarded on the `location`
+// column still existing, so re-runs after the drop are no-ops.
+export async function migrateRoutineLocationToWeekly() {
+  const routinesExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines'
+    ) AS exists
+  `);
+  if (!routinesExists.rows[0]?.exists) {
+    return;
+  }
+
+  const locationColumnExists = await db.execute<ExistsRow>(sql`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name = 'routines' AND column_name = 'location'
+    ) AS exists
+  `);
+  if (!locationColumnExists.rows[0]?.exists) {
+    return;
+  }
+
+  // Only routines that actually carry a location need rewriting. Weekly-mode
+  // routines never stored one (the form forced null), so in practice this is the
+  // daily-mode set, where every day holds the same entry.
+  const rows = await db.execute<RoutineLocationRow>(sql`
+    SELECT id, location, weekly FROM routines
+    WHERE location IS NOT NULL AND location <> ''
+  `);
+
+  for (const row of rows.rows) {
+    const location = row.location;
+    if (!location) {
+      continue;
+    }
+    const weekly = row.weekly ?? {};
+    const next: RoutineWeekly = {};
+    for (const [day, entry] of Object.entries(weekly)) {
+      if (entry) {
+        next[day as keyof RoutineWeekly] = {
+          ...entry,
+          location,
+        };
+      }
+    }
+    await db
+      .update(routines)
+      .set({
+        weekly: next,
+      })
+      .where(eq(routines.id, row.id));
+  }
+
+  // Drop the now-unused column. Once gone, the guard above short-circuits future
+  // runs and a later `drizzle-kit push` sees a matching (location-free) schema.
+  await db.execute(sql`ALTER TABLE routines DROP COLUMN IF EXISTS location`);
+}

--- a/packages/middleware/src/db/schema.ts
+++ b/packages/middleware/src/db/schema.ts
@@ -25,6 +25,7 @@ export interface RoutineReferenceItem {
   type: "task" | "resource" | "freeform";
   id: string;
   notes?: string | null;
+  location?: string | null;
 }
 
 export type RoutineWeekly = Partial<Record<RoutineWeekday, RoutineReferenceItem>>;
@@ -242,9 +243,6 @@ export const routines = pgTable("routines", {
   status: statusEnum().default("active"),
   weekly: jsonb().$type<RoutineWeekly>().default({}).notNull(),
   mode: routineModeEnum().default("weekly").notNull(),
-  location: varchar({
-    length: 255,
-  }),
   completions: jsonb().$type<DailyCompletion[]>().default([]).notNull(),
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
 });

--- a/packages/middleware/src/db/startup.ts
+++ b/packages/middleware/src/db/startup.ts
@@ -4,6 +4,7 @@ import { migrateConsolidateRadar } from "./migrateConsolidateRadar.ts";
 import { migrateCoursesToResources } from "./migrateCoursesToResources.ts";
 import { migrateDailiesToRoutines } from "./migrateDailiesToRoutines.ts";
 import { migrateRoutineConnections } from "./migrateRoutineConnections.ts";
+import { migrateRoutineLocationToWeekly } from "./migrateRoutineLocationToWeekly.ts";
 import { migrateIgnoreBlips } from "./migrateIgnoreBlips.ts";
 import { migrateModuleLength } from "./migrateModuleLength.ts";
 import { migrateRadarBlips } from "./migrateRadarBlips.ts";
@@ -79,6 +80,16 @@ export async function runMigrations() {
   }
   catch (err) {
     console.error("Failed to migrate routine topics → connections:", err);
+    throw err;
+  }
+
+  // Move each routine's legacy `location` onto its per-day weekly entries, then
+  // drop the column. Runs after dailies → routines so every entry exists first.
+  try {
+    await migrateRoutineLocationToWeekly();
+  }
+  catch (err) {
+    console.error("Failed to migrate routine location → weekly entries:", err);
     throw err;
   }
 }

--- a/packages/middleware/src/routes/api/routines/createRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/createRoutine.ts
@@ -31,7 +31,6 @@ const createSchema = {
         status: nullableRoutineStatusEnum,
         weekly: weeklySchema,
         mode: nullableRoutineModeEnum,
-        location: nullableString,
         completions: {
           type: "array",
           items: completionSchema,
@@ -59,7 +58,6 @@ export default async function (server: FastifyInstance) {
         status: body.status ?? "active",
         weekly: (body.weekly ?? {}) as RoutineWeekly,
         mode: body.mode ?? "weekly",
-        location: body.location ?? null,
         completions: (body.completions ?? []) as DailyCompletion[],
         criteria: (body.criteria ?? {}) as DailyCriteria,
       });

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -45,7 +45,6 @@ export default async function (server: FastifyInstance) {
         status: "inactive",
         weekly: source.weekly ?? {},
         mode: source.mode,
-        location: source.location ?? null,
         completions: [],
         criteria: source.criteria ?? {},
       });

--- a/packages/middleware/src/routes/api/routines/upsertRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/upsertRoutine.ts
@@ -34,7 +34,6 @@ const upsertSchema = {
         status: nullableRoutineStatusEnum,
         weekly: weeklySchema,
         mode: nullableRoutineModeEnum,
-        location: nullableString,
         completions: {
           type: "array",
           items: completionSchema,
@@ -78,9 +77,6 @@ export default async function (server: FastifyInstance) {
       if (body.mode !== undefined) {
         set.mode = body.mode ?? "weekly";
       }
-      if (body.location !== undefined) {
-        set.location = body.location ?? null;
-      }
       if (body.completions !== undefined) {
         set.completions = body.completions as DailyCompletion[];
       }
@@ -97,7 +93,6 @@ export default async function (server: FastifyInstance) {
           status: body.status ?? "active",
           weekly: (body.weekly ?? {}) as RoutineWeekly,
           mode: body.mode ?? "weekly",
-          location: body.location ?? null,
           completions: (body.completions ?? []) as DailyCompletion[],
           criteria: (body.criteria ?? {}) as DailyCriteria,
         })

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -58,7 +58,6 @@ export interface RoutineRow {
   status: EntityStatus | null;
   weekly: RoutineWeekly | null;
   mode: RoutineMode;
-  location: string | null;
   completions: DailyCompletion[];
   criteria: DailyCriteria;
   connections?: RoutineConnection[];
@@ -81,10 +80,14 @@ export function mapRoutineToDaily(
   resolved: { task?: ResolvedTask | null;
     resource?: ResolvedResource | null; } = {},
 ): RoutineDaily {
+  // The representative entry carries the per-item location (daily mode mirrors
+  // the same entry on every day) and the prepend/append text below.
+  const entry = representativeEntry(routine.weekly);
+
   const daily = mapDaily({
     id: routine.id,
     name: routine.name,
-    location: routine.location,
+    location: entry?.location ?? null,
     description: routine.description,
     completions: routine.completions ?? [],
     status: routine.status,
@@ -100,7 +103,6 @@ export function mapRoutineToDaily(
   // Wrap the representative entry's name with its prepend/append text into a
   // natural sentence. Only set when the user actually added prepend/append text,
   // so untouched dailies keep falling back to the routine name.
-  const entry = representativeEntry(routine.weekly);
   const baseName
     = resolved.resource?.name
       ?? resolved.task?.name

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -61,6 +61,7 @@ export const routineReferenceItemSchema = {
       type: "string",
     },
     notes: nullableString,
+    location: nullableString,
     prependText: nullableString,
     appendText: nullableString,
   },

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -27,6 +27,9 @@ export interface RoutineReferenceItem {
   // Optional free-text annotation for this day's scheduled item (e.g. "focus
   // on the subjunctive"). Empty/absent means no note.
   notes?: string | null;
+  // Optional place/link where this day's item happens (e.g. "gym", "Spanish
+  // app", or a URL). Empty/absent means no location.
+  location?: string | null;
   // Optional text wrapped around the item's name to form a natural, actionable
   // sentence (e.g. prepend "Review" / append "for 10 minutes"). Empty/absent
   // means the name stands alone.
@@ -48,7 +51,6 @@ export interface Routine {
   status?: EntityStatus | null;
   weekly?: RoutineWeekly | null;
   mode?: RoutineMode | null;
-  location?: string | null;
   completions?: DailyCompletion[] | null;
   criteria?: DailyCriteria | null;
 }


### PR DESCRIPTION
## Summary

Refactors the data model for routine locations: instead of storing a single `location` field on the routine itself, location is now a per-item property on each day's weekly entry. This allows different items on different days to have different locations, and aligns with the weekly-mode UI where each day can have its own task/resource with its own context.

## Key Changes

- **Schema & Types:** Removed `location` column from `routines` table; added `location?: string | null` to `RoutineReferenceItem` in the type definitions
- **Migration:** Added `migrateRoutineLocationToWeekly()` that folds each routine's legacy `location` onto all populated weekly entries, then drops the column (idempotent, guarded on column existence)
- **Daily-to-Routines Migration:** Updated `migrateDailiesToRoutines()` to pass location into `buildWeekly()` so daily locations ride along on every entry
- **Frontend UI:** 
  - Removed the `location` input field from the routine edit form's Details tab
  - Added `location` input fields to both `WeeklyScheduleField` (weekly mode) and `WeeklyEntryEditor` (daily mode)
  - Updated `SingleRoutine` view to display location with a map pin icon alongside notes
  - Updated `WeeklyRow` interface and conversion functions (`weeklyToRows`, `rowsToWeekly`, `representativeRow`, `fillAllDays`) to handle location
- **API:** Removed `location` from upsert/create request schemas; updated `mapRoutineToDaily()` to extract location from the representative entry instead of the routine root
- **Tests:** Added comprehensive test coverage for location handling in weekly schedule conversions

## Implementation Details

- Location defaults to empty string in UI rows but is omitted from the stored `RoutineWeekly` object if empty (to keep the JSON clean)
- Daily mode mirrors the same entry (with its location) onto all 7 days, maintaining the existing behavior
- The migration is safe to re-run: it checks for column existence and short-circuits if already applied

https://claude.ai/code/session_01UWtfvBCnHWzzixALd58Ucp