### PR TITLE
Show weekly routines in the dashboard Routines table

### DIFF
--- a/packages/client/src/components/dailies/DailyCadenceBadge.tsx
+++ b/packages/client/src/components/dailies/DailyCadenceBadge.tsx
@@ -1,0 +1,30 @@
+import type { Daily, RoutineMode } from "@emstack/types/src";
+
+import { cn } from "@/lib/utils";
+
+// Dailies here come from the routine projection (mapRoutineToDaily), which
+// carries the routine's mode even though the base Daily type doesn't declare it.
+// Read it through a narrow local view, mirroring DailyTitle.
+export function DailyCadenceBadge({
+  daily,
+}: {
+  daily: Daily;
+}) {
+  const mode = (daily as Daily & { mode?: RoutineMode }).mode;
+  const isWeekly = mode === "weekly";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        isWeekly
+          ? `
+            bg-purple-100 text-purple-700
+            dark:bg-purple-950 dark:text-purple-300
+          `
+          : "bg-muted text-muted-foreground",
+      )}
+    >
+      {isWeekly ? "Weekly" : "Daily"}
+    </span>
+  );
+}

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -2,6 +2,7 @@ export { ActionableSentence } from "./ActionableSentence";
 export { DailiesActiveListView } from "./DailiesActiveListView";
 export { DailyCriteriaTemplateEditModal } from "./DailyCriteriaTemplateEditModal";
 export { DailiesViewModeToggle } from "./DailiesViewModeToggle";
