### PR TITLE
feat: add Quick Add menu for rapid record creation

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddDialogs.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddDialogs.tsx
@@ -1,0 +1,55 @@
+import type { QuickAddKey } from "./quickAddOptions";
+
+import { QuickAddProviderDialog } from "./QuickAddProviderDialog";
+import { QuickAddReadwiseDialog } from "./QuickAddReadwiseDialog";
+import { QuickAddResourceDialog } from "./QuickAddResourceDialog";
+import { QuickAddRoutineDialog } from "./QuickAddRoutineDialog";
+import { QuickAddTaskDialog } from "./QuickAddTaskDialog";
+import { QuickAddTodoistDialog } from "./QuickAddTodoistDialog";
+
+interface QuickAddDialogsProps {
+  active: QuickAddKey | null;
+  onClose: () => void;
+}
+
+/**
+ * Renders all Quick Add modals once and opens the one matching `active`. Lifted
+ * to the root so the desktop dropdown and the mobile menu share one set.
+ */
+export function QuickAddDialogs({
+  active,
+  onClose,
+}: QuickAddDialogsProps) {
+  const onOpenChange = (open: boolean) => {
+    if (!open) onClose();
+  };
+
+  return (
+    <>
+      <QuickAddReadwiseDialog
+        open={active === "readwise"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddTodoistDialog
+        open={active === "todoist"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddResourceDialog
+        open={active === "resource"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddProviderDialog
+        open={active === "provider"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddRoutineDialog
+        open={active === "routine"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddTaskDialog
+        open={active === "task"}
+        onOpenChange={onOpenChange}
+      />
+    </>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddMenu.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddMenu.tsx
@@ -1,0 +1,124 @@
+import type { QuickAddKey } from "./quickAddOptions";
+
+import { useCallback, useRef, useState } from "react";
+
+import { ChevronDownIcon } from "lucide-react";
+
+import { QUICK_ADD_OPTIONS } from "./quickAddOptions";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface QuickAddMenuProps {
+  onSelect: (key: QuickAddKey) => void;
+}
+
+/**
+ * Desktop nav dropdown for Quick Add. Mirrors NavDropdown's hover-to-open
+ * behaviour and trigger styling, but its items open modals (via `onSelect`)
+ * rather than navigating.
+ */
+export function QuickAddMenu({
+  onSelect,
+}: QuickAddMenuProps) {
+  const [open, setOpen] = useState(false);
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+    setOpen(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+    }
+    closeTimeout.current = setTimeout(() => setOpen(false), 400);
+  }, []);
+
+  const external = QUICK_ADD_OPTIONS.filter(o => o.group === "external");
+  const tracker = QUICK_ADD_OPTIONS.filter(o => o.group === "tracker");
+
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <DropdownMenuTrigger asChild>
+        <div
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          className="
+            inline-flex cursor-pointer items-center gap-0.5 outline-none
+          "
+        >
+          <span
+            className="
+              underline-offset-2
+              hover:underline
+            "
+          >
+            Quick Add
+          </span>
+          <span
+            aria-label="Open Quick Add menu"
+            role="button"
+            className="
+              inline-flex size-5 items-center justify-center rounded-sm
+              text-muted-foreground
+              hover:bg-accent hover:text-accent-foreground
+            "
+          >
+            <ChevronDownIcon className="size-3.5" />
+          </span>
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        side="bottom"
+        sideOffset={0}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <DropdownMenuLabel>Send to</DropdownMenuLabel>
+        {external.map((option) => {
+          const Icon = option.icon;
+          return (
+            <DropdownMenuItem
+              key={option.key}
+              className="cursor-pointer"
+              onSelect={() => onSelect(option.key)}
+            >
+              <Icon />
+              {option.label}
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>New record</DropdownMenuLabel>
+        {tracker.map((option) => {
+          const Icon = option.icon;
+          return (
+            <DropdownMenuItem
+              key={option.key}
+              className="cursor-pointer"
+              onSelect={() => onSelect(option.key)}
+            >
+              <Icon />
+              {option.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createProvider } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface QuickAddProviderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddProviderDialog({
+  open,
+  onOpenChange,
+}: QuickAddProviderDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setUrl("");
+    }
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: (input: {
+      name: string;
+      url: string;
+    }) => createProvider(input),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.providers.list(),
+      });
+      onOpenChange(false);
+      toast.success("Provider created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/providers/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmedName = name.trim();
+  const trimmedUrl = url.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedUrl.length > 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add Provider</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canSubmit) {
+              mutation.mutate({
+                name: trimmedName,
+                url: trimmedUrl,
+              });
+            }
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="quick-add-provider-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id="quick-add-provider-name"
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Provider name"
+              maxLength={255}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="quick-add-provider-url"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              URL
+            </label>
+            <Input
+              id="quick-add-provider-url"
+              type="url"
+              value={url}
+              onChange={e => setUrl(e.target.value)}
+              placeholder="https://example.com"
+              maxLength={255}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canSubmit || mutation.isPending}
+            >
+              {mutation.isPending && <Loader2 className="animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { fetchSettings, saveReadwiseArticle } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface QuickAddReadwiseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddReadwiseDialog({
+  open,
+  onOpenChange,
+}: QuickAddReadwiseDialogProps) {
+  const queryClient = useQueryClient();
+  const [url, setUrl] = useState("");
+  const [title, setTitle] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setUrl("");
+      setTitle("");
+    }
+  }, [open]);
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const configured = settingsQuery.data?.readwiseConfigured ?? false;
+
+  const mutation = useMutation({
+    mutationFn: (input: {
+      url: string;
+      title?: string;
+    }) => saveReadwiseArticle(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.readwise.readingList(),
+      });
+      onOpenChange(false);
+      toast.success("Saved to Readwise");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmedUrl = url.trim();
+  const trimmedTitle = title.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Save to Readwise</DialogTitle>
+          <DialogDescription>
+            The article is tagged
+            {" "}
+            <code>from-coursetracker</code>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        {configured
+          ? (
+            <form
+              className="flex flex-col gap-4"
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (trimmedUrl) {
+                  mutation.mutate({
+                    url: trimmedUrl,
+                    title: trimmedTitle || undefined,
+                  });
+                }
+              }}
+            >
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="quick-add-readwise-url"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  URL
+                </label>
+                <Input
+                  id="quick-add-readwise-url"
+                  type="url"
+                  autoFocus
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  placeholder="https://example.com/article"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="quick-add-readwise-title"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Title (optional)
+                </label>
+                <Input
+                  id="quick-add-readwise-title"
+                  value={title}
+                  onChange={e => setTitle(e.target.value)}
+                  placeholder="Leave blank to use the page title"
+                />
+              </div>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={!trimmedUrl || mutation.isPending}
+                >
+                  {mutation.isPending && <Loader2 className="animate-spin" />}
+                  Save
+                </Button>
+              </DialogFooter>
+            </form>
+          )
+          : (
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Add a Readwise API key in
+                {" "}
+                <Link
+                  to="/settings"
+                  onClick={() => onOpenChange(false)}
+                  className="
+                    text-primary underline-offset-2
+                    hover:underline
+                  "
+                >
+                  Settings
+                </Link>
+                {" "}
+                to enable this.
+              </p>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Close
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { upsertResource, uuidv4 } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface QuickAddResourceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddResourceDialog({
+  open,
+  onOpenChange,
+}: QuickAddResourceDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) setName("");
+  }, [open]);
+
+  const mutation = useMutation({
+    // Resources have no POST create endpoint — a PUT with a fresh id upserts,
+    // matching how the full edit page creates new resources.
+    mutationFn: async (resourceName: string) => {
+      const id = uuidv4();
+      await upsertResource(id, {
+        name: resourceName,
+      });
+      return id;
+    },
+    onSuccess: (id) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.resources.list(),
+      });
+      onOpenChange(false);
+      toast.success("Resource created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/resources/$id/edit",
+              params: {
+                id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmed = name.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add Resource</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) mutation.mutate(trimmed);
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="quick-add-resource-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id="quick-add-resource-name"
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Resource name"
+              maxLength={255}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!trimmed || mutation.isPending}
+            >
+              {mutation.isPending && <Loader2 className="animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createRoutine } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+type RoutineMode = "weekly" | "daily";
+
+interface QuickAddRoutineDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddRoutineDialog({
+  open,
+  onOpenChange,
+}: QuickAddRoutineDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [mode, setMode] = useState<RoutineMode>("weekly");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setMode("weekly");
+    }
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: (input: {
+      name: string;
+      mode: RoutineMode;
+    }) =>
+      createRoutine({
+        name: input.name,
+        mode: input.mode,
+        status: "active",
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.routines.list(),
+      });
+      onOpenChange(false);
+      toast.success("Routine created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/routines/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmed = name.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add Routine</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) {
+              mutation.mutate({
+                name: trimmed,
+                mode,
+              });
+            }
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="quick-add-routine-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id="quick-add-routine-name"
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Routine name"
+              maxLength={255}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Type
+            </span>
+            <RadioGroup
+              value={mode}
+              onValueChange={value => setMode(value as RoutineMode)}
+            >
+              <label
+                htmlFor="quick-add-routine-weekly"
+                className="flex items-center gap-2 text-sm"
+              >
+                <RadioGroupItem
+                  id="quick-add-routine-weekly"
+                  value="weekly"
+                />
+                Weekly Schedule
+              </label>
+              <label
+                htmlFor="quick-add-routine-daily"
+                className="flex items-center gap-2 text-sm"
+              >
+                <RadioGroupItem
+                  id="quick-add-routine-daily"
+                  value="daily"
+                />
+                Daily Task
+              </label>
+            </RadioGroup>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!trimmed || mutation.isPending}
+            >
+              {mutation.isPending && <Loader2 className="animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createTask } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface QuickAddTaskDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddTaskDialog({
+  open,
+  onOpenChange,
+}: QuickAddTaskDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) setName("");
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: (taskName: string) =>
+      createTask({
+        name: taskName,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.tasks.list(),
+      });
+      onOpenChange(false);
+      toast.success("Task created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/tasks/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmed = name.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add Task</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) mutation.mutate(trimmed);
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="quick-add-task-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id="quick-add-task-name"
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Task name"
+              maxLength={255}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!trimmed || mutation.isPending}
+            >
+              {mutation.isPending && <Loader2 className="animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Textarea } from "@/components/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createTodoistTask, fetchSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface QuickAddTodoistDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function QuickAddTodoistDialog({
+  open,
+  onOpenChange,
+}: QuickAddTodoistDialogProps) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setContent("");
+      setDescription("");
+    }
+  }, [open]);
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const configured = settingsQuery.data?.todoistConfigured ?? false;
+
+  const mutation = useMutation({
+    mutationFn: (input: {
+      content: string;
+      description?: string;
+    }) => createTodoistTask(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.todoist.tasks(),
+      });
+      onOpenChange(false);
+      toast.success("Added to Todoist");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmedContent = content.trim();
+  const trimmedDescription = description.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Add Todoist task</DialogTitle>
+          <DialogDescription>
+            The task is labeled
+            {" "}
+            <code>from-coursetracker</code>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        {configured
+          ? (
+            <form
+              className="flex flex-col gap-4"
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (trimmedContent) {
+                  mutation.mutate({
+                    content: trimmedContent,
+                    description: trimmedDescription || undefined,
+                  });
+                }
+              }}
+            >
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="quick-add-todoist-content"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Title
+                </label>
+                <Input
+                  id="quick-add-todoist-content"
+                  autoFocus
+                  value={content}
+                  onChange={e => setContent(e.target.value)}
+                  placeholder="What needs doing?"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="quick-add-todoist-description"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Description (optional)
+                </label>
+                <Textarea
+                  id="quick-add-todoist-description"
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="Add any extra detail"
+                />
+              </div>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={!trimmedContent || mutation.isPending}
+                >
+                  {mutation.isPending && <Loader2 className="animate-spin" />}
+                  Add
+                </Button>
+              </DialogFooter>
+            </form>
+          )
+          : (
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Add a Todoist API key in
+                {" "}
+                <Link
+                  to="/settings"
+                  onClick={() => onOpenChange(false)}
+                  className="
+                    text-primary underline-offset-2
+                    hover:underline
+                  "
+                >
+                  Settings
+                </Link>
+                {" "}
+                to enable this.
+              </p>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Close
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/index.ts
+++ b/packages/client/src/components/quickAdd/index.ts
@@ -1,0 +1,3 @@
+export { QuickAddDialogs } from "./QuickAddDialogs";
+export { QuickAddMenu } from "./QuickAddMenu";
+export { QUICK_ADD_OPTIONS, type QuickAddKey } from "./quickAddOptions";

--- a/packages/client/src/components/quickAdd/quickAddOptions.tsx
+++ b/packages/client/src/components/quickAdd/quickAddOptions.tsx
@@ -1,0 +1,68 @@
+import type { LucideIcon } from "lucide-react";
+
+import {
+  BookOpenIcon,
+  Building2Icon,
+  CircleCheckIcon,
+  LibraryIcon,
+  ListTodoIcon,
+  RepeatIcon,
+} from "lucide-react";
+
+export type QuickAddKey
+  = | "readwise"
+    | "todoist"
+    | "resource"
+    | "provider"
+    | "routine"
+    | "task";
+
+export type QuickAddGroup = "external" | "tracker";
+
+export interface QuickAddOption {
+  key: QuickAddKey;
+  label: string;
+  icon: LucideIcon;
+  group: QuickAddGroup;
+}
+
+// Single source of truth for the Quick Add entries so the desktop dropdown and
+// the mobile hamburger menu stay in sync.
+export const QUICK_ADD_OPTIONS: QuickAddOption[] = [
+  {
+    key: "readwise",
+    label: "Readwise",
+    icon: BookOpenIcon,
+    group: "external",
+  },
+  {
+    key: "todoist",
+    label: "Todoist",
+    icon: ListTodoIcon,
+    group: "external",
+  },
+  {
+    key: "resource",
+    label: "Resource",
+    icon: LibraryIcon,
+    group: "tracker",
+  },
+  {
+    key: "provider",
+    label: "Provider",
+    icon: Building2Icon,
+    group: "tracker",
+  },
+  {
+    key: "routine",
+    label: "Routine",
+    icon: RepeatIcon,
+    group: "tracker",
+  },
+  {
+    key: "task",
+    label: "Task",
+    icon: CircleCheckIcon,
+    group: "tracker",
+  },
+];

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+import type { QuickAddKey } from "@/components/quickAdd";
+
+import React, { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -10,12 +12,20 @@ import { HomeIcon, MenuIcon } from "lucide-react";
 
 import { DropdownNavItem } from "@/components/layout/DropdownNavItem";
 import { NavDropdown } from "@/components/layout/NavDropdown";
+import {
+  QuickAddDialogs,
+  QuickAddMenu,
+  QUICK_ADD_OPTIONS,
+
+} from "@/components/quickAdd";
 import { Toaster } from "@/components/sonner";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -28,6 +38,8 @@ import {
 import { queryKeys } from "@/utils/queryKeys";
 
 const RootComponent: React.FunctionComponent = () => {
+  const [activeQuickAdd, setActiveQuickAdd] = useState<QuickAddKey | null>(null);
+
   const {
     data: resourcesData,
   } = useQuery({
@@ -201,6 +213,23 @@ const RootComponent: React.FunctionComponent = () => {
               </DropdownMenuGroup>
               <DropdownMenuSeparator />
               <DropdownMenuGroup>
+                <DropdownMenuLabel>Quick Add</DropdownMenuLabel>
+                {QUICK_ADD_OPTIONS.map((option) => {
+                  const Icon = option.icon;
+                  return (
+                    <DropdownMenuItem
+                      key={option.key}
+                      className="cursor-pointer"
+                      onSelect={() => setActiveQuickAdd(option.key)}
+                    >
+                      <Icon />
+                      {option.label}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
                 <DropdownNavItem to="/settings">Settings</DropdownNavItem>
               </DropdownMenuGroup>
             </DropdownMenuContent>
@@ -208,10 +237,11 @@ const RootComponent: React.FunctionComponent = () => {
         </div>
         <div
           className={`
-            hidden flex-row gap-2
+            hidden flex-row items-center gap-4
             md:flex
           `}
         >
+          <QuickAddMenu onSelect={setActiveQuickAdd} />
           <Link
             to="/settings"
             className={navLinkClass}
@@ -224,6 +254,10 @@ const RootComponent: React.FunctionComponent = () => {
       <div className="mb-8">
         <Outlet />
       </div>
+      <QuickAddDialogs
+        active={activeQuickAdd}
+        onClose={() => setActiveQuickAdd(null)}
+      />
       <Toaster />
     </>
   );

--- a/packages/client/src/utils/api/readwise.ts
+++ b/packages/client/src/utils/api/readwise.ts
@@ -1,7 +1,19 @@
 import type { ReadwiseReadingList } from "@emstack/types";
 
-import { fetchJson } from "./client";
+import { fetchJson, postJson } from "./client";
 
 export function fetchReadwiseReadingList(): Promise<ReadwiseReadingList> {
   return fetchJson<ReadwiseReadingList>("/api/readwise/reading-list");
+}
+
+export function saveReadwiseArticle(input: {
+  url: string;
+  title?: string;
+}): Promise<{ status: string;
+  id: string; }> {
+  return postJson(
+    "/api/readwise/save",
+    input,
+    "Failed to save to Readwise",
+  );
 }

--- a/packages/client/src/utils/api/todoist.ts
+++ b/packages/client/src/utils/api/todoist.ts
@@ -1,7 +1,19 @@
 import type { TodoistTasks } from "@emstack/types";
 
-import { fetchJson } from "./client";
+import { fetchJson, postJson } from "./client";
 
 export function fetchTodoistTasks(): Promise<TodoistTasks> {
   return fetchJson<TodoistTasks>("/api/todoist/tasks");
+}
+
+export function createTodoistTask(input: {
+  content: string;
+  description?: string;
+}): Promise<{ status: string;
+  id: string; }> {
+  return postJson(
+    "/api/todoist/tasks",
+    input,
+    "Failed to add Todoist task",
+  );
 }

--- a/packages/middleware/src/routes/api/readwise/root.ts
+++ b/packages/middleware/src/routes/api/readwise/root.ts
@@ -5,8 +5,10 @@ import {
   fetchReadingList,
   getReadwiseToken,
   ReadwiseError,
+  saveReadwiseDocument,
 } from "@/services/readwise";
 import { sendBadRequest } from "@/utils/errors";
+import { nullableString } from "@/utils/schemas";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -45,6 +47,51 @@ export default async function (server: FastifyInstance) {
           });
         }
         return sendBadRequest(reply, "Failed to load Readwise reading list.");
+      }
+    },
+  );
+
+  fastify.post(
+    "/save",
+    {
+      schema: {
+        body: {
+          type: "object",
+          required: ["url"],
+          additionalProperties: false,
+          properties: {
+            url: {
+              type: "string",
+              minLength: 1,
+            },
+            title: nullableString,
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const token = await getReadwiseToken();
+      if (!token) {
+        return sendBadRequest(reply, "Readwise is not configured.");
+      }
+
+      const {
+        url, title,
+      } = request.body;
+      try {
+        const saved = await saveReadwiseDocument(token, url, title ?? undefined);
+        return {
+          status: "ok",
+          id: saved.id,
+        };
+      }
+      catch (err) {
+        if (err instanceof ReadwiseError) {
+          return reply.code(err.statusCode).send({
+            message: err.message,
+          });
+        }
+        return sendBadRequest(reply, "Failed to save to Readwise.");
       }
     },
   );

--- a/packages/middleware/src/routes/api/todoist/root.ts
+++ b/packages/middleware/src/routes/api/todoist/root.ts
@@ -2,11 +2,13 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import { FastifyInstance } from "fastify";
 import type { TodoistTasks } from "@emstack/types";
 import {
+  createTodoistTask,
   fetchTodayAndOverdue,
   getTodoistToken,
   TodoistError,
 } from "@/services/todoist";
 import { sendBadRequest } from "@/utils/errors";
+import { nullableString } from "@/utils/schemas";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -45,6 +47,55 @@ export default async function (server: FastifyInstance) {
           });
         }
         return sendBadRequest(reply, "Failed to load Todoist tasks.");
+      }
+    },
+  );
+
+  fastify.post(
+    "/tasks",
+    {
+      schema: {
+        body: {
+          type: "object",
+          required: ["content"],
+          additionalProperties: false,
+          properties: {
+            content: {
+              type: "string",
+              minLength: 1,
+            },
+            description: nullableString,
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const token = await getTodoistToken();
+      if (!token) {
+        return sendBadRequest(reply, "Todoist is not configured.");
+      }
+
+      const {
+        content, description,
+      } = request.body;
+      try {
+        const created = await createTodoistTask(
+          token,
+          content,
+          description ?? undefined,
+        );
+        return {
+          status: "ok",
+          id: created.id,
+        };
+      }
+      catch (err) {
+        if (err instanceof TodoistError) {
+          return reply.code(err.statusCode).send({
+            message: err.message,
+          });
+        }
+        return sendBadRequest(reply, "Failed to add Todoist task.");
       }
     },
   );

--- a/packages/middleware/src/services/readwise.ts
+++ b/packages/middleware/src/services/readwise.ts
@@ -3,6 +3,11 @@ import { db } from "@/db";
 import { appSettings } from "@/db/schema";
 
 const READWISE_LIST_URL = "https://readwise.io/api/v3/list/";
+const READWISE_SAVE_URL = "https://readwise.io/api/v3/save/";
+
+// Tag stamped on everything saved from Course Tracker so the source is traceable
+// inside Readwise.
+const SOURCE_TAG = "from-coursetracker";
 
 // Active reading locations only — archived/feed items are excluded so the card
 // shows a true "to read" / "reading" list. A document lives in exactly one
@@ -166,5 +171,59 @@ export async function fetchReadingList(
   return {
     started,
     unstarted,
+  };
+}
+
+/**
+ * Save a URL to the user's Readwise Reader, tagged with the source tag.
+ * Readwise resolves the title/metadata from the page itself, so `title` is only
+ * an override hint. Returns the created (or pre-existing) document's id and url.
+ */
+export async function saveReadwiseDocument(
+  token: string,
+  url: string,
+  title?: string,
+): Promise<{ id: string;
+  url: string; }> {
+  let response: Response;
+  try {
+    response = await fetch(READWISE_SAVE_URL, {
+      method: "POST",
+      headers: {
+        "Authorization": `Token ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url,
+        tags: [SOURCE_TAG],
+        ...(title
+          ? {
+            title,
+          }
+          : {}),
+      }),
+    });
+  }
+  catch {
+    throw new ReadwiseError("Could not reach Readwise.", 502);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new ReadwiseError("Readwise rejected the API key.", 401);
+  }
+  if (response.status === 429) {
+    throw new ReadwiseError("Readwise rate limit reached — try again shortly.", 429);
+  }
+  if (!response.ok) {
+    throw new ReadwiseError(`Readwise request failed (${response.status}).`, 502);
+  }
+
+  const body = (await response.json()) as {
+    id?: string;
+    url?: string;
+  };
+  return {
+    id: body.id ?? "",
+    url: body.url ?? url,
   };
 }

--- a/packages/middleware/src/services/todoist.ts
+++ b/packages/middleware/src/services/todoist.ts
@@ -10,6 +10,13 @@ const TODOIST_FILTER_URL = "https://api.todoist.com/api/v1/tasks/filter";
 // payload, so we build one from the task id.
 const TODOIST_TASK_URL = "https://app.todoist.com/app/task";
 
+// Create endpoint for the unified v1 REST API.
+const TODOIST_CREATE_URL = "https://api.todoist.com/api/v1/tasks";
+
+// Label stamped on tasks created from Course Tracker so the source is traceable.
+// Todoist creates the label by name on first use.
+const SOURCE_LABEL = "from-coursetracker";
+
 // Filter query for the dashboard card: anything due today or already overdue.
 const DUE_FILTER = "today | overdue";
 
@@ -161,5 +168,55 @@ export async function fetchTodayAndOverdue(
   return {
     overdue,
     today: dueToday,
+  };
+}
+
+/**
+ * Create a Todoist task, labeled with the source label. `content` is the task
+ * title; `description` is the optional note body. Returns the new task id.
+ */
+export async function createTodoistTask(
+  token: string,
+  content: string,
+  description?: string,
+): Promise<{ id: string }> {
+  let response: Response;
+  try {
+    response = await fetch(TODOIST_CREATE_URL, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        labels: [SOURCE_LABEL],
+        ...(description
+          ? {
+            description,
+          }
+          : {}),
+      }),
+    });
+  }
+  catch {
+    throw new TodoistError("Could not reach Todoist.", 502);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new TodoistError("Todoist rejected the API key.", 401);
+  }
+  if (response.status === 429) {
+    throw new TodoistError("Todoist rate limit reached — try again shortly.", 429);
+  }
+  if (!response.ok) {
+    throw new TodoistError(`Todoist request failed (${response.status}).`, 502);
+  }
+
+  const body = (await response.json()) as {
+    id?: string;
+  };
+  return {
+    id: body.id ?? "",
   };
 }


### PR DESCRIPTION
## Summary

Introduces a "Quick Add" feature that allows users to rapidly create records (tasks, resources, providers, routines) and send content to external services (Readwise, Todoist) via modal dialogs. Accessible from both desktop (dropdown menu) and mobile (hamburger menu) navigation.

## Key Changes

- **New Quick Add Components** (`packages/client/src/components/quickAdd/`)
  - `QuickAddMenu.tsx` — Desktop dropdown menu with hover-to-open behavior
  - `QuickAddDialogs.tsx` — Container rendering all Quick Add modals
  - `quickAddOptions.tsx` — Single source of truth for Quick Add entries (6 options across 2 groups: external services and tracker records)
  - Individual dialog components for each action: `QuickAddReadwiseDialog`, `QuickAddTodoistDialog`, `QuickAddResourceDialog`, `QuickAddProviderDialog`, `QuickAddRoutineDialog`, `QuickAddTaskDialog`

- **Backend API Endpoints**
  - `POST /api/readwise/save` — Save a URL to Readwise Reader with optional title override; tagged with `from-coursetracker` for traceability
  - `POST /api/todoist/tasks` — Create a Todoist task with optional description; labeled with `from-coursetracker`
  - New service functions: `saveReadwiseDocument()` and `createTodoistTask()` in middleware

- **Client API Utilities**
  - `saveReadwiseArticle()` and `createTodoistTask()` in `packages/client/src/utils/api/`

- **Root Layout Integration** (`packages/client/src/routes/__root.tsx`)
  - Added Quick Add state management and modal container
  - Integrated `QuickAddMenu` into desktop navigation
  - Integrated Quick Add options into mobile hamburger menu

## Implementation Details

- **Consistent UX:** All dialogs follow the same pattern — form with validation, loading state, success toast with optional "Edit" action, error handling
- **Configuration checks:** Readwise and Todoist dialogs check if the service is configured; if not, they show a link to Settings instead of the form
- **Source tagging:** Both external services tag/label created items with `from-coursetracker` for traceability within those platforms
- **Shared state:** `QuickAddDialogs` is lifted to the root so desktop dropdown and mobile menu share one set of modals
- **Menu behavior:** Desktop dropdown mirrors `NavDropdown`'s hover-to-open behavior with a 400ms close delay

https://claude.ai/code/session_016RT8egB55TRP1Z9da4Cm7s