### PR TITLE
Add "Explore Something" dashboard card and focused domains feature

### DIFF
--- a/packages/client/src/components/boxes/DomainBox.tsx
+++ b/packages/client/src/components/boxes/DomainBox.tsx
@@ -1,6 +1,6 @@
 import type { Domain } from "@emstack/types";
 
-import { BookIcon } from "lucide-react";
+import { BookIcon, StarIcon } from "lucide-react";
 
 import { CourseMetaItem } from "@/components/boxElements/CourseMetaItem";
 import { Description } from "@/components/boxElements/Description";
@@ -19,18 +19,30 @@ export function DomainBox({
   title,
   description,
   topicCount,
-}: Domain) {
+  focused = false,
+}: Domain & { focused?: boolean }) {
   return (
     <ContentBox>
       <ContentBoxHeader>
         <ContentBoxHeaderBar />
         <ContentBoxTitle>
-          <h3 className="text-2xl">
+          <h3 className="flex items-center gap-2 text-2xl">
             <EntityLink
               entity="domains"
               id={id}
             >{title}
             </EntityLink>
+            {focused && (
+              <span
+                className="
+                  inline-flex items-center gap-1 rounded-full bg-primary/10 px-2
+                  py-0.5 text-xs font-medium text-primary
+                "
+              >
+                <StarIcon className="size-3 fill-current" />
+                Focused
+              </span>
+            )}
           </h3>
         </ContentBoxTitle>
       </ContentBoxHeader>

--- a/packages/client/src/hooks/useExploreRing.ts
+++ b/packages/client/src/hooks/useExploreRing.ts
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+const STORAGE_KEY = "emstack-explore-ring";
+const DEFAULT_RING = "Trial";
+
+/**
+ * Persists the "Explore Something" card's selected ring in localStorage. When
+ * the stored ring isn't among the available ring names (config changed, or
+ * first use), falls back to "Trial" if present, otherwise the first ring.
+ */
+export function useExploreRing(rings: string[] | undefined) {
+  const [storedRing, setStoredRing] = useState<string>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_RING;
+    }
+    catch {
+      return DEFAULT_RING;
+    }
+  });
+
+  const setRing = (ring: string) => {
+    setStoredRing(ring);
+    try {
+      localStorage.setItem(STORAGE_KEY, ring);
+    }
+    catch {
+      // Ignore storage failures (private mode / quota) — selection still works
+      // for the session.
+    }
+  };
+
+  // While rings are still loading, surface the stored value as-is so the
+  // <Select> has a stable value and doesn't flicker.
+  const ring = !rings || rings.includes(storedRing)
+    ? storedRing
+    : rings.includes(DEFAULT_RING)
+      ? DEFAULT_RING
+      : rings[0] ?? DEFAULT_RING;
+
+  return {
+    ring,
+    setRing,
+  };
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
@@ -1,0 +1,198 @@
+import type { ExploreItem } from "@emstack/types";
+
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import {
+  DashboardCard,
+  DashboardSectionStatus,
+} from "@/components/boxes/DashboardCard";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { useExploreRing } from "@/hooks/useExploreRing";
+import { fetchDomains, fetchExplore, fetchSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+const ALL_TAB = "all";
+
+function ItemList({
+  items,
+  showDomain,
+}: {
+  items: ExploreItem[];
+  showDomain: boolean;
+}) {
+  return (
+    <ul className="flex flex-col divide-y">
+      {items.map(item => (
+        <li
+          key={`${item.domainId}:${item.topicId}`}
+          className="flex flex-row items-center gap-2 py-2"
+        >
+          <div className="flex min-w-0 flex-col">
+            <Link
+              to="/topics/$id"
+              params={{
+                id: item.topicId,
+              }}
+              className="
+                truncate font-medium
+                hover:text-blue-600
+              "
+            >
+              {item.topicName}
+            </Link>
+            {showDomain && (
+              <span className="truncate text-xs text-muted-foreground">
+                {item.domainTitle}
+              </span>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function DashboardExplore() {
+  const {
+    data, isPending, error,
+  } = useQuery({
+    queryKey: queryKeys.domains.explore(),
+    queryFn: () => fetchExplore(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: settings,
+  } = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+
+  const {
+    data: domains,
+  } = useQuery({
+    queryKey: queryKeys.domains.list(),
+    queryFn: () => fetchDomains(),
+  });
+
+  const rings = data?.rings ?? [];
+  const {
+    ring, setRing,
+  } = useExploreRing(data ? rings : undefined);
+
+  // Focused domains (in saved order), limited to ones that still exist.
+  const domainTitleById = new Map(
+    (domains ?? []).map(d => [d.id, d.title]),
+  );
+  const focusedDomains = (settings?.focusedDomainIds ?? [])
+    .filter(id => domainTitleById.has(id))
+    .map(id => ({
+      id,
+      title: domainTitleById.get(id) ?? "",
+    }));
+
+  const matchesRing = (item: ExploreItem) =>
+    item.ringName?.toLowerCase() === ring.toLowerCase();
+  const itemsInRing = (data?.items ?? []).filter(matchesRing);
+
+  return (
+    <DashboardCard
+      title="Explore Something"
+      action={rings.length > 0
+        ? (
+          <Select
+            value={ring}
+            onValueChange={setRing}
+          >
+            <SelectTrigger size="sm">
+              <SelectValue placeholder="Ring" />
+            </SelectTrigger>
+            <SelectContent>
+              {rings.map(r => (
+                <SelectItem
+                  key={r}
+                  value={r}
+                >
+                  {r}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )
+        : null}
+    >
+      <Tabs defaultValue={ALL_TAB}>
+        <TabsList className="h-8">
+          <TabsTrigger
+            value={ALL_TAB}
+            className="text-xs"
+          >
+            All Domains
+          </TabsTrigger>
+          {focusedDomains.map(d => (
+            <TabsTrigger
+              key={d.id}
+              value={d.id}
+              className="text-xs"
+            >
+              {d.title}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value={ALL_TAB}>
+          <DashboardSectionStatus
+            isPending={isPending}
+            error={error}
+            isEmpty={!isPending && !error && itemsInRing.length === 0}
+            entity="items"
+            emptyMessage={`No items in the ${ring} ring.`}
+          />
+          {itemsInRing.length > 0 && (
+            <ItemList
+              items={itemsInRing}
+              showDomain
+            />
+          )}
+        </TabsContent>
+
+        {focusedDomains.map((d) => {
+          const domainItems = itemsInRing.filter(item => item.domainId === d.id);
+          return (
+            <TabsContent
+              key={d.id}
+              value={d.id}
+            >
+              <DashboardSectionStatus
+                isPending={isPending}
+                error={error}
+                isEmpty={!isPending && !error && domainItems.length === 0}
+                entity="items"
+                emptyMessage={`No items in the ${ring} ring.`}
+              />
+              {domainItems.length > 0 && (
+                <ItemList
+                  items={domainItems}
+                  showDomain={false}
+                />
+              )}
+            </TabsContent>
+          );
+        })}
+      </Tabs>
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -6,6 +6,7 @@ import { DndGrid } from "@dnd-grid/react";
 import { DashboardCoursesByAmortization } from "./-DashboardCoursesByAmortization";
 import { DashboardCoursesInProgress } from "./-DashboardCoursesInProgress";
 import { DashboardDailies } from "./-DashboardDailies";
+import { DashboardExplore } from "./-DashboardExplore";
 import { DashboardRadars } from "./-DashboardRadars";
 import { DashboardReadwise } from "./-DashboardReadwise";
 import {
@@ -24,6 +25,7 @@ const TILE_COMPONENTS: Record<DashboardTileId, React.ComponentType> = {
   coursesByAmortization: DashboardCoursesByAmortization,
   coursesInProgress: DashboardCoursesInProgress,
   radars: DashboardRadars,
+  exploreSomething: DashboardExplore,
   readwise: DashboardReadwise,
   todoist: DashboardTodoist,
 };

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
@@ -37,6 +37,11 @@ export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
     minW: 1,
     minH: 4,
   },
+  exploreSomething: {
+    title: "Explore Something",
+    minW: 1,
+    minH: 4,
+  },
   readwise: {
     title: "Readwise",
     minW: 2,
@@ -80,6 +85,10 @@ const DEFAULT_TILE_HEIGHTS: { tileId: DashboardTileId;
   },
   {
     tileId: "radars",
+    h: 7,
+  },
+  {
+    tileId: "exploreSomething",
     h: 7,
   },
   {

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -10,7 +10,8 @@ import { EntityError, EntityPending } from "@/components/EntityStates";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { Button } from "@/components/ui/button";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
-import { fetchDomains } from "@/utils";
+import { fetchDomains, fetchSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
 
 export const Route = createFileRoute("/domains/")({
   component: DomainsIndex,
@@ -30,9 +31,36 @@ function DomainsIndex() {
   const {
     data,
   } = useQuery({
-    queryKey: ["domains"],
+    queryKey: queryKeys.domains.list(),
     queryFn: () => fetchDomains(),
   });
+
+  const {
+    data: settings,
+  } = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+
+  const focusedIds = settings?.focusedDomainIds ?? [];
+  const focusedRank = new Map(focusedIds.map((id, i) => [id, i]));
+  // Focused domains first (in their saved order), then everything else in its
+  // original order. A stable sort keeps non-focused domains as the API returned
+  // them.
+  const sortedDomains = (data ?? [])
+    .map((domain, index) => ({
+      domain,
+      index,
+    }))
+    .sort((a, b) => {
+      const aRank = focusedRank.get(a.domain.id ?? "");
+      const bRank = focusedRank.get(b.domain.id ?? "");
+      if (aRank !== undefined && bRank !== undefined) return aRank - bRank;
+      if (aRank !== undefined) return -1;
+      if (bRank !== undefined) return 1;
+      return a.index - b.index;
+    })
+    .map(entry => entry.domain);
 
   return (
     <div>
@@ -74,15 +102,15 @@ function DomainsIndex() {
             </div>
           )}
 
-          {data
-            && data.length > 0
-            && data.map((domain: Domain) => {
+          {sortedDomains.length > 0
+            && sortedDomains.map((domain: Domain) => {
               if (domain.title === "" || domain.id === undefined) {
                 return;
               }
               return (
                 <DomainBox
                   {...domain}
+                  focused={focusedRank.has(domain.id)}
                   key={domain.id}
                 />
               );

--- a/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
@@ -1,0 +1,138 @@
+import type { AppSettingsSummary, Domain } from "@emstack/types";
+
+import { MAX_FOCUSED_DOMAINS } from "@emstack/types";
+import { useStore } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAppForm } from "@/components/formFields";
+import { EditForm } from "@/components/layout/EditForm";
+import { Button } from "@/components/ui/button";
+import { fetchDomains, fetchSettings, updateSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+const formSchema = z.object({
+  focusedDomainIds: z
+    .array(z.string())
+    .max(MAX_FOCUSED_DOMAINS, `Pick at most ${MAX_FOCUSED_DOMAINS} domains.`),
+});
+
+export function FocusedDomainsSection() {
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const domainsQuery = useQuery({
+    queryKey: queryKeys.domains.list(),
+    queryFn: () => fetchDomains(),
+  });
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xl font-semibold">Focused Domains</h2>
+      <p className="text-sm text-muted-foreground">
+        Choose up to
+        {" "}
+        {MAX_FOCUSED_DOMAINS}
+        {" "}
+        domains to focus on. Focused domains sort to the top of the Domains page
+        and each get their own tab in the dashboard&apos;s Explore Something
+        card.
+      </p>
+      {settingsQuery.data && domainsQuery.data
+        ? (
+          <FocusedDomainsForm
+            settings={settingsQuery.data}
+            domains={domainsQuery.data}
+          />
+        )
+        : (
+          <p className="text-sm text-muted-foreground">Loading domains...</p>
+        )}
+    </section>
+  );
+}
+
+function FocusedDomainsForm({
+  settings,
+  domains,
+}: {
+  settings: AppSettingsSummary;
+  domains: Domain[];
+}) {
+  const queryClient = useQueryClient();
+
+  const domainOptions = domains
+    .filter((d): d is Domain & { id: string } => Boolean(d.id))
+    .map(d => ({
+      value: d.id,
+      label: d.title,
+    }));
+
+  // Drop stale ids (domains deleted since the selection was saved) so chips
+  // only show currently-existing domains.
+  const existingIds = new Set(domainOptions.map(o => o.value));
+  const initialFocused = settings.focusedDomainIds.filter(id =>
+    existingIds.has(id));
+
+  const saveMutation = useMutation({
+    mutationFn: (focusedDomainIds: string[]) =>
+      updateSettings({
+        focusedDomainIds,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.settings.detail(),
+      });
+      toast.success("Focused domains saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const form = useAppForm({
+    defaultValues: {
+      focusedDomainIds: initialFocused,
+    },
+    validators: {
+      onChange: formSchema,
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      await saveMutation.mutateAsync(value.focusedDomainIds);
+    },
+  });
+
+  const canSubmit = useStore(form.store, state => state.canSubmit);
+
+  return (
+    <EditForm
+      onSubmit={form.handleSubmit}
+      className="flex max-w-xl flex-col gap-4"
+    >
+      <form.AppField name="focusedDomainIds">
+        {field => (
+          <field.MultiComboboxField
+            label="Focused domains"
+            options={domainOptions}
+            placeholder="Search domains..."
+          />
+        )}
+      </form.AppField>
+      <div>
+        <Button
+          type="submit"
+          disabled={!canSubmit || saveMutation.isPending}
+        >
+          {saveMutation.isPending && <Loader2 className="animate-spin" />}
+          Save Focused Domains
+        </Button>
+      </div>
+    </EditForm>
+  );
+}

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -4,6 +4,7 @@ import { MoonIcon, SunIcon } from "lucide-react";
 import { CriteriaTemplatesSection } from "./settings.-components/-CriteriaTemplatesSection";
 import { DashboardLayoutsSection } from "./settings.-components/-DashboardLayoutsSection";
 import { DataToolsSection } from "./settings.-components/-DataToolsSection";
+import { FocusedDomainsSection } from "./settings.-components/-FocusedDomainsSection";
 import { ReadwiseSection } from "./settings.-components/-ReadwiseSection";
 import { RoutineTemplatesSection } from "./settings.-components/-RoutineTemplatesSection";
 import { TaskTypesSection } from "./settings.-components/-TaskTypesSection";
@@ -36,6 +37,8 @@ function Settings() {
         <CriteriaTemplatesSection />
 
         <RoutineTemplatesSection />
+
+        <FocusedDomainsSection />
 
         <DashboardLayoutsSection />
 

--- a/packages/client/src/utils/api/domains.ts
+++ b/packages/client/src/utils/api/domains.ts
@@ -1,6 +1,6 @@
-import type { Domain } from "@emstack/types";
+import type { Domain, ExploreData } from "@emstack/types";
 
-import { createEntityClient } from "./client";
+import { createEntityClient, fetchJson } from "./client";
 
 const domainsApi = createEntityClient<Domain>("domains", "domain");
 
@@ -10,3 +10,6 @@ export const upsertDomain = domainsApi.upsert;
 export const createDomain = domainsApi.create;
 export const deleteSingleDomain = domainsApi.delete;
 export const duplicateDomain = domainsApi.duplicate;
+
+// Radar items across all domains for the "Explore Something" dashboard card.
+export const fetchExplore = () => fetchJson<ExploreData>("/api/domains/explore");

--- a/packages/client/src/utils/queryKeys.ts
+++ b/packages/client/src/utils/queryKeys.ts
@@ -38,6 +38,7 @@ export const queryKeys = {
     list: () => ["domains"] as const,
     detail: (id: string) => ["domain", id] as const,
     radar: (id: string) => ["radar", id] as const,
+    explore: () => ["domains-explore"] as const,
   },
   tagGroups: {
     list: () => ["tagGroups"] as const,

--- a/packages/middleware/src/db/schema/settings.ts
+++ b/packages/middleware/src/db/schema/settings.ts
@@ -1,4 +1,4 @@
-import { pgTable, varchar } from "drizzle-orm/pg-core";
+import { jsonb, pgTable, varchar } from "drizzle-orm/pg-core";
 
 // Single-row application settings. The row is keyed by a constant id ("global")
 // and created on first write via onConflictDoUpdate — there is no multi-user
@@ -8,4 +8,11 @@ export const appSettings = pgTable("app_settings", {
   id: varchar().primaryKey().default("global"),
   readwiseApiKey: varchar("readwise_api_key"),
   todoistApiKey: varchar("todoist_api_key"),
+  // Ordered ids of the domains the user has marked "Focused". Capped at 3 by the
+  // update handler; ordering drives the focused tabs in the dashboard's
+  // "Explore Something" card.
+  focusedDomainIds: jsonb("focused_domain_ids")
+    .$type<string[]>()
+    .notNull()
+    .default([]),
 });

--- a/packages/middleware/src/routes/api/domains/explore.ts
+++ b/packages/middleware/src/routes/api/domains/explore.ts
@@ -1,0 +1,74 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import type { ExploreData, ExploreItem } from "@emstack/types";
+
+const exploreSchema = {
+  schema: {
+    description:
+      "Radar items (non-ignored blips) across all domains, with each blip's ring resolved to its name. Powers the dashboard's \"Explore Something\" card.",
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/explore",
+    exploreSchema,
+    async (): Promise<ExploreData> => {
+      const domains = await db.query.domains.findMany({
+        with: {
+          radarBlips: {
+            with: {
+              topic: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const items: ExploreItem[] = [];
+      // name -> smallest ring position seen, so the selector lists rings in the
+      // usual radar order (Adopt, Trial, …) rather than alphabetically.
+      const ringPositions = new Map<string, number>();
+
+      for (const domain of domains) {
+        const rings = domain.radarConfig?.rings ?? [];
+        const ringNameById = new Map(rings.map(r => [r.id, r.name]));
+
+        for (const ring of rings) {
+          const prev = ringPositions.get(ring.name);
+          if (prev === undefined || ring.position < prev) {
+            ringPositions.set(ring.name, ring.position);
+          }
+        }
+
+        for (const blip of domain.radarBlips ?? []) {
+          if (blip.isIgnored) continue;
+          items.push({
+            topicId: blip.topicId,
+            topicName: blip.topic?.name ?? "",
+            domainId: domain.id,
+            domainTitle: domain.title,
+            ringName: blip.ringId ? ringNameById.get(blip.ringId) ?? null : null,
+          });
+        }
+      }
+
+      const ringNames = [...ringPositions.keys()].sort((a, b) => {
+        const posDiff = (ringPositions.get(a) ?? 0) - (ringPositions.get(b) ?? 0);
+        return posDiff !== 0 ? posDiff : a.localeCompare(b);
+      });
+
+      return {
+        rings: ringNames,
+        items,
+      };
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/domains/routes.ts
+++ b/packages/middleware/src/routes/api/domains/routes.ts
@@ -2,6 +2,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 
 import domainRoot from "./root";
+import explore from "./explore";
 import getDomain from "./getDomain";
 import createDomain from "./createDomain";
 import upsertDomain from "./upsertDomain";
@@ -18,6 +19,7 @@ export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
 
   fastify.register(domainRoot);
+  fastify.register(explore);
   fastify.register(getDomain);
   fastify.register(createDomain);
   fastify.register(upsertDomain);

--- a/packages/middleware/src/routes/api/settings/root.ts
+++ b/packages/middleware/src/routes/api/settings/root.ts
@@ -25,6 +25,7 @@ export default async function (server: FastifyInstance) {
         readwiseKeyHint: maskKey(readwiseKey),
         todoistConfigured: Boolean(todoistKey),
         todoistKeyHint: maskKey(todoistKey),
+        focusedDomainIds: row?.focusedDomainIds ?? [],
       };
     },
   );

--- a/packages/middleware/src/routes/api/settings/updateSettings.ts
+++ b/packages/middleware/src/routes/api/settings/updateSettings.ts
@@ -1,5 +1,6 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
+import { MAX_FOCUSED_DOMAINS } from "@emstack/types";
 import { db } from "@/db";
 import { appSettings } from "@/db/schema";
 import { nullableString } from "@/utils/schemas";
@@ -16,6 +17,12 @@ const updateSchema = {
       properties: {
         readwiseApiKey: nullableString,
         todoistApiKey: nullableString,
+        focusedDomainIds: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
       },
     },
   },
@@ -42,6 +49,12 @@ export default async function (server: FastifyInstance) {
       }
       if (request.body.todoistApiKey !== undefined) {
         updates.todoistApiKey = normalizeKey(request.body.todoistApiKey);
+      }
+      if (request.body.focusedDomainIds !== undefined) {
+        // Dedupe while preserving order, then enforce the focus cap server-side
+        // so the limit holds regardless of the client.
+        const deduped = [...new Set(request.body.focusedDomainIds)];
+        updates.focusedDomainIds = deduped.slice(0, MAX_FOCUSED_DOMAINS);
       }
 
       if (Object.keys(updates).length > 0) {

--- a/packages/types/src/AppSettings.ts
+++ b/packages/types/src/AppSettings.ts
@@ -1,3 +1,8 @@
+// The maximum number of domains that can be marked "Focused" at once. Focused
+// domains sort to the top of the Domains page and get their own tab in the
+// "Explore Something" dashboard card.
+export const MAX_FOCUSED_DOMAINS = 3;
+
 // Response shape for GET /api/settings. Raw API tokens are never sent to the
 // client — only whether each integration is configured plus a short masked hint.
 export interface AppSettingsSummary {
@@ -5,6 +10,8 @@ export interface AppSettingsSummary {
   readwiseKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
   todoistConfigured: boolean;
   todoistKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
+  // Ordered ids of the domains marked "Focused" (capped at MAX_FOCUSED_DOMAINS).
+  focusedDomainIds: string[];
 }
 
 // Request body for PUT /api/settings. Only the keys present in the body are
@@ -12,4 +19,7 @@ export interface AppSettingsSummary {
 export interface AppSettingsUpdate {
   readwiseApiKey?: string | null;
   todoistApiKey?: string | null;
+  // Replaces the focused-domain selection wholesale. Order is preserved and the
+  // server caps the list at MAX_FOCUSED_DOMAINS.
+  focusedDomainIds?: string[];
 }

--- a/packages/types/src/DashboardLayout.ts
+++ b/packages/types/src/DashboardLayout.ts
@@ -7,6 +7,7 @@ export const DASHBOARD_TILE_IDS = [
   "coursesByAmortization",
   "coursesInProgress",
   "radars",
+  "exploreSomething",
   "readwise",
   "todoist",
 ] as const;

--- a/packages/types/src/Explore.ts
+++ b/packages/types/src/Explore.ts
@@ -1,0 +1,22 @@
+// Data for the "Explore Something" dashboard card. An "item" is a topic placed
+// on some domain's radar (a non-ignored radar blip). Because rings are defined
+// per-domain in each domain's radarConfig, a blip's ring is resolved to its
+// human-readable name so the card can match a ring (e.g. "Trial") across
+// domains by name.
+export interface ExploreItem {
+  topicId: string;
+  topicName: string;
+  domainId: string;
+  domainTitle: string;
+  // Resolved ring name (null when the blip has no ring assigned, or its ringId
+  // no longer matches a ring in the domain's config).
+  ringName: string | null;
+}
+
+// Response shape for GET /api/domains/explore.
+export interface ExploreData {
+  // Distinct ring names across all domains, used to populate the card's ring
+  // selector.
+  rings: string[];
+  items: ExploreItem[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,7 @@ export * from "./Topic.js";
 export * from "./TopicForTopicsPage.js";
 export * from "./TopicsToResources.js";
 export * from "./Domain.js";
+export * from "./Explore.js";
 export * from "./Daily.js";
 export * from "./DailyCriteriaTemplate.js";
 export * from "./DashboardLayout.js";


### PR DESCRIPTION
## Summary

Adds a new "Explore Something" dashboard card that surfaces non-ignored radar blips (topics) across all domains, filterable by ring and focused domain. Also introduces a "Focused Domains" settings section allowing users to mark up to 3 domains as favorites, which sort to the top of the Domains page and get dedicated tabs in the Explore card.

## Key Changes

**Backend (middleware)**
- New `GET /api/domains/explore` endpoint that aggregates radar blips across all domains, resolves ring IDs to human-readable names, and returns distinct ring names for filtering
- Extended `PATCH /api/settings` to accept and persist `focusedDomainIds` array (deduplicated, capped at 3 server-side)
- Updated settings schema to store focused domain IDs as JSONB

**Frontend (client)**
- New `DashboardExplore` component: displays items in a tabbed interface (All Domains + one tab per focused domain), with a ring selector dropdown
- New `FocusedDomainsSection` component: settings form to select and save up to 3 focused domains via multi-combobox
- New `useExploreRing` hook: persists selected ring in localStorage with fallback logic (prefers "Trial" if available, otherwise first ring)
- Updated `DomainsIndex` to sort domains with focused ones first (in saved order), and pass `focused` prop to `DomainBox`
- Updated `DomainBox` to display a "Focused" badge with star icon when marked as focused
- Added "Explore Something" tile to dashboard layout metadata and default heights
- Integrated new components into dashboard grid and settings routes

**Types**
- New `ExploreItem` and `ExploreData` types for the explore endpoint
- New `MAX_FOCUSED_DOMAINS` constant (3) exported from `AppSettings`
- Extended `AppSettingsSummary` with `focusedDomainIds` field
- Added "exploreSomething" to `DASHBOARD_TILE_IDS`

**Query & Routing**
- Added `queryKeys.domains.explore()` for the new endpoint
- Updated `domains.index` to fetch and use settings for sorting and focused indicators

## Implementation Details

- Ring selection persists across sessions via localStorage with graceful degradation (ignores storage errors in private mode)
- Focused domains maintain user-specified order; non-focused domains preserve API order (stable sort)
- Server-side deduplication and cap enforcement ensures data integrity
- Empty states and loading states handled consistently with existing dashboard patterns
- Ring names resolved per-domain to support cross-domain filtering by name

https://claude.ai/code/session_01CB9kJLuYtJmHCN814supdM