### PR TITLE
Show weekly routine day-of-week tasks in Day Entries rows

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -1,9 +1,13 @@
 import type { ViewMonth } from "./MonthYearPicker";
-import type { Daily, DailyCompletionStatus } from "@emstack/types";
+import type {
+  Daily,
+  DailyCompletionStatus,
+  RoutineWeekday,
+} from "@emstack/types";
 
 import { useMemo, useState } from "react";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   CalendarIcon,
   ChevronDownIcon,
@@ -20,9 +24,12 @@ import { MonthYearPicker } from "./MonthYearPicker";
 import { NoteEditButton } from "./NoteEditButton";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
+import { RoutineEntryLabel } from "@/components/routines/RoutineEntryLabel";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
+  fetchResources,
+  fetchTasks,
   getReferenceDateKey,
   getTodayKey,
   shiftDateKey,
@@ -48,6 +55,14 @@ function formatDateLabel(dateKey: string): string {
     day: "numeric",
     timeZone: "UTC",
   });
+}
+
+// Day-of-week key for a UTC date key, matching RoutineWeekday ("0" = Sunday …
+// "6" = Saturday) so it can index a routine's `weekly` grid.
+function weekdayKey(dateKey: string): RoutineWeekday {
+  return String(
+    new Date(`${dateKey}T00:00:00Z`).getUTCDay(),
+  ) as RoutineWeekday;
 }
 
 function formatMonthLabel(year: number, month: number): string {
@@ -128,6 +143,37 @@ export function DailyCompletionsManager({
   const [viewMonth, setViewMonth] = useState<ViewMonth>(currentMonth);
   const [monthPickerOpen, setMonthPickerOpen] = useState(false);
   const [expandedDateKey, setExpandedDateKey] = useState<string | null>(null);
+
+  // Weekly routines schedule a different item per weekday; surface that item on
+  // each date row. The grid carries unresolved ids, so resolve task/resource
+  // names from the (already cached) task/resource lists.
+  const isWeekly = daily.mode === "weekly";
+  const weekly = daily.weekly ?? {};
+
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: ["tasks"],
+    queryFn: () => fetchTasks(),
+    enabled: isWeekly,
+  });
+
+  const {
+    data: resources,
+  } = useQuery({
+    queryKey: ["courses"],
+    queryFn: () => fetchResources(),
+    enabled: isWeekly,
+  });
+
+  const taskNames = useMemo(
+    () => new Map((tasks ?? []).map(t => [t.id, t.name])),
+    [tasks],
+  );
+  const resourceNames = useMemo(
+    () => new Map((resources ?? []).map(r => [r.id, r.name])),
+    [resources],
+  );
 
   const completionsByDate = useMemo(() => {
     const map = new Map<
@@ -281,6 +327,9 @@ export function DailyCompletionsManager({
               : null;
             const showVerticalConnector
               = status !== null && nextStatus !== null;
+            const scheduledEntry = isWeekly
+              ? (weekly[weekdayKey(dateKey)] ?? null)
+              : null;
             return (
               <li
                 key={dateKey}
@@ -310,9 +359,21 @@ export function DailyCompletionsManager({
                       />
                     )}
                   </div>
-                  <span className="shrink-0 text-sm font-medium">
-                    {formatDateLabel(dateKey)}
-                  </span>
+                  <div className="flex min-w-0 shrink-0 flex-col">
+                    <span className="text-sm font-medium">
+                      {formatDateLabel(dateKey)}
+                    </span>
+                    {scheduledEntry && (
+                      <span className="text-xs text-muted-foreground">
+                        <RoutineEntryLabel
+                          entry={scheduledEntry}
+                          taskNames={taskNames}
+                          resourceNames={resourceNames}
+                          showMeta={false}
+                        />
+                      </span>
+                    )}
+                  </div>
                   {note && (
                     <Popover>
                       <PopoverTrigger asChild>

--- a/packages/client/src/components/routines/RoutineEntryLabel.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.tsx
@@ -1,0 +1,92 @@
+import type { RoutineReferenceItem } from "@emstack/types";
+
+import { Link } from "@tanstack/react-router";
+import { MapPinIcon } from "lucide-react";
+
+import { ActionableSentence } from "@/components/dailies/ActionableSentence";
+
+interface RoutineEntryLabelProps {
+  entry: RoutineReferenceItem;
+  taskNames: Map<string, string>;
+  resourceNames: Map<string, string>;
+  // When true (default), render the full presentation: a leading TYPE badge plus
+  // any notes/location. When false, render only the actionable sentence (compact
+  // form used inline, e.g. inside a Day Entries row).
+  showMeta?: boolean;
+}
+
+// Renders a routine's per-day reference item (task / resource / freeform) as an
+// actionable sentence, resolving the task/resource name from the supplied maps
+// and linking task/resource entries to their detail pages.
+export function RoutineEntryLabel({
+  entry,
+  taskNames,
+  resourceNames,
+  showMeta = true,
+}: RoutineEntryLabelProps) {
+  // The entry's name as a clickable link (task / resource) or plain text
+  // (freeform) — no type badge, so it can sit inside an actionable sentence.
+  const nameNode = entry.type === "freeform"
+    ? entry.id
+    : (
+      <Link
+        to={entry.type === "task" ? "/tasks/$id" : "/resources/$id"}
+        params={{
+          id: entry.id,
+        }}
+        className="
+          text-blue-800
+          hover:text-blue-600
+          dark:text-blue-300
+        "
+      >
+        {entry.type === "task"
+          ? (taskNames.get(entry.id) ?? entry.id)
+          : (resourceNames.get(entry.id) ?? entry.id)}
+      </Link>
+    );
+
+  const actionable = (
+    <ActionableSentence
+      prependText={entry.prependText}
+      appendText={entry.appendText}
+      name={nameNode}
+    />
+  );
+
+  if (!showMeta) {
+    return actionable;
+  }
+
+  const main = (
+    <span className="text-sm">
+      <span className="mr-2 text-xs text-muted-foreground uppercase">
+        {entry.type}
+      </span>
+      {actionable}
+    </span>
+  );
+
+  if (!entry.notes && !entry.location) {
+    return main;
+  }
+
+  return (
+    <span className="flex flex-col gap-0.5">
+      {main}
+      {entry.notes && (
+        <span className="text-sm text-muted-foreground">{entry.notes}</span>
+      )}
+      {entry.location && (
+        <span
+          className="
+            inline-flex items-center gap-1 text-xs text-muted-foreground
+          "
+        >
+          <MapPinIcon className="size-3.5 shrink-0" />
+          {entry.location}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -5,18 +5,18 @@ import { useMemo } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { EditIcon, FlameIcon, LaughIcon, MapPinIcon } from "lucide-react";
+import { EditIcon, FlameIcon, LaughIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 import { TodayStatusCell } from "@/components/dailies";
-import { ActionableSentence } from "@/components/dailies/ActionableSentence";
 import { DailyDetailsPanel } from "@/components/dailies/DailyDetailsPanel";
 import { DAILY_DETAIL_TABS } from "@/components/dailies/dailyStatusMeta";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { RoutineEntryLabel } from "@/components/routines/RoutineEntryLabel";
 import {
   DAY_LABELS,
   DAY_ORDER,
@@ -195,87 +195,6 @@ function SingleRoutine() {
     completions,
   });
 
-  // The entry's name as a clickable link (task / resource) or plain text
-  // (freeform) — no type badge, so it can sit inside an actionable sentence.
-  function entryNameLink(entry: { type: string;
-    id: string; }) {
-    if (entry.type === "freeform") {
-      return entry.id;
-    }
-    return (
-      <Link
-        to={entry.type === "task" ? "/tasks/$id" : "/resources/$id"}
-        params={{
-          id: entry.id,
-        }}
-        className="
-          text-blue-800
-          hover:text-blue-600
-          dark:text-blue-300
-        "
-      >
-        {entry.type === "task"
-          ? (taskNames.get(entry.id) ?? entry.id)
-          : (resourceNames.get(entry.id) ?? entry.id)}
-      </Link>
-    );
-  }
-
-  // prepend text + linked name + append text, forming the actionable sentence
-  // while keeping the name itself clickable. The affixes render a notch lighter
-  // than the name so the resource itself stands out.
-  function renderActionable(entry: { type: string;
-    id: string;
-    prependText?: string | null;
-    appendText?: string | null; }) {
-    return (
-      <ActionableSentence
-        prependText={entry.prependText}
-        appendText={entry.appendText}
-        name={entryNameLink(entry)}
-      />
-    );
-  }
-
-  function renderEntryLink(entry: { type: string;
-    id: string;
-    notes?: string | null;
-    location?: string | null;
-    prependText?: string | null;
-    appendText?: string | null; }) {
-    const main = (
-      <span className="text-sm">
-        <span className="mr-2 text-xs text-muted-foreground uppercase">
-          {entry.type}
-        </span>
-        {renderActionable(entry)}
-      </span>
-    );
-
-    if (!entry.notes && !entry.location) {
-      return main;
-    }
-
-    return (
-      <span className="flex flex-col gap-0.5">
-        {main}
-        {entry.notes && (
-          <span className="text-sm text-muted-foreground">{entry.notes}</span>
-        )}
-        {entry.location && (
-          <span
-            className="
-              inline-flex items-center gap-1 text-xs text-muted-foreground
-            "
-          >
-            <MapPinIcon className="size-3.5 shrink-0" />
-            {entry.location}
-          </span>
-        )}
-      </span>
-    );
-  }
-
   // A Daily-shaped view of this routine for the shared today's-status modal,
   // which only reads name / completions / criteria / description.
   const dailyForStatus: Daily = {
@@ -331,7 +250,12 @@ function SingleRoutine() {
             ? (
               <>
                 <p className="text-lg font-medium">
-                  {renderActionable(todayEntry)}
+                  <RoutineEntryLabel
+                    entry={todayEntry}
+                    taskNames={taskNames}
+                    resourceNames={resourceNames}
+                    showMeta={false}
+                  />
                 </p>
                 {todayEntry.notes && (
                   <p className="text-sm text-muted-foreground">
@@ -476,7 +400,13 @@ function SingleRoutine() {
                             {DAY_LABELS[day]}
                           </span>
                           {entry
-                            ? renderEntryLink(entry)
+                            ? (
+                              <RoutineEntryLabel
+                                entry={entry}
+                                taskNames={taskNames}
+                                resourceNames={resourceNames}
+                              />
+                            )
                             : (
                               <span
                                 className="text-sm text-muted-foreground italic"

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -1,4 +1,5 @@
 import type { EntityStatus } from "./EntityStatus";
+import type { RoutineMode, RoutineWeekly } from "./Routine";
 
 export type DailyCompletionStatus = "incomplete" | "touched" | "goal" | "exceeded" | "freeze";
 
@@ -67,4 +68,9 @@ export interface Daily {
   // is set; both null = the daily targets the whole course.
   moduleGroupId?: string | null;
   moduleId?: string | null;
+  // Per-weekday scheduled grid (unresolved names). Present only on weekly-mode
+  // routine projections; absent/null for daily-mode dailies.
+  weekly?: RoutineWeekly | null;
+  // Routine mode. "weekly" means the `weekly` grid is meaningful per day.
+  mode?: RoutineMode | null;
 }


### PR DESCRIPTION
For weekly-mode routines, each date row in the Day Entries area now
displays the task/resource scheduled for that weekday, resolved from the
routine's weekly grid.

- Extend the Daily type with optional weekly/mode (routine projection
  already carries them at runtime).
- Extract the routine entry renderer from the routine view page into a
  reusable RoutineEntryLabel component and reuse it in both places.
- Resolve task/resource names in DailyCompletionsManager and render the
  scheduled item as a de-emphasized line under each date (weekly only).

https://claude.ai/code/session_01E7sa2EiJ77bCEwF23v6QcH