### PR TITLE
Speed up lint and typecheck with ESLint cache and incremental tsc

### DIFF
--- a/.claude/hooks/eslint-fix.sh
+++ b/.claude/hooks/eslint-fix.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PostToolUse hook (Edit|Write): auto-fix the edited file with ESLint so agent
+# edits match the repo's stylistic rules (e.g. better-tailwindcss class
+# wrapping) instead of being rewritten later by the pre-commit hook.
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+
+case "$file_path" in
+  *.js | *.jsx | *.mjs | *.cjs | *.ts | *.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Skip silently when deps aren't installed or the file vanished.
+[ -d node_modules ] || exit 0
+[ -f "$file_path" ] || exit 0
+
+pnpm exec eslint --fix --cache --cache-location node_modules/.cache/eslint/ \
+  --cache-strategy content --no-warn-ignored "$file_path" || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,36 @@
       "Bash(docker compose ps:*)",
       "Bash(docker compose logs:*)",
       "Bash(curl http://localhost:*)"
+    ],
+    "deny": [
+      "Read(packages/client/src/routeTree.gen.ts)",
+      "Edit(packages/client/src/routeTree.gen.ts)",
+      "Edit(pnpm-lock.yaml)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -d node_modules ] || pnpm install --frozen-lockfile",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/eslint-fix.sh",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/add-db-migration/SKILL.md
+++ b/.claude/skills/add-db-migration/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: add-db-migration
+description: >-
+  Add an idempotent runtime database migration to the middleware (rename a
+  column, backfill data, move data between tables, drop a legacy table). Use
+  whenever a schema change needs existing rows transformed — drizzle-kit push
+  only diffs the shape, it never moves data.
+---
+
+# Add a runtime DB migration (course-tracker)
+
+This project uses `drizzle-kit push` (no drizzle migration files) plus **idempotent runtime migrations** in `packages/middleware/src/db/migrate*.ts`. They run on every server start (`app.ts` → `runMigrations()`) and at the front of `pnpm push:dev` / `push:prod`, so they must be safe to re-run forever.
+
+**Exemplar to copy:** `packages/middleware/src/db/migrateIgnoreBlips.ts`.
+
+## Steps
+
+1. **Update the schema** in `packages/middleware/src/db/schema/` to the *final* shape (new columns/tables ship in the schema; the migration only transforms existing data). Relations go in `relations.ts`.
+
+2. **Write `packages/middleware/src/db/migrate<Thing>.ts`** exporting one async function. Rules, all non-negotiable:
+   - Raw SQL via `db.execute(sql\`...\`)`. Use `IF NOT EXISTS` / `IF EXISTS` on every DDL statement.
+   - **Early-return on a fresh DB**: check the target table exists before touching it. CRITICAL: always qualify `information_schema` checks with `AND table_schema = 'public'` — information_schema has built-in views named `domains` and `routines`, so an unqualified `WHERE table_name = 'domains'` matches on an *empty* database and the guard silently lies.
+   - Guard each transform on a "has this already run?" condition (legacy column still exists, legacy table still has rows, etc.), not on a version number.
+   - Wrap multi-statement data moves in `db.transaction(...)`.
+   - Top-of-file comment explaining what it migrates and why.
+
+3. **Register it in `runMigrations()`** in `packages/middleware/src/db/startup.ts`:
+   - `try/catch` with a descriptive `console.error("Failed to …", err)` and re-`throw`, matching the existing blocks.
+   - **Order matters**: place it after every migration it depends on, with an ordering comment like the existing ones (e.g. "Runs after dailies → routines so every routine row exists first").
+
+4. **Verify**:
+   ```bash
+   pnpm typecheck && pnpm lint
+   pnpm push:dev          # runs migrations, then drizzle-kit push
+   pnpm push:dev          # MUST succeed again unchanged — idempotency check
+   ```
+   If data was transformed, spot-check with `pnpm studio` or psql. Also verify against a fresh DB when feasible (`docker compose down -v && docker compose up --wait db && pnpm push:dev`) — fresh-DB early returns are where migrations usually break.
+
+## Don'ts
+
+- Don't edit old migrations to add new behavior — add a new file.
+- Don't query Drizzle table objects for tables/columns the final schema no longer declares; use raw SQL.
+- Don't assume the migration runs once: prod and every dev clone replay the whole list on each start.

--- a/.claude/skills/add-entity/SKILL.md
+++ b/.claude/skills/add-entity/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: add-entity
+description: >-
+  Add a brand-new resource/entity to the app end to end: DB table, shared
+  type, middleware CRUD route folder, client API helpers, route pages and
+  navigation. Use when asked to "add a new resource/entity/model" or "track
+  a new kind of thing".
+---
+
+# Add a new entity (course-tracker)
+
+Work through the layers in order; each one depends on the previous. `references/file-checklist.md` lists every file a finished entity touches — diff your work against it before declaring done. Mirror an existing entity of similar shape throughout (junctions → **topics**; plain → **providers**; JSONB-heavy → **routines**).
+
+## 1. Schema — `packages/middleware/src/db/schema/`
+
+- New table in the matching domain file (or a new file, re-exported from `schema/index.ts`). Copy column idioms from a sibling table (uuid pk, `statusEnum`, timestamps).
+- All `relations()` go in `relations.ts`; junction tables live next to the entity.
+- `pnpm push:dev` to create it. Existing-data transforms → `add-db-migration` skill.
+
+## 2. Shared type — `packages/types/src/`
+
+- `<Name>.ts` interface, re-export from `index.ts`, then `pnpm --filter=@emstack/types build`.
+
+## 3. Middleware — `packages/middleware/src/routes/api/<name>/`
+
+Files (see `topics/` for the junction-ful version, `providers/` for the minimal one):
+
+- `<name>Rows.ts` — `<Name>Body` interface, `<name>BodySchema` (reuse `src/utils/schemas.ts` fragments; import it **relatively** — `../../../utils/schemas.ts` — so `node --test` can load the file), `build<Name>Row`, junction row builders (return `undefined` when input absent, `[]` to clear).
+- `create<Name>.ts` — `createCreateHandler` from `src/utils/createCreateHandler.ts`.
+- `upsert<Name>.ts` — `createUpsertHandler` (junction sync, `updateableColumns`, optional `buildSetClause` for partial merge).
+- `delete<Name>.ts` — `createDeleteHandler` (junction cascade, optional reference `guard` → 409).
+- `get<Name>.ts` + `root.ts` — GET single / GET list + POST registration; share any row→DTO mapping via a projection in `src/utils/` when list and single return the same shape.
+- `duplicate<Name>.ts` — only if duplication makes sense (see `routines/duplicateRoutine.ts`).
+- `routes.ts` — registers the handlers; then add `fastify.register(<name>, { prefix: "/<name>" })` in `src/routes/api/routes.ts`.
+
+## 4. Client API — `packages/client/src/utils/api/`
+
+- `<name>.ts` with `export const <name>Api = createEntityClient<Type>("<endpoint>", "<label>")` plus named re-exports (`fetchXs = xsApi.list`, …); re-export from `api/index.ts`.
+
+## 5. Client routes — `packages/client/src/routes/`
+
+- `<name>.tsx` (layout, usually a bare `<Outlet/>`), `<name>.index.tsx` (list), `<name>.$id.tsx`, `<name>.$id.index.tsx` (detail), `<name>.$id.edit.tsx` (edit/create — `id === "new"`).
+- Edit page: `useEditFormPage` (`makeSubmitHandler` + `makeDeleteHandler` + `shouldBlockFn`), `useAppForm` with a zod schema, `EditPageFooter` + `UnsavedChangesDialog`. Copy `topics.$id.edit.tsx`.
+- Loading/error: `EntityPending` / `EntityError` from `components/EntityStates.tsx`.
+- List card → new `components/boxes/<Name>Box.tsx` if the list shows cards.
+- Regenerate the route tree: `pnpm --filter=@emstack/client run routeTree` (never edit `routeTree.gen.ts`).
+
+## 6. Navigation
+
+- `src/routes/__root.tsx`: add a `<Link>` inside the matching `NavDropdown` (desktop) **and** the mobile menu lower in the file.
+- `components/layout/PageHeader.tsx`: add the new `pageSection` if the header maps sections.
+
+## 7. Verify
+
+```bash
+pnpm push:dev && pnpm typecheck && pnpm lint && pnpm test && pnpm build
+```
+
+Runtime smoke (server running via `pnpm dev`): POST → GET list → GET single → PUT → DELETE through `http://localhost:3001/api/<name>`, then click through list → create → edit → delete in the UI at `http://localhost:5173`. Check `git diff --stat`: `routeTree.gen.ts` should be regenerated, nothing else unexpected.

--- a/.claude/skills/add-entity/references/file-checklist.md
+++ b/.claude/skills/add-entity/references/file-checklist.md
@@ -1,0 +1,41 @@
+# New-entity file checklist
+
+Distilled from the Routines resource (commit `9e4d1af`, 24 files) plus the
+factory refactors that landed since. `<name>` = plural kebab/camel entity name.
+
+## Database & types
+
+- [ ] `packages/middleware/src/db/schema/<domain>.ts` — table (+ junction tables)
+- [ ] `packages/middleware/src/db/schema/relations.ts` — relations
+- [ ] `packages/middleware/src/db/schema/enums.ts` — only if a new enum
+- [ ] `packages/types/src/<Name>.ts` — shared interface
+- [ ] `packages/types/src/index.ts` — re-export
+
+## Middleware (`packages/middleware/src/routes/api/<name>/`)
+
+- [ ] `<name>Rows.ts` — body interface + JSON body schema + row/junction builders
+- [ ] `create<Name>.ts` — `createCreateHandler`
+- [ ] `upsert<Name>.ts` — `createUpsertHandler`
+- [ ] `delete<Name>.ts` — `createDeleteHandler`
+- [ ] `get<Name>.ts` — GET `/:id`
+- [ ] `root.ts` — GET `/` list
+- [ ] `duplicate<Name>.ts` — optional
+- [ ] `routes.ts` — registers the above
+- [ ] `packages/middleware/src/routes/api/routes.ts` — `fastify.register(..., { prefix })`
+- [ ] `packages/middleware/src/utils/<name>Projection.ts` — optional shared row→DTO mapper
+- [ ] `packages/middleware/src/utils/schemas.ts` — only if new reusable schema fragments
+
+## Client
+
+- [ ] `packages/client/src/utils/api/<name>.ts` — `createEntityClient` + named exports
+- [ ] `packages/client/src/utils/api/index.ts` — re-export
+- [ ] `packages/client/src/routes/<name>.tsx` — layout
+- [ ] `packages/client/src/routes/<name>.index.tsx` — list page
+- [ ] `packages/client/src/routes/<name>.$id.tsx` — detail layout
+- [ ] `packages/client/src/routes/<name>.$id.index.tsx` — detail page
+- [ ] `packages/client/src/routes/<name>.$id.edit.tsx` — edit/create page
+- [ ] `packages/client/src/components/boxes/<Name>Box.tsx` — list card (if cards)
+- [ ] `packages/client/src/components/<name>/…` — entity-specific widgets (as needed)
+- [ ] `packages/client/src/routes/__root.tsx` — desktop nav + mobile nav links
+- [ ] `packages/client/src/components/layout/PageHeader.tsx` — page section (if mapped)
+- [ ] `packages/client/src/routeTree.gen.ts` — regenerated, never hand-edited

--- a/.claude/skills/add-field-to-entity/SKILL.md
+++ b/.claude/skills/add-field-to-entity/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: add-field-to-entity
+description: >-
+  Add a new field/column to an existing entity (topic, task, resource,
+  routine, daily, provider, domain, module, tag…) end to end: DB schema,
+  shared type, API handlers, client form and detail display. Use when asked
+  to "add a field", "store X on Y", or "let users set X".
+---
+
+# Add a field to an existing entity (course-tracker)
+
+The layers, in dependency order. Skipping one is the classic source of "saves but doesn't show up" bugs.
+
+## 1. Database (`packages/middleware/src/db/schema/`)
+
+- Add the column to the entity's table (file split by domain: `courses.ts` holds resources/providers/modules, `topics.ts`, `tasks.ts`, `routines.ts`, `dailies.ts`, `radar.ts`, `tags.ts`). New enums go in `enums.ts`.
+- Plain new nullable column → `pnpm push:dev` is enough. Rename / backfill / data move → **use the `add-db-migration` skill** for a runtime migration first.
+
+## 2. Shared type (`packages/types/src/`)
+
+- Add the field to the entity's interface (e.g. `Topic.ts`, `Task.ts`, `Resource.ts`). Build it so consumers see it: `pnpm --filter=@emstack/types build` (or rely on `pnpm dev`'s watch).
+
+## 3. Middleware (`packages/middleware/src/routes/api/<entity>/`)
+
+- **`<entity>Rows.ts`** is the single source shared by create + upsert: add the field to the `<Entity>Body` interface, the `<entity>BodySchema` JSON schema (reuse `nullableString` / `nullableBoolean` / `nullableInteger` etc. from `src/utils/schemas.ts`), and `build<Entity>Row`.
+- Note: rows files import `schemas.ts` **relatively** (`../../../utils/schemas.ts`), not via `@/`, so `node --test` can load them.
+- **`upsert<Entity>.ts`**: add the column name to `updateableColumns` (and to `buildSetClause` if the entity uses partial-merge, like routines).
+- **GET handlers**: if the entity has a projection (`src/utils/taskProjection.ts`, `resourceProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`), add the field there — both list (`root.ts`) and single (`get<Entity>.ts`) flow through it.
+- **`duplicate<Entity>.ts`** (if it exists): copy the new field, or duplicates silently drop it.
+
+## 4. Client
+
+- **Edit page** `packages/client/src/routes/<entity>.$id.edit.tsx`:
+  - add to the zod `formSchema`, to `startingValues` (with `data?.field ?? <default>`), to the payload passed to the submit handler, and a `form.AppField` control (`InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField` — registered in `hooks/useAppForm.ts`).
+- **Detail page** `<entity>.$id.index.tsx`: display the field (see `components/layout/InfoRow.tsx` / `InfoArea.tsx` patterns).
+- List/card views (`components/boxes/*`) only if the field belongs there.
+
+## 5. Verify
+
+```bash
+pnpm push:dev && pnpm typecheck && pnpm lint && pnpm test
+```
+
+Then runtime-check round-tripping (server must be running — `pnpm dev`):
+
+```bash
+curl -s -X POST http://localhost:3001/api/<entity>s -H 'Content-Type: application/json' \
+  -d '{"name":"smoke","<field>":"value"}'        # returns {"status":"ok","id":...}
+curl -s http://localhost:3001/api/<entity>s/<id> # field comes back
+curl -s -X PUT  http://localhost:3001/api/<entity>s/<id> -H 'Content-Type: application/json' \
+  -d '{"name":"smoke2","<field>":"value2"}'      # update persists
+```
+
+Gotcha: a PUT that omits optional junction arrays (tagIds, resourceLinks…) deliberately leaves those rows untouched — don't "fix" that.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Course Tracker ("emstack") — a full-stack TypeScript monorepo for tracking online courses, learning topics, daily habits, and tasks. Built with pnpm workspaces.
+Course Tracker ("emstack") — a full-stack TypeScript monorepo for tracking learning resources (courses/books/etc.), topics, routines, daily habits, and tasks. Built with pnpm workspaces.
 
 ## Tech Stack
 
