### PR TITLE
Add Todoist dashboard tile and make tiles full-width by default

### DIFF
--- a/packages/client/src/components/boxes/DashboardCard.tsx
+++ b/packages/client/src/components/boxes/DashboardCard.tsx
@@ -19,8 +19,8 @@ function DashboardCard({
     <section
       data-slot="dashboard-card"
       className={cn(`
-        flex flex-col gap-3 rounded-md border bg-card text-card-foreground
-        shadow-sm
+        flex w-full flex-col gap-3 rounded-md border bg-card
+        text-card-foreground shadow-sm
       `, className)}
       {...props}
     >

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -13,6 +13,7 @@ import {
   sortTilesForMobile,
   tilesToLayoutItems,
 } from "./-dashboardTileMeta";
+import { DashboardTodoist } from "./-DashboardTodoist";
 import { DashboardUnderutilizedProviders } from "./-DashboardUnderutilizedProviders";
 
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -24,6 +25,7 @@ const TILE_COMPONENTS: Record<DashboardTileId, React.ComponentType> = {
   coursesInProgress: DashboardCoursesInProgress,
   radars: DashboardRadars,
   readwise: DashboardReadwise,
+  todoist: DashboardTodoist,
 };
 
 interface DashboardGridProps {
@@ -84,6 +86,7 @@ export function DashboardGrid({
         gap={12}
         dragHandle="[data-slot=dashboard-card-header]"
         dragCancel="a, button, input, select, [role=menuitem]"
+        resizeHandles={["se"]}
         onLayoutChange={(next: readonly GridLayoutItem[]) =>
           onTilesChange(layoutItemsToTiles(next))}
       >

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
@@ -1,0 +1,197 @@
+import type { TodoistTask } from "@emstack/types";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ExternalLink, Repeat } from "lucide-react";
+
+import {
+  DashboardCard,
+  DashboardSectionStatus,
+} from "@/components/boxes/DashboardCard";
+import { Button } from "@/components/ui/button";
+import { fetchTodoistTasks } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Todoist priority is 1–4 with 4 the most urgent (shown as "P1" in the app).
+// Only the two highest priorities get a coloured dot; the rest stay muted.
+function priorityDotClass(priority: number): string {
+  if (priority >= 4) return "bg-red-500";
+  if (priority === 3) return "bg-orange-500";
+  return "bg-muted-foreground/40";
+}
+
+function TaskList({
+  tasks,
+  overdue,
+}: {
+  tasks: TodoistTask[];
+  overdue: boolean;
+}) {
+  return (
+    <ul className="flex flex-col divide-y">
+      {tasks.map(task => (
+        <li
+          key={task.id}
+          className="flex flex-row items-center gap-2 py-2"
+        >
+          <span
+            aria-hidden
+            className={`
+              size-2 shrink-0 rounded-full
+              ${priorityDotClass(task.priority)}
+            `}
+          />
+          <div className="flex min-w-0 flex-col">
+            <a
+              href={task.url}
+              target="_blank"
+              rel="noreferrer"
+              className="
+                truncate font-medium
+                hover:text-blue-600
+              "
+            >
+              {task.content}
+            </a>
+            {task.due && (
+              <span
+                className={`
+                  flex items-center gap-1 truncate text-xs
+                  ${
+              overdue ? "text-destructive" : "text-muted-foreground"
+              }
+                `}
+              >
+                {task.due}
+                {task.isRecurring && <Repeat className="size-3" />}
+              </span>
+            )}
+          </div>
+          <a
+            href={task.url}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open task in Todoist"
+            className="
+              ml-auto text-muted-foreground
+              hover:text-foreground
+            "
+          >
+            <ExternalLink className="size-4" />
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function DashboardTodoist() {
+  const {
+    data, isPending, error,
+  } = useQuery({
+    queryKey: queryKeys.todoist.tasks(),
+    queryFn: () => fetchTodoistTasks(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const configured = data?.configured ?? false;
+  const overdue = data?.overdue ?? [];
+  const today = data?.today ?? [];
+
+  return (
+    <DashboardCard
+      title="Todoist"
+      action={(
+        <>
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+          >
+            <a
+              href="https://app.todoist.com/app/today"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open Todoist
+              <ExternalLink />
+            </a>
+          </Button>
+          <Link
+            to="/settings"
+            className="
+              text-sm text-primary underline-offset-2
+              hover:underline
+            "
+          >
+            Settings
+          </Link>
+        </>
+      )}
+    >
+      {!isPending && !error && !configured
+        ? (
+          <p className="text-sm text-muted-foreground">
+            Add your Todoist API key in
+            {" "}
+            <Link
+              to="/settings"
+              className="
+                text-primary underline-offset-2
+                hover:underline
+              "
+            >
+              Settings
+            </Link>
+            {" "}
+            to see tasks due today and overdue.
+          </p>
+        )
+        : (
+          <>
+            <DashboardSectionStatus
+              isPending={isPending}
+              error={error}
+              isEmpty={configured && overdue.length === 0 && today.length === 0}
+              entity="tasks"
+              emptyMessage="Nothing due today. 🎉"
+            />
+            {overdue.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <h3
+                  className="
+                    text-xs font-semibold tracking-wide text-destructive
+                    uppercase
+                  "
+                >
+                  Overdue (
+                  {overdue.length}
+                  )
+                </h3>
+                <TaskList
+                  tasks={overdue}
+                  overdue
+                />
+              </div>
+            )}
+            {today.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <h3
+                  className="
+                    text-xs font-semibold tracking-wide text-muted-foreground
+                    uppercase
+                  "
+                >
+                  Today
+                </h3>
+                <TaskList
+                  tasks={today}
+                  overdue={false}
+                />
+              </div>
+            )}
+          </>
+        )}
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.test.ts
@@ -58,16 +58,33 @@ describe("buildDefaultTiles", () => {
 });
 
 describe("sortTilesForMobile", () => {
-  test("orders by row first, then column", () => {
+  test("orders tiles top to bottom by row", () => {
     const tiles = buildDefaultTiles();
-    const shuffled = [tiles[3], tiles[0], tiles[5], tiles[4], tiles[2], tiles[1]];
-    expect(sortTilesForMobile(shuffled).map(t => t.tileId)).toEqual([
+    const expectedOrder = tiles.map(t => t.tileId);
+    const shuffled = tiles.slice().reverse();
+    expect(sortTilesForMobile(shuffled).map(t => t.tileId)).toEqual(
+      expectedOrder,
+    );
+  });
+
+  test("breaks ties on the same row by column", () => {
+    const right: DashboardLayoutTile = {
+      tileId: "radars",
+      x: 2,
+      y: 0,
+      w: 2,
+      h: 4,
+    };
+    const left: DashboardLayoutTile = {
+      tileId: "dailies",
+      x: 0,
+      y: 0,
+      w: 2,
+      h: 4,
+    };
+    expect(sortTilesForMobile([right, left]).map(t => t.tileId)).toEqual([
       "dailies",
-      "underutilizedProviders",
-      "coursesByAmortization",
-      "coursesInProgress",
       "radars",
-      "readwise",
     ]);
   });
 

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
@@ -42,58 +42,68 @@ export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
     minW: 2,
     minH: 4,
   },
+  todoist: {
+    title: "Todoist",
+    minW: 1,
+    minH: 4,
+  },
 };
 
 function isDashboardTileId(id: string): id is DashboardTileId {
   return (DASHBOARD_TILE_IDS as readonly string[]).includes(id);
 }
 
-/** Replicates the pre-grid arrangement: dailies full-width, then a 2×2. */
+// Every tile starts full-width (spanning all 4 columns) and stacked top to
+// bottom. Users narrow a tile by dragging the resize handle in its bottom-right
+// corner, which lets the grid pack the freed space with the next tile.
+const DEFAULT_TILE_HEIGHTS: { tileId: DashboardTileId;
+  h: number; }[] = [
+  {
+    tileId: "dailies",
+    h: 8,
+  },
+  {
+    tileId: "todoist",
+    h: 7,
+  },
+  {
+    tileId: "coursesInProgress",
+    h: 7,
+  },
+  {
+    tileId: "underutilizedProviders",
+    h: 7,
+  },
+  {
+    tileId: "coursesByAmortization",
+    h: 7,
+  },
+  {
+    tileId: "radars",
+    h: 7,
+  },
+  {
+    tileId: "readwise",
+    h: 7,
+  },
+];
+
+/** Full-width tiles stacked top to bottom, dailies first. */
 export function buildDefaultTiles(): DashboardLayoutTile[] {
-  return [
-    {
-      tileId: "dailies",
+  let y = 0;
+  return DEFAULT_TILE_HEIGHTS.map(({
+    tileId, h,
+  }) => {
+    const tile: DashboardLayoutTile = {
+      tileId,
       x: 0,
-      y: 0,
+      y,
       w: 4,
-      h: 8,
-    },
-    {
-      tileId: "underutilizedProviders",
-      x: 0,
-      y: 8,
-      w: 2,
-      h: 7,
-    },
-    {
-      tileId: "coursesByAmortization",
-      x: 2,
-      y: 8,
-      w: 2,
-      h: 7,
-    },
-    {
-      tileId: "coursesInProgress",
-      x: 0,
-      y: 15,
-      w: 2,
-      h: 7,
-    },
-    {
-      tileId: "radars",
-      x: 2,
-      y: 15,
-      w: 2,
-      h: 7,
-    },
-    {
-      tileId: "readwise",
-      x: 0,
-      y: 22,
-      w: 4,
-      h: 7,
-    },
-  ];
+      h,
+    };
+    y += h;
+    return tile;
+  });
 }
 
 /** Reading order for the stacked mobile rendering: top-to-bottom, then
@@ -120,7 +130,7 @@ export function toggleTile(
       tileId,
       x: 0,
       y: bottom,
-      w: 2,
+      w: 4,
       h: 7,
     },
   ];

--- a/packages/client/src/routes/settings.-components/-TodoistSection.tsx
+++ b/packages/client/src/routes/settings.-components/-TodoistSection.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import { fetchSettings, updateSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+export function TodoistSection() {
+  const queryClient = useQueryClient();
+  const [apiKey, setApiKey] = useState("");
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (key: string | null) =>
+      updateSettings({
+        todoistApiKey: key,
+      }),
+    onSuccess: (_data, key) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.settings.detail(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.todoist.tasks(),
+      });
+      setApiKey("");
+      toast.success(key ? "Todoist API key saved" : "Todoist API key removed");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const configured = settingsQuery.data?.todoistConfigured ?? false;
+  const hint = settingsQuery.data?.todoistKeyHint ?? null;
+
+  function handleSave() {
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    saveMutation.mutate(trimmed);
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xl font-semibold">Todoist</h2>
+      <p className="text-sm text-muted-foreground">
+        Connect your Todoist account to show tasks due today and overdue on the
+        dashboard. Copy your API token from
+        {" "}
+        <a
+          href="https://app.todoist.com/app/settings/integrations/developer"
+          target="_blank"
+          rel="noreferrer"
+          className="
+            text-primary underline-offset-2
+            hover:underline
+          "
+        >
+          Settings → Integrations → Developer
+        </a>
+        .
+      </p>
+      {configured && (
+        <p className="text-sm text-muted-foreground">
+          A key is currently saved
+          {hint ? ` (ending ${hint})` : ""}
+          .
+        </p>
+      )}
+      <div
+        className="
+          flex flex-col gap-2
+          sm:flex-row sm:items-center
+        "
+      >
+        <Input
+          type="password"
+          autoComplete="off"
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+          placeholder={configured
+            ? "Enter a new key to replace the saved one"
+            : "Paste your Todoist API token"}
+          className="sm:max-w-md"
+        />
+        <div className="flex gap-2">
+          <Button
+            onClick={handleSave}
+            disabled={!apiKey.trim() || saveMutation.isPending}
+          >
+            {configured ? "Update key" : "Save key"}
+          </Button>
+          {configured && (
+            <Button
+              variant="outline"
+              onClick={() => saveMutation.mutate(null)}
+              disabled={saveMutation.isPending}
+            >
+              Remove
+            </Button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -7,6 +7,7 @@ import { DataToolsSection } from "./settings.-components/-DataToolsSection";
 import { ReadwiseSection } from "./settings.-components/-ReadwiseSection";
 import { RoutineTemplatesSection } from "./settings.-components/-RoutineTemplatesSection";
 import { TaskTypesSection } from "./settings.-components/-TaskTypesSection";
+import { TodoistSection } from "./settings.-components/-TodoistSection";
 
 import { PageHeader } from "@/components/layout/PageHeader";
 import { TagGroupsAdmin } from "@/components/TagGroupsAdmin";
@@ -39,6 +40,8 @@ function Settings() {
         <DashboardLayoutsSection />
 
         <ReadwiseSection />
+
+        <TodoistSection />
 
         <section className="flex flex-col gap-3">
           <h2 className="text-xl font-semibold">Appearance</h2>

--- a/packages/client/src/utils/api/index.ts
+++ b/packages/client/src/utils/api/index.ts
@@ -17,4 +17,5 @@ export * from "./settings";
 export * from "./tags";
 export * from "./tasks";
 export * from "./templates";
+export * from "./todoist";
 export * from "./topics";

--- a/packages/client/src/utils/api/todoist.ts
+++ b/packages/client/src/utils/api/todoist.ts
@@ -1,0 +1,7 @@
+import type { TodoistTasks } from "@emstack/types";
+
+import { fetchJson } from "./client";
+
+export function fetchTodoistTasks(): Promise<TodoistTasks> {
+  return fetchJson<TodoistTasks>("/api/todoist/tasks");
+}

--- a/packages/client/src/utils/queryKeys.ts
+++ b/packages/client/src/utils/queryKeys.ts
@@ -66,4 +66,7 @@ export const queryKeys = {
   readwise: {
     readingList: () => ["readwise", "reading-list"] as const,
   },
+  todoist: {
+    tasks: () => ["todoist", "tasks"] as const,
+  },
 };

--- a/packages/middleware/.env.example
+++ b/packages/middleware/.env.example
@@ -5,3 +5,8 @@ DATABASE_URL=postgres://postgres:password@localhost:5432/coursetracker
 # in-app via Settings (stored in the DB); this env var is only used when no key
 # has been saved there. Get a token at https://readwise.io/access_token
 READWISE_API_KEY=
+
+# Optional fallback for the Todoist integration. Normally the key is set in-app
+# via Settings (stored in the DB); this env var is only used when no key has
+# been saved there. Get a token at https://app.todoist.com/app/settings/integrations/developer
+TODOIST_API_KEY=

--- a/packages/middleware/src/db/schema/settings.ts
+++ b/packages/middleware/src/db/schema/settings.ts
@@ -2,9 +2,10 @@ import { pgTable, varchar } from "drizzle-orm/pg-core";
 
 // Single-row application settings. The row is keyed by a constant id ("global")
 // and created on first write via onConflictDoUpdate — there is no multi-user
-// concept yet. Holds the personal Readwise Reader token used by the server-side
-// proxy in src/services/readwise.ts.
+// concept yet. Holds the personal API tokens used by the server-side proxies in
+// src/services/readwise.ts and src/services/todoist.ts.
 export const appSettings = pgTable("app_settings", {
   id: varchar().primaryKey().default("global"),
   readwiseApiKey: varchar("readwise_api_key"),
+  todoistApiKey: varchar("todoist_api_key"),
 });

--- a/packages/middleware/src/routes/api/routes.ts
+++ b/packages/middleware/src/routes/api/routes.ts
@@ -21,6 +21,7 @@ import routineTemplates from "./routine-templates/routes";
 import dashboardLayouts from "./dashboard-layouts/routes";
 import settings from "./settings/routes";
 import readwise from "./readwise/routes";
+import todoist from "./todoist/routes";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -82,5 +83,8 @@ export default async function (server: FastifyInstance) {
   });
   fastify.register(readwise, {
     prefix: "/readwise",
+  });
+  fastify.register(todoist, {
+    prefix: "/todoist",
   });
 }

--- a/packages/middleware/src/routes/api/settings/root.ts
+++ b/packages/middleware/src/routes/api/settings/root.ts
@@ -18,10 +18,13 @@ export default async function (server: FastifyInstance) {
     "/",
     async (): Promise<AppSettingsSummary> => {
       const [row] = await db.select().from(appSettings).limit(1);
-      const key = row?.readwiseApiKey ?? null;
+      const readwiseKey = row?.readwiseApiKey ?? null;
+      const todoistKey = row?.todoistApiKey ?? null;
       return {
-        readwiseConfigured: Boolean(key),
-        readwiseKeyHint: maskKey(key),
+        readwiseConfigured: Boolean(readwiseKey),
+        readwiseKeyHint: maskKey(readwiseKey),
+        todoistConfigured: Boolean(todoistKey),
+        todoistKeyHint: maskKey(todoistKey),
       };
     },
   );

--- a/packages/middleware/src/routes/api/settings/updateSettings.ts
+++ b/packages/middleware/src/routes/api/settings/updateSettings.ts
@@ -10,16 +10,22 @@ const SETTINGS_ROW_ID = "global";
 
 const updateSchema = {
   schema: {
-    description: "Update application settings (e.g. the Readwise API key)",
+    description: "Update application settings (e.g. the Readwise or Todoist API keys)",
     body: {
       type: "object",
-      required: ["readwiseApiKey"],
       properties: {
         readwiseApiKey: nullableString,
+        todoistApiKey: nullableString,
       },
     },
   },
 } as const;
+
+// Treat a blank/whitespace key as "clear it".
+function normalizeKey(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -28,22 +34,28 @@ export default async function (server: FastifyInstance) {
     "/",
     updateSchema,
     async function (request) {
-      // Treat a blank/whitespace key as "clear it".
-      const trimmed = request.body.readwiseApiKey?.trim();
-      const value = trimmed ? trimmed : null;
+      // Only touch the columns the request actually included, so updating one
+      // integration's key never clobbers another's.
+      const updates: Partial<typeof appSettings.$inferInsert> = {};
+      if (request.body.readwiseApiKey !== undefined) {
+        updates.readwiseApiKey = normalizeKey(request.body.readwiseApiKey);
+      }
+      if (request.body.todoistApiKey !== undefined) {
+        updates.todoistApiKey = normalizeKey(request.body.todoistApiKey);
+      }
 
-      await db
-        .insert(appSettings)
-        .values({
-          id: SETTINGS_ROW_ID,
-          readwiseApiKey: value,
-        })
-        .onConflictDoUpdate({
-          target: appSettings.id,
-          set: {
-            readwiseApiKey: value,
-          },
-        });
+      if (Object.keys(updates).length > 0) {
+        await db
+          .insert(appSettings)
+          .values({
+            id: SETTINGS_ROW_ID,
+            ...updates,
+          })
+          .onConflictDoUpdate({
+            target: appSettings.id,
+            set: updates,
+          });
+      }
 
       return {
         status: "ok",

--- a/packages/middleware/src/routes/api/todoist/root.ts
+++ b/packages/middleware/src/routes/api/todoist/root.ts
@@ -1,0 +1,51 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import type { TodoistTasks } from "@emstack/types";
+import {
+  fetchTodayAndOverdue,
+  getTodoistToken,
+  TodoistError,
+} from "@/services/todoist";
+import { sendBadRequest } from "@/utils/errors";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/tasks",
+    async (request, reply) => {
+      const token = await getTodoistToken();
+
+      // No key yet — respond 200 with configured:false so the dashboard card can
+      // prompt the user to add one rather than rendering an error state.
+      if (!token) {
+        const empty: TodoistTasks = {
+          configured: false,
+          overdue: [],
+          today: [],
+        };
+        return empty;
+      }
+
+      try {
+        const {
+          overdue, today,
+        } = await fetchTodayAndOverdue(token);
+        const result: TodoistTasks = {
+          configured: true,
+          overdue,
+          today,
+        };
+        return result;
+      }
+      catch (err) {
+        if (err instanceof TodoistError) {
+          return reply.code(err.statusCode).send({
+            message: err.message,
+          });
+        }
+        return sendBadRequest(reply, "Failed to load Todoist tasks.");
+      }
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/todoist/routes.ts
+++ b/packages/middleware/src/routes/api/todoist/routes.ts
@@ -1,0 +1,10 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+
+import root from "./root";
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.register(root);
+}

--- a/packages/middleware/src/services/todoist.ts
+++ b/packages/middleware/src/services/todoist.ts
@@ -1,0 +1,165 @@
+import type { TodoistTask } from "@emstack/types";
+import { db } from "@/db";
+import { appSettings } from "@/db/schema";
+
+// Todoist API v1 (unified REST). The dedicated filter endpoint runs a Todoist
+// filter query server-side and returns matching active tasks, paginated.
+const TODOIST_FILTER_URL = "https://api.todoist.com/api/v1/tasks/filter";
+
+// Deep-link base for the Todoist web app. Tasks don't carry a URL in the v1
+// payload, so we build one from the task id.
+const TODOIST_TASK_URL = "https://app.todoist.com/app/task";
+
+// Filter query for the dashboard card: anything due today or already overdue.
+const DUE_FILTER = "today | overdue";
+
+// Bound pagination defensively so a huge backlog can't hang the request or
+// burn through the rate limit. 200 tasks/page × 5 pages is far more than a
+// dashboard card needs.
+const PAGE_LIMIT = 200;
+const MAX_PAGES = 5;
+
+/** Raw shape of the fields we read off a Todoist v1 task. */
+interface RawTodoistTask {
+  id: string;
+  content?: string | null;
+  priority?: number | null;
+  due?: {
+    date?: string | null;
+    string?: string | null;
+    is_recurring?: boolean | null;
+  } | null;
+}
+
+interface RawFilterResponse {
+  results: RawTodoistTask[];
+  next_cursor: string | null;
+}
+
+/** Error carrying an HTTP status so the route can map it to a friendly reply. */
+export class TodoistError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "TodoistError";
+    this.statusCode = statusCode;
+  }
+}
+
+/**
+ * Resolve the Todoist token: the DB-stored key (set via Settings) takes
+ * precedence, falling back to the TODOIST_API_KEY env var for deployments that
+ * prefer to inject it. Returns null when neither is set.
+ */
+export async function getTodoistToken(): Promise<string | null> {
+  const [row] = await db.select().from(appSettings).limit(1);
+  const stored = row?.todoistApiKey?.trim();
+  if (stored) return stored;
+  const fromEnv = process.env.TODOIST_API_KEY?.trim();
+  return fromEnv ? fromEnv : null;
+}
+
+/** Today's calendar date as YYYY-MM-DD in the server's local timezone. */
+function todayDateString(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function mapTask(raw: RawTodoistTask): TodoistTask {
+  // due.date can be a plain date ("2026-06-13") or a full datetime
+  // ("2026-06-13T09:00:00Z"); the leading 10 chars are the calendar date.
+  const dueDate = raw.due?.date ? raw.due.date.slice(0, 10) : null;
+  return {
+    id: raw.id,
+    content: raw.content?.trim() || "Untitled task",
+    url: `${TODOIST_TASK_URL}/${raw.id}`,
+    priority: raw.priority ?? 1,
+    due: raw.due?.string ?? null,
+    dueDate,
+    isRecurring: raw.due?.is_recurring ?? false,
+  };
+}
+
+async function fetchFilteredTasks(token: string): Promise<RawTodoistTask[]> {
+  const collected: RawTodoistTask[] = [];
+  let cursor: string | null = null;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const params = new URLSearchParams({
+      query: DUE_FILTER,
+      limit: String(PAGE_LIMIT),
+    });
+    if (cursor) params.set("cursor", cursor);
+
+    let response: Response;
+    try {
+      response = await fetch(`${TODOIST_FILTER_URL}?${params.toString()}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    }
+    catch {
+      throw new TodoistError("Could not reach Todoist.", 502);
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new TodoistError("Todoist rejected the API key.", 401);
+    }
+    if (response.status === 429) {
+      throw new TodoistError("Todoist rate limit reached — try again shortly.", 429);
+    }
+    if (!response.ok) {
+      throw new TodoistError(`Todoist request failed (${response.status}).`, 502);
+    }
+
+    const body = (await response.json()) as RawFilterResponse;
+    collected.push(...(body.results ?? []));
+
+    cursor = body.next_cursor;
+    if (!cursor) break;
+  }
+
+  return collected;
+}
+
+export interface TodoistTasksData {
+  overdue: TodoistTask[];
+  today: TodoistTask[];
+}
+
+/**
+ * Fetch the user's active tasks due today or overdue and split them by whether
+ * their due date falls before today (overdue) or on today. Tasks with a higher
+ * Todoist priority surface first within the "today" list; overdue tasks are
+ * ordered oldest-first.
+ */
+export async function fetchTodayAndOverdue(
+  token: string,
+): Promise<TodoistTasksData> {
+  const today = todayDateString();
+  const raw = await fetchFilteredTasks(token);
+
+  const overdue: TodoistTask[] = [];
+  const dueToday: TodoistTask[] = [];
+  for (const item of raw) {
+    const task = mapTask(item);
+    if (task.dueDate && task.dueDate < today) {
+      overdue.push(task);
+    }
+    else {
+      dueToday.push(task);
+    }
+  }
+
+  overdue.sort((a, b) => (a.dueDate ?? "").localeCompare(b.dueDate ?? ""));
+  dueToday.sort((a, b) => b.priority - a.priority);
+
+  return {
+    overdue,
+    today: dueToday,
+  };
+}

--- a/packages/types/src/AppSettings.ts
+++ b/packages/types/src/AppSettings.ts
@@ -1,11 +1,15 @@
-// Response shape for GET /api/settings. The raw Readwise token is never sent to
-// the client — only whether one is configured plus a short masked hint.
+// Response shape for GET /api/settings. Raw API tokens are never sent to the
+// client — only whether each integration is configured plus a short masked hint.
 export interface AppSettingsSummary {
   readwiseConfigured: boolean;
   readwiseKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
+  todoistConfigured: boolean;
+  todoistKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
 }
 
-// Request body for PUT /api/settings. A null or empty key clears the value.
+// Request body for PUT /api/settings. Only the keys present in the body are
+// updated; a null or empty value clears that key.
 export interface AppSettingsUpdate {
-  readwiseApiKey: string | null;
+  readwiseApiKey?: string | null;
+  todoistApiKey?: string | null;
 }

--- a/packages/types/src/DashboardLayout.ts
+++ b/packages/types/src/DashboardLayout.ts
@@ -8,6 +8,7 @@ export const DASHBOARD_TILE_IDS = [
   "coursesInProgress",
   "radars",
   "readwise",
+  "todoist",
 ] as const;
 
 export type DashboardTileId = (typeof DASHBOARD_TILE_IDS)[number];

--- a/packages/types/src/Todoist.ts
+++ b/packages/types/src/Todoist.ts
@@ -1,0 +1,26 @@
+// Slimmed-down projection of a Todoist task, returned by
+// GET /api/todoist/tasks. The middleware maps the raw Todoist API task onto
+// this shape so the client never sees the full payload.
+export interface TodoistTask {
+  id: string;
+  content: string;
+  // Deep link to the task in the Todoist web app.
+  url: string;
+  // Todoist's 1–4 priority scale (4 = most urgent, shown as "P1" in Todoist).
+  priority: number;
+  // Human-readable due string from Todoist (e.g. "13 Jun", "every day"), or null.
+  due: string | null;
+  // Calendar date portion (YYYY-MM-DD) of the due date, for display/sorting.
+  dueDate: string | null;
+  isRecurring: boolean;
+}
+
+export interface TodoistTasks {
+  // false when no Todoist token has been saved yet — lets the dashboard card
+  // prompt the user to add one instead of surfacing an error.
+  configured: boolean;
+  // Tasks whose due date is before today, oldest first.
+  overdue: TodoistTask[];
+  // Tasks due today.
+  today: TodoistTask[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,3 +30,4 @@ export * from "./TaskResource.js";
 export * from "./TaskResourceLink.js";
 export * from "./TaskTodo.js";
 export * from "./TaskType.js";
+export * from "./Todoist.js";


### PR DESCRIPTION
Resolves #258: a dashboard tile that lists Todoist tasks due today or
overdue, with the API key managed in Settings.

- middleware: app_settings gains a todoist_api_key column; a /api/todoist/tasks
  proxy mirrors the Readwise service (DB key first, TODOIST_API_KEY env
  fallback) and splits the "today | overdue" filter results into overdue/today
- settings: GET reports todoistConfigured/hint; PUT now does a partial update
  so saving one integration's key never clobbers another's
- client: Todoist dashboard card + Settings section, query key, API client
- dashboard: register the todoist tile; default new layouts to full-width
  tiles stacked top to bottom, and make the bottom-right (SE) resize handle
  explicit so width is adjustable. DashboardCard fills its container (w-full).

https://claude.ai/code/session_01JXbd5kEECAxMw5jVxcEzyb