### PR TITLE
Add warning indicator for daily routines with no task assigned

### DIFF
--- a/packages/client/src/components/boxes/RoutineBox.tsx
+++ b/packages/client/src/components/boxes/RoutineBox.tsx
@@ -1,7 +1,7 @@
 import type { Routine, RoutineWeekday } from "@emstack/types";
 
 import { Link } from "@tanstack/react-router";
-import { FlameIcon } from "lucide-react";
+import { AlertTriangleIcon, FlameIcon } from "lucide-react";
 
 import { Description } from "@/components/boxElements/Description";
 import { EntityLink } from "@/components/boxElements/EntityLink";
@@ -14,6 +14,7 @@ import {
   ContentBoxTitle,
 } from "@/components/boxes/ContentBox";
 import { ActionableSentence } from "@/components/dailies/ActionableSentence";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   connectionEntityKind,
@@ -75,6 +76,12 @@ export function RoutineBox({
   todayAction,
 }: Routine & { todayAction?: RoutineTodayAction | null }) {
   const isDaily = mode === "daily";
+  // A daily routine mirrors the same entry on every weekday, so "no task
+  // assigned" means none of the grid's entries is a task (it may be a
+  // resource, freeform, or empty). Flag it so the card can caution the user.
+  const dailyHasNoTask
+    = isDaily
+      && !Object.values(weekly ?? {}).some(entry => entry?.type === "task");
   const scheduledCount = weekly
     ? Object.values(weekly).filter(Boolean).length
     : 0;
@@ -119,9 +126,17 @@ export function RoutineBox({
           </div>
           <div className="flex flex-row items-center gap-2">
             <span
-              className="
-                rounded-sm border px-2 py-0.5 text-xs text-muted-foreground
-              "
+              className={cn(
+                "rounded-sm border px-2 py-0.5 text-xs",
+                dailyHasNoTask
+                  ? `
+                    border-amber-400 bg-amber-100 text-amber-900
+                    dark:border-amber-500/50 dark:bg-amber-900/40
+                    dark:text-amber-100
+                  `
+                  : "text-muted-foreground",
+              )}
+              title={dailyHasNoTask ? "No task assigned" : undefined}
             >
               {isDaily ? "Daily" : "Weekly"}
             </span>
@@ -138,7 +153,7 @@ export function RoutineBox({
           </div>
         </ContentBoxHeaderBar>
         <ContentBoxTitle>
-          <h3 className="text-xl">
+          <h3 className="flex items-center gap-1.5 text-xl">
             <Link
               to="/routines/$id"
               params={{
@@ -156,6 +171,19 @@ export function RoutineBox({
                 )
                 : name}
             </Link>
+            {dailyHasNoTask && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex shrink-0 text-amber-500"
+                    aria-label="No task assigned"
+                  >
+                    <AlertTriangleIcon className="size-4" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>No task assigned</TooltipContent>
+              </Tooltip>
+            )}
           </h3>
         </ContentBoxTitle>
       </ContentBoxHeader>


### PR DESCRIPTION
## Summary
Adds a visual warning to daily routines that have no task assigned in their weekly grid. This helps users identify routines that may be misconfigured (e.g., containing only resources, freeform entries, or empty slots instead of actual tasks).

## Changes
- Import `AlertTriangleIcon` from lucide-react and `Tooltip` components from shadcn/ui
- Add `dailyHasNoTask` logic that checks if a daily routine has no task-type entries across its weekly grid
- Style the "Daily" badge with amber warning colors when `dailyHasNoTask` is true
- Add a tooltip-wrapped warning icon next to the routine title when no task is assigned
- Include appropriate ARIA labels and title attributes for accessibility

## Implementation Details
- The `dailyHasNoTask` flag is only computed for daily routines (not weekly), since daily routines mirror the same entry across all weekdays
- Warning styling uses Tailwind's amber palette with dark mode support
- The warning icon is inline with the title and uses a 4px size to avoid visual clutter
- Tooltip provides additional context on hover/focus

https://claude.ai/code/session_01GBte5HJ7p4zU4xFpmB1eKV