### PR TITLE
Add padding around radar chart to prevent label clipping

### DIFF
--- a/packages/client/src/components/radar/RadarChart.tsx
+++ b/packages/client/src/components/radar/RadarChart.tsx
@@ -21,6 +21,8 @@ import {
   IGNORED_LABEL_COLOR,
   IGNORED_LABEL_GAP,
   QUADRANT_PALETTE,
+  RADAR_LABEL_PADDING_X,
+  RADAR_LABEL_PADDING_Y,
   computeRingRadii,
   layoutStripBlips,
   positionRadarBlips,
@@ -267,10 +269,10 @@ export function RadarChart({
       >
         <div className="flex-1">
           <svg
-            viewBox={`0 0 ${size} ${totalHeight}`}
+            viewBox={`${-RADAR_LABEL_PADDING_X} ${-RADAR_LABEL_PADDING_Y} ${size + RADAR_LABEL_PADDING_X * 2} ${totalHeight + RADAR_LABEL_PADDING_Y * 2}`}
             width="100%"
             style={{
-              maxWidth: size,
+              maxWidth: size + RADAR_LABEL_PADDING_X * 2,
             }}
             role="img"
             aria-label="Radar chart"

--- a/packages/client/src/components/radar/radarLayout.ts
+++ b/packages/client/src/components/radar/radarLayout.ts
@@ -18,6 +18,11 @@ export const QUADRANT_PALETTE = [
   "#db2777",
 ];
 
+// Gutters around the radar drawing so slice/ring labels positioned just outside
+// the circle (RadarChart) aren't clipped by the SVG viewport.
+export const RADAR_LABEL_PADDING_X = 88;
+export const RADAR_LABEL_PADDING_Y = 24;
+
 export const ADOPTED_DOT_RADIUS = 8;
 export const ADOPTED_DOT_SPACING = 22;
 export const ADOPTED_AREA_BOTTOM_PAD = 12;


### PR DESCRIPTION
## Summary
Adds configurable padding around the radar chart SVG viewport to prevent slice and ring labels positioned just outside the circle from being clipped by the viewport boundaries.

## Changes
- **radarLayout.ts:** Export two new constants (`RADAR_LABEL_PADDING_X` and `RADAR_LABEL_PADDING_Y`) that define gutters around the radar drawing area
- **RadarChart.tsx:** 
  - Import the new padding constants
  - Adjust SVG `viewBox` to include negative offsets and expanded dimensions based on the padding values
  - Update `maxWidth` style to account for horizontal padding on both sides

## Implementation Details
The padding values (88px horizontal, 24px vertical) provide sufficient space for labels that are positioned just outside the radar circle without being clipped. The SVG viewport is expanded symmetrically in all directions by adjusting the viewBox origin to negative coordinates and increasing the viewBox dimensions accordingly.

https://claude.ai/code/session_01D9H7VEZxPS7voa9GuKFW8a