### PR TITLE
feat: improve Explore Something card with grid, descriptions, and focus hint

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
@@ -1,5 +1,7 @@
 import type { ExploreItem } from "@emstack/types";
 
+import { useState } from "react";
+
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
@@ -21,10 +23,42 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { useExploreRing } from "@/hooks/useExploreRing";
+import { cn } from "@/lib/utils";
 import { fetchDomains, fetchExplore, fetchSettings } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
 const ALL_TAB = "all";
+
+// Two-line description with an inline toggle that expands the full text within
+// the tile. Renders nothing when there's no description to show.
+function ExploreItemDescription({
+  description,
+}: {
+  description: string | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const text = description?.trim();
+  if (!text) return null;
+
+  return (
+    <div className="text-xs text-muted-foreground">
+      <p className={cn("whitespace-pre-wrap", !expanded && "line-clamp-2")}>
+        {text}
+      </p>
+      <button
+        type="button"
+        onClick={() => setExpanded(prev => !prev)}
+        aria-expanded={expanded}
+        className="
+          mt-0.5 font-medium text-primary underline-offset-2
+          hover:underline
+        "
+      >
+        {expanded ? "Show less" : "Read more"}
+      </button>
+    </div>
+  );
+}
 
 function ItemList({
   items,
@@ -34,11 +68,17 @@ function ItemList({
   showDomain: boolean;
 }) {
   return (
-    <ul className="flex flex-col divide-y">
+    <ul
+      className="
+        grid grid-cols-[repeat(auto-fill,minmax(min(100%,260px),300px))] gap-2
+      "
+    >
       {items.map(item => (
         <li
           key={`${item.domainId}:${item.topicId}`}
-          className="flex flex-row items-center gap-2 py-2"
+          className="
+            flex max-w-[300px] min-w-0 flex-col gap-1 rounded-md border p-2
+          "
         >
           <div className="flex min-w-0 flex-col">
             <Link
@@ -59,6 +99,7 @@ function ItemList({
               </span>
             )}
           </div>
+          <ExploreItemDescription description={item.description} />
         </li>
       ))}
     </ul>
@@ -152,6 +193,22 @@ export function DashboardExplore() {
             </TabsTrigger>
           ))}
         </TabsList>
+
+        {focusedDomains.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            {"Set "}
+            <Link
+              to="/settings"
+              className="
+                text-primary underline-offset-2
+                hover:underline
+              "
+            >
+              focused domains
+            </Link>
+            {" in settings to organize this by domain."}
+          </p>
+        )}
 
         <TabsContent value={ALL_TAB}>
           <DashboardSectionStatus

--- a/packages/middleware/src/routes/api/domains/explore.ts
+++ b/packages/middleware/src/routes/api/domains/explore.ts
@@ -25,6 +25,7 @@ export default async function (server: FastifyInstance) {
                 columns: {
                   id: true,
                   name: true,
+                  description: true,
                 },
               },
             },
@@ -56,6 +57,10 @@ export default async function (server: FastifyInstance) {
             domainId: domain.id,
             domainTitle: domain.title,
             ringName: blip.ringId ? ringNameById.get(blip.ringId) ?? null : null,
+            // Prefer the blip's reasoning; fall back to the topic's own
+            // description. `||` (not `??`) so an empty-string blip description
+            // also falls through to the topic description.
+            description: blip.description || blip.topic?.description || null,
           });
         }
       }

--- a/packages/types/src/Explore.ts
+++ b/packages/types/src/Explore.ts
@@ -11,6 +11,9 @@ export interface ExploreItem {
   // Resolved ring name (null when the blip has no ring assigned, or its ringId
   // no longer matches a ring in the domain's config).
   ringName: string | null;
+  // Blip reasoning if present, else the topic's own description; null when
+  // neither is set.
+  description: string | null;
 }
 
 // Response shape for GET /api/domains/explore.


### PR DESCRIPTION
## Summary
Adds support for displaying item descriptions in the dashboard explore view with an expandable "Read more" toggle. Descriptions are sourced from blip reasoning (if present) or fall back to the topic's own description.

## Changes

**Frontend (`packages/client`):**
- New `ExploreItemDescription` component that displays descriptions with a two-line clamp and expandable toggle
- Refactored `ItemList` layout from a vertical list to a responsive grid (260–300px columns) with card-style tiles
- Added helper message when no focused domains are configured, with a link to settings
- Imported `useState` hook and `cn` utility for conditional styling

**Backend (`packages/middleware`):**
- Updated `/api/domains/explore` endpoint to fetch and include the `description` field from topics
- Implemented fallback logic: prefer blip's `description`, fall back to topic's `description`, or `null` if neither exists
- Empty-string blip descriptions intentionally fall through to topic description (using `||` instead of `??`)

**Types (`packages/types`):**
- Added `description: string | null` field to `ExploreItem` interface with documentation

## Implementation Details
- The description component renders nothing when there's no text to display
- Grid layout uses `auto-fill` with `minmax` to responsively fill available space while maintaining consistent tile sizing
- Expandable state is local to each item; toggling one doesn't affect others
- Accessibility: button includes `aria-expanded` attribute for screen readers

https://claude.ai/code/session_01FobKvSvBaou8pnPvoc52pY