### PR TITLE
Add weekly target ("days per week") to daily routines

### DIFF
--- a/packages/client/src/components/dailies/DailiesLimitSetting.tsx
+++ b/packages/client/src/components/dailies/DailiesLimitSetting.tsx
@@ -1,3 +1,5 @@
+import type { WeekTargetWindow } from "@/context/SettingsProviderContext";
+
 import { useState } from "react";
 
 import { SettingsIcon } from "lucide-react";
@@ -9,11 +11,25 @@ import {
   PopoverTrigger,
 } from "@/components/popover";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { WEEK_TARGET_WINDOWS } from "@/context/SettingsProviderContext";
 import { useSettings } from "@/hooks/useSettings";
+
+const WEEK_WINDOW_LABELS: Record<WeekTargetWindow, string> = {
+  sunday: "Week starts Sunday",
+  monday: "Week starts Monday",
+  rolling7: "Rolling 7 days",
+};
 
 export function DailiesLimitSetting() {
   const {
-    settings, setMaxActiveDailies,
+    settings, setMaxActiveDailies, setWeekTargetWindow,
   } = useSettings();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(String(settings.maxActiveDailies));
@@ -41,8 +57,8 @@ export function DailiesLimitSetting() {
           type="button"
           variant="ghost"
           size="sm"
-          aria-label="Configure active dailies limit"
-          title="Configure active dailies limit"
+          aria-label="Routine tracker settings"
+          title="Routine tracker settings"
         >
           <SettingsIcon className="size-4" />
         </Button>
@@ -91,6 +107,39 @@ export function DailiesLimitSetting() {
             </Button>
           </div>
         </form>
+        <div className="mt-3 flex flex-col gap-2 border-t pt-3">
+          <label
+            className="text-sm font-medium"
+            htmlFor="week-target-window"
+          >
+            Weekly target reset
+          </label>
+          <p className="text-xs text-muted-foreground">
+            How a daily routine&apos;s “days per week” target counts a week.
+          </p>
+          <Select
+            value={settings.weekTargetWindow}
+            onValueChange={value =>
+              setWeekTargetWindow(value as WeekTargetWindow)}
+          >
+            <SelectTrigger
+              id="week-target-window"
+              className="w-full"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WEEK_TARGET_WINDOWS.map(window => (
+                <SelectItem
+                  key={window}
+                  value={window}
+                >
+                  {WEEK_WINDOW_LABELS[window]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/packages/client/src/components/dailies/DailyTitle.tsx
+++ b/packages/client/src/components/dailies/DailyTitle.tsx
@@ -7,7 +7,9 @@ import type {
 
 import { ActionableSentence } from "./ActionableSentence";
 
+import { useSettings } from "@/hooks/useSettings";
 import { cn } from "@/lib/utils";
+import { getTodayKey, isWeeklyTargetMet } from "@/utils";
 
 // The action name (the assigned task/resource/freeform the routine points at,
 // with any prepend/append affixes) on top, and a smaller, de-emphasized subtitle
@@ -31,18 +33,33 @@ export function DailyTitle({
     weekly?: RoutineWeekly | null;
   };
 
+  const {
+    settings,
+  } = useSettings();
+
   const isWeekly = routineView.mode === "weekly";
   const todayWeekday = String(new Date().getDay()) as RoutineWeekday;
   const todayEntry = isWeekly ? routineView.weekly?.[todayWeekday] : null;
   const hasTodayEntry = !!(todayEntry && todayEntry.id);
 
-  // Weekly: today's note when scheduled, else a placeholder. Daily: description.
+  // A daily-mode routine that's met its weekly target needs nothing more today.
+  // Completed/paused routines don't track a "today", so the note doesn't apply.
+  const isActive = daily.status !== "complete" && daily.status !== "paused";
+  const targetMet
+    = !isWeekly
+      && isActive
+      && isWeeklyTargetMet(daily, getTodayKey(), settings.weekTargetWindow);
+
+  // Weekly: today's note when scheduled, else a placeholder. Daily: the
+  // "nothing required today" note when the target is met, otherwise description.
   const subtitle = isWeekly
     ? hasTodayEntry
       ? (todayEntry?.notes ?? null)
       : "Nothing scheduled today"
-    : (daily.description ?? null);
-  const isPlaceholder = isWeekly && !hasTodayEntry;
+    : targetMet
+      ? "Nothing required today"
+      : (daily.description ?? null);
+  const isPlaceholder = (isWeekly && !hasTodayEntry) || targetMet;
   const showSubtitle = subtitle != null && subtitle !== "";
 
   return (

--- a/packages/client/src/context/SettingsProvider.tsx
+++ b/packages/client/src/context/SettingsProvider.tsx
@@ -1,11 +1,16 @@
-import type { DailiesViewMode } from "@/context/SettingsProviderContext";
+import type {
+  DailiesViewMode,
+  WeekTargetWindow,
+} from "@/context/SettingsProviderContext";
 import type { ReactNode } from "react";
 
 import { useEffect, useState } from "react";
 
 import {
   DEFAULT_MAX_ACTIVE_DAILIES,
+  DEFAULT_WEEK_TARGET_WINDOW,
   SettingsProviderContext,
+  WEEK_TARGET_WINDOWS,
 } from "@/context/SettingsProviderContext";
 
 const STORAGE_KEY = "emstack-settings";
@@ -13,6 +18,7 @@ const STORAGE_KEY = "emstack-settings";
 interface PersistedSettings {
   maxActiveDailies?: number;
   dailiesViewMode?: DailiesViewMode | null;
+  weekTargetWindow?: WeekTargetWindow | null;
 }
 
 function readPersistedSettings(): PersistedSettings {
@@ -57,6 +63,16 @@ export function SettingsProvider({
       return null;
     });
 
+  const [weekTargetWindow, setWeekTargetWindowState]
+    = useState<WeekTargetWindow>(() => {
+      const persisted = readPersistedSettings();
+      if (persisted.weekTargetWindow
+        && WEEK_TARGET_WINDOWS.includes(persisted.weekTargetWindow)) {
+        return persisted.weekTargetWindow;
+      }
+      return DEFAULT_WEEK_TARGET_WINDOW;
+    });
+
   useEffect(() => {
     try {
       localStorage.setItem(
@@ -64,13 +80,14 @@ export function SettingsProvider({
         JSON.stringify({
           maxActiveDailies,
           dailiesViewMode,
+          weekTargetWindow,
         }),
       );
     }
     catch {
       // ignore quota errors
     }
-  }, [maxActiveDailies, dailiesViewMode]);
+  }, [maxActiveDailies, dailiesViewMode, weekTargetWindow]);
 
   const setMaxActiveDailies = (value: number) => {
     if (Number.isFinite(value) && value > 0) {
@@ -82,15 +99,21 @@ export function SettingsProvider({
     setDailiesViewModeState(value);
   };
 
+  const setWeekTargetWindow = (value: WeekTargetWindow) => {
+    setWeekTargetWindowState(value);
+  };
+
   return (
     <SettingsProviderContext.Provider
       value={{
         settings: {
           maxActiveDailies,
           dailiesViewMode,
+          weekTargetWindow,
         },
         setMaxActiveDailies,
         setDailiesViewMode,
+        setWeekTargetWindow,
       }}
     >
       {children}

--- a/packages/client/src/context/SettingsProviderContext.ts
+++ b/packages/client/src/context/SettingsProviderContext.ts
@@ -2,28 +2,45 @@ import { createContext } from "react";
 
 export type DailiesViewMode = "table" | "list";
 
+// How the "X days a week" routine target counts a week:
+// - "sunday"   : calendar week, Sunday → Saturday
+// - "monday"   : calendar week, Monday → Sunday
+// - "rolling7" : the trailing 7-day window ending today
+export type WeekTargetWindow = "sunday" | "monday" | "rolling7";
+
+export const WEEK_TARGET_WINDOWS: WeekTargetWindow[] = [
+  "sunday",
+  "monday",
+  "rolling7",
+];
+
 interface AppSettings {
   maxActiveDailies: number;
   dailiesViewMode: DailiesViewMode | null;
+  weekTargetWindow: WeekTargetWindow;
 }
 
 export const DEFAULT_MAX_ACTIVE_DAILIES = 5;
+export const DEFAULT_WEEK_TARGET_WINDOW: WeekTargetWindow = "sunday";
 
 const DEFAULT_SETTINGS: AppSettings = {
   maxActiveDailies: DEFAULT_MAX_ACTIVE_DAILIES,
   dailiesViewMode: null,
+  weekTargetWindow: DEFAULT_WEEK_TARGET_WINDOW,
 };
 
 export interface SettingsProviderState {
   settings: AppSettings;
   setMaxActiveDailies: (value: number) => void;
   setDailiesViewMode: (value: DailiesViewMode | null) => void;
+  setWeekTargetWindow: (value: WeekTargetWindow) => void;
 }
 
 const initialState: SettingsProviderState = {
   settings: DEFAULT_SETTINGS,
   setMaxActiveDailies: () => null,
   setDailiesViewMode: () => null,
+  setWeekTargetWindow: () => null,
 };
 
 export const SettingsProviderContext

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
@@ -90,6 +90,9 @@ const detailsSchema = z.object({
   status: z.enum(["active", "inactive", "complete", "paused"]),
   mode: z.enum(["weekly", "daily"]),
   weekly: z.array(weeklyRowSchema).length(7),
+  // Daily-mode only: how many days a week the routine needs doing. Null = no
+  // target (every day).
+  weeklyTarget: z.number().int().min(1).max(7).nullable(),
 });
 
 interface DetailsTabProps {
@@ -146,6 +149,7 @@ export function DetailsTab({
       status: routine.status ?? "active",
       mode: routine.mode ?? "weekly",
       weekly: weeklyToRows(routine.weekly),
+      weeklyTarget: routine.weeklyTarget ?? null,
     }),
     [routine],
   );
@@ -179,6 +183,9 @@ export function DetailsTab({
             value.mode === "daily"
               ? rowsToWeekly(fillAllDays(representativeRow(value.weekly)))
               : rowsToWeekly(value.weekly),
+          // The weekly target only applies to daily routines; clear it for
+          // weekly schedules.
+          weeklyTarget: value.mode === "daily" ? value.weeklyTarget : null,
         });
         lastSavedRef.current = value;
         onChangeStateChange?.(false);
@@ -324,6 +331,24 @@ export function DetailsTab({
               </div>
             )}
       </form.Field>
+
+      {isDaily && (
+        <div className="flex flex-col gap-1">
+          <form.AppField name="weeklyTarget">
+            {field => (
+              <field.NumberField
+                label="Days per week"
+                min={1}
+              />
+            )}
+          </form.AppField>
+          <p className="text-sm text-muted-foreground">
+            Optional. How many days a week this needs doing — once you hit it
+            (counting days you reached your goal), the tracker shows “Nothing
+            required today.” Leave blank to require it every day.
+          </p>
+        </div>
+      )}
 
       <div>
         <Button

--- a/packages/client/src/routes/routines.$id.index.tsx
+++ b/packages/client/src/routes/routines.$id.index.tsx
@@ -22,6 +22,7 @@ import {
   DAY_ORDER,
 } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
+import { useSettings } from "@/hooks/useSettings";
 import {
   connectionEntityKind,
   fetchResources,
@@ -31,6 +32,7 @@ import {
   getCurrentChain,
   getTodayKey,
   getTotalCompletedDays,
+  isWeeklyTargetMet,
   upsertRoutine,
   withCompletion,
   withCompletionNote,
@@ -72,6 +74,9 @@ function SingleRoutine() {
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const {
+    settings,
+  } = useSettings();
   const search = Route.useSearch();
   const tab: DailyDetailTab = search.tab ?? "details";
 
@@ -189,6 +194,17 @@ function SingleRoutine() {
     ? dailyEntry
     : (weekly[todayKey as keyof typeof weekly] ?? null);
   const completions = data.completions ?? [];
+  // Daily-mode routines with a met weekly target need nothing more today.
+  const weekTargetMet
+    = isDaily
+      && isWeeklyTargetMet(
+        {
+          completions,
+          weeklyTarget: data.weeklyTarget ?? null,
+        },
+        todayDateKey,
+        settings.weekTargetWindow,
+      );
   const chain = getCurrentChain({
     completions,
   });
@@ -270,6 +286,11 @@ function SingleRoutine() {
                 Nothing, take a break!
               </p>
             )}
+          {weekTargetMet && (
+            <p className="mt-2 text-sm text-muted-foreground italic">
+              Nothing required today — weekly goal met.
+            </p>
+          )}
         </DashboardCard>
         <DailyDetailsPanel
           dailyId={id}

--- a/packages/client/src/utils/dailyHelpers.test.ts
+++ b/packages/client/src/utils/dailyHelpers.test.ts
@@ -1,0 +1,117 @@
+import type { DailyCompletion } from "@emstack/types";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  getCompletedDaysThisWeek,
+  isWeeklyTargetMet,
+} from "./dailyHelpers.ts";
+
+// 2026-06-11 is a Thursday. The three windows that contain it:
+//   sunday   -> 2026-06-07 (Sun) … 2026-06-13 (Sat)
+//   monday   -> 2026-06-08 (Mon) … 2026-06-14 (Sun)
+//   rolling7 -> 2026-06-05 (Fri) … 2026-06-11 (Thu)
+const TODAY = "2026-06-11";
+
+const completions: DailyCompletion[] = [
+  {
+    date: "2026-06-05",
+    status: "exceeded",
+  }, // only rolling7
+  {
+    date: "2026-06-07",
+    status: "goal",
+  }, // sunday + rolling7
+  {
+    date: "2026-06-10",
+    status: "goal",
+  }, // all three windows
+  {
+    date: "2026-06-11",
+    status: "touched",
+  }, // never counts (not goal/exceeded)
+];
+
+describe("getCompletedDaysThisWeek", () => {
+  test("counts goal/exceeded days inside each window", () => {
+    expect(getCompletedDaysThisWeek({
+      completions,
+    }, TODAY, "sunday")).toBe(2);
+    expect(getCompletedDaysThisWeek({
+      completions,
+    }, TODAY, "monday")).toBe(1);
+    expect(getCompletedDaysThisWeek({
+      completions,
+    }, TODAY, "rolling7")).toBe(3);
+  });
+
+  test("ignores touched, freeze, incomplete and unset statuses", () => {
+    const soft: DailyCompletion[] = [
+      {
+        date: "2026-06-10",
+        status: "touched",
+      },
+      {
+        date: "2026-06-09",
+        status: "freeze",
+      },
+      {
+        date: "2026-06-08",
+        status: "incomplete",
+      },
+      {
+        date: "2026-06-07",
+      },
+    ];
+    expect(getCompletedDaysThisWeek({
+      completions: soft,
+    }, TODAY, "sunday"))
+      .toBe(0);
+  });
+});
+
+describe("isWeeklyTargetMet", () => {
+  test("true once goal/exceeded days reach the target for the window", () => {
+    expect(
+      isWeeklyTargetMet({
+        completions,
+        weeklyTarget: 2,
+      }, TODAY, "sunday"),
+    ).toBe(true);
+    expect(
+      isWeeklyTargetMet({
+        completions,
+        weeklyTarget: 3,
+      }, TODAY, "rolling7"),
+    ).toBe(true);
+  });
+
+  test("false when the window's count is below the target", () => {
+    expect(
+      isWeeklyTargetMet({
+        completions,
+        weeklyTarget: 2,
+      }, TODAY, "monday"),
+    ).toBe(false);
+  });
+
+  test("no target (null/0/undefined) is never met", () => {
+    expect(
+      isWeeklyTargetMet({
+        completions,
+        weeklyTarget: null,
+      }, TODAY, "rolling7"),
+    ).toBe(false);
+    expect(
+      isWeeklyTargetMet({
+        completions,
+        weeklyTarget: 0,
+      }, TODAY, "rolling7"),
+    ).toBe(false);
+    expect(
+      isWeeklyTargetMet({
+        completions,
+      }, TODAY, "rolling7"),
+    ).toBe(false);
+  });
+});

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -1,3 +1,4 @@
+import type { WeekTargetWindow } from "@/context/SettingsProviderContext";
 import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
 function getDateKey(date: Date = new Date()): string {
@@ -156,6 +157,65 @@ export function getRecentDays(
     });
   }
   return days;
+}
+
+// The inclusive [start, end] date-key range counted for a weekly target, given
+// the user's chosen window. Calendar weeks use JS getUTCDay (0 = Sunday); the
+// rolling window is simply the trailing 7 days ending today.
+function getWeekWindow(
+  todayKey: string,
+  window: WeekTargetWindow,
+): { start: string;
+  end: string; } {
+  if (window === "rolling7") {
+    return {
+      start: shiftDateKey(todayKey, -6),
+      end: todayKey,
+    };
+  }
+  const dow = new Date(`${todayKey}T00:00:00Z`).getUTCDay();
+  const offsetToStart = window === "monday" ? (dow === 0 ? 6 : dow - 1) : dow;
+  const start = shiftDateKey(todayKey, -offsetToStart);
+  return {
+    start,
+    end: shiftDateKey(start, 6),
+  };
+}
+
+// Only days the user actually hit their goal on count toward a weekly target —
+// a started-but-unfinished ("touched") or frozen day does not.
+function countsTowardTarget(
+  status: DailyCompletionStatus | undefined | null,
+): boolean {
+  return status === "goal" || status === "exceeded";
+}
+
+export function getCompletedDaysThisWeek(
+  daily: Pick<Daily, "completions">,
+  todayKey: string,
+  window: WeekTargetWindow,
+): number {
+  const {
+    start, end,
+  } = getWeekWindow(todayKey, window);
+  return daily.completions.filter(
+    c => countsTowardTarget(c.status) && c.date >= start && c.date <= end,
+  ).length;
+}
+
+// True for a daily-mode routine whose weekly target (N goal/exceeded days) has
+// already been reached or exceeded for the current window — i.e. nothing is
+// required today. No target (null / <= 0) is never "met".
+export function isWeeklyTargetMet(
+  daily: Pick<Daily, "completions" | "weeklyTarget">,
+  todayKey: string,
+  window: WeekTargetWindow,
+): boolean {
+  const target = daily.weeklyTarget;
+  if (!target || target <= 0) {
+    return false;
+  }
+  return getCompletedDaysThisWeek(daily, todayKey, window) >= target;
 }
 
 export function getDailyProgressPercent(daily: Daily): number {

--- a/packages/middleware/src/db/schema/routines.ts
+++ b/packages/middleware/src/db/schema/routines.ts
@@ -25,6 +25,9 @@ export const routines = pgTable("routines", {
   mode: routineModeEnum().default("weekly").notNull(),
   completions: jsonb().$type<DailyCompletion[]>().default([]).notNull(),
   criteria: jsonb().$type<DailyCriteria>().default({}).notNull(),
+  // For daily-mode routines: how many days a week the routine needs to be done.
+  // NULL means no target (do it every day). Days marked goal/exceeded count.
+  weeklyTarget: integer("weekly_target"),
 });
 
 // Polymorphic many-to-many link from a routine to Topics, Tasks, and/or

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -47,6 +47,7 @@ export default async function (server: FastifyInstance) {
         mode: source.mode,
         completions: [],
         criteria: source.criteria ?? {},
+        weeklyTarget: source.weeklyTarget ?? null,
       });
 
       // Carry the source's connections over to the copy with fresh row ids.

--- a/packages/middleware/src/routes/api/routines/routineRows.ts
+++ b/packages/middleware/src/routes/api/routines/routineRows.ts
@@ -1,6 +1,7 @@
 import {
   completionSchema,
   criteriaSchema,
+  nullableInteger,
   nullableRoutineModeEnum,
   nullableRoutineStatusEnum,
   nullableString,
@@ -24,6 +25,7 @@ export interface RoutineBody {
   mode?: "weekly" | "daily" | null;
   completions?: DailyCompletion[];
   criteria?: DailyCriteria;
+  weeklyTarget?: number | null;
 }
 
 export const routineBodySchema = {
@@ -43,6 +45,7 @@ export const routineBodySchema = {
       items: completionSchema,
     },
     criteria: criteriaSchema,
+    weeklyTarget: nullableInteger,
   },
 } as const;
 
@@ -56,5 +59,6 @@ export function buildRoutineRow(body: RoutineBody, id: string) {
     mode: body.mode ?? "weekly",
     completions: body.completions ?? [],
     criteria: body.criteria ?? {},
+    weeklyTarget: body.weeklyTarget ?? null,
   };
 }

--- a/packages/middleware/src/routes/api/routines/upsertRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/upsertRoutine.ts
@@ -19,6 +19,7 @@ export default createUpsertHandler<RoutineBody>({
     "mode",
     "completions",
     "criteria",
+    "weeklyTarget",
   ],
   // Partial merge: only the columns present in the request body are written
   // on update. The daily tracker / dashboard / comment popover send partial
@@ -46,6 +47,9 @@ export default createUpsertHandler<RoutineBody>({
     }
     if (body.criteria !== undefined) {
       set.criteria = body.criteria;
+    }
+    if (body.weeklyTarget !== undefined) {
+      set.weeklyTarget = body.weeklyTarget ?? null;
     }
     return set;
   },

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -48,6 +48,7 @@ export interface RoutineRow {
   mode: RoutineMode;
   completions: DailyCompletion[];
   criteria: DailyCriteria;
+  weeklyTarget: number | null;
   connections?: RoutineConnection[];
 }
 
@@ -57,6 +58,7 @@ export interface RoutineRow {
 export type RoutineDaily = Daily & {
   mode: RoutineMode;
   weekly: RoutineWeekly;
+  weeklyTarget: number | null;
   connections: RoutineConnection[];
 };
 
@@ -119,6 +121,7 @@ export function mapRoutineToDaily(
     actionParts,
     mode: routine.mode,
     weekly: routine.weekly ?? {},
+    weeklyTarget: routine.weeklyTarget ?? null,
     connections: routine.connections ?? [],
   };
 }

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -73,4 +73,8 @@ export interface Daily {
   weekly?: RoutineWeekly | null;
   // Routine mode. "weekly" means the `weekly` grid is meaningful per day.
   mode?: RoutineMode | null;
+  // Weekly target for daily-mode routines: how many days a week it needs doing.
+  // Null/absent means no target. Carried through the routine projection so the
+  // tracker can show a "nothing required today" note once the target is met.
+  weeklyTarget?: number | null;
 }

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -53,4 +53,7 @@ export interface Routine {
   mode?: RoutineMode | null;
   completions?: DailyCompletion[] | null;
   criteria?: DailyCriteria | null;
+  // For daily-mode routines: how many days a week the routine needs to be done.
+  // Null/absent means no target (every day). Only goal/exceeded days count.
+  weeklyTarget?: number | null;
 }


### PR DESCRIPTION
Daily-mode routines can now specify how many days a week they need to be
done. Once that many goal/exceeded days are logged for the current week,
a de-emphasized "Nothing required today" note appears under the task name
in the Routines table (and list view) and in the routine's Today's Task
box. Logging stays available; the note is informational only.

- New nullable `weekly_target` column on routines, threaded through the
  shared type, routine body schema/row builder, partial upsert set clause,
  duplicate handler, and the daily projection.
- "Days per week" field on the routine edit form, shown for daily mode only.
- New `getCompletedDaysThisWeek` / `isWeeklyTargetMet` helpers (only
  goal/exceeded days count) with Vitest coverage across all window modes.
- Week window is a configurable tracker setting: calendar week starting
  Sunday (default) or Monday, or a rolling 7-day window.