### PR TITLE
Add dashboard layout presets and enhance tab management

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-AddLayoutDialog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-AddLayoutDialog.tsx
@@ -1,0 +1,170 @@
+import type { DashboardLayout, DashboardLayoutTile } from "@emstack/types";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { LAYOUT_PRESETS } from "./-layoutPresets";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface AddLayoutDialogProps {
+  open: boolean;
+  isSaving?: boolean;
+  /** User-saved presets (template layouts) offered as starting points. */
+  savedPresets: DashboardLayout[];
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (name: string, tiles: DashboardLayoutTile[]) => void;
+}
+
+interface StartingOption {
+  value: string;
+  label: string;
+  description?: string;
+  suggestedName: string;
+  getTiles: () => DashboardLayoutTile[];
+}
+
+/**
+ * Add-tab dialog: pick a name and a starting layout ("predone layout") — Blank,
+ * a curated built-in, or any saved preset — then create the tab from its tiles.
+ */
+export function AddLayoutDialog({
+  open,
+  isSaving = false,
+  savedPresets,
+  onOpenChange,
+  onSubmit,
+}: AddLayoutDialogProps) {
+  const options = useMemo<StartingOption[]>(() => {
+    const builtIns = LAYOUT_PRESETS.map(preset => ({
+      value: `builtin:${preset.key}`,
+      label: preset.name,
+      description: preset.description,
+      suggestedName: preset.name,
+      getTiles: preset.buildTiles,
+    }));
+    const saved = savedPresets.map(preset => ({
+      value: `preset:${preset.id}`,
+      label: preset.name,
+      description: `${preset.tiles.length} tile(s)`,
+      suggestedName: preset.name,
+      getTiles: () => preset.tiles,
+    }));
+    return [...builtIns, ...saved];
+  }, [savedPresets]);
+
+  const [value, setValue] = useState(options[0]?.value ?? "");
+  const [name, setName] = useState("");
+  // Stop syncing the name from the selection once the user types their own.
+  const [nameTouched, setNameTouched] = useState(false);
+
+  const selected = options.find(o => o.value === value) ?? options[0];
+
+  // Reset to a clean state each time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      const first = options[0];
+      setValue(first?.value ?? "");
+      setName(first?.suggestedName ?? "");
+      setNameTouched(false);
+    }
+  }, [open, options]);
+
+  const handleSelect = (next: string) => {
+    setValue(next);
+    if (!nameTouched) {
+      const option = options.find(o => o.value === next);
+      if (option) setName(option.suggestedName);
+    }
+  };
+
+  const trimmed = name.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add layout</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed && selected) onSubmit(trimmed, selected.getTiles());
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Start from</label>
+            <Select
+              value={value}
+              onValueChange={handleSelect}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Choose a starting layout" />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map(option => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                  >
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selected?.description && (
+              <p className="text-xs text-muted-foreground">
+                {selected.description}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Name</label>
+            <Input
+              autoFocus
+              value={name}
+              placeholder="Layout name"
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameTouched(true);
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!trimmed || isSaving}
+            >
+              Add
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
@@ -1,0 +1,62 @@
+import type { DashboardLayoutTile } from "@emstack/types";
+
+import { describe, expect, test } from "vitest";
+
+import { TILE_META } from "./-dashboardTileMeta";
+import { LAYOUT_PRESETS } from "./-layoutPresets";
+
+function overlaps(a: DashboardLayoutTile, b: DashboardLayoutTile): boolean {
+  return (
+    a.x < b.x + b.w
+    && b.x < a.x + a.w
+    && a.y < b.y + b.h
+    && b.y < a.y + a.h
+  );
+}
+
+describe("LAYOUT_PRESETS", () => {
+  test("includes a blank preset that yields no tiles", () => {
+    const blank = LAYOUT_PRESETS.find(p => p.key === "blank");
+    expect(blank).toBeDefined();
+    expect(blank?.buildTiles()).toEqual([]);
+  });
+
+  test("preset keys are unique", () => {
+    const keys = LAYOUT_PRESETS.map(p => p.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  for (const preset of LAYOUT_PRESETS) {
+    describe(preset.key, () => {
+      test("stays within the 4-column grid with valid sizes", () => {
+        for (const tile of preset.buildTiles()) {
+          expect(tile.x).toBeGreaterThanOrEqual(0);
+          expect(tile.y).toBeGreaterThanOrEqual(0);
+          expect(tile.x + tile.w).toBeLessThanOrEqual(4);
+          expect(tile.w).toBeGreaterThanOrEqual(1);
+          expect(tile.w).toBeLessThanOrEqual(4);
+          expect(tile.h).toBeGreaterThanOrEqual(1);
+        }
+      });
+
+      test("has no overlapping tiles and no duplicate tile ids", () => {
+        const tiles = preset.buildTiles();
+        const ids = tiles.map(t => t.tileId);
+        expect(new Set(ids).size).toBe(ids.length);
+        for (const tile of tiles) {
+          for (const other of tiles) {
+            if (other === tile) continue;
+            expect(overlaps(tile, other)).toBe(false);
+          }
+        }
+      });
+
+      test("respects each tile's minimum size", () => {
+        for (const tile of preset.buildTiles()) {
+          expect(tile.w).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minW);
+          expect(tile.h).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minH);
+        }
+      });
+    });
+  }
+});

--- a/packages/client/src/routes/dashboard.-components/-layoutPresets.ts
+++ b/packages/client/src/routes/dashboard.-components/-layoutPresets.ts
@@ -1,0 +1,69 @@
+import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
+
+import { buildDefaultTiles, TILE_META } from "./-dashboardTileMeta";
+
+// Curated, code-defined starting layouts offered when adding a tab. Built-ins
+// are never persisted as rows — picking one just creates a new layout from the
+// tiles `buildTiles()` returns. Kept as a pure module (no component imports)
+// so it stays unit-testable like -dashboardTileMeta.ts.
+
+export interface LayoutPreset {
+  /** Stable id used as the picker's select value. */
+  key: string;
+  /** Suggested tab name when this preset is chosen. */
+  name: string;
+  description: string;
+  buildTiles: () => DashboardLayoutTile[];
+}
+
+/** Full-width tiles stacked top to bottom, in the given order. Heights respect
+ * each tile's minimum from TILE_META, so the result satisfies the same grid
+ * invariants the backend's dashboardLayoutTilesSchema enforces. */
+function stackTiles(ids: DashboardTileId[]): DashboardLayoutTile[] {
+  let y = 0;
+  return ids.map((tileId) => {
+    const h = Math.max(TILE_META[tileId].minH, 7);
+    const tile: DashboardLayoutTile = {
+      tileId,
+      x: 0,
+      y,
+      w: 4,
+      h,
+    };
+    y += h;
+    return tile;
+  });
+}
+
+export const LAYOUT_PRESETS: LayoutPreset[] = [
+  {
+    key: "blank",
+    name: "New layout",
+    description: "Start empty and add tiles yourself.",
+    buildTiles: () => [],
+  },
+  {
+    key: "default",
+    name: "Default",
+    description: "Every tile, full-width and stacked.",
+    buildTiles: buildDefaultTiles,
+  },
+  {
+    key: "courses",
+    name: "Courses focus",
+    description: "Dailies plus course progress and spend.",
+    buildTiles: () =>
+      stackTiles([
+        "dailies",
+        "coursesInProgress",
+        "coursesByAmortization",
+        "underutilizedProviders",
+      ]),
+  },
+  {
+    key: "tasks",
+    name: "Tasks & habits",
+    description: "Dailies, Todoist tasks, and radars.",
+    buildTiles: () => stackTiles(["dailies", "todoist", "radars"]),
+  },
+];

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -1,13 +1,21 @@
-import type { DashboardLayout, DashboardLayoutTile } from "@emstack/types";
+import type { DashboardLayout, DashboardLayoutTile, DashboardTileId } from "@emstack/types";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { PlusIcon, SlidersHorizontalIcon } from "lucide-react";
+import {
+  BookmarkIcon,
+  CopyIcon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { toast } from "sonner";
 
+import { AddLayoutDialog } from "./dashboard.-components/-AddLayoutDialog";
 import { DashboardGrid } from "./dashboard.-components/-DashboardGrid";
 import {
   buildDefaultTiles,
@@ -16,6 +24,7 @@ import {
   toggleTile,
 } from "./dashboard.-components/-dashboardTileMeta";
 
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { LayoutNameDialog } from "@/components/LayoutNameDialog";
 import { Button } from "@/components/ui/button";
@@ -23,13 +32,20 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useActiveDashboardLayoutId } from "@/hooks/useActiveDashboardLayoutId";
-import { createDashboardLayout, fetchDashboardLayouts, upsertDashboardLayout } from "@/utils/api";
+import {
+  createDashboardLayout,
+  deleteSingleDashboardLayout,
+  duplicateDashboardLayout,
+  fetchDashboardLayouts,
+  upsertDashboardLayout,
+} from "@/utils/api";
 import { queryKeys } from "@/utils/queryKeys";
 
 export const Route = createFileRoute("/dashboard")({
@@ -38,9 +54,100 @@ export const Route = createFileRoute("/dashboard")({
 
 const SAVE_DEBOUNCE_MS = 600;
 
+interface LayoutTabProps {
+  layout: DashboardLayout;
+  onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) => void;
+  onRename: (layout: DashboardLayout) => void;
+  onDuplicate: (layout: DashboardLayout) => void;
+  onSaveAs: (layout: DashboardLayout) => void;
+  onDelete: (layout: DashboardLayout) => void;
+}
+
+/** A dashboard tab plus its hover-revealed "More" menu. The trigger is a
+ * sibling of the Radix TabsTrigger (never nested, which would be invalid
+ * button-in-button) and is always visible on touch where hover doesn't fire. */
+function LayoutTab({
+  layout,
+  onToggleTile,
+  onRename,
+  onDuplicate,
+  onSaveAs,
+  onDelete,
+}: LayoutTabProps) {
+  return (
+    <div className="group relative">
+      <TabsTrigger
+        value={layout.id}
+        className="pr-8"
+      >
+        {layout.name}
+      </TabsTrigger>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${layout.name} options`}
+            onClick={e => e.stopPropagation()}
+            className="
+              absolute top-1/2 right-1 flex size-5 -translate-y-1/2 items-center
+              justify-center rounded-sm text-muted-foreground opacity-0
+              transition-opacity
+              group-focus-within:opacity-100
+              group-hover:opacity-100
+              hover:bg-background/60 hover:text-foreground
+              focus-visible:opacity-100
+              max-md:opacity-100
+            "
+          >
+            <MoreHorizontalIcon className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Visible tiles</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {DASHBOARD_TILE_IDS.map(tileId => (
+            <DropdownMenuCheckboxItem
+              key={tileId}
+              checked={layout.tiles.some(t => t.tileId === tileId)}
+              onCheckedChange={() => onToggleTile(layout, tileId)}
+              onSelect={e => e.preventDefault()}
+            >
+              {TILE_META[tileId].title}
+            </DropdownMenuCheckboxItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => onRename(layout)}>
+            <PencilIcon />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onDuplicate(layout)}>
+            <CopyIcon />
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
+            <BookmarkIcon />
+            Save as layout…
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onSelect={() => onDelete(layout)}
+          >
+            <Trash2Icon />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 function Dashboard() {
   const queryClient = useQueryClient();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
+  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const {
     data: layouts,
@@ -51,25 +158,44 @@ function Dashboard() {
     queryFn: () => fetchDashboardLayouts(),
   });
 
+  // Tabs are the non-template layouts; presets are offered as starting points
+  // when adding a tab and never appear in the strip.
+  const tabs = useMemo(
+    () => layouts?.filter(l => !l.isTemplate) ?? [],
+    [layouts],
+  );
+  const presets = useMemo(
+    () => layouts?.filter(l => l.isTemplate) ?? [],
+    [layouts],
+  );
+
   const {
     activeId, setActiveId,
-  } = useActiveDashboardLayoutId(layouts);
-  const activeLayout = layouts?.find(l => l.id === activeId) ?? null;
+  } = useActiveDashboardLayoutId(tabs);
+  const activeLayout = tabs.find(l => l.id === activeId) ?? null;
 
-  const createLayoutMutation = useMutation({
+  const renameTarget = layouts?.find(l => l.id === renameTargetId) ?? null;
+  const saveAsTarget = layouts?.find(l => l.id === saveAsTargetId) ?? null;
+  const deleteTarget = layouts?.find(l => l.id === deleteTargetId) ?? null;
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.dashboardLayouts.list(),
+    });
+
+  const createTabMutation = useMutation({
     mutationFn: ({
       name, tiles,
     }: { name: string;
       tiles: DashboardLayoutTile[]; }) =>
       createDashboardLayout({
         name,
-        position: layouts?.length ?? 0,
+        position: tabs.length,
         tiles,
+        isTemplate: false,
       }),
     onSuccess: async (res) => {
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.dashboardLayouts.list(),
-      });
+      await invalidate();
       setActiveId(res.id);
       setAddDialogOpen(false);
     },
@@ -84,7 +210,7 @@ function Dashboard() {
   const autoCreatedRef = useRef(false);
   const {
     mutate: autoCreate,
-  } = createLayoutMutation;
+  } = createTabMutation;
   useEffect(() => {
     if (layouts && layouts.length === 0 && !autoCreatedRef.current) {
       autoCreatedRef.current = true;
@@ -94,6 +220,71 @@ function Dashboard() {
       });
     }
   }, [layouts, autoCreate]);
+
+  const saveAsPresetMutation = useMutation({
+    mutationFn: ({
+      name, tiles,
+    }: { name: string;
+      tiles: DashboardLayoutTile[]; }) =>
+      createDashboardLayout({
+        name,
+        position: null,
+        tiles,
+        isTemplate: true,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      setSaveAsTargetId(null);
+      toast.success("Saved as a layout you can reuse");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({
+      layout, name,
+    }: { layout: DashboardLayout;
+      name: string; }) =>
+      upsertDashboardLayout(layout.id, {
+        name,
+        position: layout.position ?? null,
+        tiles: layout.tiles,
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      setRenameTargetId(null);
+      toast.success("Layout renamed");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (id: string) => duplicateDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      toast.success("Layout duplicated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      setDeleteTargetId(null);
+      toast.success("Layout deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
 
   // Tile moves/resizes save through an optimistic cache write with no
   // invalidate on success — a refetch mid-drag would snap tiles back.
@@ -106,6 +297,7 @@ function Dashboard() {
         name: layout.name,
         position: layout.position ?? null,
         tiles,
+        isTemplate: layout.isTemplate ?? false,
       }),
     onMutate: ({
       layout, tiles,
@@ -123,9 +315,7 @@ function Dashboard() {
     },
     onError: (err: Error) => {
       toast.error(err.message);
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.dashboardLayouts.list(),
-      });
+      void invalidate();
     },
   });
 
@@ -145,12 +335,14 @@ function Dashboard() {
     }, SAVE_DEBOUNCE_MS);
   };
 
-  const handleToggleTile = (tileId: (typeof DASHBOARD_TILE_IDS)[number]) => {
-    if (!activeLayout) return;
+  const handleToggleTile = (
+    layout: DashboardLayout,
+    tileId: DashboardTileId,
+  ) => {
     clearTimeout(saveTimerRef.current);
     saveTilesMutation.mutate({
-      layout: activeLayout,
-      tiles: toggleTile(activeLayout.tiles, tileId),
+      layout,
+      tiles: toggleTile(layout.tiles, tileId),
     });
   };
 
@@ -166,78 +358,115 @@ function Dashboard() {
             Failed to load dashboard layouts.
           </p>
         )}
-        {activeLayout && (
+        {!isPending && error == null && layouts != null && (
           <>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <Tabs
-                  value={activeLayout.id}
-                  onValueChange={setActiveId}
-                >
-                  <TabsList>
-                    {layouts?.map(layout => (
-                      <TabsTrigger
-                        key={layout.id}
-                        value={layout.id}
-                      >
-                        {layout.name}
-                      </TabsTrigger>
-                    ))}
-                  </TabsList>
-                </Tabs>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  title="Add layout"
-                  onClick={() => setAddDialogOpen(true)}
-                >
-                  <PlusIcon />
-                </Button>
-              </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                  >
-                    <SlidersHorizontalIcon />
-                    Tiles
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuLabel>Visible tiles</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {DASHBOARD_TILE_IDS.map(tileId => (
-                    <DropdownMenuCheckboxItem
-                      key={tileId}
-                      checked={activeLayout.tiles.some(t => t.tileId === tileId)}
-                      onCheckedChange={() => handleToggleTile(tileId)}
-                      onSelect={e => e.preventDefault()}
-                    >
-                      {TILE_META[tileId].title}
-                    </DropdownMenuCheckboxItem>
+            <div className="flex flex-wrap items-center gap-2">
+              <Tabs
+                value={activeId ?? ""}
+                onValueChange={setActiveId}
+              >
+                <TabsList>
+                  {tabs.map(layout => (
+                    <LayoutTab
+                      key={layout.id}
+                      layout={layout}
+                      onToggleTile={handleToggleTile}
+                      onRename={l => setRenameTargetId(l.id)}
+                      onDuplicate={l => duplicateMutation.mutate(l.id)}
+                      onSaveAs={l => setSaveAsTargetId(l.id)}
+                      onDelete={l => setDeleteTargetId(l.id)}
+                    />
                   ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                </TabsList>
+              </Tabs>
+              <Button
+                variant="outline"
+                size="sm"
+                title="Add layout"
+                onClick={() => setAddDialogOpen(true)}
+              >
+                <PlusIcon />
+              </Button>
             </div>
-            <DashboardGrid
-              tiles={activeLayout.tiles}
-              onTilesChange={handleTilesChange}
-            />
+            {activeLayout
+              ? (
+                <DashboardGrid
+                  tiles={activeLayout.tiles}
+                  onTilesChange={handleTilesChange}
+                />
+              )
+              : (
+                <p className="text-sm text-muted-foreground">
+                  No layout selected. Add one to get started.
+                </p>
+              )}
           </>
         )}
       </div>
-      <LayoutNameDialog
+
+      <AddLayoutDialog
         open={addDialogOpen}
-        title="Add layout"
-        submitLabel="Add"
-        isSaving={createLayoutMutation.isPending}
+        isSaving={createTabMutation.isPending}
+        savedPresets={presets}
         onOpenChange={setAddDialogOpen}
-        onSubmit={name =>
-          createLayoutMutation.mutate({
+        onSubmit={(name, tiles) =>
+          createTabMutation.mutate({
             name,
-            tiles: activeLayout?.tiles ?? buildDefaultTiles(),
+            tiles,
           })}
+      />
+
+      <LayoutNameDialog
+        open={renameTarget !== null}
+        title="Rename layout"
+        initialName={renameTarget?.name ?? ""}
+        isSaving={renameMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) setRenameTargetId(null);
+        }}
+        onSubmit={(name) => {
+          if (renameTarget) {
+            renameMutation.mutate({
+              layout: renameTarget,
+              name,
+            });
+          }
+        }}
+      />
+
+      <LayoutNameDialog
+        open={saveAsTarget !== null}
+        title="Save as layout"
+        submitLabel="Save"
+        initialName={saveAsTarget?.name ?? ""}
+        isSaving={saveAsPresetMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) setSaveAsTargetId(null);
+        }}
+        onSubmit={(name) => {
+          if (saveAsTarget) {
+            saveAsPresetMutation.mutate({
+              name,
+              tiles: saveAsTarget.tiles,
+            });
+          }
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete layout?"
+        description={
+          deleteTarget
+            ? `"${deleteTarget.name}" will be removed. This can't be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onCancel={() => setDeleteTargetId(null)}
       />
     </div>
   );

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -1,26 +1,135 @@
-import type { DashboardLayout } from "@emstack/types";
+import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
 import { useState } from "react";
 
+import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import {
+  BookmarkIcon,
+  CopyIcon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { toast } from "sonner";
 
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { LayoutNameDialog } from "@/components/LayoutNameDialog";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  TILE_META,
+  toggleTile,
+} from "@/routes/dashboard.-components/-dashboardTileMeta";
+import {
   createDashboardLayout,
   deleteSingleDashboardLayout,
+  duplicateDashboardLayout,
   fetchDashboardLayouts,
   upsertDashboardLayout,
 } from "@/utils/api";
 import { queryKeys } from "@/utils/queryKeys";
 
+type CreateKind = "tab" | "preset";
+
+interface LayoutRowProps {
+  layout: DashboardLayout;
+  onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) => void;
+  onRename: (layout: DashboardLayout) => void;
+  onDuplicate: (layout: DashboardLayout) => void;
+  onSaveAs: (layout: DashboardLayout) => void;
+  onDelete: (layout: DashboardLayout) => void;
+}
+
+/** One layout/preset row with the same actions as the dashboard's tab menu. */
+function LayoutRow({
+  layout,
+  onToggleTile,
+  onRename,
+  onDuplicate,
+  onSaveAs,
+  onDelete,
+}: LayoutRowProps) {
+  return (
+    <li
+      className="flex flex-wrap items-center justify-between gap-2 p-3"
+    >
+      <div className="flex flex-col gap-1">
+        <span className="font-medium">{layout.name}</span>
+        <span className="text-xs text-muted-foreground">
+          {layout.tiles.length}
+          {" "}
+          tile(s) shown
+        </span>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="sm"
+            variant="outline"
+            aria-label={`${layout.name} options`}
+          >
+            <MoreHorizontalIcon className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Visible tiles</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {DASHBOARD_TILE_IDS.map(tileId => (
+            <DropdownMenuCheckboxItem
+              key={tileId}
+              checked={layout.tiles.some(t => t.tileId === tileId)}
+              onCheckedChange={() => onToggleTile(layout, tileId)}
+              onSelect={e => e.preventDefault()}
+            >
+              {TILE_META[tileId].title}
+            </DropdownMenuCheckboxItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => onRename(layout)}>
+            <PencilIcon />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onDuplicate(layout)}>
+            <CopyIcon />
+            Duplicate
+          </DropdownMenuItem>
+          {!layout.isTemplate && (
+            <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
+              <BookmarkIcon />
+              Save as preset…
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onSelect={() => onDelete(layout)}
+          >
+            <Trash2Icon />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </li>
+  );
+}
+
 export function DashboardLayoutsSection() {
   const queryClient = useQueryClient();
 
-  const [renamingLayoutId, setRenamingLayoutId] = useState<string | null>(null);
-  const [creatingNewLayout, setCreatingNewLayout] = useState(false);
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
+  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [creatingKind, setCreatingKind] = useState<CreateKind | null>(null);
 
   const layoutsQuery = useQuery({
     queryKey: queryKeys.dashboardLayouts.list(),
@@ -32,24 +141,38 @@ export function DashboardLayoutsSection() {
       queryKey: queryKeys.dashboardLayouts.list(),
     });
 
-  const createLayoutMutation = useMutation({
-    mutationFn: (name: string) =>
+  const layouts = layoutsQuery.data ?? [];
+  const tabs = layouts.filter(l => !l.isTemplate);
+  const presets = layouts.filter(l => l.isTemplate);
+
+  const renameTarget = layouts.find(l => l.id === renameTargetId) ?? null;
+  const saveAsTarget = layouts.find(l => l.id === saveAsTargetId) ?? null;
+  const deleteTarget = layouts.find(l => l.id === deleteTargetId) ?? null;
+
+  const createMutation = useMutation({
+    mutationFn: ({
+      name, kind,
+    }: { name: string;
+      kind: CreateKind; }) =>
       createDashboardLayout({
         name,
-        position: layoutsQuery.data?.length ?? 0,
+        position: kind === "tab" ? tabs.length : null,
         tiles: [],
+        isTemplate: kind === "preset",
       }),
-    onSuccess: () => {
+    onSuccess: (_res, {
+      kind,
+    }) => {
       void invalidate();
-      setCreatingNewLayout(false);
-      toast.success("Dashboard layout created");
+      setCreatingKind(null);
+      toast.success(kind === "preset" ? "Preset created" : "Layout created");
     },
     onError: (err: Error) => {
       toast.error(err.message);
     },
   });
 
-  const renameLayoutMutation = useMutation({
+  const renameMutation = useMutation({
     mutationFn: ({
       layout, name,
     }: { layout: DashboardLayout;
@@ -58,31 +181,92 @@ export function DashboardLayoutsSection() {
         name,
         position: layout.position ?? null,
         tiles: layout.tiles,
+        isTemplate: layout.isTemplate ?? false,
       }),
     onSuccess: () => {
       void invalidate();
-      setRenamingLayoutId(null);
-      toast.success("Dashboard layout saved");
+      setRenameTargetId(null);
+      toast.success("Layout renamed");
     },
     onError: (err: Error) => {
       toast.error(err.message);
     },
   });
 
-  const deleteLayoutMutation = useMutation({
+  const saveAsPresetMutation = useMutation({
+    mutationFn: ({
+      name, layout,
+    }: { name: string;
+      layout: DashboardLayout; }) =>
+      createDashboardLayout({
+        name,
+        position: null,
+        tiles: layout.tiles,
+        isTemplate: true,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      setSaveAsTargetId(null);
+      toast.success("Saved as a layout you can reuse");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (id: string) => duplicateDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      toast.success("Layout duplicated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteSingleDashboardLayout(id),
     onSuccess: () => {
       void invalidate();
-      toast.success("Dashboard layout deleted");
+      setDeleteTargetId(null);
+      toast.success("Layout deleted");
     },
     onError: (err: Error) => {
       toast.error(err.message);
     },
   });
 
-  const layouts = layoutsQuery.data ?? [];
-  const renamingLayout
-    = layouts.find(l => l.id === renamingLayoutId) ?? null;
+  const toggleTileMutation = useMutation({
+    mutationFn: ({
+      layout, tileId,
+    }: { layout: DashboardLayout;
+      tileId: DashboardTileId; }) =>
+      upsertDashboardLayout(layout.id, {
+        name: layout.name,
+        position: layout.position ?? null,
+        tiles: toggleTile(layout.tiles, tileId),
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onSuccess: () => {
+      void invalidate();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const rowProps = {
+    onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) =>
+      toggleTileMutation.mutate({
+        layout,
+        tileId,
+      }),
+    onRename: (layout: DashboardLayout) => setRenameTargetId(layout.id),
+    onDuplicate: (layout: DashboardLayout) => duplicateMutation.mutate(layout.id),
+    onSaveAs: (layout: DashboardLayout) => setSaveAsTargetId(layout.id),
+    onDelete: (layout: DashboardLayout) => setDeleteTargetId(layout.id),
+  };
 
   return (
     <>
@@ -91,80 +275,95 @@ export function DashboardLayoutsSection() {
           <h2 className="text-xl font-semibold">
             Dashboard Layouts
           </h2>
-          <Button
-            variant="outline"
-            onClick={() => setCreatingNewLayout(true)}
-          >
-            <PlusIcon />
-            New Layout
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setCreatingKind("preset")}
+            >
+              <BookmarkIcon />
+              New Preset
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setCreatingKind("tab")}
+            >
+              <PlusIcon />
+              New Layout
+            </Button>
+          </div>
         </div>
         <p className="text-sm text-muted-foreground">
-          Saved tile arrangements selectable from the dashboard&apos;s tab bar.
+          Tabs shown on the dashboard, plus saved presets you can start a new
+          tab from.
         </p>
+
         {layoutsQuery.isPending
           ? <p className="text-sm text-muted-foreground">Loading...</p>
-          : layouts.length === 0
-            ? (
-              <p className="text-sm text-muted-foreground">
-                No layouts yet. Visit the dashboard to create the default
-                one, or add one here.
-              </p>
-            )
-            : (
-              <ul className="flex flex-col divide-y rounded-md border">
-                {layouts.map(layout => (
-                  <li
-                    key={layout.id}
-                    className="
-                      flex flex-wrap items-center justify-between gap-2 p-3
-                    "
-                  >
-                    <div className="flex flex-col gap-1">
-                      <span className="font-medium">{layout.name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {layout.tiles.length}
-                        {" "}
-                        tile(s) shown
-                      </span>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => setRenamingLayoutId(layout.id)}
-                      >
-                        <PencilIcon className="size-4" />
-                        Rename
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => deleteLayoutMutation.mutate(layout.id)}
-                        disabled={deleteLayoutMutation.isPending}
-                      >
-                        <Trash2Icon className="size-4" />
-                        Delete
-                      </Button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
+          : (
+            <>
+              <div className="flex flex-col gap-2">
+                <h3 className="text-sm font-medium text-muted-foreground">
+                  Tabs
+                </h3>
+                {tabs.length === 0
+                  ? (
+                    <p className="text-sm text-muted-foreground">
+                      No layouts yet. Visit the dashboard to create the default
+                      one, or add one here.
+                    </p>
+                  )
+                  : (
+                    <ul className="flex flex-col divide-y rounded-md border">
+                      {tabs.map(layout => (
+                        <LayoutRow
+                          key={layout.id}
+                          layout={layout}
+                          {...rowProps}
+                        />
+                      ))}
+                    </ul>
+                  )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <h3 className="text-sm font-medium text-muted-foreground">
+                  Saved presets
+                </h3>
+                {presets.length === 0
+                  ? (
+                    <p className="text-sm text-muted-foreground">
+                      No saved presets yet. Use “Save as preset” on a layout to
+                      reuse its tiles later.
+                    </p>
+                  )
+                  : (
+                    <ul className="flex flex-col divide-y rounded-md border">
+                      {presets.map(layout => (
+                        <LayoutRow
+                          key={layout.id}
+                          layout={layout}
+                          {...rowProps}
+                        />
+                      ))}
+                    </ul>
+                  )}
+              </div>
+            </>
+          )}
       </section>
 
       <LayoutNameDialog
-        open={renamingLayout !== null}
+        open={renameTarget !== null}
         title="Rename layout"
-        initialName={renamingLayout?.name ?? ""}
-        isSaving={renameLayoutMutation.isPending}
+        initialName={renameTarget?.name ?? ""}
+        isSaving={renameMutation.isPending}
         onOpenChange={(open) => {
-          if (!open) setRenamingLayoutId(null);
+          if (!open) setRenameTargetId(null);
         }}
         onSubmit={(name) => {
-          if (renamingLayout) {
-            renameLayoutMutation.mutate({
-              layout: renamingLayout,
+          if (renameTarget) {
+            renameMutation.mutate({
+              layout: renameTarget,
               name,
             });
           }
@@ -172,12 +371,56 @@ export function DashboardLayoutsSection() {
       />
 
       <LayoutNameDialog
-        open={creatingNewLayout}
-        title="New layout"
+        open={saveAsTarget !== null}
+        title="Save as preset"
+        submitLabel="Save"
+        initialName={saveAsTarget?.name ?? ""}
+        isSaving={saveAsPresetMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) setSaveAsTargetId(null);
+        }}
+        onSubmit={(name) => {
+          if (saveAsTarget) {
+            saveAsPresetMutation.mutate({
+              name,
+              layout: saveAsTarget,
+            });
+          }
+        }}
+      />
+
+      <LayoutNameDialog
+        open={creatingKind !== null}
+        title={creatingKind === "preset" ? "New preset" : "New layout"}
         submitLabel="Create"
-        isSaving={createLayoutMutation.isPending}
-        onOpenChange={setCreatingNewLayout}
-        onSubmit={name => createLayoutMutation.mutate(name)}
+        isSaving={createMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) setCreatingKind(null);
+        }}
+        onSubmit={(name) => {
+          if (creatingKind) {
+            createMutation.mutate({
+              name,
+              kind: creatingKind,
+            });
+          }
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete layout?"
+        description={
+          deleteTarget
+            ? `"${deleteTarget.name}" will be removed. This can't be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        onCancel={() => setDeleteTargetId(null)}
       />
     </>
   );

--- a/packages/client/src/utils/api/dashboardLayouts.ts
+++ b/packages/client/src/utils/api/dashboardLayouts.ts
@@ -11,3 +11,4 @@ export const fetchDashboardLayouts = dashboardLayoutsApi.list;
 export const createDashboardLayout = dashboardLayoutsApi.create;
 export const upsertDashboardLayout = dashboardLayoutsApi.upsert;
 export const deleteSingleDashboardLayout = dashboardLayoutsApi.delete;
+export const duplicateDashboardLayout = dashboardLayoutsApi.duplicate;

--- a/packages/middleware/src/db/schema/dashboardLayouts.ts
+++ b/packages/middleware/src/db/schema/dashboardLayouts.ts
@@ -1,10 +1,12 @@
-import { integer, jsonb, pgTable, varchar } from "drizzle-orm/pg-core";
+import { boolean, integer, jsonb, pgTable, varchar } from "drizzle-orm/pg-core";
 
 import type { DashboardLayoutTile } from "./enums";
 
 // Named dashboard layouts selectable from the dashboard's tab bar. `position`
 // orders the tabs; `tiles` holds the enabled tiles with their grid placement
-// (disabled tiles are absent from the array).
+// (disabled tiles are absent from the array). `isTemplate` marks a saved
+// preset ("saved layout") — excluded from the tab strip and offered as a
+// starting point when adding a tab.
 export const dashboardLayouts = pgTable("dashboard_layouts", {
   id: varchar().primaryKey(),
   name: varchar({
@@ -12,4 +14,5 @@ export const dashboardLayouts = pgTable("dashboard_layouts", {
   }).notNull(),
   position: integer(),
   tiles: jsonb().$type<DashboardLayoutTile[]>().default([]).notNull(),
+  isTemplate: boolean("is_template").default(false).notNull(),
 });

--- a/packages/middleware/src/routes/api/dashboard-layouts/duplicateDashboardLayout.ts
+++ b/packages/middleware/src/routes/api/dashboard-layouts/duplicateDashboardLayout.ts
@@ -1,0 +1,64 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { v4 as uuidv4 } from "uuid";
+import { db } from "@/db";
+import { dashboardLayouts } from "@/db/schema";
+import { sendNotFound } from "@/utils/errors";
+import { idParamSchema } from "@/utils/schemas";
+
+const duplicateSchema = {
+  schema: {
+    description: "Duplicate a dashboard layout by ID",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.post(
+    "/:id/duplicate",
+    duplicateSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const source = await db.query.dashboardLayouts.findFirst({
+        where: (l, {
+          eq,
+        }) => eq(l.id, id),
+      });
+
+      if (!source) {
+        return sendNotFound(reply, "Dashboard layout");
+      }
+
+      // A duplicated preset stays a preset (no tab position); a duplicated tab
+      // is placed at the end of the strip.
+      let position: number | null = null;
+      if (!source.isTemplate) {
+        const rows = await db.query.dashboardLayouts.findMany();
+        const maxPosition = rows.reduce(
+          (max, l) => (l.isTemplate ? max : Math.max(max, l.position ?? 0)),
+          -1,
+        );
+        position = maxPosition + 1;
+      }
+
+      const newId = uuidv4();
+      await db.insert(dashboardLayouts).values({
+        id: newId,
+        name: `${source.name} (Copy)`,
+        position,
+        tiles: source.tiles,
+        isTemplate: source.isTemplate,
+      });
+
+      return {
+        status: "ok",
+        id: newId,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/dashboard-layouts/root.ts
+++ b/packages/middleware/src/routes/api/dashboard-layouts/root.ts
@@ -4,7 +4,11 @@ import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db";
 import { dashboardLayouts } from "@/db/schema";
 import type { DashboardLayoutTile } from "@/db/schema";
-import { dashboardLayoutTilesSchema, nullableInteger } from "@/utils/schemas";
+import {
+  dashboardLayoutTilesSchema,
+  nullableBoolean,
+  nullableInteger,
+} from "@/utils/schemas";
 
 const createSchema = {
   schema: {
@@ -19,6 +23,7 @@ const createSchema = {
         },
         position: nullableInteger,
         tiles: dashboardLayoutTilesSchema,
+        isTemplate: nullableBoolean,
       },
     },
   },
@@ -51,6 +56,7 @@ export default async function (server: FastifyInstance) {
         name: body.name,
         position: body.position ?? null,
         tiles: (body.tiles ?? []) as DashboardLayoutTile[],
+        isTemplate: body.isTemplate ?? false,
       });
 
       return {

--- a/packages/middleware/src/routes/api/dashboard-layouts/routes.ts
+++ b/packages/middleware/src/routes/api/dashboard-layouts/routes.ts
@@ -5,6 +5,7 @@ import root from "./root";
 import getDashboardLayout from "./getDashboardLayout";
 import upsertDashboardLayout from "./upsertDashboardLayout";
 import deleteDashboardLayout from "./deleteDashboardLayout";
+import duplicateDashboardLayout from "./duplicateDashboardLayout";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -13,4 +14,5 @@ export default async function (server: FastifyInstance) {
   fastify.register(getDashboardLayout);
   fastify.register(upsertDashboardLayout);
   fastify.register(deleteDashboardLayout);
+  fastify.register(duplicateDashboardLayout);
 }

--- a/packages/middleware/src/routes/api/dashboard-layouts/upsertDashboardLayout.ts
+++ b/packages/middleware/src/routes/api/dashboard-layouts/upsertDashboardLayout.ts
@@ -1,18 +1,24 @@
 import { dashboardLayouts } from "@/db/schema";
 import type { DashboardLayoutTile } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
-import { dashboardLayoutTilesSchema, nullableInteger } from "@/utils/schemas";
+import {
+  dashboardLayoutTilesSchema,
+  nullableBoolean,
+  nullableInteger,
+} from "@/utils/schemas";
 
 interface DashboardLayoutBody {
   name: string;
   position?: number | null;
   tiles?: DashboardLayoutTile[];
+  isTemplate?: boolean | null;
 }
 
 const updateableColumns = [
   "name",
   "position",
   "tiles",
+  "isTemplate",
 ] as const;
 
 export default createUpsertHandler<DashboardLayoutBody>({
@@ -28,6 +34,7 @@ export default createUpsertHandler<DashboardLayoutBody>({
       },
       position: nullableInteger,
       tiles: dashboardLayoutTilesSchema,
+      isTemplate: nullableBoolean,
     },
   },
   buildRow: (body, id) => ({
@@ -35,6 +42,7 @@ export default createUpsertHandler<DashboardLayoutBody>({
     name: body.name,
     position: body.position ?? null,
     tiles: (body.tiles ?? []) as DashboardLayoutTile[],
+    isTemplate: body.isTemplate ?? false,
   }),
   updateableColumns,
 });

--- a/packages/types/src/DashboardLayout.ts
+++ b/packages/types/src/DashboardLayout.ts
@@ -28,4 +28,8 @@ export interface DashboardLayout {
   name: string;
   position?: number | null;
   tiles: DashboardLayoutTile[];
+  // Presets ("saved layouts") are excluded from the dashboard's tab strip and
+  // offered as starting points when adding a tab. A missing value means "a
+  // normal tab", so existing layouts read as tabs without a backfill.
+  isTemplate?: boolean;
 }


### PR DESCRIPTION
## Summary

This PR introduces a two-tier dashboard layout system: **tabs** (layouts shown in the dashboard strip) and **presets** (saved tile arrangements offered as starting points when creating new tabs). It also adds comprehensive tab management features including rename, duplicate, delete, and per-tab tile visibility controls.

## Key Changes

### Dashboard Layout System
- Split layouts into tabs (`isTemplate: false`) and presets (`isTemplate: true`)
- Tabs appear in the dashboard tab strip; presets are hidden but offered when adding a new tab
- Added `isTemplate` boolean field to `DashboardLayout` type and database schema

### Tab Management Features
- **Rename:** Edit tab names via dialog
- **Duplicate:** Create a copy of any tab or preset with "(Copy)" suffix
- **Save as preset:** Convert a tab's tile arrangement into a reusable preset
- **Delete:** Remove tabs/presets with confirmation dialog
- **Toggle tiles:** Per-tab visibility controls in a dropdown menu (same UX as the old global tiles menu)

### New Components & Utilities
- `LayoutTab` component: Dashboard tab with hover-revealed "More" menu (never nested buttons, always visible on touch)
- `LayoutRow` component: Settings page layout/preset row with dropdown actions
- `AddLayoutDialog`: New tab creation dialog with preset picker (built-in curated layouts + saved presets)
- `LAYOUT_PRESETS`: Code-defined starting layouts (Blank, Default, Courses focus, Tasks & habits)
- `duplicateDashboardLayout` API endpoint: Backend support for cloning layouts

### API & Backend
- New `POST /:id/duplicate` endpoint to clone a layout with auto-positioned tabs
- Updated `upsertDashboardLayout` to handle `isTemplate` field
- Updated `createDashboardLayout` to accept `isTemplate` and position logic (tabs get positions, presets don't)

### Settings Page Refactor
- Separated layouts into "Tabs" and "Saved presets" sections
- Unified action menu (rename, duplicate, save as preset, delete, tile toggles) for both
- Improved empty states with contextual guidance

### Testing
- Added `layoutPresets.test.ts`: Validates preset grid layout, tile overlap, minimum sizes, and uniqueness

## Implementation Details

- **Tile toggle mutations:** Extracted into `toggleTileMutation` to support both dashboard tabs and settings rows
- **State management:** Separate `renameTargetId`, `saveAsTargetId`, `deleteTargetId` for dialog targeting
- **Preset picker:** `AddLayoutDialog` syncs suggested name from selection until user types; built-in presets and saved presets are merged into a single dropdown
- **Position logic:** Tabs are positioned sequentially; presets have `position: null`
- **Confirmation dialog:** Delete operations now require explicit confirmation

https://claude.ai/code/session_019DZBiKZSaBkSxQU9owijiV