@@ -17,158 +17,74 @@ Course Tracker ("emstack") — a full-stack TypeScript monorepo for tracking onl
 
 ```
 packages/
-  client/       # React frontend (Vite + TypeScript)
+  client/       # React frontend (Vite + TypeScript) — see packages/client/CLAUDE.md
   gateway/      # Fastify reverse proxy (production entrypoint)
-  middleware/   # Fastify API backend
+  middleware/   # Fastify API backend — see packages/middleware/CLAUDE.md
   types/        # Shared TypeScript type definitions
 ```
 
-Build order: types → middleware → client (gateway is plain JS, no build step)
+Build order: types → middleware → client (gateway is plain JS, no build step).
+
+**Per-package conventions live in `packages/client/CLAUDE.md` and `packages/middleware/CLAUDE.md`** — read them before changing code in those packages.
 
 ## Common Commands
 
 ```bash
 pnpm install          # Install all dependencies
-pnpm dev              # Start all packages concurrently (client + middleware + types watch)
+pnpm dev              # Start db + all packages concurrently (client + middleware + types watch)
 pnpm build            # Build all packages
 pnpm start            # Start the gateway (production mode, requires pnpm build first)
 pnpm test             # Run all tests
 pnpm typecheck        # Type-check all buildable packages (no emit)
-pnpm lint             # Lint all files (ESLint flat config)
+pnpm lint             # Lint all files (ESLint flat config, cached)
 pnpm lint:fix         # Auto-fix lint issues
 pnpm storybook        # Run Storybook on port 6006
 pnpm studio           # Drizzle ORM database GUI
-pnpm push:dev         # Push DB schema to dev (drizzle-kit push)
-pnpm push:prod        # Push DB schema to prod (drizzle-kit push)
-```
+pnpm push:dev         # Run runtime migrations + push DB schema to dev
+pnpm push:prod        # Run runtime migrations + push DB schema to prod
 
-### Package-specific commands
-
-```bash
-# Client
-pnpm --filter=@emstack/client test            # Run client tests (Vitest)
-pnpm --filter=@emstack/client typecheck       # Type-check only
-pnpm --filter=@emstack/client build           # Build client
-pnpm --filter=@emstack/client run routeTree   # Regenerate TanStack Router route tree
-
-# Middleware
-pnpm --filter=@emstack/middleware test        # Run middleware tests (node --test)
-pnpm --filter=@emstack/middleware typecheck   # Type-check only
-pnpm --filter=@emstack/middleware dev         # Run middleware dev server
-pnpm --filter=@emstack/middleware push:dev    # Push DB schema (dev)
-pnpm --filter=@emstack/middleware push:prod   # Push DB schema (prod)
-```
-
-### Running a single test
-
-```bash
-# Client (Vitest)
-pnpm --filter=@emstack/client exec vitest run path/to/file.test.tsx
-
-# Middleware (Node test runner)
-pnpm --filter=@emstack/middleware exec node --test src/tests/<file>.test.js
+# Package-scoped: pnpm --filter=@emstack/<client|middleware|types> <script>
+# Single client test:     pnpm --filter=@emstack/client exec vitest run path/to/file.test.tsx
+# Single middleware test: pnpm --filter=@emstack/middleware exec node --test src/tests/<file>.test.js
+# Regenerate route tree:  pnpm --filter=@emstack/client run routeTree
 ```
 
 ## Local Development Setup
 
 1. Run `pnpm install`
