### PR TITLE
feat(client): add changelog dashboard tile

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
@@ -1,8 +1,11 @@
 import type { ReactNode } from "react";
 
-// Bundled at build time from the repo-root CHANGELOG.md (the `@root` alias), so
-// the card needs no API round-trip and the file stays the single source of
-// truth — Vite inlines `?raw` imports into the bundle.
+// Bundled at build time from the repo-root CHANGELOG.md (the `@root` Vite
+// alias), so the card needs no API round-trip and the file stays the single
+// source of truth — Vite inlines `?raw` imports into the bundle. fallow's
+// static resolver only reads tsconfig paths, so the Vite-only alias reads as
+// unresolved; the import is real, hence the suppression.
+// fallow-ignore-next-line unresolved-import
 import changelogMarkdown from "@root/CHANGELOG.md?raw";
 
 import { parseChangelog } from "./-changelog";

--- a/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
@@ -1,0 +1,166 @@
+import type { ReactNode } from "react";
+
+// Bundled at build time from the repo-root CHANGELOG.md (the `@root` alias), so
+// the card needs no API round-trip and the file stays the single source of
+// truth — Vite inlines `?raw` imports into the bundle.
+import changelogMarkdown from "@root/CHANGELOG.md?raw";
+
+import { parseChangelog } from "./-changelog";
+
+import { DashboardCard } from "@/components/boxes/DashboardCard";
+
+const REPO_URL = "https://github.com/emilyeserven/course-tracker";
+
+const releases = parseChangelog(changelogMarkdown);
+
+// Inline markdown inside list items: `code`, [text](url) links, and (#123) PR
+// references which we linkify to the matching GitHub pull request.
+const INLINE_TOKEN = /(`[^`]+`)|(\[[^\]]+\]\([^)]+\))|#(\d+)/g;
+const LINK = /^\[([^\]]+)\]\(([^)]+)\)$/;
+
+const linkClass = `
+  text-primary underline-offset-2
+  hover:underline
+`;
+
+function renderInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of text.matchAll(INLINE_TOKEN)) {
+    const index = match.index;
+    if (index > lastIndex) {
+      nodes.push(text.slice(lastIndex, index));
+    }
+
+    const [token, code, link, prNumber] = match;
+    if (code != null) {
+      nodes.push(
+        <code
+          key={key++}
+          className="rounded-sm bg-muted px-1 py-0.5 text-xs"
+        >
+          {code.slice(1, -1)}
+        </code>,
+      );
+    }
+    else if (link != null) {
+      const parts = LINK.exec(link);
+      nodes.push(
+        <a
+          key={key++}
+          href={parts?.[2] ?? "#"}
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+        >
+          {parts?.[1] ?? link}
+        </a>,
+      );
+    }
+    else {
+      nodes.push(
+        <a
+          key={key++}
+          href={`${REPO_URL}/pull/${prNumber}`}
+          target="_blank"
+          rel="noreferrer"
+          className={linkClass}
+        >
+          {`#${prNumber}`}
+        </a>,
+      );
+    }
+
+    lastIndex = index + token.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+}
+
+export function DashboardChangelog() {
+  return (
+    <DashboardCard
+      title="Changelog"
+      action={(
+        <a
+          href={`${REPO_URL}/blob/HEAD/CHANGELOG.md`}
+          target="_blank"
+          rel="noreferrer"
+          className="
+            text-sm text-primary underline-offset-2
+            hover:underline
+          "
+        >
+          View on GitHub
+        </a>
+      )}
+    >
+      {releases.length === 0
+        ? (
+          <p className="text-sm text-muted-foreground">
+            <i>No changelog entries.</i>
+          </p>
+        )
+        : (
+          <div className="flex flex-col gap-2">
+            {releases.map((release, releaseIndex) => (
+              <details
+                key={release.version}
+                open={releaseIndex === 0}
+                className="rounded-md border bg-background/40"
+              >
+                <summary
+                  className="
+                    flex cursor-pointer items-center justify-between gap-2 px-3
+                    py-2 text-sm font-semibold
+                  "
+                >
+                  <span>{release.version}</span>
+                  {release.date != null && (
+                    <span className="text-xs font-normal text-muted-foreground">
+                      {release.date}
+                    </span>
+                  )}
+                </summary>
+                <div className="flex flex-col gap-3 px-3 pb-3">
+                  {release.sections.map(section => (
+                    <div
+                      key={section.heading || "general"}
+                      className="flex flex-col gap-1"
+                    >
+                      {section.heading !== "" && (
+                        <h3
+                          className="
+                            text-xs font-semibold tracking-wide
+                            text-muted-foreground uppercase
+                          "
+                        >
+                          {section.heading}
+                        </h3>
+                      )}
+                      <ul className="flex list-disc flex-col gap-1 pl-4">
+                        {section.items.map(item => (
+                          <li
+                            key={item}
+                            className="text-sm/snug"
+                          >
+                            {renderInline(item)}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            ))}
+          </div>
+        )}
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -3,6 +3,7 @@ import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
 
 import { DndGrid } from "@dnd-grid/react";
 
+import { DashboardChangelog } from "./-DashboardChangelog";
 import { DashboardCoursesByAmortization } from "./-DashboardCoursesByAmortization";
 import { DashboardCoursesInProgress } from "./-DashboardCoursesInProgress";
 import { DashboardDailies } from "./-DashboardDailies";
@@ -28,6 +29,7 @@ const TILE_COMPONENTS: Record<DashboardTileId, React.ComponentType> = {
   exploreSomething: DashboardExplore,
   readwise: DashboardReadwise,
   todoist: DashboardTodoist,
+  changelog: DashboardChangelog,
 };
 
 interface DashboardGridProps {

--- a/packages/client/src/routes/dashboard.-components/-changelog.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-changelog.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+
+import { parseChangelog } from "./-changelog";
+
+const SAMPLE = `# Changelog
+
+All notable changes to this project are documented here.
+
+## [1.2.0] - 2026-06-13
+
+### Bug Fixes
+
+- Fix radar slice labels getting clipped (#266)
+- Refactor combobox grouping to use explicit \`group\` field (#230)
+
+### Features
+
+- Add daily streak badge (#101)
+
+## [1.1.0]
+
+### Changed
+
+- Speed up Docker builds (#241)
+`;
+
+describe("parseChangelog", () => {
+  test("splits the document into one release per `##` heading", () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases.map(r => r.version)).toEqual(["1.2.0", "1.1.0"]);
+  });
+
+  test("strips brackets from the version and pulls out the date", () => {
+    const [first] = parseChangelog(SAMPLE);
+    expect(first.version).toBe("1.2.0");
+    expect(first.date).toBe("2026-06-13");
+  });
+
+  test("leaves date null when the heading omits it", () => {
+    const second = parseChangelog(SAMPLE)[1];
+    expect(second.version).toBe("1.1.0");
+    expect(second.date).toBeNull();
+  });
+
+  test("groups list items under their `###` section heading", () => {
+    const [first] = parseChangelog(SAMPLE);
+    expect(first.sections.map(s => s.heading)).toEqual([
+      "Bug Fixes",
+      "Features",
+    ]);
+    expect(first.sections[0].items).toEqual([
+      "Fix radar slice labels getting clipped (#266)",
+      "Refactor combobox grouping to use explicit `group` field (#230)",
+    ]);
+    expect(first.sections[1].items).toEqual(["Add daily streak badge (#101)"]);
+  });
+
+  test("ignores the title and intro above the first release", () => {
+    const releases = parseChangelog(SAMPLE);
+    expect(releases).toHaveLength(2);
+    expect(
+      releases.some(r => r.version.toLowerCase().includes("changelog")),
+    ).toBe(false);
+  });
+
+  test("collects ungrouped items into a section with an empty heading", () => {
+    const releases = parseChangelog("## [0.1.0]\n\n- Initial release\n");
+    expect(releases[0].sections).toEqual([
+      {
+        heading: "",
+        items: ["Initial release"],
+      },
+    ]);
+  });
+
+  test("returns no releases for an empty document", () => {
+    expect(parseChangelog("")).toEqual([]);
+  });
+});

--- a/packages/client/src/routes/dashboard.-components/-changelog.ts
+++ b/packages/client/src/routes/dashboard.-components/-changelog.ts
@@ -1,0 +1,82 @@
+// Pure parser for the repo CHANGELOG.md (the Keep a Changelog / release-please
+// shape: `## [version] - date` releases, `### Section` groups, `-` list items).
+// No component imports, so it stays unit-testable like -dashboardTileMeta.ts;
+// the raw markdown import and inline rendering live in -DashboardChangelog.tsx.
+
+export interface ChangelogSection {
+  /** Section heading, e.g. "Bug Fixes" — "" for items with no `###` heading. */
+  heading: string;
+  /** Raw list-item text with inline markdown intact (e.g. "Fix … (#266)"). */
+  items: string[];
+}
+
+export interface ChangelogRelease {
+  /** Version label, e.g. "1.0.0" (brackets stripped) or the raw heading text. */
+  version: string;
+  /** Release date as written, e.g. "2026-06-13", or null when absent. */
+  date: string | null;
+  sections: ChangelogSection[];
+}
+
+const RELEASE_HEADING = /^##\s+(.+?)\s*$/;
+const SECTION_HEADING = /^###\s+(.+?)\s*$/;
+const LIST_ITEM = /^[-*]\s+(.+?)\s*$/;
+// "[1.0.0] - 2026-06-13" / "1.0.0 - 2026-06-13" → version (brackets optional)
+// plus an optional trailing date after an en- or hyphen dash.
+const VERSION_DATE = /^\[?(.+?)\]?(?:\s*[-–]\s*(.+))?$/;
+
+/**
+ * Parses CHANGELOG.md into releases, each grouped into titled sections. Lenient
+ * about formatting: anything before the first `##` release heading (the doc
+ * title and intro) is ignored, and non-list, non-heading lines inside a release
+ * are skipped.
+ */
+export function parseChangelog(markdown: string): ChangelogRelease[] {
+  const releases: ChangelogRelease[] = [];
+  let release: ChangelogRelease | null = null;
+  let section: ChangelogSection | null = null;
+
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.replace(/\r$/, "").trimEnd();
+
+    const releaseMatch = RELEASE_HEADING.exec(line);
+    if (releaseMatch) {
+      const versionDate = VERSION_DATE.exec(releaseMatch[1]);
+      release = {
+        version: versionDate ? versionDate[1].trim() : releaseMatch[1],
+        date: versionDate?.[2]?.trim() ?? null,
+        sections: [],
+      };
+      section = null;
+      releases.push(release);
+      continue;
+    }
+
+    // Drop the `# Changelog` title and intro paragraph above the first release.
+    if (!release) continue;
+
+    const sectionMatch = SECTION_HEADING.exec(line);
+    if (sectionMatch) {
+      section = {
+        heading: sectionMatch[1],
+        items: [],
+      };
+      release.sections.push(section);
+      continue;
+    }
+
+    const itemMatch = LIST_ITEM.exec(line);
+    if (itemMatch) {
+      if (!section) {
+        section = {
+          heading: "",
+          items: [],
+        };
+        release.sections.push(section);
+      }
+      section.items.push(itemMatch[1]);
+    }
+  }
+
+  return releases;
+}

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
@@ -52,6 +52,11 @@ export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
     minW: 1,
     minH: 4,
   },
+  changelog: {
+    title: "Changelog",
+    minW: 2,
+    minH: 4,
+  },
 };
 
 function isDashboardTileId(id: string): id is DashboardTileId {
@@ -94,6 +99,10 @@ const DEFAULT_TILE_HEIGHTS: { tileId: DashboardTileId;
   {
     tileId: "readwise",
     h: 7,
+  },
+  {
+    tileId: "changelog",
+    h: 8,
   },
 ];
 

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -39,6 +39,10 @@ export default defineConfig(({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // Repo-root files bundled into the client (e.g. CHANGELOG.md). A relative
+      // path is autofixed into the bare `emstack/...` package import, which
+      // doesn't resolve — an alias keeps it pointing at the monorepo root.
+      "@root": path.resolve(__dirname, "../.."),
     },
   },
   test: {

--- a/packages/types/src/DashboardLayout.ts
+++ b/packages/types/src/DashboardLayout.ts
@@ -10,6 +10,7 @@ export const DASHBOARD_TILE_IDS = [
   "exploreSomething",
   "readwise",
   "todoist",
+  "changelog",
 ] as const;
 
 export type DashboardTileId = (typeof DASHBOARD_TILE_IDS)[number];


### PR DESCRIPTION
## Summary

Adds a new "Changelog" dashboard tile that displays the project's CHANGELOG.md directly on the dashboard. The changelog is bundled at build time via Vite's `?raw` import, eliminating the need for an API round-trip and keeping the file as the single source of truth.

## Key Changes

- **New component `DashboardChangelog`** (`-DashboardChangelog.tsx`): Renders the changelog with styled release sections, expandable details (first release open by default), and inline markdown support for code blocks, links, and GitHub PR references (#123 → linked to the PR).

- **New parser `parseChangelog`** (`-changelog.ts`): Pure, unit-testable parser for Keep a Changelog / release-please format (`## [version] - date` releases, `### Section` groups, `-` list items). Lenient about formatting; ignores doc title and intro above the first release.

- **Parser tests** (`-changelog.test.ts`): Comprehensive test coverage for version/date extraction, section grouping, ungrouped items, and edge cases.

- **Vite alias `@root`** (`vite.config.ts`): Added to resolve repo-root files (e.g., CHANGELOG.md) into the client bundle. Necessary because relative imports would resolve incorrectly in the monorepo context.

- **Dashboard tile registration** (`-dashboardTileMeta.ts`): Registered "changelog" as a new tile with min dimensions (2×4) and default height (8).

- **Grid integration** (`-DashboardGrid.tsx`): Imported and rendered the new `DashboardChangelog` component.

- **Type definition** (`DashboardLayout.ts`): Added "changelog" to `DASHBOARD_TILE_IDS`.

- **Vite environment types** (`vite-env.d.ts`): Added type reference for Vite client types (supports `?raw` imports).

## Implementation Details

- Inline markdown rendering uses regex to parse backticks (code), `[text](url)` links, and `#123` PR references, converting them to styled React elements.
- The changelog is bundled at build time, so no runtime parsing or API calls are needed.
- The first release is expanded by default; others are collapsed.
- A "View on GitHub" link in the card header points to the full CHANGELOG.md on the repo.

https://claude.ai/code/session_01WoVqNLZv25w8816uN2CLA2