### PR TITLE
Optimize Docker build cache by excluding test and dev files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,15 @@
 **/coverage
 **/storybook-static
 **/.env*
+
+# Test / story / dev-tooling files — not needed to build or run the app, and
+# excluding them keeps the build-* stage cache warm when only tests change
+**/*.test.*
+**/*.spec.*
+**/*.stories.*
+**/setupTests.*
+**/playwright.config.*
+**/.storybook
 .git
 .gitignore
 .github

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-RUN npm install -g corepack
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Improves Docker build performance by excluding test, story, and dev-tooling files from the build context, keeping the `build-*` stage cache warm when only tests or stories change. Also removes a redundant `corepack` installation step.

## Changes

- **`.dockerignore`:** Added exclusions for test files (`*.test.*`, `*.spec.*`), story files (`*.stories.*`), test setup files (`setupTests.*`), Playwright config, and Storybook directory. These files are not needed to build or run the application and were unnecessarily invalidating the Docker layer cache.
- **`Dockerfile`:** Removed redundant `RUN npm install -g corepack` — `corepack enable` (the next line) is sufficient and doesn't require a global install on Node.js 22, which ships with corepack built-in.

## Benefits

- Faster Docker builds when only test or story files change (cache layers remain valid)
- Smaller build context sent to Docker daemon
- Cleaner Dockerfile with one fewer unnecessary step

https://claude.ai/code/session_01CwxUVj2qSUyFbMFov2DfbF