### PR TITLE
refactor(client): reorganize settings into tabbed interface

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
@@ -148,6 +148,9 @@ export function QuickAddReadwiseDialog({
                 {" "}
                 <Link
                   to="/settings"
+                  search={{
+                    tab: "connections",
+                  }}
                   onClick={() => onOpenChange(false)}
                   className="
                     text-primary underline-offset-2

--- a/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
@@ -148,6 +148,9 @@ export function QuickAddTodoistDialog({
                 {" "}
                 <Link
                   to="/settings"
+                  search={{
+                    tab: "connections",
+                  }}
                   onClick={() => onOpenChange(false)}
                   className="
                     text-primary underline-offset-2

--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
@@ -132,6 +132,9 @@ export function DashboardReadwise() {
           </Button>
           <Link
             to="/settings"
+            search={{
+              tab: "connections",
+            }}
             className="
               text-sm text-primary underline-offset-2
               hover:underline
@@ -149,6 +152,9 @@ export function DashboardReadwise() {
             {" "}
             <Link
               to="/settings"
+              search={{
+                tab: "connections",
+              }}
               className="
                 text-primary underline-offset-2
                 hover:underline

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
@@ -119,6 +119,9 @@ export function DashboardTodoist() {
           </Button>
           <Link
             to="/settings"
+            search={{
+              tab: "connections",
+            }}
             className="
               text-sm text-primary underline-offset-2
               hover:underline
@@ -136,6 +139,9 @@ export function DashboardTodoist() {
             {" "}
             <Link
               to="/settings"
+              search={{
+                tab: "connections",
+              }}
               className="
                 text-primary underline-offset-2
                 hover:underline

--- a/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.tsx
+++ b/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.tsx
@@ -108,7 +108,7 @@ export function CriteriaTemplatesSection() {
       <section className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">
           <h2 className="text-xl font-semibold">
-            Dailies Status Criteria Templates
+            Status Criteria Templates
           </h2>
           <Button
             variant="outline"

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -272,9 +272,6 @@ export function DashboardLayoutsSection() {
     <>
       <section className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-2">
-          <h2 className="text-xl font-semibold">
-            Dashboard Layouts
-          </h2>
           <div className="flex gap-2">
             <Button
               variant="outline"

--- a/packages/client/src/routes/settings.-components/-DataToolsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DataToolsSection.tsx
@@ -49,7 +49,6 @@ export function DataToolsSection() {
 
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="text-xl font-semibold">Data Tools</h2>
       <div className="flex flex-col items-start gap-2">
         <Button
           variant="outline"

--- a/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
@@ -31,7 +31,6 @@ export function FocusedDomainsSection() {
 
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="text-xl font-semibold">Focused Domains</h2>
       <p className="text-sm text-muted-foreground">
         Choose up to
         {" "}

--- a/packages/client/src/routes/settings.-components/-ThemeSection.tsx
+++ b/packages/client/src/routes/settings.-components/-ThemeSection.tsx
@@ -1,0 +1,40 @@
+import { MoonIcon, SunIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/hooks/useTheme.ts";
+
+export function ThemeSection() {
+  const {
+    theme, setTheme,
+  } = useTheme();
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex flex-col items-start gap-2">
+        {theme === "dark"
+          ? (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTheme("light");
+              }}
+            >
+              <SunIcon />
+              Set to Light Mode
+            </Button>
+          )
+          : (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTheme("dark");
+              }}
+            >
+              <MoonIcon />
+              Set to Dark Mode
+            </Button>
+          )}
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { MoonIcon, SunIcon } from "lucide-react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 import { CriteriaTemplatesSection } from "./settings.-components/-CriteriaTemplatesSection";
 import { DashboardLayoutsSection } from "./settings.-components/-DashboardLayoutsSection";
@@ -8,72 +7,115 @@ import { FocusedDomainsSection } from "./settings.-components/-FocusedDomainsSec
 import { ReadwiseSection } from "./settings.-components/-ReadwiseSection";
 import { RoutineTemplatesSection } from "./settings.-components/-RoutineTemplatesSection";
 import { TaskTypesSection } from "./settings.-components/-TaskTypesSection";
+import { ThemeSection } from "./settings.-components/-ThemeSection";
 import { TodoistSection } from "./settings.-components/-TodoistSection";
 
 import { PageHeader } from "@/components/layout/PageHeader";
+import { PageTabs } from "@/components/layout/PageTabs";
 import { TagGroupsAdmin } from "@/components/TagGroupsAdmin";
-import { Button } from "@/components/ui/button";
-import { useTheme } from "@/hooks/useTheme.ts";
+
+const TAB_VALUES = [
+  "tasks",
+  "routines",
+  "domains",
+  "dashboard",
+  "connections",
+  "display",
+  "advanced",
+] as const;
+type SettingsTab = (typeof TAB_VALUES)[number];
+
+export interface SettingsSearch {
+  tab?: SettingsTab;
+}
 
 export const Route = createFileRoute("/settings")({
   component: Settings,
+  validateSearch: (search: Record<string, unknown>): SettingsSearch => ({
+    tab:
+      typeof search.tab === "string"
+      && (TAB_VALUES as readonly string[]).includes(search.tab)
+        ? (search.tab as SettingsTab)
+        : undefined,
+  }),
 });
 
 function Settings() {
-  const {
-    theme, setTheme,
-  } = useTheme();
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+
+  const tab: SettingsTab = search.tab ?? "tasks";
+
+  function changeTab(next: SettingsTab) {
+    navigate({
+      to: "/settings",
+      search: {
+        tab: next,
+      },
+      replace: true,
+    });
+  }
 
   return (
     <div>
       <PageHeader pageTitle="Settings" />
-      <div className="container flex flex-col gap-8">
-        <DataToolsSection />
-
-        <TaskTypesSection />
-
-        <TagGroupsAdmin />
-
-        <CriteriaTemplatesSection />
-
-        <RoutineTemplatesSection />
-
-        <FocusedDomainsSection />
-
-        <DashboardLayoutsSection />
-
-        <ReadwiseSection />
-
-        <TodoistSection />
-
-        <section className="flex flex-col gap-3">
-          <h2 className="text-xl font-semibold">Appearance</h2>
-          <div className="flex flex-col items-start gap-2">
-            {theme === "dark"
-              ? (
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setTheme("light");
-                  }}
-                >
-                  <SunIcon />
-                  Set to Light Mode
-                </Button>
-              )
-              : (
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setTheme("dark");
-                  }}
-                >
-                  <MoonIcon />
-                  Set to Dark Mode
-                </Button>
-              )}
-          </div>
-        </section>
+      <div className="container">
+        <PageTabs
+          value={tab}
+          onValueChange={changeTab}
+          tabs={[
+            {
+              value: "tasks",
+              label: "Task Settings",
+              content: (
+                <>
+                  <TaskTypesSection />
+                  <TagGroupsAdmin />
+                </>
+              ),
+            },
+            {
+              value: "routines",
+              label: "Routine Settings",
+              content: (
+                <>
+                  <CriteriaTemplatesSection />
+                  <RoutineTemplatesSection />
+                </>
+              ),
+            },
+            {
+              value: "domains",
+              label: "Domains Settings",
+              content: <FocusedDomainsSection />,
+            },
+            {
+              value: "dashboard",
+              label: "Dashboard Settings",
+              content: <DashboardLayoutsSection />,
+            },
+            {
+              value: "connections",
+              label: "Third Party Connections",
+              content: (
+                <>
+                  <ReadwiseSection />
+                  <TodoistSection />
+                </>
+              ),
+            },
+            {
+              value: "display",
+              label: "Display Settings",
+              content: <ThemeSection />,
+            },
+            {
+              value: "advanced",
+              label: "Advanced",
+              content: <DataToolsSection />,
+            },
+          ]}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Restructured the settings page to use a tabbed navigation system, grouping related settings sections into logical categories. This improves discoverability and reduces cognitive load by organizing settings into seven distinct tabs.

## Key Changes
- **Tabbed Settings Layout:** Introduced `PageTabs` component to organize settings into tabs:
  - Tasks (Task Types, Tag Groups)
  - Routines (Criteria Templates, Routine Templates)
  - Domains (Focused Domains)
  - Dashboard (Dashboard Layouts)
  - Connections (Readwise, Todoist)
  - Display (Theme settings)
  - Advanced (Data Tools)

- **Theme Section Extraction:** Extracted theme toggle logic into a new `ThemeSection` component (`-ThemeSection.tsx`) for better modularity and reusability

- **Search-Based Tab Navigation:** Implemented URL-based tab state using TanStack Router's search parameters (`?tab=connections`, etc.) with validation, allowing users to link directly to specific settings tabs

- **Updated Internal Links:** Updated all navigation links to settings from dashboard components and quick-add dialogs to target the "connections" tab when directing users to configure third-party integrations (Readwise, Todoist)

- **Removed Redundant Headers:** Removed section-level headings from individual settings components since tab labels now provide context

## Implementation Details
- Added `SettingsSearch` interface and `TAB_VALUES` constant for type-safe tab validation
- Implemented `validateSearch` in route definition to ensure only valid tab values are accepted
- Used `useNavigate` with `replace: true` to maintain clean browser history when switching tabs
- Maintained backward compatibility: accessing `/settings` without a tab parameter defaults to the "tasks" tab

https://claude.ai/code/session_016FpXY4mfKKFSyeqVcdVHhV