### PR TITLE
Show current day's task and note for weekly routines in Routines card

### DIFF
--- a/packages/client/src/components/dailies/DailyTitle.tsx
+++ b/packages/client/src/components/dailies/DailyTitle.tsx
@@ -7,32 +7,17 @@ import type {
 
 import { ActionableSentence } from "./ActionableSentence";
 
-// Date.getDay() order ("0" = Sunday … "6" = Saturday); mirrors the middleware's
-// representativeEntry scan so the "first scheduled day" fallback matches the API.
-const DAY_KEYS: RoutineWeekday[] = ["0", "1", "2", "3", "4", "5", "6"];
-
-// The first scheduled day's note, used as a fallback when today has no entry.
-function firstPopulatedNote(
-  weekly: RoutineWeekly | null | undefined,
-): string | null {
-  if (!weekly) {
-    return null;
-  }
-  for (const key of DAY_KEYS) {
-    const note = weekly[key]?.notes;
-    if (note) {
-      return note;
-    }
-  }
-  return null;
-}
+import { cn } from "@/lib/utils";
 
 // The action name (the assigned task/resource/freeform the routine points at,
 // with any prepend/append affixes) on top, and a smaller, de-emphasized subtitle
-// beneath it. The subtitle is the routine's description for daily-mode routines,
-// or the scheduled note (today's day-of-week entry, falling back to the first
-// scheduled day) for weekly-mode routines. It is omitted when empty, so a daily
-// with no description — or a weekly routine with no notes — stays a single line.
+// beneath it. For daily-mode routines the subtitle is the routine's description.
+// For weekly-mode routines the action title and subtitle both describe the
+// current day of week's entry (fed by the API's projection): the scheduled note
+// underneath when there is a task today, or a muted "Nothing scheduled today"
+// placeholder when the weekday is unscheduled. The subtitle is omitted when
+// empty, so a daily with no description — or a scheduled day with no note —
+// stays a single line.
 export function DailyTitle({
   daily,
 }: {
@@ -46,12 +31,18 @@ export function DailyTitle({
     weekly?: RoutineWeekly | null;
   };
 
+  const isWeekly = routineView.mode === "weekly";
   const todayWeekday = String(new Date().getDay()) as RoutineWeekday;
-  const weeklyNote
-    = routineView.weekly?.[todayWeekday]?.notes
-      ?? firstPopulatedNote(routineView.weekly);
-  const subtitle
-    = routineView.mode === "weekly" ? weeklyNote : (daily.description ?? null);
+  const todayEntry = isWeekly ? routineView.weekly?.[todayWeekday] : null;
+  const hasTodayEntry = !!(todayEntry && todayEntry.id);
+
+  // Weekly: today's note when scheduled, else a placeholder. Daily: description.
+  const subtitle = isWeekly
+    ? hasTodayEntry
+      ? (todayEntry?.notes ?? null)
+      : "Nothing scheduled today"
+    : (daily.description ?? null);
+  const isPlaceholder = isWeekly && !hasTodayEntry;
   const showSubtitle = subtitle != null && subtitle !== "";
 
   return (
@@ -62,7 +53,12 @@ export function DailyTitle({
         name={daily.actionParts?.name ?? daily.name}
       />
       {showSubtitle && (
-        <span className="text-xs font-normal text-muted-foreground">
+        <span
+          className={cn(
+            "text-xs font-normal text-muted-foreground",
+            isPlaceholder && "italic",
+          )}
+        >
           {subtitle}
         </span>
       )}

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -4,8 +4,9 @@ import { db } from "@/db";
 import { nullableRoutineModeEnum } from "@/utils/schemas";
 import { resolveRoutineConnections } from "@/utils/resolveRoutineConnections";
 import {
+  activeEntry,
+  currentWeekday,
   mapRoutineToDaily,
-  representativeEntry,
   type RoutineRow,
 } from "@/utils/routineProjection";
 
@@ -58,11 +59,15 @@ export default async function (server: FastifyInstance) {
       return withConnections;
     }
 
-    // Batch-resolve every representative task/resource id up front to avoid N+1.
+    // Resolve against one "today" for the whole request so id-collection,
+    // resolution, and projection all agree on which weekday's entry is active.
+    const weekday = currentWeekday();
+
+    // Batch-resolve every active task/resource id up front to avoid N+1.
     const taskIds: string[] = [];
     const resourceIds: string[] = [];
     for (const routine of withConnections) {
-      const entry = representativeEntry(routine.weekly);
+      const entry = activeEntry(routine.weekly, routine.mode, weekday);
       if (entry?.type === "task") {
         taskIds.push(entry.id);
       }
@@ -115,7 +120,7 @@ export default async function (server: FastifyInstance) {
     const resourceMap = new Map(resourceRows.map(r => [r.id, r]));
 
     return withConnections.map((routine) => {
-      const entry = representativeEntry(routine.weekly);
+      const entry = activeEntry(routine.weekly, routine.mode, weekday);
       const task = entry?.type === "task"
         ? taskMap.get(entry.id) ?? null
         : null;
@@ -125,7 +130,7 @@ export default async function (server: FastifyInstance) {
       return mapRoutineToDaily(routine as RoutineRow, {
         task,
         resource,
-      });
+      }, weekday);
     });
   });
 }

--- a/packages/middleware/src/tests/routineProjection.test.ts
+++ b/packages/middleware/src/tests/routineProjection.test.ts
@@ -1,0 +1,60 @@
+import type { RoutineReferenceItem, RoutineWeekly } from "@emstack/types";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+import {
+  activeEntry,
+  currentWeekday,
+  representativeEntry,
+} from "../utils/routineWeekday.ts";
+
+const mondayTask: RoutineReferenceItem = {
+  type: "task",
+  id: "task-mon",
+  notes: "Focus on the subjunctive",
+  prependText: "Review",
+  appendText: "for 10 minutes",
+};
+
+const wednesdayResource: RoutineReferenceItem = {
+  type: "resource",
+  id: "res-wed",
+};
+
+// Scheduled Monday ("1") and Wednesday ("3"); Tuesday ("2") is unscheduled.
+const weekly: RoutineWeekly = {
+  1: mondayTask,
+  3: wednesdayResource,
+};
+
+test("currentWeekday returns the Date.getDay() key", () => {
+  // 2026-06-08 is a Monday → "1"; 2026-06-07 is a Sunday → "0".
+  assert.strictEqual(currentWeekday(new Date("2026-06-08T12:00:00")), "1");
+  assert.strictEqual(currentWeekday(new Date("2026-06-07T12:00:00")), "0");
+});
+
+test("representativeEntry returns the first populated day, null when empty", () => {
+  assert.strictEqual(representativeEntry(weekly), mondayTask);
+  assert.strictEqual(representativeEntry({}), null);
+  assert.strictEqual(representativeEntry(null), null);
+});
+
+test("activeEntry returns the current weekday's entry for weekly routines", () => {
+  assert.strictEqual(activeEntry(weekly, "weekly", "1"), mondayTask);
+  assert.strictEqual(activeEntry(weekly, "weekly", "3"), wednesdayResource);
+});
+
+test("activeEntry returns null for an unscheduled weekday in weekly mode", () => {
+  assert.strictEqual(activeEntry(weekly, "weekly", "2"), null);
+});
+
+test("activeEntry ignores the weekday for daily routines (uses representative)", () => {
+  // Daily mode mirrors one entry across every day, so the first populated entry
+  // represents it regardless of which weekday we ask for.
+  assert.strictEqual(
+    activeEntry(weekly, "daily", "2"),
+    representativeEntry(weekly),
+  );
+  assert.strictEqual(activeEntry(weekly, "daily", "2"), mondayTask);
+});

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -5,34 +5,22 @@ import type {
   EntityStatus,
   RoutineConnection,
   RoutineMode,
-  RoutineReferenceItem,
+  RoutineWeekday,
   RoutineWeekly,
 } from "@emstack/types";
 import { buildActionableSentence } from "@emstack/types";
 import { mapDaily } from "./dailyProjection";
+import {
+  activeEntry,
+  currentWeekday,
+  representativeEntry,
+} from "./routineWeekday";
 
-const DAY_KEYS = ["0", "1", "2", "3", "4", "5", "6"] as const;
+// Entry-selection helpers live in a dependency-free leaf module so they can be
+// unit-tested directly; re-export them here so callers keep a single import site.
+export { activeEntry, currentWeekday, representativeEntry };
 
-// In daily mode every weekday holds the same entry, so the first populated day
-// is a faithful "representative" of the routine's single task/resource. Returns
-// null for an empty grid or a freeform-only routine (where the name carries the
-// label).
-export function representativeEntry(
-  weekly: RoutineWeekly | null | undefined,
-): RoutineReferenceItem | null {
-  if (!weekly) {
-    return null;
-  }
-  for (const key of DAY_KEYS) {
-    const entry = weekly[key];
-    if (entry && entry.id) {
-      return entry;
-    }
-  }
-  return null;
-}
-
-// Resolved task/resource rows the handler loads for a representative entry. They
+// Resolved task/resource rows the handler loads for an active entry. They
 // mirror the column selection mapDaily expects (see dailyProjection.ts).
 export interface ResolvedTask {
   id: string;
@@ -79,10 +67,12 @@ export function mapRoutineToDaily(
   routine: RoutineRow,
   resolved: { task?: ResolvedTask | null;
     resource?: ResolvedResource | null; } = {},
+  weekday: RoutineWeekday = currentWeekday(),
 ): RoutineDaily {
-  // The representative entry carries the per-item location (daily mode mirrors
-  // the same entry on every day) and the prepend/append text below.
-  const entry = representativeEntry(routine.weekly);
+  // The active entry carries the per-item location and the prepend/append text
+  // below: today's scheduled entry for weekly routines, or the representative
+  // entry (mirrored on every day) for daily ones.
+  const entry = activeEntry(routine.weekly, routine.mode, weekday);
 
   const daily = mapDaily({
     id: routine.id,

--- a/packages/middleware/src/utils/routineWeekday.ts
+++ b/packages/middleware/src/utils/routineWeekday.ts
@@ -1,0 +1,49 @@
+import type {
+  RoutineMode,
+  RoutineReferenceItem,
+  RoutineWeekday,
+  RoutineWeekly,
+} from "@emstack/types";
+
+// Date.getDay() order ("0" = Sunday … "6" = Saturday).
+const DAY_KEYS: RoutineWeekday[] = ["0", "1", "2", "3", "4", "5", "6"];
+
+// In daily mode every weekday holds the same entry, so the first populated day
+// is a faithful "representative" of the routine's single task/resource. Returns
+// null for an empty grid or a freeform-only routine (where the name carries the
+// label).
+export function representativeEntry(
+  weekly: RoutineWeekly | null | undefined,
+): RoutineReferenceItem | null {
+  if (!weekly) {
+    return null;
+  }
+  for (const key of DAY_KEYS) {
+    const entry = weekly[key];
+    if (entry && entry.id) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+// "Today" as a weekday key in Date.getDay() form ("0" = Sunday … "6" = Saturday).
+export function currentWeekday(now: Date = new Date()): RoutineWeekday {
+  return String(now.getDay()) as RoutineWeekday;
+}
+
+// The entry that drives the projected action title. Weekly routines surface the
+// current day of week's entry (null when that weekday is unscheduled), so the
+// dashboard / tracker show today's task. Daily routines mirror the same entry on
+// every day, so the first populated one faithfully represents them.
+export function activeEntry(
+  weekly: RoutineWeekly | null | undefined,
+  mode: RoutineMode,
+  weekday: RoutineWeekday,
+): RoutineReferenceItem | null {
+  if (mode === "weekly") {
+    const entry = weekly?.[weekday];
+    return entry && entry.id ? entry : null;
+  }
+  return representativeEntry(weekly);
+}


### PR DESCRIPTION
Weekly routines in the Routines card (and tracker) showed the first
scheduled day's task on the action line while the subtitle showed today's
note, so the two could describe different days. Resolve the current day of
week's entry instead, so the action line, prepend/append text, and note all
describe today's scheduled task.

- Extract entry-selection helpers into a dependency-free routineWeekday
  leaf module (representativeEntry, currentWeekday, new activeEntry) so they
  can be unit-tested; re-export from routineProjection for callers.
- activeEntry picks today's weekday entry for weekly routines (null when
  unscheduled) and the representative entry for daily routines.
- root.ts resolves and projects against one shared "today" per request.
- DailyTitle ties the subtitle to today's entry: the scheduled note when
  present, or a muted "Nothing scheduled today" when the day is empty.

Resolves #238

https://claude.ai/code/session_011aGwHWAALVb5Z3kmjTBAtB