### PR TITLE
Remove unused representativeEntry variable in mapRoutineToDaily

### DIFF
--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -106,7 +106,6 @@ export function mapRoutineToDaily(
   // optional and may be null — so a daily assigned to something shows that
   // thing's name even without affixes, with the routine name rendered beneath.
   // A daily with no representative entry still falls back to the routine name.
-  const entry = representativeEntry(routine.weekly);
   const baseName
     = resolved.resource?.name
       ?? resolved.task?.name


### PR DESCRIPTION
## Summary
Removes an unused variable declaration in the `mapRoutineToDaily` function that was assigned but never referenced.

## Changes
- Removed the unused `const entry = representativeEntry(routine.weekly);` line from `packages/middleware/src/utils/routineProjection.ts`

## Details
The variable was declared but not used anywhere in the function logic. This cleanup removes dead code and improves code clarity without affecting functionality.

https://claude.ai/code/session_01P6mmtRAh3FKpF5VSzMTUqM