### PR TITLE
Add Routines tab to Resource pages; description/note in DailyTitle

### DIFF
--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -88,14 +88,6 @@ export function DailiesActiveListView({
                 >
                   <DailyTitle daily={daily} />
                 </Link>
-                {daily.description && (
-                  <span
-                    className="line-clamp-2 text-xs text-muted-foreground"
-                    title={daily.description}
-                  >
-                    {daily.description}
-                  </span>
-                )}
                 <div
                   className="
                     flex flex-row flex-wrap items-center gap-x-4 gap-y-2 text-sm

--- a/packages/client/src/components/dailies/DailyTitle.tsx
+++ b/packages/client/src/components/dailies/DailyTitle.tsx
@@ -1,31 +1,69 @@
-import type { Daily } from "@emstack/types/src";
+import type {
+  Daily,
+  RoutineMode,
+  RoutineWeekday,
+  RoutineWeekly,
+} from "@emstack/types/src";
 
 import { ActionableSentence } from "./ActionableSentence";
 
+// Date.getDay() order ("0" = Sunday … "6" = Saturday); mirrors the middleware's
+// representativeEntry scan so the "first scheduled day" fallback matches the API.
+const DAY_KEYS: RoutineWeekday[] = ["0", "1", "2", "3", "4", "5", "6"];
+
+// The first scheduled day's note, used as a fallback when today has no entry.
+function firstPopulatedNote(
+  weekly: RoutineWeekly | null | undefined,
+): string | null {
+  if (!weekly) {
+    return null;
+  }
+  for (const key of DAY_KEYS) {
+    const note = weekly[key]?.notes;
+    if (note) {
+      return note;
+    }
+  }
+  return null;
+}
+
 // The action name (the assigned task/resource/freeform the routine points at,
-// with any prepend/append affixes) on top, and the routine's own title beneath
-// it in smaller, de-emphasized text. The subtitle shows only when the title is
-// derived from an assigned item AND differs from the routine name, so an
-// unassigned daily — or one whose assigned name equals its routine name — stays
-// a single line.
+// with any prepend/append affixes) on top, and a smaller, de-emphasized subtitle
+// beneath it. The subtitle is the routine's description for daily-mode routines,
+// or the scheduled note (today's day-of-week entry, falling back to the first
+// scheduled day) for weekly-mode routines. It is omitted when empty, so a daily
+// with no description — or a weekly routine with no notes — stays a single line.
 export function DailyTitle({
   daily,
 }: {
   daily: Daily;
 }) {
-  const routineTitle = daily.name;
-  const showRoutineSubtitle
-    = daily.actionParts != null && daily.actionParts.name !== routineTitle;
+  // Dailies here come from the routine projection (mapRoutineToDaily), which
+  // carries the routine's mode and weekly grid even though the base Daily type
+  // doesn't declare them. Read them through a narrow local view.
+  const routineView = daily as Daily & {
+    mode?: RoutineMode;
+    weekly?: RoutineWeekly | null;
+  };
+
+  const todayWeekday = String(new Date().getDay()) as RoutineWeekday;
+  const weeklyNote
+    = routineView.weekly?.[todayWeekday]?.notes
+      ?? firstPopulatedNote(routineView.weekly);
+  const subtitle
+    = routineView.mode === "weekly" ? weeklyNote : (daily.description ?? null);
+  const showSubtitle = subtitle != null && subtitle !== "";
+
   return (
     <span className="flex flex-col">
       <ActionableSentence
         prependText={daily.actionParts?.prependText}
         appendText={daily.actionParts?.appendText}
-        name={daily.actionParts?.name ?? routineTitle}
+        name={daily.actionParts?.name ?? daily.name}
       />
-      {showRoutineSubtitle && (
+      {showSubtitle && (
         <span className="text-xs font-normal text-muted-foreground">
-          {routineTitle}
+          {subtitle}
         </span>
       )}
     </span>

--- a/packages/client/src/routes/resources.$id.index.tsx
+++ b/packages/client/src/routes/resources.$id.index.tsx
@@ -6,6 +6,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
 import { TopicList } from "@/components/boxElements/TopicList";
+import { RoutineBox } from "@/components/boxes/RoutineBox";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { CourseInteractionsLog } from "@/components/courses/CourseInteractionsLog";
 import { CourseModulesAdmin } from "@/components/courses/CourseModulesAdmin";
@@ -20,7 +21,7 @@ import {
 } from "@/components/ui/tabs";
 import { fetchRoutines, fetchSingleResource, makePercentageComplete } from "@/utils";
 
-const TAB_VALUES = ["details", "modules", "interactions"] as const;
+const TAB_VALUES = ["details", "modules", "routines", "interactions"] as const;
 type ResourceTab = (typeof TAB_VALUES)[number];
 
 export interface CourseSearch {
@@ -105,6 +106,7 @@ function SingleCourse() {
         <TabsList>
           <TabsTrigger value="details">Details</TabsTrigger>
           <TabsTrigger value="modules">Modules</TabsTrigger>
+          <TabsTrigger value="routines">Routines</TabsTrigger>
           <TabsTrigger value="interactions">Interactions</TabsTrigger>
         </TabsList>
 
@@ -234,68 +236,50 @@ function SingleCourse() {
           />
         </TabsContent>
 
-        <TabsContent value="interactions">
-          <div className="flex flex-col gap-12">
-            <InfoArea
-              header="Routines"
-              condition={true}
-            >
-              <div className="flex flex-col gap-3">
-                {linkedRoutines.length === 0 && (
-                  <span className="text-sm text-muted-foreground">
-                    No routines include this resource yet.
-                  </span>
-                )}
-                {linkedRoutines.map(r => (
-                  <div
-                    key={r.id}
-                    className="
-                      flex flex-row items-center justify-between gap-2
-                      rounded-md border bg-card p-3
-                    "
+        <TabsContent value="routines">
+          <InfoArea
+            header="Routines"
+            condition={true}
+          >
+            <div className="flex flex-col gap-3">
+              {linkedRoutines.length === 0 && (
+                <span className="text-sm text-muted-foreground">
+                  No routines include this resource yet.
+                </span>
+              )}
+              {linkedRoutines.map(r => (
+                <RoutineBox
+                  key={r.id}
+                  {...r}
+                />
+              ))}
+              <div>
+                <Link
+                  to="/routines/$id/edit"
+                  params={{
+                    id: "new",
+                  }}
+                  search={{
+                    mode: "daily",
+                    entryType: "resource",
+                    entryId: id,
+                  }}
+                >
+                  <Button
+                    variant="outline"
+                    size="sm"
                   >
-                    <Link
-                      to="/routines/$id"
-                      params={{
-                        id: r.id,
-                      }}
-                      className="
-                        font-medium
-                        hover:text-blue-600
-                      "
-                    >
-                      {r.name}
-                    </Link>
-                    <span className="text-xs text-muted-foreground">
-                      {r.mode === "daily" ? "Daily" : "Weekly"}
-                    </span>
-                  </div>
-                ))}
-                <div>
-                  <Link
-                    to="/routines/$id/edit"
-                    params={{
-                      id: "new",
-                    }}
-                    search={{
-                      mode: "daily",
-                      entryType: "resource",
-                      entryId: id,
-                    }}
-                  >
-                    <Button
-                      variant="outline"
-                      size="sm"
-                    >
-                      <PlusIcon />
-                      New Routine
-                    </Button>
-                  </Link>
-                </div>
+                    <PlusIcon />
+                    New Routine
+                  </Button>
+                </Link>
               </div>
-            </InfoArea>
-            <CourseInteractionsLog resourceId={id} />
-          </div>
+            </div>
+          </InfoArea>
+        </TabsContent>
+
+        <TabsContent value="interactions">
+          <CourseInteractionsLog resourceId={id} />
         </TabsContent>
       </Tabs>
       <ConfirmDialog

--- a/packages/client/src/routes/routines.tracker.tsx
+++ b/packages/client/src/routes/routines.tracker.tsx
@@ -373,7 +373,6 @@ function DailyTracker() {
                       <th className="p-2 font-medium whitespace-nowrap">
                         Type
                       </th>
-                      <th className="max-w-xs p-2 font-medium">Description</th>
                       <th className="p-2 font-medium whitespace-nowrap">
                         Streak
                       </th>
@@ -443,24 +442,6 @@ function DailyTracker() {
                               <DailyCourseIndicator daily={daily} />
                               <DailyTaskIndicator daily={daily} />
                             </span>
-                          </td>
-                          <td className="max-w-xs p-2">
-                            {daily.description
-                              ? (
-                                <span
-                                  className="
-                                    block truncate text-muted-foreground
-                                  "
-                                  title={daily.description}
-                                >
-                                  {daily.description}
-                                </span>
-                              )
-                              : (
-                                <span className="text-muted-foreground/60">
-                                  <i>No description</i>
-                                </span>
-                              )}
                           </td>
                           <td className="p-2">
                             <span


### PR DESCRIPTION
- Move the routines list out of the Interactions tab into a dedicated
  Routines tab on single Resource pages, rendering each linked routine as
  a RoutineBox card (keeps the empty state and New Routine button). The
  Interactions tab now holds only the interactions log.
- DailyTitle's subtitle now shows the routine description (daily mode) or
  the day-of-week entry's note (weekly mode) instead of the routine title,
  everywhere DailyTitle is used.
- Remove the now-redundant standalone description displays (the tracker
  active-table Description column and the active list-view span) so the
  description isn't shown twice.

https://claude.ai/code/session_01Akcpw3RXcQBRhnv5LvcswU