-2. Start PostgreSQL (pick one):
-   - **Docker Compose (recommended):** `docker compose up --wait db` (uses compose defaults; the `db` service has a healthcheck so `--wait` blocks until it's ready)
-   - **Standalone:** `docker run --name course-postgres -e POSTGRES_PASSWORD=password -d -p 5432:5432 postgres`
+2. Start PostgreSQL: `docker compose up --wait db` (the `db` service has a healthcheck, so `--wait` blocks until ready)
 3. Copy `packages/middleware/.env.example` to `packages/middleware/.env` and adjust if needed
-4. Push DB schema: `pnpm --filter=@emstack/middleware push:dev`
+4. Push DB schema: `pnpm push:dev`
 5. Run `pnpm dev`
 
 Ports: client dev server on 5173 (Vite proxies `/api` to middleware), middleware on 3001. **Both must be running** for the app to work in dev — `pnpm dev` starts everything together.
 
 ### Database reset / re-seed
 
-The middleware **auto-seeds** an empty database on startup via `packages/middleware/src/db/seed.ts`. To clear and reseed:
+The middleware **auto-seeds** an empty database on startup (`packages/middleware/src/db/seed.ts`). To clear and reseed:
 
 ```bash
 # Option A: nuke the docker volume and recreate
-docker compose down -v && docker compose up --wait db
-pnpm --filter=@emstack/middleware push:dev
+docker compose down -v && docker compose up --wait db && pnpm push:dev
 
 # Option B: hit the dev-only endpoints (server must be running)
 curl http://localhost:3001/api/clearData
 curl http://localhost:3001/api/seed
 ```
 
-If you change `packages/middleware/src/db/schema.ts`, run `pnpm --filter=@emstack/middleware push:dev` to push the new schema (this project uses `drizzle-kit push`, not migration files).
+Schema changes: edit `packages/middleware/src/db/schema/` and run `pnpm push:dev` (this project uses `drizzle-kit push` plus idempotent runtime migrations in `src/db/migrate*.ts` — see the middleware CLAUDE.md).
 
-## Architecture Notes
+## Generated Files — Do Not Edit
 
-### Frontend
-- File-based routing with TanStack Router (routes in `packages/client/src/routes/`)
-- Auto-generated route tree (`routeTree.gen.ts` — do not edit manually)
-- Components organized by purpose: `ui/` (shadcn-style primitives), `layout/`, `boxes/`, `boxElements/`, `dailies/`, `radar/`, `tasks/`, `forms/` (field composition primitives + `CourseFields`), `formFields/` (TanStack Form-aware field components), plus shared primitives at the root (`button`, `calendar`, `combobox`, `input`, `input-group`, `popover`, `radio-group`, `textarea`, `sonner`, etc.)
-- shadcn/ui components live in `components/ui/` — add new ones via shadcn CLI
-- Path alias: `@` → `packages/client/src`
-- Theme support via ThemeProvider context (dark/light mode)
-- **Forms:** Uses TanStack Form's `createFormHook` API. The `useAppForm` hook (re-exported from `components/formFields/index.ts`, defined in `hooks/useAppForm.ts`) registers context-based field components (`InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) accessed via `form.AppField` — do not import the field components directly. They live in `components/formFields/` and access form state via `useFieldContext()` from `utils/fieldContext.ts`. To add a new reusable field: create the component, register it in `useAppForm.ts`.
-- **Edit-page boilerplate** (skip-blocker, query invalidation, navigation, delete handler) lives in `hooks/useEditFormPage.ts`. New edit routes should reuse it.
-- **Loading / error placeholders** for routes use `<EntityPending entity="..."/>` and `<EntityError entity="..."/>` from `components/EntityStates.tsx`. Inside a `DashboardCard`, use the inline `<DashboardSectionStatus isPending error isEmpty entity="..." emptyMessage="..." />` from `components/boxes/DashboardCard.tsx` instead — it renders pending / error / empty rows in the card body.
-- **Fetch layer:** `utils/fetchFunctions.ts` builds typed entity clients with `createEntityClient(endpoint, label)` (CRUD + duplicate). Each entity gets a `<name>Api` object and named function re-exports (`upsertCourse`, `fetchSingleCourse`, etc.). Reuse the helper rather than hand-rolling `fetch` calls.
-
-### Backend
-- Fastify plugin pattern with nested route modules under `src/routes/api/`
-- **Resources:** `courses`, `topics`, `providers`, `domains`, `dailies`, `tasks`, `task-types`, `daily-criteria-templates`, plus `domains/$id/radar` sub-resource (quadrants, rings, blips)
-- Each resource folder follows the convention: `routes.ts` (registers handlers), `root.ts` (collection-level GET/POST), per-operation handler files (`getX.ts`, `upsertX.ts`, `deleteX.ts`, `duplicateX.ts`, etc.)
-- Drizzle ORM schema in `src/db/schema.ts`
-- JSON Schema type provider (`@fastify/type-provider-json-schema-to-ts`) for type-safe route handlers
-- Swagger/OpenAPI docs auto-generated at `/documentation`
-- Auto-seeds on empty database via `src/db/seed.ts`
-- **Shared handler factories** in `src/utils/`: `createDeleteHandler` (single or multi-junction cascade), `createUpsertHandler` (insert + onConflictDoUpdate + junction sync). Reuse these instead of hand-writing CRUD.
-- **Shared schemas** in `src/utils/schemas.ts`: `idParamSchema`, `nullableString/Boolean/Integer`, `statusEnum`, `resourceLevelEnum`, `dailyStatusEnum`, `resourceSchema`, `todoSchema`, `completionSchema`, `criteriaSchema`.
-- **Error helpers** in `src/utils/errors.ts`: `sendNotFound(reply, resource)`, `sendBadRequest(reply, message)`, `sendConflict(reply, message)`.
-- **Junction projection** in `src/utils/processResourceLinks.ts`: `processResourceLinks(rows, "resource" | "topic")` flattens a `topicsToResources` join into `{id, name}[]` from one side of the relation. Use it in GET handlers instead of bespoke `.map(...)` projections.
-
-### Database Schema
-Defined in `packages/middleware/src/db/schema.ts`.
-
-- **Core tables:** `users`, `topics`, `courseProviders`, `courses`, `dailies`, `tasks`, `resources` (task resources), `task_todos`, `domains`
-- **Junction tables:** `topics_to_courses`, `domain_within_scope_topics`, `routine_connections` (polymorphic many-to-many linking a routine to Topics/Tasks/Resources via `connected_type` + `connected_id`; any number may be active)
-- **Radar tables:** `radar_blips` (a blip's `is_ignored` flag marks an "out of scope" / ignored topic; its `description` holds the ignore reasoning). Quadrants/rings live in the `domains.radar_config` JSONB column.
-- **Enums:** `recurPeriodUnit` (days/months/years), `status` (active/inactive/complete/paused), `dailyCompletionStatus` (incomplete/touched/goal/exceeded/freeze), `resourceLevel` (low/medium/high)
-- Uses `drizzle-kit push` (not migration files) — schema changes pushed directly to database
-
-### Shared Types
-- `@emstack/types` package exports Course, Topic, CourseProvider, Domain, Daily, Task, Radar, etc.
-- Used by both client and middleware via workspace protocol
-- Add new types as `packages/types/src/MyType.ts` and re-export from `packages/types/src/index.ts`. Run `pnpm --filter=@emstack/types build` (or `pnpm dev` which runs `tsc --watch`) so the dist output picks them up before consumers import them.
-
-## Common Workflows
-
-### Adding a new API endpoint to an existing resource
-
-1. Create a handler file in `packages/middleware/src/routes/api/<resource>/<verb><Thing>.ts`. Define a `schema` with `idParamSchema` for params (if applicable) and shared schemas from `src/utils/schemas.ts` for the body.
-2. For DELETE handlers, prefer `createDeleteHandler` from `src/utils/createDeleteHandler.ts`. For PUT/upsert handlers, prefer `createUpsertHandler` from `src/utils/createUpsertHandler.ts`.
-3. Register the new handler in the resource's `routes.ts` with `fastify.register(...)`.
-4. Add a corresponding fetch function — usually you want to add a method on the entity client in `packages/client/src/utils/fetchFunctions.ts`. The named exports (`upsertCourse`, etc.) are thin re-exports of `coursesApi.upsert`, etc.
-
-### Adding a new resource
-
-1. Add the table(s) and relations to `packages/middleware/src/db/schema.ts` and run `pnpm --filter=@emstack/middleware push:dev`.
-2. Add a shared type at `packages/types/src/<Name>.ts` and re-export from `index.ts`.
-3. Create `packages/middleware/src/routes/api/<name>/` with `routes.ts`, `root.ts`, and per-operation handler files. Reuse `createDeleteHandler` / `createUpsertHandler`.
-4. Register the resource in `packages/middleware/src/routes/api/routes.ts`.
-5. Add an `<name>Api = createEntityClient<...>(...)` in `packages/client/src/utils/fetchFunctions.ts`.
-6. Add routes in `packages/client/src/routes/<name>.*.tsx`. Run `pnpm --filter=@emstack/client run routeTree` to regenerate `routeTree.gen.ts` (or it'll happen automatically when `vite` runs).
-
-### Adding a new page (client)
-
-1. Create the route file in `packages/client/src/routes/`. File naming follows TanStack Router conventions: `foo.tsx` is the layout, `foo.index.tsx` is the index page, `foo.$id.tsx` is the dynamic-segment layout, `foo.$id.edit.tsx` is a child route.
-2. Run `pnpm --filter=@emstack/client run routeTree` to regenerate `routeTree.gen.ts` (the dev server also regenerates it on file save when running).
-3. For edit pages, use the `useEditFormPage` hook from `@/hooks/useEditFormPage` to avoid re-implementing skip-blocker / invalidation / navigation boilerplate.
-4. For loading/error placeholders use `<EntityPending entity="..."/>` and `<EntityError entity="..."/>` from `@/components/EntityStates`.
+- `packages/client/src/routeTree.gen.ts` — regenerate with `pnpm --filter=@emstack/client run routeTree` (also auto-regenerates while the `vite` dev server runs). Don't read it either; it's derivable from `src/routes/`.
+- `pnpm-lock.yaml` — only `pnpm install` should change it. Grep it rather than reading it whole.
 
 ## Code Quality
 
-- **ESLint:** Flat config (`eslint.config.js`) with typescript-eslint and Tailwind CSS plugin
-- **Git hooks:** Husky pre-commit and pre-push run lint-staged (`eslint --fix` on all staged files)
+- **ESLint:** Flat config (`eslint.config.js`) extending the external `@emilyeserven/eslint-config` package; caching enabled via `--cache` in the lint scripts
+- **Git hooks:** Husky pre-commit runs lint-staged (`eslint --fix` on staged files)
 - **Dependency checks:** knip for unused dependencies, syncpack for version consistency
-- **TypeScript:** Strict mode, ES2022 target
+- **TypeScript:** Strict mode, ES2022 target, incremental typecheck
 
 ## Environment Variables
 
@@ -183,7 +99,6 @@ See `packages/middleware/.env.example` for env templates.
 
 ## Deployment
 
-- **Gateway pattern:** The gateway (`packages/gateway`) is the single production entrypoint — a Fastify server (using `@fastify/http-proxy` and `@fastify/static`) that spawns middleware as a child process, proxies `/api/*` to it, and serves the client's static build files. This means same-origin requests (no CORS needed) and a single container to deploy.
-- **Containers:** Docker Compose for local multi-service; root `Dockerfile` builds everything and runs the gateway
+- **Gateway pattern:** `packages/gateway` is the single production entrypoint — a Fastify server (`@fastify/http-proxy` + `@fastify/static`) that spawns middleware as a child process, proxies `/api/*` to it, and serves the client's static build. Same-origin requests (no CORS) and a single container to deploy.
+- **Containers:** Docker Compose for local multi-service; root `Dockerfile` builds everything and runs the gateway.
 - **Coolify:** Deploy the root Dockerfile. Only `DATABASE_URL` is needed as an env var.
-- **Environment:** Middleware uses `.env` (local) / `.env.production` with `DATABASE_URL` as the key variable

--- a/docs/eslint-config-upstream-suggestions.md
+++ b/docs/eslint-config-upstream-suggestions.md
@@ -1,0 +1,39 @@
+# Suggestions for `@emilyeserven/eslint-config`
+
+Findings from the agent-experience pass on this repo (June 2026) that can only
+be fixed upstream in the shared config package. Local mitigations are in place
+where possible (`--cache` on lint scripts, scoped disables in vendored files).
+
+## Rule changes
+
+1. **Disable `react/prop-types` for TypeScript files.** Props are already
+   type-checked; the rule only generates noise (see the scoped disable block in
+   `packages/client/src/components/calendar.tsx`). Add to the TS override:
+   `"react/prop-types": "off"`.
+
+2. **Carve barrel files out of `import/max-dependencies`.** Barrel/index files
+   exist to aggregate imports; the rule forces blanket disables in
+   `packages/types/src/index.ts`, `packages/client/src/utils/index.ts`,
+   `packages/client/src/utils/api/index.ts`. Suggested override:
+   `files: ["**/index.ts"]` with the rule off (or a higher max).
+
+3. **Investigate the `@stylistic/indent` ↔ JSX-wrapping conflict.** On nested
+   JSX in attribute position (`render={<Button ... />}` — base-ui pattern),
+   the indent fixer and the JSX wrapping rules fight each other; ESLint reports
+   `ESLintCircularFixesWarning` and leaves unfixable errors. Reproduce with
+   `packages/client/src/components/combobox.tsx` (currently carries a
+   file-level `@stylistic/indent` disable because of this).
+
+## Performance
+
+4. **Prefer `projectService: true`** (typescript-eslint v8) over explicit
+   `parserOptions.project` globs if not already used — it scales better in
+   pnpm monorepos and avoids redundant program builds.
+
+5. **Export a non-type-aware subset** (e.g. `@emilyeserven/eslint-config/fast`)
+   without type-checked rules and without `better-tailwindcss`, for use in
+   editor save hooks / lint-staged / per-file PostToolUse hooks where the
+   full config's startup cost dominates single-file runs.
+
+6. **Document `--cache --cache-strategy content` as the recommended invocation**
+   (this repo now uses it; warm full-repo runs went from ~35s to ~2s).

--- a/docs/refactoring-backlog.md
+++ b/docs/refactoring-backlog.md
@@ -1,0 +1,28 @@
+# Refactoring backlog
+
+Deduplication candidates evaluated during the agent-experience pass
+(June 2026). Done: `createCreateHandler` + shared `<entity>Rows.ts` files,
+`makeSubmitHandler` in `useEditFormPage`.
+
+## Deferred
+
+- **Adopt `makeSubmitHandler` in the remaining edit pages** (`resources`,
+  `domains`, `routines` use bespoke submit flows — multi-step saves, tabs,
+  per-tab autosave). Adopt opportunistically when those pages are next
+  touched; don't force it where the flow genuinely differs.
+- **`EditFormLayout` component** wrapping form + `EditPageFooter` +
+  `UnsavedChangesDialog`. Moderate win (~30 lines/page); revisit if more
+  simple edit pages get added.
+- **Delete the `utils/fetchFunctions.ts` shim** once nothing imports through
+  the old path (it just re-exports `./api`).
+- **`domains/createBlip.ts` / `bulkCreateBlips.ts`** stay bespoke (membership
+  diffing, bulk semantics); could share blip row builders if they grow.
+
+## Rejected (don't redo this analysis)
+
+- **`createListHandler` factory for the 13 `root.ts` GET handlers** — the
+  handlers are dominated by entity-specific Drizzle `with:` joins and
+  projections; the shareable shell is ~10 lines. A factory would force a
+  config DSL that's harder to read than the Fastify handler it replaces.
+  Shared projections in `src/utils/*Projection.ts` already capture the
+  duplicated mapping logic.

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "start": "pnpm --filter=@emstack/gateway start",
     "test": "pnpm run -r test",
     "dev": "docker compose up --wait db && pnpm --filter=@emstack/middleware run push:dev && concurrently -n \"models,server,ui\" -c \"yellow,blue,green\" \"pnpm --filter=@emstack/types --stream run dev\" \"pnpm --filter=@emstack/middleware --stream run dev\" \"pnpm --filter=@emstack/client --stream run dev\"",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content",
+    "lint:fix": "eslint . --fix --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content",
     "typecheck": "pnpm --filter=@emstack/types build && pnpm -r --filter=@emstack/middleware --filter=@emstack/client run typecheck",
     "storybook": "pnpm --filter=@emstack/client run storybook",
     "studio": "pnpm --filter=@emstack/middleware run studio",
@@ -39,7 +39,7 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --fix"
+    "*.{js,jsx,mjs,cjs,ts,tsx}": "eslint --fix --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content"
   },
   "type": "module",
   "pnpm": {

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md — @emstack/client
+
+React 19 + Vite frontend. Read the root CLAUDE.md for commands and setup; this file covers client conventions.
+
+## Routing
+
+- File-based routing with TanStack Router; route files live in `src/routes/`.
+- Naming: `foo.tsx` is the layout, `foo.index.tsx` the index page, `foo.$id.tsx` the dynamic-segment layout, `foo.$id.edit.tsx` a child route. Route-private components live in sibling `foo.-components/` directories (the `.-` prefix keeps them out of routing).
+- `src/routeTree.gen.ts` is **generated — never edit or read it**. Regenerate with `pnpm --filter=@emstack/client run routeTree` (the vite dev server also regenerates it on save).
+- Path alias: `@` → `packages/client/src`.
+
+## Fetch layer (`src/utils/api/`)
+
+- `client.ts` exports `fetchJson`/`postJson`/`putJson`/`deleteJson` and `createEntityClient<TEntity, TList>(endpoint, label)`, which returns `{ list, get, create, upsert, delete, duplicate }` against `/api/<endpoint>`.
+- Each entity has a file (`topics.ts`, `resources.ts`, `routines.ts`, …) exporting a `<name>Api` client plus named function re-exports (`upsertTopic`, `fetchSingleTopic`, …). Custom endpoints (e.g. `incrementResourceProgress`) are added as extra functions in the entity file.
+- Reuse `createEntityClient` and the JSON helpers rather than hand-rolling `fetch`.
+- `src/utils/fetchFunctions.ts` is a legacy shim that re-exports `./api` — import from `@/utils/api` (or the barrel) in new code.
+
+## Forms
+
+- Uses TanStack Form's `createFormHook` API. The `useAppForm` hook (defined in `src/hooks/useAppForm.ts`, re-exported from `src/components/formFields/index.ts`) registers context-based field components: `InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`.
+- Access fields via `form.AppField` — do **not** import the field components directly. They live in `src/components/formFields/` and read form state via `useFieldContext()` from `src/utils/fieldContext.ts`.
+- To add a new reusable field: create the component in `components/formFields/`, register it in `hooks/useAppForm.ts`.
+
+## Edit pages
+
+- Shared boilerplate (skip-blocker, query invalidation, navigation, delete handler) lives in `src/hooks/useEditFormPage.ts`. All `<entity>.$id.edit.tsx` routes use it — new edit routes must too.
+- Footer/unsaved-changes UI: `components/layout/EditPageFooter.tsx` + `components/UnsavedChangesDialog.tsx`.
+
+## Loading / error / empty states
+
+- Route-level: `<EntityPending entity="..."/>` and `<EntityError entity="..."/>` from `src/components/EntityStates.tsx`.
+- Inside a `DashboardCard`: `<DashboardSectionStatus isPending error isEmpty entity="..." emptyMessage="..."/>` from `src/components/boxes/DashboardCard.tsx` — renders pending/error/empty rows in the card body.
+
+## Components
+
+Organized by purpose under `src/components/`:
+
+- `ui/` — shadcn-style primitives (add new ones via the shadcn CLI)
+- Root-level primitives — `button.tsx`, `calendar.tsx`, `combobox.tsx`, `input.tsx`, `input-group.tsx`, `popover.tsx`, `radio-group.tsx`, `textarea.tsx`, `sonner.tsx`: vendored shadcn-derived files; keep edits minimal and preserve their scoped eslint-disable comments
+- `layout/` — page chrome (`PageHeader`, `EditPageFooter`, `NavDropdown`, …)
+- `boxes/` / `boxElements/` — dashboard cards and their building blocks
+- `courses/` — resource/module components (directory predates the courses → resources rename)
+- `dailies/`, `routines/`, `radar/`, `tasks/` — feature components
+- `forms/` — field-composition primitives; `formFields/` — TanStack Form-aware fields
+
+Theme support via ThemeProvider context (`src/hooks/useTheme.ts`, dark/light mode).
+
+## Adding a new page
+
+1. Create the route file in `src/routes/` following the naming conventions above.
+2. Regenerate the route tree (`pnpm --filter=@emstack/client run routeTree`).
+3. Edit pages: use `useEditFormPage`; loading/error placeholders: `EntityPending` / `EntityError`.
+4. Add navigation in `src/routes/__root.tsx` if the page should appear in the nav.
+
+## Testing
+
+- Vitest + Testing Library; co-located `*.test.ts(x)` files.
+- Run all: `pnpm --filter=@emstack/client test`; single file: `pnpm --filter=@emstack/client exec vitest run path/to/file.test.tsx`.

--- a/packages/client/src/components/button.tsx
+++ b/packages/client/src/components/button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import type { VariantProps } from "class-variance-authority";
 
 import * as React from "react";
@@ -28,50 +27,50 @@ const buttonVariants = cva(
           hover:bg-primary/90
         `,
         destructive: `
-            bg-destructive text-white
-            hover:bg-destructive/90
-            focus-visible:ring-destructive/20
-            dark:bg-destructive/60
-            dark:focus-visible:ring-destructive/40
-          `,
+          bg-destructive text-white
+          hover:bg-destructive/90
+          focus-visible:ring-destructive/20
+          dark:bg-destructive/60
+          dark:focus-visible:ring-destructive/40
+        `,
         outline: `
-            border bg-background shadow-xs
-            hover:bg-accent hover:text-accent-foreground
-            dark:border-input dark:bg-input/30
-            dark:hover:bg-input/50
-          `,
+          border bg-background shadow-xs
+          hover:bg-accent hover:text-accent-foreground
+          dark:border-input dark:bg-input/30
+          dark:hover:bg-input/50
+        `,
         secondary: `
-            bg-secondary text-secondary-foreground
-            hover:bg-secondary/80
-          `,
+          bg-secondary text-secondary-foreground
+          hover:bg-secondary/80
+        `,
         ghost: `
-            hover:bg-accent hover:text-accent-foreground
-            dark:hover:bg-accent/50
-          `,
+          hover:bg-accent hover:text-accent-foreground
+          dark:hover:bg-accent/50
+        `,
         link: `
           text-primary underline-offset-4
           hover:underline
         `,
       },
       size: {
-        default: `
+        "default": `
           h-9 px-4 py-2
           has-[>svg]:px-3
         `,
-        xs: `
+        "xs": `
           h-6 gap-1 rounded-md px-2 text-xs
           has-[>svg]:px-1.5
           [&_svg:not([class*='size-'])]:size-3
         `,
-        sm: `
+        "sm": `
           h-8 gap-1.5 rounded-md px-3
           has-[>svg]:px-2.5
         `,
-        lg: `
+        "lg": `
           h-10 rounded-md px-6
           has-[>svg]:px-4
         `,
-        icon: "size-9",
+        "icon": "size-9",
         "icon-xs": `
           size-6 rounded-md
           [&_svg:not([class*='size-'])]:size-3
@@ -93,8 +92,8 @@ function Button({
   size = "default",
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
+}: React.ComponentProps<"button">
+  & VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
   }) {
   const Comp = asChild ? Slot.Root : "button";
@@ -116,4 +115,5 @@ function Button({
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- vendored shadcn file exports its cva variants alongside the component
 export { Button, buttonVariants };

--- a/packages/client/src/components/combobox.tsx
+++ b/packages/client/src/components/combobox.tsx
@@ -1,4 +1,6 @@
-/* eslint-disable */
+/* eslint-disable @stylistic/indent -- vendored shadcn/base-ui file; the
+   indent fixer conflicts with JSX wrapping rules on nested render={...}
+   props (circular fixes) */
 "use client";
 
 import * as React from "react";
@@ -17,8 +19,15 @@ import { cn } from "@/lib/utils";
 
 const Combobox = ComboboxPrimitive.Root;
 
-function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
-  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />;
+function ComboboxValue({
+  ...props
+}: ComboboxPrimitive.Value.Props) {
+  return (
+    <ComboboxPrimitive.Value
+      data-slot="combobox-value"
+      {...props}
+    />
+  );
 }
 
 function ComboboxTrigger({
@@ -41,11 +50,16 @@ function ComboboxTrigger({
   );
 }
 
-function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+function ComboboxClear({
+  className, ...props
+}: ComboboxPrimitive.Clear.Props) {
   return (
     <ComboboxPrimitive.Clear
       data-slot="combobox-clear"
-      render={<InputGroupButton variant="ghost" size="icon-xs" />}
+      render={<InputGroupButton
+        variant="ghost"
+        size="icon-xs"
+              />}
       className={cn(className)}
       {...props}
     >
@@ -102,8 +116,8 @@ function ComboboxContent({
   alignOffset = 0,
   anchor,
   ...props
-}: ComboboxPrimitive.Popup.Props &
-  Pick<
+}: ComboboxPrimitive.Popup.Props
+  & Pick<
     ComboboxPrimitive.Positioner.Props,
     "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
   >) {
@@ -151,7 +165,9 @@ function ComboboxContent({
   );
 }
 
-function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+function ComboboxList({
+  className, ...props
+}: ComboboxPrimitive.List.Props) {
   return (
     <ComboboxPrimitive.List
       data-slot="combobox-list"
@@ -212,7 +228,9 @@ function ComboboxItem({
   );
 }
 
-function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+function ComboboxGroup({
+  className, ...props
+}: ComboboxPrimitive.Group.Props) {
   return (
     <ComboboxPrimitive.Group
       data-slot="combobox-group"
@@ -241,13 +259,20 @@ function ComboboxLabel({
   );
 }
 
-function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+function ComboboxCollection({
+  ...props
+}: ComboboxPrimitive.Collection.Props) {
   return (
-    <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
+    <ComboboxPrimitive.Collection
+      data-slot="combobox-collection"
+      {...props}
+    />
   );
 }
 
-function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+function ComboboxEmpty({
+  className, ...props
+}: ComboboxPrimitive.Empty.Props) {
   return (
     <ComboboxPrimitive.Empty
       data-slot="combobox-empty"
@@ -280,8 +305,8 @@ function ComboboxSeparator({
 function ComboboxChips({
   className,
   ...props
-}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> &
-  ComboboxPrimitive.Chips.Props) {
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips>
+  & ComboboxPrimitive.Chips.Props) {
   return (
     <ComboboxPrimitive.Chips
       data-slot="combobox-chips"
@@ -333,7 +358,10 @@ function ComboboxChip({
       {children}
       {showRemove && (
         <ComboboxPrimitive.ChipRemove
-          render={<Button variant="ghost" size="icon-xs" />}
+          render={<Button
+            variant="ghost"
+            size="icon-xs"
+                  />}
           className="
             -ml-1 opacity-50
             hover:opacity-100
@@ -381,5 +409,6 @@ export {
   ComboboxChipsInput,
   ComboboxTrigger,
   ComboboxValue,
+  // eslint-disable-next-line react-refresh/only-export-components -- vendored shadcn file exports its anchor hook alongside the components
   useComboboxAnchor,
 };

--- a/packages/client/src/hooks/useEditFormPage.ts
+++ b/packages/client/src/hooks/useEditFormPage.ts
@@ -20,12 +20,22 @@ interface MakeDeleteHandlerOptions {
   navigateToList: () => void | Promise<void>;
 }
 
+interface MakeSubmitHandlerOptions<TPayload> {
+  createFn: (data: TPayload) => Promise<{ id: string }>;
+  upsertFn: (id: string, data: TPayload) => Promise<unknown>;
+  entityLabel: string;
+  navigateToEntity: (id: string) => void | Promise<void>;
+}
+
 /**
  * Shared boilerplate for entity edit pages:
  *   - fetches the entity via useQuery (skipped when isNew)
  *   - manages the "skip unsaved-changes blocker" ref
  *   - exposes invalidateRelated() to refresh list/detail caches
  *   - exposes makeDeleteHandler(...) that wires up delete + invalidate + nav
+ *   - exposes makeSubmitHandler(...) that wires up create/upsert + invalidate
+ *     + nav + error toast; call the returned function from the form's
+ *     onSubmit with the API payload
  *
  * Navigation stays in the route file so TanStack Router types are preserved.
  */
@@ -87,6 +97,38 @@ export function useEditFormPage<TData>({
     [id, invalidateRelated, skipBlock],
   );
 
+  const makeSubmitHandler = useCallback(
+    <TPayload>({
+      createFn,
+      upsertFn,
+      entityLabel,
+      navigateToEntity,
+    }: MakeSubmitHandlerOptions<TPayload>) =>
+      async (payload: TPayload) => {
+        try {
+          let entityId = id;
+          if (isNew) {
+            const result = await createFn(payload);
+            entityId = result.id;
+          }
+          else {
+            await upsertFn(id, payload);
+          }
+          await invalidateRelated();
+          skipBlock();
+          await navigateToEntity(entityId);
+        }
+        catch {
+          toast.error(
+            isNew
+              ? `Failed to create ${entityLabel}. Please try again.`
+              : `Failed to save ${entityLabel}. Please try again.`,
+          );
+        }
+      },
+    [id, isNew, invalidateRelated, skipBlock],
+  );
+
   return {
     data,
     queryClient,
@@ -94,5 +136,6 @@ export function useEditFormPage<TData>({
     invalidateRelated,
     shouldBlockFn,
     makeDeleteHandler,
+    makeSubmitHandler,
   };
 }

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -21,8 +21,10 @@ declare module "@tanstack/react-router" {
 
 const queryClient = new QueryClient();
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const rootElement = document.getElementById("root")!;
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found in index.html");
+}
 if (!rootElement.innerHTML) {
   const root = createRoot(rootElement);
 

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { useStore } from "@tanstack/react-form";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
@@ -45,16 +44,27 @@ function SingleProviderEdit() {
 
   const {
     data,
-    skipBlock,
-    invalidateRelated,
     shouldBlockFn,
     makeDeleteHandler,
+    makeSubmitHandler,
   } = useEditFormPage({
     id,
     isNew,
     queryKey: ["provider", id],
     queryFn: () => fetchSingleProvider(id),
     relatedQueryKeys: [["providers"]],
+  });
+
+  const submitProvider = makeSubmitHandler({
+    createFn: createProvider,
+    upsertFn: upsertProvider,
+    entityLabel: "provider",
+    navigateToEntity: providerId => navigate({
+      to: "/providers/$id",
+      params: {
+        id: providerId,
+      },
+    }),
   });
 
   const startingValues = useMemo(
@@ -80,7 +90,7 @@ function SingleProviderEdit() {
     onSubmit: async ({
       value,
     }) => {
-      const providerData = {
+      await submitProvider({
         name: value.name,
         description: value.description || null,
         url: value.url,
@@ -93,34 +103,7 @@ function SingleProviderEdit() {
           value.isRecurring === "true" ? value.recurPeriodUnit : null,
         recurPeriod: value.isRecurring === "true" ? value.recurPeriod : null,
         isCourseFeesShared: value.isCourseFeesShared === "true",
-      };
-
-      try {
-        let providerId: string;
-        if (isNew) {
-          const result = await createProvider(providerData);
-          providerId = result.id;
-        }
-        else {
-          await upsertProvider(id, providerData);
-          providerId = id;
-        }
-        await invalidateRelated();
-        skipBlock();
-        await navigate({
-          to: "/providers/$id",
-          params: {
-            id: providerId,
-          },
-        });
-      }
-      catch {
-        toast.error(
-          isNew
-            ? "Failed to create provider. Please try again."
-            : "Failed to save provider. Please try again.",
-        );
-      }
+      });
     },
   });
 

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -4,7 +4,6 @@ import { useStore } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
@@ -58,16 +57,27 @@ function SingleTaskEdit() {
 
   const {
     data,
-    skipBlock,
-    invalidateRelated,
     shouldBlockFn,
     makeDeleteHandler,
+    makeSubmitHandler,
   } = useEditFormPage({
     id,
     isNew,
     queryKey: ["task", id],
     queryFn: () => fetchSingleTask(id),
     relatedQueryKeys: [["tasks"]],
+  });
+
+  const submitTask = makeSubmitHandler({
+    createFn: createTask,
+    upsertFn: upsertTask,
+    entityLabel: "task",
+    navigateToEntity: taskId => navigate({
+      to: "/tasks/$id",
+      params: {
+        id: taskId,
+      },
+    }),
   });
 
   const {
@@ -133,7 +143,7 @@ function SingleTaskEdit() {
         url: t.url ?? null,
       }));
 
-      const taskData = {
+      await submitTask({
         name: value.name,
         description: value.description || null,
         topicId: value.topicId || null,
@@ -141,34 +151,7 @@ function SingleTaskEdit() {
         tagIds: value.tagIds,
         resources: existingResources,
         todos: existingTodos,
-      };
-
-      try {
-        let taskId: string;
-        if (isNew) {
-          const result = await createTask(taskData);
-          taskId = result.id;
-        }
-        else {
-          await upsertTask(id, taskData);
-          taskId = id;
-        }
-        await invalidateRelated();
-        skipBlock();
-        await navigate({
-          to: "/tasks/$id",
-          params: {
-            id: taskId,
-          },
-        });
-      }
-      catch {
-        toast.error(
-          isNew
-            ? "Failed to create task. Please try again."
-            : "Failed to save task. Please try again.",
-        );
-      }
+      });
     },
   });
 

--- a/packages/client/src/routes/topics.$id.edit.tsx
+++ b/packages/client/src/routes/topics.$id.edit.tsx
@@ -4,7 +4,6 @@ import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import * as z from "zod";
 
 import { useAppForm } from "@/components/formFields";
@@ -59,10 +58,9 @@ function SingleTopicEdit() {
 
   const {
     data,
-    skipBlock,
-    invalidateRelated,
     shouldBlockFn,
     makeDeleteHandler,
+    makeSubmitHandler,
   } = useEditFormPage({
     id,
     isNew,
@@ -139,6 +137,18 @@ function SingleTopicEdit() {
     [data],
   );
 
+  const submitTopic = makeSubmitHandler({
+    createFn: createTopic,
+    upsertFn: upsertTopic,
+    entityLabel: "topic",
+    navigateToEntity: topicId => navigate({
+      to: "/topics/$id",
+      params: {
+        id: topicId,
+      },
+    }),
+  });
+
   const form = useAppForm({
     defaultValues: startingValues,
     validators: {
@@ -147,7 +157,7 @@ function SingleTopicEdit() {
     onSubmit: async ({
       value,
     }) => {
-      const topicData = {
+      await submitTopic({
         name: value.name,
         description: value.description || null,
         reason: value.reason || null,
@@ -160,34 +170,7 @@ function SingleTopicEdit() {
             moduleGroupId: l.moduleGroupId,
             moduleId: l.moduleId,
           })),
-      };
-
-      try {
-        let topicId: string;
-        if (isNew) {
-          const result = await createTopic(topicData);
-          topicId = result.id;
-        }
-        else {
-          await upsertTopic(id, topicData);
-          topicId = id;
-        }
-        await invalidateRelated();
-        skipBlock();
-        await navigate({
-          to: "/topics/$id",
-          params: {
-            id: topicId,
-          },
-        });
-      }
-      catch {
-        toast.error(
-          isNew
-            ? "Failed to create topic. Please try again."
-            : "Failed to save topic. Please try again.",
-        );
-      }
+      });
     },
   });
 

--- a/packages/client/tsconfig.app.json
+++ b/packages/client/tsconfig.app.json
@@ -6,6 +6,7 @@
       "@/*": ["./src/*"]
     },
 
+    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,

--- a/packages/client/tsconfig.node.json
+++ b/packages/client/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.node.tsbuildinfo",
     "target": "ES2023",
     "useDefineForClassFields": true,

--- a/packages/middleware/CLAUDE.md
+++ b/packages/middleware/CLAUDE.md
@@ -11,7 +11,8 @@ Fastify 5 + Drizzle ORM API backend. Read the root CLAUDE.md for commands and se
 
 ## Shared utilities (`src/utils/`) — reuse these, don't hand-roll
 
-- **Handler factories:** `createUpsertHandler` (PUT `/:id`: insert + `onConflictDoUpdate` + junction sync), `createDeleteHandler` (single or multi-junction cascade).
+- **Handler factories:** `createCreateHandler` (POST `/`: uuid + insert + junction inserts), `createUpsertHandler` (PUT `/:id`: insert + `onConflictDoUpdate` + junction sync), `createDeleteHandler` (single or multi-junction cascade).
+- Junction semantics: a builder returning `undefined` means "leave existing rows untouched" (request omitted the array), `[]` means "clear". The `<x>Rows.ts` files import `schemas.ts` relatively (not via `@/`) so `node --test` can load them.
 - **Schemas** (`schemas.ts`): `idParamSchema`, `nullableString/Boolean/Integer`, `statusEnum`, `resourceLevelEnum`, `dailyStatusEnum`, `resourceSchema`, `todoSchema`, `completionSchema`, `criteriaSchema`.
 - **Error helpers** (`errors.ts`): `sendNotFound(reply, resource)`, `sendBadRequest(reply, message)`, `sendConflict(reply, message)`.
 - **Projections:** `taskProjection.ts`, `resourceProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`, and `processResourceLinks.ts` (flattens a `topicsToResources` join into `{id, name}[]`). Use these in GET handlers instead of bespoke `.map(...)`.

--- a/packages/middleware/CLAUDE.md
+++ b/packages/middleware/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md — @emstack/middleware
+
+Fastify 5 + Drizzle ORM API backend. Read the root CLAUDE.md for commands and setup; this file covers middleware conventions.
+
+## Route structure
+
+- Fastify plugin pattern with nested route modules under `src/routes/api/`; all resources are registered with prefixes in `src/routes/api/routes.ts`.
+- **Resources:** `resources`, `topics`, `providers`, `domains` (incl. `domains/$id/radar` sub-resource: quadrants/rings/blips), `dailies`, `routines`, `tasks`, `task-types`, `tags`, `tag-groups`, `modules`, `module-groups`, `interactions`, `daily-criteria-templates`, `routine-templates`.
+- Each resource folder follows the convention: `routes.ts` (registers handlers), `root.ts` (collection-level GET/POST), per-operation handler files (`get<X>.ts`, `create<X>.ts`, `upsert<X>.ts`, `delete<X>.ts`, `duplicate<X>.ts`), and a `<x>Rows.ts` with shared row/junction builders where create and upsert share logic (see `topics/topicRows.ts`).
+- JSON Schema type provider (`@fastify/type-provider-json-schema-to-ts`) for type-safe handlers; Swagger/OpenAPI docs auto-generated at `/documentation`.
+
+## Shared utilities (`src/utils/`) — reuse these, don't hand-roll
+
+- **Handler factories:** `createUpsertHandler` (PUT `/:id`: insert + `onConflictDoUpdate` + junction sync), `createDeleteHandler` (single or multi-junction cascade).
+- **Schemas** (`schemas.ts`): `idParamSchema`, `nullableString/Boolean/Integer`, `statusEnum`, `resourceLevelEnum`, `dailyStatusEnum`, `resourceSchema`, `todoSchema`, `completionSchema`, `criteriaSchema`.
+- **Error helpers** (`errors.ts`): `sendNotFound(reply, resource)`, `sendBadRequest(reply, message)`, `sendConflict(reply, message)`.
+- **Projections:** `taskProjection.ts`, `resourceProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`, and `processResourceLinks.ts` (flattens a `topicsToResources` join into `{id, name}[]`). Use these in GET handlers instead of bespoke `.map(...)`.
+- **Junction sync:** `syncJunctionTable.ts`; routine connections: `resolveRoutineConnections.ts`, `routineConnectionRows.ts`.
+
+## Database schema (`src/db/schema/`)
+
+Split by domain; all `relations()` declarations live in `relations.ts`, everything re-exported from `index.ts`:
+
+- `courses.ts` — `courseProviders`, `resources`, `module_groups`, `modules`, `interactions` (filename predates the courses → resources rename)
+- `topics.ts` — `topics`, `topics_to_courses` junction (table name is legacy; links topics ↔ resources)
+- `tasks.ts` — `task_types`, `tasks`, `task_resources`, `task_todos`, `tasks_to_courses` junction
+- `routines.ts` — `routines`, `routine_connections` (polymorphic many-to-many linking a routine to Topics/Tasks/Resources via `connected_type` + `connected_id`), `routine_templates`
+- `dailies.ts` — `dailies`, `daily_criteria_templates`
+- `radar.ts` — `domains` (quadrants/rings live in the `domains.radar_config` JSONB column), `domain_within_scope_topics`, `radar_blips` (`is_ignored` marks an out-of-scope topic; `description` holds the reasoning)
+- `tags.ts` — `tag_groups`, `tags`, plus per-entity tag junctions
+- `enums.ts` — `recurPeriodUnit`, `status`, `dailyCompletionStatus`, `resourceLevel`, `routine_mode`, `interaction_progress/difficulty/understanding`
+- `users.ts` — `users`
+
+## Schema changes & migrations
+
+This project uses `drizzle-kit push` (no drizzle migration files) **plus idempotent runtime migrations**:
+
+1. Edit `src/db/schema/`, then run `pnpm push:dev` (runs runtime migrations via `migrate:dev`, then `drizzle-kit push`).
+2. If existing data must be transformed (renames, backfills, moves), add `src/db/migrate<Thing>.ts`. Convention (exemplar: `migrateIgnoreBlips.ts`):
+   - **Idempotent raw SQL** via `db.execute(sql\`...\`)` — `IF NOT EXISTS` / `IF EXISTS` guards, `information_schema` checks.
+   - **Early-return on a fresh DB** (target tables don't exist yet — `drizzle-kit push` will create the final shape).
+   - Register it in `runMigrations()` in `src/db/startup.ts`, wrapped in try/catch with a descriptive `console.error`, **ordered after any migrations it depends on** (add an ordering comment like the existing ones).
+3. Migrations run on every server start (`app.ts` calls `runMigrations()` then `seedIfEmpty()`) and via `pnpm push:dev`/`push:prod`, so they must be safe to re-run.
+
+Auto-seeding: `seedIfEmpty()` seeds via `src/db/seed.ts` when the `resources` table is empty. Dev-only endpoints: `GET /api/clearData`, `GET /api/seed`.
+
+## Testing
+
+- Node test runner: `pnpm --filter=@emstack/middleware test`; single file: `pnpm --filter=@emstack/middleware exec node --test src/tests/<file>.test.js`.

--- a/packages/middleware/drizzle.config.ts
+++ b/packages/middleware/drizzle.config.ts
@@ -1,13 +1,20 @@
-// eslint-disable-next-line import/no-unassigned-import
-import "dotenv/config";
+import process from "node:process";
+
+import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
+
+config();
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL must be set to run drizzle-kit");
+}
 
 export default defineConfig({
   out: "./drizzle",
   schema: "./src/db/schema/index.ts",
   dialect: "postgresql",
   dbCredentials: {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion,no-undef
-    url: process.env.DATABASE_URL!,
+    url: databaseUrl,
   },
 });

--- a/packages/middleware/src/db/migrateConsolidateRadar.ts
+++ b/packages/middleware/src/db/migrateConsolidateRadar.ts
@@ -20,7 +20,7 @@ export async function migrateConsolidateRadar() {
   const domainsTableExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_name = 'domains'
+      WHERE table_name = 'domains' AND table_schema = 'public'
     ) AS exists
   `);
   if (!domainsTableExists.rows[0]?.exists) {
@@ -39,7 +39,7 @@ export async function migrateConsolidateRadar() {
   const hasRadarColumn = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'domains' AND column_name = 'has_radar'
+      WHERE table_name = 'domains' AND column_name = 'has_radar' AND table_schema = 'public'
     ) AS exists
   `);
   if (!hasRadarColumn.rows[0]?.exists) {
@@ -50,13 +50,13 @@ export async function migrateConsolidateRadar() {
     const quadrantsTableExists = await tx.execute<ExistsRow>(sql`
       SELECT EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_name = 'radar_quadrants'
+        WHERE table_name = 'radar_quadrants' AND table_schema = 'public'
       ) AS exists
     `);
     const ringsTableExists = await tx.execute<ExistsRow>(sql`
       SELECT EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_name = 'radar_rings'
+        WHERE table_name = 'radar_rings' AND table_schema = 'public'
       ) AS exists
     `);
 
@@ -108,7 +108,7 @@ export async function migrateConsolidateRadar() {
     const ttdExists = await tx.execute<ExistsRow>(sql`
       SELECT EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_name = 'topics_to_domains'
+        WHERE table_name = 'topics_to_domains' AND table_schema = 'public'
       ) AS exists
     `);
     if (ttdExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateCoursesToResources.ts
+++ b/packages/middleware/src/db/migrateCoursesToResources.ts
@@ -22,7 +22,7 @@ async function columnExists(table: string, column: string): Promise<boolean> {
   const result = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = ${table} AND column_name = ${column}
+      WHERE table_name = ${table} AND column_name = ${column} AND table_schema = 'public'
     ) AS exists
   `);
   return result.rows[0]?.exists ?? false;

--- a/packages/middleware/src/db/migrateDailiesToRoutines.ts
+++ b/packages/middleware/src/db/migrateDailiesToRoutines.ts
@@ -41,7 +41,7 @@ function buildWeekly(
 export async function migrateDailiesToRoutines() {
   const routinesExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines'
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines' AND table_schema = 'public'
     ) AS exists
   `);
   if (!routinesExists.rows[0]?.exists) {
@@ -50,7 +50,7 @@ export async function migrateDailiesToRoutines() {
 
   const dailiesExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables WHERE table_name = 'dailies'
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'dailies' AND table_schema = 'public'
     ) AS exists
   `);
   if (!dailiesExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateIgnoreBlips.ts
+++ b/packages/middleware/src/db/migrateIgnoreBlips.ts
@@ -16,7 +16,7 @@ export async function migrateIgnoreBlips() {
   const blipsTableExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_name = 'radar_blips'
+      WHERE table_name = 'radar_blips' AND table_schema = 'public'
     ) AS exists
   `);
   if (!blipsTableExists.rows[0]?.exists) {
@@ -31,7 +31,7 @@ export async function migrateIgnoreBlips() {
   const excludedTableExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_name = 'domain_excluded_topics'
+      WHERE table_name = 'domain_excluded_topics' AND table_schema = 'public'
     ) AS exists
   `);
   if (!excludedTableExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateModuleLength.ts
+++ b/packages/middleware/src/db/migrateModuleLength.ts
@@ -10,13 +10,13 @@ export async function migrateModuleLength() {
   const lengthExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'modules' AND column_name = 'length'
+      WHERE table_name = 'modules' AND column_name = 'length' AND table_schema = 'public'
     ) AS exists
   `);
   const minutesExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'modules' AND column_name = 'minutes_length'
+      WHERE table_name = 'modules' AND column_name = 'minutes_length' AND table_schema = 'public'
     ) AS exists
   `);
   if (!lengthExists.rows[0]?.exists || !minutesExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateRadarBlips.ts
+++ b/packages/middleware/src/db/migrateRadarBlips.ts
@@ -28,7 +28,7 @@ export async function migrateRadarBlips() {
   const tableExistsResult = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_name = 'radar_blips'
+      WHERE table_name = 'radar_blips' AND table_schema = 'public'
     ) AS exists
   `);
   if (!tableExistsResult.rows[0]?.exists) {
@@ -38,7 +38,7 @@ export async function migrateRadarBlips() {
   const nameExistsResult = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'radar_blips' AND column_name = 'name'
+      WHERE table_name = 'radar_blips' AND column_name = 'name' AND table_schema = 'public'
     ) AS exists
   `);
   const nameExists = nameExistsResult.rows[0]?.exists ?? false;
@@ -85,7 +85,7 @@ export async function migrateRadarBlips() {
 
   const topicNullable = await db.execute<ColumnRow>(sql`
     SELECT is_nullable FROM information_schema.columns
-    WHERE table_name = 'radar_blips' AND column_name = 'topic_id'
+    WHERE table_name = 'radar_blips' AND column_name = 'topic_id' AND table_schema = 'public'
   `);
   if (topicNullable.rows[0]?.is_nullable === "YES") {
     await db.execute(sql`ALTER TABLE radar_blips ALTER COLUMN topic_id SET NOT NULL`);

--- a/packages/middleware/src/db/migrateRoutineConnections.ts
+++ b/packages/middleware/src/db/migrateRoutineConnections.ts
@@ -18,7 +18,7 @@ type ConnectionRow = { routine_id: string;
 export async function migrateRoutineConnections() {
   const routinesExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines'
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines' AND table_schema = 'public'
     ) AS exists
   `);
   if (!routinesExists.rows[0]?.exists) {
@@ -41,7 +41,7 @@ export async function migrateRoutineConnections() {
   const topicColumnExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'routines' AND column_name = 'topic_id'
+      WHERE table_name = 'routines' AND column_name = 'topic_id' AND table_schema = 'public'
     ) AS exists
   `);
   if (!topicColumnExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateRoutineLocationToWeekly.ts
+++ b/packages/middleware/src/db/migrateRoutineLocationToWeekly.ts
@@ -18,7 +18,7 @@ type RoutineLocationRow = {
 export async function migrateRoutineLocationToWeekly() {
   const routinesExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines'
+      SELECT 1 FROM information_schema.tables WHERE table_name = 'routines' AND table_schema = 'public'
     ) AS exists
   `);
   if (!routinesExists.rows[0]?.exists) {
@@ -28,7 +28,7 @@ export async function migrateRoutineLocationToWeekly() {
   const locationColumnExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = 'routines' AND column_name = 'location'
+      WHERE table_name = 'routines' AND column_name = 'location' AND table_schema = 'public'
     ) AS exists
   `);
   if (!locationColumnExists.rows[0]?.exists) {

--- a/packages/middleware/src/db/migrateTasksToResources.ts
+++ b/packages/middleware/src/db/migrateTasksToResources.ts
@@ -13,7 +13,7 @@ async function migrateJunctionToUuidPk(tableName: string) {
   const tableExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.tables
-      WHERE table_name = ${tableName}
+      WHERE table_name = ${tableName} AND table_schema = 'public'
     ) AS exists
   `);
   if (!tableExists.rows[0]?.exists) return;
@@ -21,7 +21,7 @@ async function migrateJunctionToUuidPk(tableName: string) {
   const idExists = await db.execute<ExistsRow>(sql`
     SELECT EXISTS (
       SELECT 1 FROM information_schema.columns
-      WHERE table_name = ${tableName} AND column_name = 'id'
+      WHERE table_name = ${tableName} AND column_name = 'id' AND table_schema = 'public'
     ) AS exists
   `);
   if (idExists.rows[0]?.exists) return;
@@ -33,7 +33,7 @@ async function migrateJunctionToUuidPk(tableName: string) {
 
     const pkRow = await tx.execute<ConstraintRow>(sql`
       SELECT constraint_name FROM information_schema.table_constraints
-      WHERE table_name = ${tableName} AND constraint_type = 'PRIMARY KEY'
+      WHERE table_name = ${tableName} AND constraint_type = 'PRIMARY KEY' AND table_schema = 'public'
     `);
     for (const row of pkRow.rows) {
       await tx.execute(

--- a/packages/middleware/src/routes/api/dailies/createDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/createDaily.ts
@@ -1,73 +1,13 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { dailies } from "@/db/schema";
-import {
-  completionSchema,
-  criteriaSchema,
-  nullableDailyStatusEnum,
-  nullableString,
-} from "@/utils/schemas";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types";
-import { v4 as uuidv4 } from "uuid";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 
-const createSchema = {
-  schema: {
-    description: "Create a new daily",
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        location: nullableString,
-        description: nullableString,
-        completions: {
-          type: "array",
-          items: completionSchema,
-        },
-        courseProviderId: nullableString,
-        resourceId: nullableString,
-        moduleGroupId: nullableString,
-        moduleId: nullableString,
-        taskId: nullableString,
-        status: nullableDailyStatusEnum,
-        criteria: criteriaSchema,
-      },
-    },
-  },
-} as const;
+import { buildDailyRow, dailyBodySchema } from "./dailyRows";
 
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+import type { DailyBody } from "./dailyRows";
 
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request) {
-      const body = request.body;
-      const id = uuidv4();
-
-      await db.insert(dailies).values({
-        id,
-        name: body.name,
-        location: body.location ?? null,
-        description: body.description ?? null,
-        completions: (body.completions ?? []) as DailyCompletion[],
-        courseProviderId: body.courseProviderId ?? null,
-        resourceId: body.resourceId ?? null,
-        moduleGroupId: body.moduleGroupId ?? null,
-        moduleId: body.moduleId ?? null,
-        taskId: body.taskId || null,
-        status: body.status ?? "active",
-        criteria: (body.criteria ?? {}) as DailyCriteria,
-      });
-
-      return {
-        status: "ok",
-        id,
-      };
-    },
-  );
-}
+export default createCreateHandler<DailyBody>({
+  description: "Create a new daily",
+  table: dailies,
+  bodySchema: dailyBodySchema,
+  buildRow: buildDailyRow,
+});

--- a/packages/middleware/src/routes/api/dailies/dailyRows.ts
+++ b/packages/middleware/src/routes/api/dailies/dailyRows.ts
@@ -1,0 +1,64 @@
+import {
+  completionSchema,
+  criteriaSchema,
+  nullableDailyStatusEnum,
+  nullableString,
+} from "../../../utils/schemas.ts";
+
+import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+
+// Body schema and row builder shared by the daily create and upsert handlers.
+
+export interface DailyBody {
+  name: string;
+  location?: string | null;
+  description?: string | null;
+  completions?: DailyCompletion[];
+  courseProviderId?: string | null;
+  resourceId?: string | null;
+  moduleGroupId?: string | null;
+  moduleId?: string | null;
+  taskId?: string | null;
+  status?: "active" | "inactive" | "complete" | "paused" | null;
+  criteria?: DailyCriteria;
+}
+
+export const dailyBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+    },
+    location: nullableString,
+    description: nullableString,
+    completions: {
+      type: "array",
+      items: completionSchema,
+    },
+    courseProviderId: nullableString,
+    resourceId: nullableString,
+    moduleGroupId: nullableString,
+    moduleId: nullableString,
+    taskId: nullableString,
+    status: nullableDailyStatusEnum,
+    criteria: criteriaSchema,
+  },
+} as const;
+
+export function buildDailyRow(body: DailyBody, id: string) {
+  return {
+    id,
+    name: body.name,
+    location: body.location ?? null,
+    description: body.description ?? null,
+    completions: body.completions ?? [],
+    courseProviderId: body.courseProviderId ?? null,
+    resourceId: body.resourceId ?? null,
+    moduleGroupId: body.moduleGroupId ?? null,
+    moduleId: body.moduleId ?? null,
+    taskId: body.taskId || null,
+    status: body.status ?? "active",
+    criteria: body.criteria ?? {},
+  };
+}

--- a/packages/middleware/src/routes/api/dailies/upsertDaily.ts
+++ b/packages/middleware/src/routes/api/dailies/upsertDaily.ts
@@ -1,82 +1,28 @@
 import { dailies } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import {
-  completionSchema,
-  criteriaSchema,
-  nullableDailyStatusEnum,
-  nullableString,
-} from "@/utils/schemas";
 
-import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import { buildDailyRow, dailyBodySchema } from "./dailyRows";
 
-interface DailyBody {
-  name: string;
-  location?: string | null;
-  description?: string | null;
-  completions?: DailyCompletion[];
-  courseProviderId?: string | null;
-  resourceId?: string | null;
-  moduleGroupId?: string | null;
-  moduleId?: string | null;
-  taskId?: string | null;
-  status?: "active" | "inactive" | "complete" | "paused" | null;
-  criteria?: DailyCriteria;
-}
-
-const updateableColumns = [
-  "name",
-  "location",
-  "description",
-  "completions",
-  "courseProviderId",
-  "resourceId",
-  "moduleGroupId",
-  "moduleId",
-  "taskId",
-  "status",
-  "criteria",
-] as const;
+import type { DailyBody } from "./dailyRows";
 
 export default createUpsertHandler<DailyBody>({
   description: "Create or update a daily",
   table: dailies,
-  bodySchema: {
-    type: "object",
-    required: ["name"],
-    properties: {
-      name: {
-        type: "string",
-      },
-      location: nullableString,
-      description: nullableString,
-      completions: {
-        type: "array",
-        items: completionSchema,
-      },
-      courseProviderId: nullableString,
-      resourceId: nullableString,
-      moduleGroupId: nullableString,
-      moduleId: nullableString,
-      taskId: nullableString,
-      status: nullableDailyStatusEnum,
-      criteria: criteriaSchema,
-    },
-  },
-  buildRow: (body, id) => ({
-    id,
-    name: body.name,
-    location: body.location ?? null,
-    description: body.description ?? null,
-    completions: body.completions ?? [],
-    courseProviderId: body.courseProviderId ?? null,
-    resourceId: body.resourceId ?? null,
-    moduleGroupId: body.moduleGroupId ?? null,
-    moduleId: body.moduleId ?? null,
-    taskId: body.taskId || null,
-    status: body.status ?? "active",
-    criteria: body.criteria ?? {},
-  }),
-  updateableColumns,
+  bodySchema: dailyBodySchema,
+  buildRow: buildDailyRow,
+  updateableColumns: [
+    "name",
+    "location",
+    "description",
+    "completions",
+    "courseProviderId",
+    "resourceId",
+    "moduleGroupId",
+    "moduleId",
+    "taskId",
+    "status",
+    "criteria",
+  ],
   generateIdIfMissing: true,
   returnId: true,
 });

--- a/packages/middleware/src/routes/api/domains/createDomain.ts
+++ b/packages/middleware/src/routes/api/domains/createDomain.ts
@@ -1,89 +1,32 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
-import {
-  domains,
-  domainWithinScopeTopics,
-} from "@/db/schema";
-import { sendBadRequest } from "@/utils/errors";
-import { nullableString } from "@/utils/schemas";
+import { domains, domainWithinScopeTopics } from "@/db/schema";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 import { syncDomainMembershipByDomain } from "@/utils/syncMembershipBlips";
-import { v4 as uuidv4 } from "uuid";
 
-const createSchema = {
-  schema: {
-    description: "Create a new domain",
-    body: {
-      type: "object",
-      required: ["title"],
-      properties: {
-        title: {
-          type: "string",
-          minLength: 1,
-        },
-        description: nullableString,
-        withinScopeDescription: nullableString,
-        outOfScopeDescription: nullableString,
-        topicIds: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-        withinScopeTopicIds: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
+import {
+  buildDomainRow,
+  buildWithinScopeTopicRows,
+  domainBodySchema,
+  validateDomainBody,
+} from "./domainRows";
+
+import type { DomainBody } from "./domainRows";
+
+export default createCreateHandler<DomainBody>({
+  description: "Create a new domain",
+  table: domains,
+  bodySchema: domainBodySchema,
+  validate: validateDomainBody,
+  buildRow: buildDomainRow,
+  junctions: [
+    {
+      table: domainWithinScopeTopics,
+      buildRows: (body, id) => buildWithinScopeTopicRows(body.withinScopeTopicIds, id),
     },
+  ],
+  afterCreate: async (body, id) => {
+    const uniqueTopicIds = Array.from(new Set(body.topicIds ?? []));
+    if (uniqueTopicIds.length > 0) {
+      await syncDomainMembershipByDomain(id, uniqueTopicIds);
+    }
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request, reply) {
-      const body = request.body;
-      const title = body.title.trim();
-      if (!title) {
-        return sendBadRequest(reply, "Title is required");
-      }
-      const id = uuidv4();
-
-      await db.insert(domains).values({
-        id,
-        title,
-        description: body.description ?? null,
-        withinScopeDescription: body.withinScopeDescription ?? null,
-        outOfScopeDescription: body.outOfScopeDescription ?? null,
-      });
-
-      const uniqueTopicIds = Array.from(new Set(body.topicIds ?? []));
-      if (uniqueTopicIds.length > 0) {
-        await syncDomainMembershipByDomain(id, uniqueTopicIds);
-      }
-
-      const uniqueWithinScopeTopicIds = Array.from(
-        new Set(body.withinScopeTopicIds ?? []),
-      );
-      if (uniqueWithinScopeTopicIds.length > 0) {
-        await db.insert(domainWithinScopeTopics).values(
-          uniqueWithinScopeTopicIds.map(topicId => ({
-            topicId,
-            domainId: id,
-          })),
-        );
-      }
-
-      return {
-        status: "ok",
-        id,
-      };
-    },
-  );
-}
+});

--- a/packages/middleware/src/routes/api/domains/domainRows.ts
+++ b/packages/middleware/src/routes/api/domains/domainRows.ts
@@ -1,0 +1,64 @@
+import { nullableString } from "../../../utils/schemas.ts";
+
+// Body schema and row builders shared by the domain create and upsert
+// handlers.
+
+export interface DomainBody {
+  title: string;
+  description?: string | null;
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
+  topicIds?: string[];
+  withinScopeTopicIds?: string[];
+}
+
+export const domainBodySchema = {
+  type: "object",
+  required: ["title"],
+  properties: {
+    title: {
+      type: "string",
+      minLength: 1,
+    },
+    description: nullableString,
+    withinScopeDescription: nullableString,
+    outOfScopeDescription: nullableString,
+    topicIds: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    withinScopeTopicIds: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+  },
+} as const;
+
+export function validateDomainBody(body: DomainBody) {
+  return body.title.trim() ? null : "Title is required";
+}
+
+export function buildDomainRow(body: DomainBody, id: string) {
+  return {
+    id,
+    title: body.title.trim(),
+    description: body.description ?? null,
+    withinScopeDescription: body.withinScopeDescription ?? null,
+    outOfScopeDescription: body.outOfScopeDescription ?? null,
+  };
+}
+
+export function buildWithinScopeTopicRows(
+  withinScopeTopicIds: readonly string[] | undefined,
+  domainId: string,
+) {
+  if (withinScopeTopicIds === undefined) return undefined;
+  return Array.from(new Set(withinScopeTopicIds)).map(topicId => ({
+    topicId,
+    domainId,
+  }));
+}

--- a/packages/middleware/src/routes/api/domains/upsertDomain.ts
+++ b/packages/middleware/src/routes/api/domains/upsertDomain.ts
@@ -1,53 +1,22 @@
 import { domains, domainWithinScopeTopics } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import { nullableString } from "@/utils/schemas";
 import { syncDomainMembershipByDomain } from "@/utils/syncMembershipBlips";
 
-interface DomainBody {
-  title: string;
-  description?: string | null;
-  withinScopeDescription?: string | null;
-  outOfScopeDescription?: string | null;
-  topicIds?: string[];
-  withinScopeTopicIds?: string[];
-}
+import {
+  buildDomainRow,
+  buildWithinScopeTopicRows,
+  domainBodySchema,
+  validateDomainBody,
+} from "./domainRows";
+
+import type { DomainBody } from "./domainRows";
 
 export default createUpsertHandler<DomainBody>({
   description: "Create or update a domain",
   table: domains,
-  bodySchema: {
-    type: "object",
-    required: ["title"],
-    properties: {
-      title: {
-        type: "string",
-        minLength: 1,
-      },
-      description: nullableString,
-      withinScopeDescription: nullableString,
-      outOfScopeDescription: nullableString,
-      topicIds: {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      },
-      withinScopeTopicIds: {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      },
-    },
-  },
-  validate: body => (body.title.trim() ? null : "Title is required"),
-  buildRow: (body, id) => ({
-    id,
-    title: body.title.trim(),
-    description: body.description ?? null,
-    withinScopeDescription: body.withinScopeDescription ?? null,
-    outOfScopeDescription: body.outOfScopeDescription ?? null,
-  }),
+  bodySchema: domainBodySchema,
+  validate: validateDomainBody,
+  buildRow: buildDomainRow,
   updateableColumns: [
     "title",
     "description",
@@ -58,13 +27,7 @@ export default createUpsertHandler<DomainBody>({
     {
       table: domainWithinScopeTopics,
       foreignKey: domainWithinScopeTopics.domainId,
-      buildRows: (body, id) => {
-        if (body.withinScopeTopicIds === undefined) return undefined;
-        return Array.from(new Set(body.withinScopeTopicIds)).map(topicId => ({
-          topicId,
-          domainId: id,
-        }));
-      },
+      buildRows: (body, id) => buildWithinScopeTopicRows(body.withinScopeTopicIds, id),
     },
   ],
   afterUpsert: async (body, id) => {

--- a/packages/middleware/src/routes/api/providers/createProvider.ts
+++ b/packages/middleware/src/routes/api/providers/createProvider.ts
@@ -1,69 +1,13 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { courseProviders } from "@/db/schema";
-import {
-  nullableBoolean,
-  nullableInteger,
-  nullableString,
-} from "@/utils/schemas";
-import { v4 as uuidv4 } from "uuid";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 
-const createSchema = {
-  schema: {
-    description: "Create a new provider",
-    body: {
-      type: "object",
-      required: ["name", "url"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        description: nullableString,
-        url: {
-          type: "string",
-        },
-        cost: nullableString,
-        isRecurring: nullableBoolean,
-        recurDate: nullableString,
-        recurPeriodUnit: {
-          type: ["string", "null"],
-          enum: ["days", "months", "years", null],
-        },
-        recurPeriod: nullableInteger,
-        isCourseFeesShared: nullableBoolean,
-      },
-    },
-  },
-} as const;
+import { buildProviderRow, providerBodySchema } from "./providerRows";
 
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+import type { ProviderBody } from "./providerRows";
 
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request, reply) {
-      const body = request.body;
-      const id = uuidv4();
-
-      await db.insert(courseProviders).values({
-        id,
-        name: body.name,
-        description: body.description ?? null,
-        url: body.url,
-        cost: body.cost ?? null,
-        isRecurring: body.isRecurring ?? null,
-        recurDate: body.recurDate ?? null,
-        recurPeriodUnit: body.recurPeriodUnit as "days" | "months" | "years" | undefined,
-        recurPeriod: body.recurPeriod ?? null,
-        isCourseFeesShared: body.isCourseFeesShared ?? null,
-      });
-
-      return {
-        status: "ok",
-        id,
-      };
-    },
-  );
-}
+export default createCreateHandler<ProviderBody>({
+  description: "Create a new provider",
+  table: courseProviders,
+  bodySchema: providerBodySchema,
+  buildRow: buildProviderRow,
+});

--- a/packages/middleware/src/routes/api/providers/providerRows.ts
+++ b/packages/middleware/src/routes/api/providers/providerRows.ts
@@ -1,0 +1,58 @@
+import {
+  nullableBoolean,
+  nullableInteger,
+  nullableString,
+} from "../../../utils/schemas.ts";
+
+// Body schema and row builder shared by the provider create and upsert
+// handlers.
+
+export interface ProviderBody {
+  name: string;
+  url: string;
+  description?: string | null;
+  cost?: string | null;
+  isRecurring?: boolean | null;
+  recurDate?: string | null;
+  recurPeriodUnit?: "days" | "months" | "years" | null;
+  recurPeriod?: number | null;
+  isCourseFeesShared?: boolean | null;
+}
+
+export const providerBodySchema = {
+  type: "object",
+  required: ["name", "url"],
+  properties: {
+    name: {
+      type: "string",
+    },
+    description: nullableString,
+    url: {
+      type: "string",
+    },
+    cost: nullableString,
+    isRecurring: nullableBoolean,
+    recurDate: nullableString,
+    recurPeriodUnit: {
+      type: ["string", "null"],
+      enum: ["days", "months", "years", null],
+    },
+    recurPeriod: nullableInteger,
+    isCourseFeesShared: nullableBoolean,
+  },
+} as const;
+
+export function buildProviderRow(body: ProviderBody, id: string) {
+  return {
+    id,
+    name: body.name,
+    description: body.description ?? null,
+    url: body.url,
+    cost: body.cost ?? null,
+    isRecurring: body.isRecurring ?? null,
+    recurDate: body.recurDate ?? null,
+    recurPeriodUnit: body.recurPeriodUnit ?? undefined,
+    recurPeriod: body.recurPeriod ?? null,
+    isCourseFeesShared: body.isCourseFeesShared ?? null,
+  };
+}

--- a/packages/middleware/src/routes/api/providers/upsertProvider.ts
+++ b/packages/middleware/src/routes/api/providers/upsertProvider.ts
@@ -1,71 +1,24 @@
 import { courseProviders } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import {
-  nullableBoolean,
-  nullableInteger,
-  nullableString,
-} from "@/utils/schemas";
 
-interface ProviderBody {
-  name: string;
-  url: string;
-  description?: string | null;
-  cost?: string | null;
-  isRecurring?: boolean | null;
-  recurDate?: string | null;
-  recurPeriodUnit?: "days" | "months" | "years" | null;
-  recurPeriod?: number | null;
-  isCourseFeesShared?: boolean | null;
-}
+import { buildProviderRow, providerBodySchema } from "./providerRows";
 
-const updateableColumns = [
-  "name",
-  "description",
-  "url",
-  "cost",
-  "isRecurring",
-  "recurDate",
-  "recurPeriodUnit",
-  "recurPeriod",
-  "isCourseFeesShared",
-] as const;
+import type { ProviderBody } from "./providerRows";
 
 export default createUpsertHandler<ProviderBody>({
   description: "Create or update a provider",
   table: courseProviders,
-  bodySchema: {
-    type: "object",
-    required: ["name", "url"],
-    properties: {
-      name: {
-        type: "string",
-      },
-      description: nullableString,
-      url: {
-        type: "string",
-      },
-      cost: nullableString,
-      isRecurring: nullableBoolean,
-      recurDate: nullableString,
-      recurPeriodUnit: {
-        type: ["string", "null"],
-        enum: ["days", "months", "years", null],
-      },
-      recurPeriod: nullableInteger,
-      isCourseFeesShared: nullableBoolean,
-    },
-  },
-  buildRow: (body, id) => ({
-    id,
-    name: body.name,
-    description: body.description ?? null,
-    url: body.url,
-    cost: body.cost ?? null,
-    isRecurring: body.isRecurring ?? null,
-    recurDate: body.recurDate ?? null,
-    recurPeriodUnit: body.recurPeriodUnit ?? undefined,
-    recurPeriod: body.recurPeriod ?? null,
-    isCourseFeesShared: body.isCourseFeesShared ?? null,
-  }),
-  updateableColumns,
+  bodySchema: providerBodySchema,
+  buildRow: buildProviderRow,
+  updateableColumns: [
+    "name",
+    "description",
+    "url",
+    "cost",
+    "isRecurring",
+    "recurDate",
+    "recurPeriodUnit",
+    "recurPeriod",
+    "isCourseFeesShared",
+  ],
 });

--- a/packages/middleware/src/routes/api/routines/createRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/createRoutine.ts
@@ -1,76 +1,20 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { db } from "@/db";
 import { routineConnections, routines } from "@/db/schema";
-import type { RoutineWeekly } from "@/db/schema";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 import { buildRoutineConnectionRows } from "@/utils/routineConnectionRows";
-import {
-  completionSchema,
-  criteriaSchema,
-  nullableRoutineModeEnum,
-  nullableRoutineStatusEnum,
-  nullableString,
-  routineConnectionsSchema,
-  weeklySchema,
-} from "@/utils/schemas";
-import { v4 as uuidv4 } from "uuid";
 
-const createSchema = {
-  schema: {
-    description: "Create a new routine",
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        description: nullableString,
-        connections: routineConnectionsSchema,
-        status: nullableRoutineStatusEnum,
-        weekly: weeklySchema,
-        mode: nullableRoutineModeEnum,
-        completions: {
-          type: "array",
-          items: completionSchema,
-        },
-        criteria: criteriaSchema,
-      },
+import { buildRoutineRow, routineBodySchema } from "./routineRows";
+
+import type { RoutineBody } from "./routineRows";
+
+export default createCreateHandler<RoutineBody>({
+  description: "Create a new routine",
+  table: routines,
+  bodySchema: routineBodySchema,
+  buildRow: buildRoutineRow,
+  junctions: [
+    {
+      table: routineConnections,
+      buildRows: (body, id) => buildRoutineConnectionRows(body.connections, id),
     },
-  },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request) {
-      const body = request.body;
-      const id = uuidv4();
-
-      await db.insert(routines).values({
-        id,
-        name: body.name,
-        description: body.description ?? null,
-        status: body.status ?? "active",
-        weekly: (body.weekly ?? {}) as RoutineWeekly,
-        mode: body.mode ?? "weekly",
-        completions: (body.completions ?? []) as DailyCompletion[],
-        criteria: (body.criteria ?? {}) as DailyCriteria,
-      });
-
-      const connectionRows = buildRoutineConnectionRows(body.connections, id);
-      if (connectionRows.length > 0) {
-        await db.insert(routineConnections).values(connectionRows);
-      }
-
-      return {
-        status: "ok",
-        id,
-      };
-    },
-  );
-}
+  ],
+});

--- a/packages/middleware/src/routes/api/routines/routineRows.ts
+++ b/packages/middleware/src/routes/api/routines/routineRows.ts
@@ -1,0 +1,60 @@
+import {
+  completionSchema,
+  criteriaSchema,
+  nullableRoutineModeEnum,
+  nullableRoutineStatusEnum,
+  nullableString,
+  routineConnectionsSchema,
+  weeklySchema,
+} from "../../../utils/schemas.ts";
+
+import type { RoutineConnectionInput } from "@/utils/routineConnectionRows";
+import type { RoutineWeekly } from "@/db/schema";
+import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+
+// Body schema and row builder shared by the routine create and upsert
+// handlers.
+
+export interface RoutineBody {
+  name: string;
+  description?: string | null;
+  connections?: RoutineConnectionInput[];
+  status?: "active" | "inactive" | "complete" | "paused" | null;
+  weekly?: RoutineWeekly;
+  mode?: "weekly" | "daily" | null;
+  completions?: DailyCompletion[];
+  criteria?: DailyCriteria;
+}
+
+export const routineBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+    },
+    description: nullableString,
+    connections: routineConnectionsSchema,
+    status: nullableRoutineStatusEnum,
+    weekly: weeklySchema,
+    mode: nullableRoutineModeEnum,
+    completions: {
+      type: "array",
+      items: completionSchema,
+    },
+    criteria: criteriaSchema,
+  },
+} as const;
+
+export function buildRoutineRow(body: RoutineBody, id: string) {
+  return {
+    id,
+    name: body.name,
+    description: body.description ?? null,
+    status: body.status ?? "active",
+    weekly: body.weekly ?? {},
+    mode: body.mode ?? "weekly",
+    completions: body.completions ?? [],
+    criteria: body.criteria ?? {},
+  };
+}

--- a/packages/middleware/src/routes/api/routines/upsertRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/upsertRoutine.ts
@@ -1,63 +1,16 @@
 import { routineConnections, routines } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { buildRoutineConnectionRows } from "@/utils/routineConnectionRows";
-import {
-  completionSchema,
-  criteriaSchema,
-  nullableRoutineModeEnum,
-  nullableRoutineStatusEnum,
-  nullableString,
-  routineConnectionsSchema,
-  weeklySchema,
-} from "@/utils/schemas";
 
-import type { RoutineConnectionInput } from "@/utils/routineConnectionRows";
-import type { RoutineWeekly } from "@/db/schema";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import { buildRoutineRow, routineBodySchema } from "./routineRows";
 
-interface RoutineBody {
-  name: string;
-  description?: string | null;
-  connections?: RoutineConnectionInput[];
-  status?: "active" | "inactive" | "complete" | "paused" | null;
-  weekly?: RoutineWeekly;
-  mode?: "weekly" | "daily" | null;
-  completions?: DailyCompletion[];
-  criteria?: DailyCriteria;
-}
+import type { RoutineBody } from "./routineRows";
 
 export default createUpsertHandler<RoutineBody>({
   description: "Create or update a routine",
   table: routines,
-  bodySchema: {
-    type: "object",
-    required: ["name"],
-    properties: {
-      name: {
-        type: "string",
-      },
-      description: nullableString,
-      connections: routineConnectionsSchema,
-      status: nullableRoutineStatusEnum,
-      weekly: weeklySchema,
-      mode: nullableRoutineModeEnum,
-      completions: {
-        type: "array",
-        items: completionSchema,
-      },
-      criteria: criteriaSchema,
-    },
-  },
-  buildRow: (body, id) => ({
-    id,
-    name: body.name,
-    description: body.description ?? null,
-    status: body.status ?? "active",
-    weekly: body.weekly ?? {},
-    mode: body.mode ?? "weekly",
-    completions: body.completions ?? [],
-    criteria: body.criteria ?? {},
-  }),
+  bodySchema: routineBodySchema,
+  buildRow: buildRoutineRow,
   updateableColumns: [
     "name",
     "description",

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -1,22 +1,5 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { v4 as uuidv4 } from "uuid";
-
-import { db } from "@/db";
-import {
-  taskResources,
-  taskTodos,
-  tasks,
-  tasksToResources,
-  tasksToTags,
-} from "@/db/schema";
-import {
-  nullableString,
-  resourceLinksArraySchema,
-  resourceSchema,
-  tagIdsArraySchema,
-  todoSchema,
-} from "@/utils/schemas";
+import { taskResources, taskTodos, tasks, tasksToResources, tasksToTags } from "@/db/schema";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 
 import {
   buildResourceLinkRows,
@@ -24,72 +7,32 @@ import {
   buildTaskResourceRows,
   buildTaskRow,
   buildTodoRows,
+  taskBodySchema,
 } from "./taskRows";
 
-const createSchema = {
-  schema: {
-    description: "Create a new task",
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
-          type: "string",
-        },
-        description: nullableString,
-        topicId: nullableString,
-        taskTypeId: nullableString,
-        tagIds: tagIdsArraySchema,
-        resourceLinks: resourceLinksArraySchema,
-        resources: {
-          type: "array",
-          items: resourceSchema,
-        },
-        todos: {
-          type: "array",
-          items: todoSchema,
-        },
-      },
+import type { TaskBody } from "./taskRows";
+
+export default createCreateHandler<TaskBody>({
+  description: "Create a new task",
+  table: tasks,
+  bodySchema: taskBodySchema,
+  buildRow: buildTaskRow,
+  junctions: [
+    {
+      table: tasksToTags,
+      buildRows: (body, id) => buildTagRows(body.tagIds, id),
     },
-  },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request) {
-      const body = request.body;
-      const id = uuidv4();
-
-      await db.insert(tasks).values(buildTaskRow(body, id));
-
-      const tagRows = buildTagRows(body.tagIds, id) ?? [];
-      if (tagRows.length > 0) {
-        await db.insert(tasksToTags).values(tagRows);
-      }
-
-      const linkRows = buildResourceLinkRows(body.resourceLinks, id) ?? [];
-      if (linkRows.length > 0) {
-        await db.insert(tasksToResources).values(linkRows);
-      }
-
-      const resourceRows = buildTaskResourceRows(body.resources, id) ?? [];
-      if (resourceRows.length > 0) {
-        await db.insert(taskResources).values(resourceRows);
-      }
-
-      const todoRows = buildTodoRows(body.todos, id) ?? [];
-      if (todoRows.length > 0) {
-        await db.insert(taskTodos).values(todoRows);
-      }
-
-      return {
-        status: "ok",
-        id,
-      };
+    {
+      table: tasksToResources,
+      buildRows: (body, id) => buildResourceLinkRows(body.resourceLinks, id),
     },
-  );
-}
+    {
+      table: taskResources,
+      buildRows: (body, id) => buildTaskResourceRows(body.resources, id),
+    },
+    {
+      table: taskTodos,
+      buildRows: (body, id) => buildTodoRows(body.todos, id),
+    },
+  ],
+});

--- a/packages/middleware/src/routes/api/tasks/taskRows.ts
+++ b/packages/middleware/src/routes/api/tasks/taskRows.ts
@@ -1,9 +1,17 @@
 import { v4 as uuidv4 } from "uuid";
 
-// Pure row builders shared by the task create and upsert handlers. Each
-// junction builder returns `undefined` when its input is absent — callers
-// (createUpsertHandler junctions) treat that as "leave existing rows
-// untouched", while `[]` means "clear all rows".
+import {
+  nullableString,
+  resourceLinksArraySchema,
+  resourceSchema,
+  tagIdsArraySchema,
+  todoSchema,
+} from "../../../utils/schemas.ts";
+
+// Body schema and pure row builders shared by the task create and upsert
+// handlers. Each junction builder returns `undefined` when its input is
+// absent — callers (createUpsertHandler junctions) treat that as "leave
+// existing rows untouched", while `[]` means "clear all rows".
 
 export interface TaskBodyFields {
   name: string;
@@ -34,6 +42,36 @@ export interface TodoInput {
   isComplete?: boolean | null;
   url?: string | null;
 }
+
+export interface TaskBody extends TaskBodyFields {
+  tagIds?: string[];
+  resourceLinks?: ResourceLinkInput[];
+  resources?: TaskResourceInput[];
+  todos?: TodoInput[];
+}
+
+export const taskBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+    },
+    description: nullableString,
+    topicId: nullableString,
+    taskTypeId: nullableString,
+    tagIds: tagIdsArraySchema,
+    resourceLinks: resourceLinksArraySchema,
+    resources: {
+      type: "array",
+      items: resourceSchema,
+    },
+    todos: {
+      type: "array",
+      items: todoSchema,
+    },
+  },
+} as const;
 
 export function buildTaskRow(body: TaskBodyFields, id: string) {
   return {

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -1,12 +1,5 @@
 import { taskResources, taskTodos, tasks, tasksToResources, tasksToTags } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import {
-  nullableString,
-  resourceLinksArraySchema,
-  resourceSchema,
-  tagIdsArraySchema,
-  todoSchema,
-} from "@/utils/schemas";
 
 import {
   buildResourceLinkRows,
@@ -14,47 +7,15 @@ import {
   buildTaskResourceRows,
   buildTaskRow,
   buildTodoRows,
+  taskBodySchema,
 } from "./taskRows";
 
-import type {
-  ResourceLinkInput,
-  TaskBodyFields,
-  TaskResourceInput,
-  TodoInput,
-} from "./taskRows";
-
-interface TaskBody extends TaskBodyFields {
-  tagIds?: string[];
-  resourceLinks?: ResourceLinkInput[];
-  resources?: TaskResourceInput[];
-  todos?: TodoInput[];
-}
+import type { TaskBody } from "./taskRows";
 
 export default createUpsertHandler<TaskBody>({
   description: "Update a task and its resources",
   table: tasks,
-  bodySchema: {
-    type: "object",
-    required: ["name"],
-    properties: {
-      name: {
-        type: "string",
-      },
-      description: nullableString,
-      topicId: nullableString,
-      taskTypeId: nullableString,
-      tagIds: tagIdsArraySchema,
-      resourceLinks: resourceLinksArraySchema,
-      resources: {
-        type: "array",
-        items: resourceSchema,
-      },
-      todos: {
-        type: "array",
-        items: todoSchema,
-      },
-    },
-  },
+  bodySchema: taskBodySchema,
   buildRow: buildTaskRow,
   updateableColumns: ["name", "description", "topicId", "taskTypeId"],
   junctions: [

--- a/packages/middleware/src/routes/api/topics/createTopic.ts
+++ b/packages/middleware/src/routes/api/topics/createTopic.ts
@@ -1,79 +1,35 @@
-import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
-import { FastifyInstance } from "fastify";
-import { v4 as uuidv4 } from "uuid";
-
-import { db } from "@/db";
 import { topics, topicsToResources, topicsToTags } from "@/db/schema";
-import {
-  nullableString,
-  resourceLinksArraySchema,
-  tagIdsArraySchema,
-} from "@/utils/schemas";
+import { createCreateHandler } from "@/utils/createCreateHandler";
 import { syncDomainMembershipByTopic } from "@/utils/syncMembershipBlips";
 
 import {
   buildTopicResourceLinkRows,
   buildTopicRow,
   buildTopicTagRows,
+  topicBodySchema,
 } from "./topicRows";
 
-const createSchema = {
-  schema: {
-    description: "Create a new topic",
-    body: {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: {
-          type: "string",
-          minLength: 1,
-        },
-        description: nullableString,
-        reason: nullableString,
-        domainIds: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-        tagIds: tagIdsArraySchema,
-        resourceLinks: resourceLinksArraySchema,
-      },
+import type { TopicBody } from "./topicRows";
+
+export default createCreateHandler<TopicBody>({
+  description: "Create a new topic",
+  table: topics,
+  bodySchema: topicBodySchema,
+  buildRow: buildTopicRow,
+  junctions: [
+    {
+      table: topicsToTags,
+      buildRows: (body, id) => buildTopicTagRows(body.tagIds, id),
     },
+    {
+      table: topicsToResources,
+      buildRows: (body, id) => buildTopicResourceLinkRows(body.resourceLinks, id),
+    },
+  ],
+  afterCreate: async (body, id) => {
+    const uniqueDomainIds = Array.from(new Set(body.domainIds ?? []));
+    if (uniqueDomainIds.length > 0) {
+      await syncDomainMembershipByTopic(id, uniqueDomainIds);
+    }
   },
-} as const;
-
-export default async function (server: FastifyInstance) {
-  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
-
-  fastify.post(
-    "/",
-    createSchema,
-    async function (request) {
-      const body = request.body;
-      const id = uuidv4();
-
-      await db.insert(topics).values(buildTopicRow(body, id));
-
-      const uniqueDomainIds = Array.from(new Set(body.domainIds ?? []));
-      if (uniqueDomainIds.length > 0) {
-        await syncDomainMembershipByTopic(id, uniqueDomainIds);
-      }
-
-      const tagRows = buildTopicTagRows(body.tagIds, id) ?? [];
-      if (tagRows.length > 0) {
-        await db.insert(topicsToTags).values(tagRows);
-      }
-
-      const linkRows = buildTopicResourceLinkRows(body.resourceLinks, id) ?? [];
-      if (linkRows.length > 0) {
-        await db.insert(topicsToResources).values(linkRows);
-      }
-
-      return {
-        status: "ok",
-        id,
-      };
-    },
-  );
-}
+});

--- a/packages/middleware/src/routes/api/topics/topicRows.ts
+++ b/packages/middleware/src/routes/api/topics/topicRows.ts
@@ -1,8 +1,14 @@
 import { v4 as uuidv4 } from "uuid";
 
-// Pure row builders shared by the topic create and upsert handlers. Junction
-// builders return `undefined` when their input is absent (= leave existing
-// rows untouched) and `[]` to clear.
+import {
+  nullableString,
+  resourceLinksArraySchema,
+  tagIdsArraySchema,
+} from "../../../utils/schemas.ts";
+
+// Body schema and pure row builders shared by the topic create and upsert
+// handlers. Junction builders return `undefined` when their input is absent
+// (= leave existing rows untouched) and `[]` to clear.
 
 export interface TopicBodyFields {
   name: string;
@@ -15,6 +21,33 @@ export interface TopicResourceLinkInput {
   moduleGroupId?: string | null;
   moduleId?: string | null;
 }
+
+export interface TopicBody extends TopicBodyFields {
+  domainIds?: string[];
+  tagIds?: string[];
+  resourceLinks?: TopicResourceLinkInput[];
+}
+
+export const topicBodySchema = {
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: {
+      type: "string",
+      minLength: 1,
+    },
+    description: nullableString,
+    reason: nullableString,
+    domainIds: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+    },
+    tagIds: tagIdsArraySchema,
+    resourceLinks: resourceLinksArraySchema,
+  },
+} as const;
 
 export function buildTopicRow(body: TopicBodyFields, id: string) {
   return {

--- a/packages/middleware/src/routes/api/topics/upsertTopic.ts
+++ b/packages/middleware/src/routes/api/topics/upsertTopic.ts
@@ -1,49 +1,20 @@
 import { topics, topicsToResources, topicsToTags } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import {
-  nullableString,
-  resourceLinksArraySchema,
-  tagIdsArraySchema,
-} from "@/utils/schemas";
 import { syncDomainMembershipByTopic } from "@/utils/syncMembershipBlips";
 
 import {
   buildTopicResourceLinkRows,
   buildTopicRow,
   buildTopicTagRows,
+  topicBodySchema,
 } from "./topicRows";
 
-import type { TopicBodyFields, TopicResourceLinkInput } from "./topicRows";
-
-interface TopicBody extends TopicBodyFields {
-  domainIds?: string[];
-  tagIds?: string[];
-  resourceLinks?: TopicResourceLinkInput[];
-}
+import type { TopicBody } from "./topicRows";
 
 export default createUpsertHandler<TopicBody>({
   description: "Update a topic",
   table: topics,
-  bodySchema: {
-    type: "object",
-    required: ["name"],
-    properties: {
-      name: {
-        type: "string",
-        minLength: 1,
-      },
-      description: nullableString,
-      reason: nullableString,
-      domainIds: {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      },
-      tagIds: tagIdsArraySchema,
-      resourceLinks: resourceLinksArraySchema,
-    },
-  },
+  bodySchema: topicBodySchema,
   buildRow: buildTopicRow,
   updateableColumns: ["name", "description", "reason"],
   junctions: [

--- a/packages/middleware/src/utils/createCreateHandler.ts
+++ b/packages/middleware/src/utils/createCreateHandler.ts
@@ -1,0 +1,79 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance, FastifyReply } from "fastify";
+import { PgTable } from "drizzle-orm/pg-core";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { sendBadRequest } from "./errors";
+
+type Row = Record<string, unknown>;
+
+interface CreateJunctionConfig<TBody> {
+  table: PgTable;
+  /** Return `undefined` or `[]` to insert nothing for a fresh entity. */
+  buildRows: (body: TBody, id: string) => Row[] | undefined;
+}
+
+interface CreateHandlerOptions<TBody> {
+  description: string;
+  table: PgTable;
+  /** JSON Schema for the request body (passed straight through to Fastify). */
+  bodySchema: object;
+  buildRow: (body: TBody, id: string) => Row;
+  junctions?: readonly CreateJunctionConfig<TBody>[];
+  /** Runs after the row and junctions are written (cross-table side effects). */
+  afterCreate?: (body: TBody, id: string) => Promise<void>;
+  /** Return an error message string to abort with 400, or null to proceed. */
+  validate?: (body: TBody) => string | null;
+}
+
+/**
+ * POST `/` counterpart to createUpsertHandler: generates a fresh uuid, inserts
+ * the row and any junction rows, and responds `{ status: "ok", id }`. Share
+ * the bodySchema and row builders with the entity's upsert handler (see
+ * `topics/topicRows.ts`).
+ */
+export function createCreateHandler<TBody = Record<string, unknown>>(
+  options: CreateHandlerOptions<TBody>,
+) {
+  const schema = {
+    schema: {
+      description: options.description,
+      body: options.bodySchema,
+    },
+  } as const;
+
+  return async function (server: FastifyInstance) {
+    const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+    fastify.post("/", schema, async function (request, reply: FastifyReply) {
+      const body = request.body as TBody;
+
+      if (options.validate) {
+        const errorMessage = options.validate(body);
+        if (errorMessage !== null) {
+          return sendBadRequest(reply, errorMessage);
+        }
+      }
+
+      const id = uuidv4();
+
+      await db.insert(options.table).values(options.buildRow(body, id) as never);
+
+      for (const junction of options.junctions ?? []) {
+        const rows = junction.buildRows(body, id) ?? [];
+        if (rows.length > 0) {
+          await db.insert(junction.table).values(rows as never[]);
+        }
+      }
+
+      if (options.afterCreate) {
+        await options.afterCreate(body, id);
+      }
+
+      return {
+        status: "ok",
+        id,
+      };
+    });
+  };
+}

--- a/packages/middleware/src/utils/processCost.ts
+++ b/packages/middleware/src/utils/processCost.ts
@@ -1,7 +1,20 @@
 import type { CostData } from "@emstack/types";
-import { ResourceFromServer } from "@emstack/types";
 
-export function processCost(course: ResourceFromServer): CostData {
+/**
+ * The fields cost computation actually reads. Any resource row queried with
+ * its courseProvider (and the provider's resources, for fee splitting) is
+ * assignable here.
+ */
+export interface CostSource {
+  cost?: string | null;
+  courseProvider?: {
+    cost?: string | null;
+    isCourseFeesShared?: boolean | null;
+    resources?: unknown[] | null;
+  } | null;
+}
+
+export function processCost(course: CostSource): CostData {
   let costData: CostData = {
     cost: null,
     isCostFromPlatform: false,

--- a/packages/middleware/src/utils/resourceProjection.ts
+++ b/packages/middleware/src/utils/resourceProjection.ts
@@ -3,7 +3,6 @@ import { processResourceLinks } from "@/utils/processResourceLinks";
 import type {
   CostData,
   Resource,
-  ResourceFromServer,
   Tag,
   TopicsToResources,
 } from "@emstack/types";
@@ -24,14 +23,18 @@ interface ResourceProjectionRow {
   easeOfStarting: Resource["easeOfStarting"];
   timeNeeded: Resource["timeNeeded"];
   interactivity: Resource["interactivity"];
+  cost: string | null;
   courseProvider: { id: string;
-    name: string | null; } | null;
+    name: string | null;
+    cost: string | null;
+    isCourseFeesShared: boolean | null;
+    resources: unknown[]; } | null;
   topicsToResources: TopicsToResources[];
   resourceTags: { tag: Tag }[];
 }
 
 export function mapResource(course: ResourceProjectionRow): Resource {
-  const cost: CostData = processCost(course as unknown as ResourceFromServer);
+  const cost: CostData = processCost(course);
   return {
     id: course.id,
     name: course.name,

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -196,7 +196,6 @@ export const tagIdsArraySchema = {
   items: {
     type: "string",
   },
-  default: [],
 } as const;
 
 export const resourceLinkSchema = {
@@ -214,7 +213,6 @@ export const resourceLinkSchema = {
 export const resourceLinksArraySchema = {
   type: "array",
   items: resourceLinkSchema,
-  default: [],
 } as const;
 
 // Schema for a task's freeform resource entry. Ease/time/interactivity/tags

--- a/packages/middleware/src/utils/syncJunctionTable.ts
+++ b/packages/middleware/src/utils/syncJunctionTable.ts
@@ -2,14 +2,14 @@ import { eq } from "drizzle-orm";
 import { AnyPgColumn, PgTable } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 
-export async function syncJunctionTable<TRow extends Record<string, unknown>>(
-  table: PgTable,
+export async function syncJunctionTable<TTable extends PgTable>(
+  table: TTable,
   parentColumn: AnyPgColumn,
   parentId: string,
-  rows: TRow[],
+  rows: TTable["$inferInsert"][],
 ) {
   await db.delete(table).where(eq(parentColumn, parentId));
   if (rows.length > 0) {
-    await db.insert(table).values(rows as any);
+    await db.insert(table).values(rows);
   }
 }


### PR DESCRIPTION
- eslint --cache (content strategy, cache in node_modules/.cache/eslint/)
  on lint, lint:fix, and lint-staged: warm runs drop from ~35s to ~2s
- incremental: true in client tsconfigs (tsBuildInfoFile was already set
  but unused without it): warm typecheck drops from ~14s to ~4s

https://claude.ai/code/session_01BzGgiSFzkxkTyYn9R9eGZZ