### PR TITLE
build: include CHANGELOG.md in Docker build for client bundling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,9 @@
 .husky
 .claude
 *.md
+# …except CHANGELOG.md, which the client bundles at build time via the @root
+# Vite alias (see packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx).
+!CHANGELOG.md
 Dockerfile
 **/Dockerfile
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN pnpm --filter @emstack/middleware exec tsc -b tsconfig.build.json --noCheck 
 FROM build-types AS build-client
 
 COPY packages/client/ ./packages/client/
+# The client bundles the repo-root CHANGELOG.md at build time (the @root Vite
+# alias + ?raw import in -DashboardChangelog.tsx), so it must be present here.
+COPY CHANGELOG.md ./
 RUN pnpm --filter @emstack/client build
 
 


### PR DESCRIPTION
## Summary
Ensures that `CHANGELOG.md` is available during the Docker build process so the client can bundle it at build time via the `@root` Vite alias.

## Changes
- **`.dockerignore`:** Added exception to exclude `CHANGELOG.md` from the default `*.md` ignore rule, allowing it to be copied into the Docker image
- **`Dockerfile`:** Added `COPY CHANGELOG.md ./` in the `build-client` stage to make the repo-root changelog available to the client build process

## Implementation Details
The client's `-DashboardChangelog.tsx` component imports `CHANGELOG.md` using a `?raw` import via the `@root` Vite alias. This requires the file to be present in the build context. The changes ensure the changelog is:
1. Not filtered out by `.dockerignore`'s blanket `*.md` rule
2. Explicitly copied into the build stage before the client build runs

This allows the dashboard to display the changelog without requiring it to be fetched at runtime.

https://claude.ai/code/session_015T51wPMigBBVoZ5mjGfu36