### PR TITLE
Fire success toast on resource save (#58)

### DIFF
--- a/packages/client/src/routes/resources.$id.edit.tsx
+++ b/packages/client/src/routes/resources.$id.edit.tsx
@@ -233,6 +233,7 @@ function SingleResourceEdit() {
         await upsertResource(courseId, courseData);
         await invalidateRelated();
         skipBlock();
+        toast.success(isNew ? "Resource created." : "Resource saved.");
 
         const becameActive
           = value.status === "active" && (isNew || previousStatus !== "active");


### PR DESCRIPTION
The course (resource) edit form already redirected to the detail page on a
successful save but showed no confirmation. Add a toast.success on the success
path, mirroring the create/edit wording of the existing error toast.

https://claude.ai/code/session_01MxsWtDGKBapeR8QcBnSxNg