### PR TITLE
Add Storybook component test job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,36 @@ jobs:
       # combined lint + formatting gate.
       - name: Lint and format check
         run: pnpm lint
+
+  # Storybook stories run as browser-mode Vitest tests in real headless Chromium.
+  # Kept as its own job (off typecheck/lint) because the Playwright browser install
+  # is slow and shouldn't burden the fast checks.
+  storybook:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # --with-deps pulls the Ubuntu system libraries headless Chromium needs in CI.
+      - name: Install Playwright Chromium
+        run: pnpm --filter=@emstack/client exec playwright install --with-deps chromium
+
+      # `vitest run` (not watch) keeps it non-interactive; --project storybook selects
+      # the browser-mode project defined in packages/client/vite.config.ts.
+      - name: Run Storybook component tests
+        run: pnpm --filter=@emstack/client exec vitest run --project storybook


### PR DESCRIPTION
## Summary

Adds a dedicated `storybook` job to `.github/workflows/ci.yml` that runs the Storybook stories as browser-mode Vitest tests in real headless Chromium (via Playwright), on the same triggers as the existing `typecheck` / `lint` jobs (PRs + push to `master`). Check-only — no commits, `permissions: contents: read`.

## Why a separate job

The Playwright browser install is slow, so it's kept off the fast `typecheck`/`lint` checks rather than bolted onto a unit-test job.

## How it works

- `packages/client/vite.config.ts` already defines a `storybook` Vitest project (browser mode, Chromium, `headless: true`) using `storybookTest({ configDir: ".storybook" })`. The `@storybook/addon-vitest` addon compiles stories into tests in-process, so **no separate `storybook build`/`dev` server is needed**.
- The job installs Chromium with `playwright install --with-deps chromium` (the `--with-deps` flag pulls the Ubuntu system libraries headless Chromium needs in CI), then runs `vitest run --project storybook` (non-interactive).

```yaml
  storybook:
    runs-on: ubuntu-latest
    permissions:
      contents: read
    steps:
      - uses: actions/checkout@v4
      - uses: pnpm/action-setup@v4
      - uses: actions/setup-node@v4
        with: { node-version: 22, cache: pnpm }
      - run: pnpm install --frozen-lockfile
      - run: pnpm --filter=@emstack/client exec playwright install --with-deps chromium
      - run: pnpm --filter=@emstack/client exec vitest run --project storybook
```

## Test surface

Currently one story file (`packages/client/src/components/Text.stories.tsx`, a `play()` interaction test) — verified passing locally headlessly (`Test Files 1 passed (1)`). The job wires up the infrastructure so every future `*.stories.*` file is covered automatically.

## Notes

- `typecheck` and `lint` jobs are unchanged.

https://claude.ai/code/session_015EPGnNkEYKDvW48vgdsuN8

---
_Generated by [Claude Code](https://claude.ai/code/session_015EPGnNkEYKDvW48vgdsuN8)_