### PR TITLE
Add CI workflow and optimize Docker build for type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  # Also guard the mainline so a merge can't slip a type/lint error past the PR gate.
+  push:
+    branches: [master]
+
+# Superseded PR pushes don't need to keep running; cancel the in-flight run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # eslint . is check-only here (no --fix); @stylistic rules make this the
+      # combined lint + formatting gate.
+      - name: Lint and format check
+        run: pnpm lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,10 @@ RUN pnpm --filter @emstack/types build
 FROM build-types AS build-middleware
 
 COPY packages/middleware/ ./packages/middleware/
-RUN pnpm --filter @emstack/middleware build
+# Transpile-only: skip type checking here (--noCheck) since CI (.github/workflows/ci.yml)
+# owns the type gate. Mirrors the `build` script minus the type check to speed up images.
+RUN pnpm --filter @emstack/middleware exec tsc -b tsconfig.build.json --noCheck \
+ && pnpm --filter @emstack/middleware exec tsc-alias -p tsconfig.build.json --resolve-full-paths
 
 
 FROM build-types AS build-client


### PR DESCRIPTION
## Summary

Introduces a GitHub Actions CI workflow to gate type checking and linting on pull requests and the mainline, and optimizes the Docker build to skip redundant type checking in the middleware layer since CI now owns that gate.

## Changes

- **Add `.github/workflows/ci.yml`:** New CI workflow that runs on PR events and pushes to `master`. Includes two jobs:
  - `typecheck`: Runs `pnpm typecheck` to validate TypeScript across all buildable packages
  - `lint`: Runs `pnpm lint` (ESLint + formatting check via `@stylistic` rules)
  - Configured with concurrency to cancel superseded PR runs
  - Uses Node.js 22 and pnpm with frozen lockfile for reproducibility

- **Optimize `Dockerfile` middleware build:** Replace the full `pnpm build` with a transpile-only approach:
  - Runs `tsc -b tsconfig.build.json --noCheck` to skip type checking (now owned by CI)
  - Follows with `tsc-alias` for path resolution
  - Mirrors the `build` script minus type checking to reduce image build time
  - Added clarifying comment explaining the rationale

## Implementation Details

The CI workflow uses standard GitHub Actions setup (checkout, pnpm, Node.js 22) with caching enabled. The `--frozen-lockfile` flag ensures reproducible installs. The Docker optimization maintains build correctness by still transpiling and resolving paths—only the type gate is removed, since CI will catch type errors before merge.

https://claude.ai/code/session_015NKd243woJk7dMebyonXx4