+export { DailyCadenceBadge } from "./DailyCadenceBadge";
 export { DailyCommentPopover } from "./DailyCommentPopover";
 export { DailyCompletionsManager } from "./DailyCompletionsManager";
 export { DailyCourseIndicator } from "./DailyCourseIndicator";

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -20,6 +20,7 @@ import {
 import {
   DailiesActiveListView,
   DailiesViewModeToggle,
+  DailyCadenceBadge,
   DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
@@ -180,7 +181,7 @@ export function DashboardDailies() {
     <DashboardCard
       title={
         <span className="inline-flex items-center gap-2">
-          Dailies
+          Routines
           <TooManyDailiesWarning
             activeCount={activeCount}
             limit={settings.maxActiveDailies}
@@ -261,6 +262,7 @@ export function DashboardDailies() {
                   </button>
                 </th>
                 <th className="p-2 font-medium">Type</th>
+                <th className="p-2 font-medium">Cadence</th>
                 <th className="p-2 font-medium">Streak</th>
                 <th className="p-2 font-medium">Total</th>
                 <th className="p-2 font-medium" />
@@ -324,6 +326,9 @@ export function DashboardDailies() {
                         <DailyCourseIndicator daily={daily} />
                         <DailyTaskIndicator daily={daily} />
                       </span>
+                    </td>
+                    <td className="p-2">
+                      <DailyCadenceBadge daily={daily} />
                     </td>
                     <td className="p-2">
                       <span

--- a/packages/client/src/routes/routines.tracker.tsx
+++ b/packages/client/src/routes/routines.tracker.tsx
@@ -19,6 +19,7 @@ import {
   DailiesActiveListView,
   DailiesLimitSetting,
   DailiesViewModeToggle,
+  DailyCadenceBadge,
   DailyCommentPopover,
   DailyCourseIndicator,
   DailyLocationCell,
@@ -275,7 +276,7 @@ function DailyTracker() {
   return (
     <div>
       <PageHeader
-        pageTitle="Daily Tracker"
+        pageTitle="Routine Tracker"
         pageSection="routines"
         description={ENTITY_DESCRIPTIONS.dailies}
       >
@@ -297,7 +298,7 @@ function DailyTracker() {
       <div className="container flex flex-col gap-4">
         {(!baseSorted || baseSorted.length === 0) && (
           <p className="text-sm text-muted-foreground">
-            <i>No dailies yet!</i>
+            <i>No routines yet!</i>
           </p>
         )}
 
@@ -305,7 +306,7 @@ function DailyTracker() {
           <DashboardCard
             title={
               <span className="inline-flex items-center gap-2">
-                Active Dailies
+                Active Routines
                 <TooManyDailiesWarning
                   activeCount={activeDailies.length}
                   limit={settings.maxActiveDailies}
@@ -372,6 +373,9 @@ function DailyTracker() {
                       </th>
                       <th className="p-2 font-medium whitespace-nowrap">
                         Type
+                      </th>
+                      <th className="p-2 font-medium whitespace-nowrap">
+                        Cadence
                       </th>
                       <th className="p-2 font-medium whitespace-nowrap">
                         Streak
@@ -442,6 +446,9 @@ function DailyTracker() {
                               <DailyCourseIndicator daily={daily} />
                               <DailyTaskIndicator daily={daily} />
                             </span>
+                          </td>
+                          <td className="p-2">
+                            <DailyCadenceBadge daily={daily} />
                           </td>
                           <td className="p-2">
                             <span
@@ -551,7 +558,7 @@ function DailyTracker() {
         )}
 
         {pausedDailies.length > 0 && (
-          <DashboardCard title="Paused Dailies">
+          <DashboardCard title="Paused Routines">
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>
@@ -608,7 +615,7 @@ function DailyTracker() {
         )}
 
         {completedDailies.length > 0 && (
-          <DashboardCard title="Completed Dailies">
+          <DashboardCard title="Completed Routines">
             <div className="overflow-x-auto">
               <table className="w-full border-collapse text-sm">
                 <thead>

--- a/packages/client/src/utils/fetchFunctions.ts
+++ b/packages/client/src/utils/fetchFunctions.ts
@@ -189,12 +189,12 @@ export const fetchTopics = topicsApi.list;
 export const fetchProviders = providersApi.list;
 export const fetchResources = resourcesApi.list;
 export const fetchDomains = domainsApi.list;
-// Dailies are now daily-mode routines. These thin wrappers keep the existing
-// daily tracker / dashboard / detail components working unchanged: the server
-// projects daily-mode routines into the Daily shape, and writes inject
-// mode:"daily" so partial completion updates never lose the routine's mode.
+// Dailies are now routines projected into the Daily shape. `projected=true`
+// returns BOTH daily- and weekly-mode routines (each carrying its `mode`) so the
+// tracker / dashboard list weekly routines too. These thin wrappers keep the
+// existing daily tracker / dashboard / detail components working unchanged.
 export const fetchDailies = () =>
-  fetchJson<Daily[]>("/api/routines?mode=daily");
+  fetchJson<Daily[]>("/api/routines?projected=true");
 export const fetchRoutines = routinesApi.list;
 export const fetchTasks = tasksApi.list;
 export const fetchTaskTypes = taskTypesApi.list;

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -16,6 +16,12 @@ const listSchema = {
       type: "object",
       properties: {
         mode: nullableRoutineModeEnum,
+        // When true, project every returned routine (both modes) into the Daily
+        // shape for the tracker / dashboard. `mode=daily` keeps projecting on its
+        // own for back-compat.
+        projected: {
+          type: "boolean",
+        },
       },
     },
   },
@@ -27,6 +33,7 @@ export default async function (server: FastifyInstance) {
   fastify.get("/", listSchema, async (request) => {
     const {
       mode,
+      projected,
     } = request.query;
 
     const routinesList = await db.query.routines.findMany({
@@ -42,10 +49,12 @@ export default async function (server: FastifyInstance) {
 
     const withConnections = await resolveRoutineConnections(routinesList);
 
-    // Only the daily-mode list is projected into the Daily shape (task/resource
-    // progress) for the tracker. Weekly and unfiltered lists return raw routines
-    // plus resolved connections; the client resolves schedule names itself.
-    if (mode !== "daily") {
+    // Project into the Daily shape (task/resource progress) when the caller asks
+    // for it: `projected=true` covers both modes for the tracker / dashboard, and
+    // `mode=daily` keeps projecting on its own for back-compat. Otherwise return
+    // raw routines plus resolved connections; the client resolves schedule names.
+    const shouldProject = projected === true || mode === "daily";
+    if (!shouldProject) {
       return withConnections;
     }
 


### PR DESCRIPTION
Weekly-mode routines were filtered out of the dashboard/tracker because the
shared fetch hit /api/routines?mode=daily and the handler only projected
daily-mode routines into the Daily shape.

- Add a `projected=true` query param to GET /api/routines that projects every
  routine (both modes) into the Daily shape; `mode=daily` keeps its behavior.
- Point fetchDailies at projected=true so the dashboard card, tracker page, and
  courses-in-progress list weekly routines alongside daily ones.
- Rename the dashboard card to "Routines" and the tracker headings accordingly.
- Add a "Cadence" column with a Daily/Weekly badge (new DailyCadenceBadge).