### PR TITLE
Use daily-status modal on Today's Task card; make modal scrollable

### DIFF
--- a/packages/client/src/components/dailies/DailyStatusModal.tsx
+++ b/packages/client/src/components/dailies/DailyStatusModal.tsx
@@ -77,7 +77,9 @@ export function DailyStatusModal({
       open={open}
       onOpenChange={onOpenChange}
     >
-      <DialogContent className="max-w-xl">
+      <DialogContent
+        className="max-h-[90vh] w-[calc(100%-2rem)] max-w-xl overflow-y-auto"
+      >
         <DialogHeader className="text-left">
           <DialogTitle>
             {daily.name}

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -1,4 +1,5 @@
 import type { DailyDetailTab } from "@/components/dailies/dailyStatusMeta";
+import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
 import { useMemo } from "react";
 
@@ -9,6 +10,7 @@ import { toast } from "sonner";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
+import { TodayStatusCell } from "@/components/dailies";
 import { ActionableSentence } from "@/components/dailies/ActionableSentence";
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
 import { DAILY_DETAIL_TABS } from "@/components/dailies/dailyStatusMeta";
@@ -21,40 +23,18 @@ import {
 } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   connectionEntityKind,
   fetchResources,
   fetchSingleRoutine,
   fetchTasks,
+  findStatusForDate,
   getCurrentChain,
+  getTodayKey,
   getTotalCompletedDays,
   upsertRoutine,
+  withCompletion,
+  withCompletionNote,
 } from "@/utils";
-
-const STATUS_OPTIONS = [
-  {
-    value: "active",
-    label: "Active",
-  },
-  {
-    value: "inactive",
-    label: "Inactive",
-  },
-  {
-    value: "complete",
-    label: "Complete",
-  },
-  {
-    value: "paused",
-    label: "Paused",
-  },
-] as const;
 
 export interface RoutineViewSearch {
   tab?: DailyDetailTab;
@@ -137,19 +117,48 @@ function SingleRoutine() {
     [resources],
   );
 
+  const todayDateKey = getTodayKey();
+
+  // Marks today's completion status (incomplete/touched/goal/exceeded/freeze)
+  // for this routine — the same daily-status concept the dashboard table edits.
+  // Sends a partial body (name + completions), so the upsert preserves the
+  // routine's weekly grid, connections, criteria and overall status.
   const statusMutation = useMutation({
-    mutationFn: (vars: { name: string;
-      status: string; }) =>
-      upsertRoutine(id, {
-        name: vars.name,
-        status: vars.status,
-      }),
+    mutationFn: ({
+      daily,
+      status,
+      note,
+    }: {
+      daily: Daily;
+      status: DailyCompletionStatus;
+      note?: string | null;
+    }) => {
+      const withStatus = withCompletion(daily, todayDateKey, status);
+      const completions
+        = note === undefined
+          ? withStatus
+          : withCompletionNote(
+            {
+              ...daily,
+              completions: withStatus,
+            },
+            todayDateKey,
+            note,
+          );
+      return upsertRoutine(daily.id, {
+        name: daily.name,
+        completions,
+      });
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ["routine", id],
       });
       await queryClient.invalidateQueries({
         queryKey: ["routines"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["dailies"],
       });
       toast.success("Status updated.");
     },
@@ -267,31 +276,31 @@ function SingleRoutine() {
     );
   }
 
-  const currentStatus = data.status ?? "active";
+  // A Daily-shaped view of this routine for the shared today's-status modal,
+  // which only reads name / completions / criteria / description.
+  const dailyForStatus: Daily = {
+    id: data.id,
+    name: data.name,
+    description: data.description,
+    completions: data.completions ?? [],
+    criteria: data.criteria ?? null,
+    status: data.status,
+  };
+  const todayStatus = findStatusForDate(dailyForStatus, todayDateKey);
   const statusControl = (
-    <Select
-      value={currentStatus}
-      onValueChange={next =>
-        statusMutation.mutate({
-          name: data.name,
-          status: next,
-        })}
-      disabled={statusMutation.isPending}
-    >
-      <SelectTrigger size="sm">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent align="end">
-        {STATUS_OPTIONS.map(option => (
-          <SelectItem
-            key={option.value}
-            value={option.value}
-          >
-            {option.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <div className="w-40">
+      <TodayStatusCell
+        daily={dailyForStatus}
+        currentStatus={todayStatus}
+        disabled={statusMutation.isPending}
+        onChange={(status, note) =>
+          statusMutation.mutate({
+            daily: dailyForStatus,
+            status,
+            note,
+          })}
+      />
+    </div>
   );
 
   return (


### PR DESCRIPTION
Replace the routine-status dropdown on the routine detail page's Today's
Task card with the shared TodayStatusCell/DailyStatusModal used by the
Routines dashboard table, so today's completion status (incomplete/
touched/goal/exceeded/freeze) is set the same way everywhere. The status
mutation now writes a partial completions payload, which the routine
upsert merges without touching weekly/connections/criteria/status.

Also make DailyStatusModal responsive on small/short viewports by
constraining its height and allowing the content to scroll.

https://claude.ai/code/session_01874Bed4u9mpqccsL1gTm9r