### PR TITLE
refactor(radar): consolidate duplicate types and add condense-types skill

### DIFF
--- a/.claude/skills/condense-types/SKILL.md
+++ b/.claude/skills/condense-types/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: condense-types
+description: >-
+  Audit a folder or area of the app for redundant TypeScript types and
+  condense them — collapse re-declarations of shared @emstack/types shapes,
+  resolve duplicate type-name collisions, and extract shared base interfaces
+  via `extends`. Use when asked to "condense/consolidate/dedupe types",
+  "combine these interfaces", or "can these types be shared/extended".
+---
+
+# Condense types (course-tracker)
+
+Reduce duplicate and overlapping type/interface declarations in a target area
+(a folder, a feature, or a single file) **without changing behavior**. Quality
+only — for behavior cleanups use `/simplify`, for bugs use `/code-review`.
+
+The single source of truth for cross-package shapes is **`packages/types/src/`**
+(`@emstack/types`). The client and middleware both consume it; local
+re-declarations drift. Most condensing is pulling things back toward that.
+
+## 1. Inventory the target area
+
+List every type/interface in scope and where each is used:
+
+```bash
+cd <target-dir>
+grep -rn "^export type\|^export interface\|^type \|^interface " *.ts *.tsx
+```
+
+For a wide sweep (many files / "across the app"), delegate to an **Explore
+agent** — ask it for `file:line`, the type name, its shape, and which shared
+type it overlaps. Also lean on **fallow**, which already flags duplication and
+unused types in this repo:
+
+```bash
+pnpm exec fallow dupes        # duplicate code/shapes
+pnpm exec fallow dead-code    # unused exported types worth deleting outright
+```
+
+Read the actual shape of each candidate before deciding — and read the shared
+type it might match (`packages/types/src/<Name>.ts`). Don't classify from the
+name alone.
+
+## 2. Classify each candidate into a pattern
+
+### Pattern A — re-declares a shared `@emstack/types` shape → import it
+A local interface structurally equal to (or a subset of) a shared type. Delete
+it and import the shared one; update consumers.
+- Example: `QuadrantInfo`/`RingInfo`/`PersistedQuadrant`/`PersistedRing` were all
+  `RadarQuadrant`/`RadarRing` (alias of `RadarConfigEntry`).
+- **Middleware schema JSONB shapes are a hard rule**, not a judgment call: per
+  `packages/middleware/CLAUDE.md`, re-export them type-only from
+  `@emstack/types` (`export type { X } from "@emstack/types"`), never
+  re-declare — local copies have drifted before. See `db/schema/enums.ts` for
+  the canonical pattern.
+
+### Pattern B — duplicate exported name, different shape → rename to disambiguate
+Two `export`ed types sharing a name but not a shape are a footgun (easy to
+import the wrong one). They **can't** be combined — rename each to its context.
+- Example: two `EditDraft`s became `LlmEditDraft` (blipLlmReview) and
+  `BlipEditDraft` (BlipEditRow).
+
+### Pattern C — sibling interfaces share a prop cluster → extract a base, `extends`
+When 2+ interfaces repeat the same group of fields verbatim, extract a base
+interface they each `extend`. Adding/changing a field then touches one place.
+- Example: `BlipLegendItemProps` and `SimpleBlipLegendSectionProps` shared four
+  handler props → extracted `BlipLegendHandlers`.
+- If one interface is a strict superset of another, have it `extend` the
+  smaller directly instead of inventing a base.
+- Reach for `Pick<T, …>` / `Omit<T, …>` when an interface is a slice of a shared
+  type rather than a fresh cluster.
+
+## 3. Guardrails (when NOT to condense)
+
+- **Structural match ≠ semantic match.** Draft types (`QuadrantDraft`,
+  `RingDraft`, `BlipDraft` — `id?` + `localKey` for unsaved rows) and API DTOs
+  (`*Payload`, `BulkBlipEntry`) deliberately differ from persisted shapes.
+  Leave them.
+- **Don't force an `extends` when a member is sourced differently.** Verify the
+  candidate actually *receives* every base field. `RadarLegend` looked like it
+  could extend `BlipLegendHandlers`, but it builds `registerRef` internally
+  (`useCallback`) rather than taking it as a prop — so it shares the callbacks
+  but not the full set. The typecheck catches this; if forcing the fit needs
+  ever-smaller tiers, stop and leave it separate.
+- **Don't over-tier.** A base interface used by only one type earns nothing —
+  inline it.
+- **Skip generated files**: `routeTree.gen.ts`, anything under `dist/`.
+
+## 4. Apply
+
+- Update the declaration, then every importer (grep the whole package, not just
+  the folder — consumers like hooks/routes live elsewhere). After Pattern B
+  renames especially, re-grep the package for the old name; the first typecheck
+  will otherwise surface stragglers.
+- The lint-staged formatter reorders/normalizes imports on save — don't
+  hand-fuss import ordering.
+
+## 5. Verify
+
+```bash
+pnpm typecheck                                   # whole repo; types cross packages
+pnpm --filter=@emstack/client exec vitest run <changed test files>
+pnpm exec eslint <changed files>                 # run from repo ROOT — the
+                                                 # tailwind plugin needs the root
+                                                 # cwd to find its css entrypoint
+```
+
+`pnpm typecheck` is the real safety net for type-only refactors — it must be
+clean apart from pre-existing, unrelated errors (confirm with `git stash` if
+unsure one predates your change).
+
+Commit with a `refactor(<scope>):` Conventional Commit, one logical change per
+commit (consolidation vs. rename vs. extraction read better split).

--- a/packages/client/src/components/radar/BlipBulkBar.tsx
+++ b/packages/client/src/components/radar/BlipBulkBar.tsx
@@ -1,7 +1,4 @@
-import type {
-  QuadrantInfo,
-  RingInfo,
-} from "@/components/radar/blipTableFilters";
+import type { RadarQuadrant, RadarRing } from "@emstack/types";
 
 import { Loader2 } from "lucide-react";
 
@@ -17,8 +14,8 @@ import {
 
 interface BlipBulkBarProps {
   selectedCount: number;
-  quadrants: QuadrantInfo[];
-  rings: RingInfo[];
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
   bulkQuadrantId: string;
   bulkRingId: string;
   onBulkQuadrantChange: (value: string) => void;
@@ -47,11 +44,7 @@ export function BlipBulkBar({
         border-primary/40 bg-primary/5 p-2
       `}
     >
-      <span className="text-sm font-medium">
-        {selectedCount}
-        {" "}
-        selected
-      </span>
+      <span className="text-sm font-medium">{selectedCount} selected</span>
       <Select
         value={bulkQuadrantId}
         onValueChange={onBulkQuadrantChange}
@@ -100,9 +93,7 @@ export function BlipBulkBar({
         }
       >
         {bulkPending && <Loader2 className="animate-spin" />}
-        Apply to
-        {" "}
-        {selectedCount}
+        Apply to {selectedCount}
       </Button>
       <Button
         type="button"

--- a/packages/client/src/components/radar/BlipDisplayRow.tsx
+++ b/packages/client/src/components/radar/BlipDisplayRow.tsx
@@ -1,9 +1,7 @@
 import type {
-  QuadrantInfo,
-  RingInfo,
-} from "@/components/radar/blipTableFilters";
-import type {
   RadarBlip,
+  RadarQuadrant,
+  RadarRing,
   TopicForTopicsPage,
 } from "@emstack/types";
 
@@ -41,8 +39,8 @@ import { TableCell, TableRow } from "@/components/ui/table";
 interface BlipDisplayRowProps {
   blip: RadarBlip;
   topic: TopicForTopicsPage | undefined;
-  quadrantById: Map<string, QuadrantInfo>;
-  ringById: Map<string, RingInfo>;
+  quadrantById: Map<string, RadarQuadrant>;
+  ringById: Map<string, RadarRing>;
   isSelected: boolean;
   isPending: boolean;
   editingLocked: boolean;
@@ -80,37 +78,24 @@ export function BlipDisplayRow({
           onChange={onToggleSelected}
         />
       </TableCell>
-      <TableCell className="font-medium">
-        {blip.topicName}
-      </TableCell>
+      <TableCell className="font-medium">{blip.topicName}</TableCell>
       <TableCell>
         {(() => {
           if (blip.isIgnored) {
-            return (
-              <Pill className="bg-gray-200 text-gray-700">
-                Ignored
-              </Pill>
-            );
+            return <Pill className="bg-gray-200 text-gray-700">Ignored</Pill>;
           }
           const q = blip.quadrantId
             ? quadrantById.get(blip.quadrantId)
             : undefined;
           if (!q) {
             return (
-              <span
-                className="text-xs text-muted-foreground italic"
-              >
+              <span className="text-xs text-muted-foreground italic">
                 unassigned
               </span>
             );
           }
           return (
-            <Pill
-              className={pillClassByIndex(
-                SLICE_PILL_CLASSES,
-                q.position,
-              )}
-            >
+            <Pill className={pillClassByIndex(SLICE_PILL_CLASSES, q.position)}>
               {q.name}
             </Pill>
           );
@@ -119,31 +104,18 @@ export function BlipDisplayRow({
       <TableCell>
         {(() => {
           if (blip.isIgnored) {
-            return (
-              <span className="text-xs text-muted-foreground">
-                —
-              </span>
-            );
+            return <span className="text-xs text-muted-foreground">—</span>;
           }
-          const r = blip.ringId
-            ? ringById.get(blip.ringId)
-            : undefined;
+          const r = blip.ringId ? ringById.get(blip.ringId) : undefined;
           if (!r) {
             return (
-              <span
-                className="text-xs text-muted-foreground italic"
-              >
+              <span className="text-xs text-muted-foreground italic">
                 unassigned
               </span>
             );
           }
           return (
-            <Pill
-              className={pillClassByIndex(
-                RING_PILL_CLASSES,
-                r.position,
-              )}
-            >
+            <Pill className={pillClassByIndex(RING_PILL_CLASSES, r.position)}>
               {r.name}
             </Pill>
           );
@@ -182,7 +154,9 @@ export function BlipDisplayRow({
                 />
               </div>
             )
-            : "—"}
+            : (
+              "—"
+            )}
         </TableCell>
       )}
       <TableCell className="text-right">
@@ -214,8 +188,12 @@ export function BlipDisplayRow({
                 aria-label="More actions"
               >
                 {isPending
-                  ? <Loader2 className="animate-spin" />
-                  : <MoreHorizontalIcon />}
+                  ? (
+                    <Loader2 className="animate-spin" />
+                  )
+                  : (
+                    <MoreHorizontalIcon />
+                  )}
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -281,9 +259,7 @@ export function BlipDisplayRow({
                   View Topic
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={onToggleIgnore}
-              >
+              <DropdownMenuItem onClick={onToggleIgnore}>
                 {blip.isIgnored
                   ? (
                     <>
@@ -337,10 +313,7 @@ function TopicItemLink({
         title={title}
         className="text-muted-foreground/60"
       >
-        {label}
-        :
-        {" "}
-        0
+        {label}: 0
       </span>
     );
   }
@@ -356,10 +329,7 @@ function TopicItemLink({
         hover:text-blue-500 hover:underline
       `}
     >
-      {label}
-      :
-      {" "}
-      {count}
+      {label}: {count}
     </Link>
   );
 }

--- a/packages/client/src/components/radar/BlipEditRow.tsx
+++ b/packages/client/src/components/radar/BlipEditRow.tsx
@@ -1,8 +1,4 @@
-import type {
-  QuadrantInfo,
-  RingInfo,
-} from "@/components/radar/blipTableFilters";
-import type { RadarBlip } from "@emstack/types";
+import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types";
 
 import { Loader2, XIcon } from "lucide-react";
 
@@ -11,7 +7,7 @@ import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 
-export interface EditDraft {
+export interface BlipEditDraft {
   quadrantId: string;
   ringId: string;
   description: string;
@@ -21,10 +17,10 @@ export interface EditDraft {
 interface BlipEditRowProps {
   blip: RadarBlip;
   topicDescription: string | null;
-  draft: EditDraft;
-  onDraftChange: (draft: EditDraft) => void;
-  quadrants: QuadrantInfo[];
-  rings: RingInfo[];
+  draft: BlipEditDraft;
+  onDraftChange: (draft: BlipEditDraft) => void;
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
   isPending: boolean;
   onCommit: () => void;
   onCancel: () => void;
@@ -53,14 +49,10 @@ export function BlipEditRow({
           `}
         >
           <div className="flex flex-col gap-1">
-            <span
-              className="text-xs text-muted-foreground uppercase"
-            >
+            <span className="text-xs text-muted-foreground uppercase">
               Topic
             </span>
-            <h3 className="text-lg font-semibold">
-              {blip.topicName}
-            </h3>
+            <h3 className="text-lg font-semibold">{blip.topicName}</h3>
             {topicDescription
               ? (
                 <p className="text-sm text-muted-foreground">
@@ -68,17 +60,13 @@ export function BlipEditRow({
                 </p>
               )
               : (
-                <p
-                  className="text-sm text-muted-foreground italic"
-                >
+                <p className="text-sm text-muted-foreground italic">
                   (no topic description)
                 </p>
               )}
           </div>
           <div className="flex flex-col gap-3">
-            <label
-              className="flex flex-row items-center gap-2 text-sm"
-            >
+            <label className="flex flex-row items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={draft.isIgnored}
@@ -135,9 +123,7 @@ export function BlipEditRow({
                 onClick={onCommit}
                 disabled={isPending}
               >
-                {isPending && (
-                  <Loader2 className="animate-spin" />
-                )}
+                {isPending && <Loader2 className="animate-spin" />}
                 Save
               </Button>
               <Button

--- a/packages/client/src/components/radar/BlipLlmReviewTable.tsx
+++ b/packages/client/src/components/radar/BlipLlmReviewTable.tsx
@@ -1,4 +1,8 @@
-import type { EditDraft, Resolution, ResolvedLlmEntry } from "./blipLlmReview";
+import type {
+  LlmEditDraft,
+  Resolution,
+  ResolvedLlmEntry,
+} from "./blipLlmReview";
 import type {
   RadarQuadrant,
   RadarRing,
@@ -46,7 +50,7 @@ interface ReviewTableProps {
   startEdit: (idx: number) => void;
   commitEdit: (idx: number) => void;
   cancelEdit: (idx: number) => void;
-  updateDraft: (idx: number, patch: Partial<EditDraft>) => void;
+  updateDraft: (idx: number, patch: Partial<LlmEditDraft>) => void;
   setRowSelected: (idx: number, selected: boolean) => void;
   setAllSelected: (selected: boolean) => void;
 }
@@ -130,7 +134,7 @@ interface ReviewRowProps {
   startEdit: (idx: number) => void;
   commitEdit: (idx: number) => void;
   cancelEdit: (idx: number) => void;
-  updateDraft: (idx: number, patch: Partial<EditDraft>) => void;
+  updateDraft: (idx: number, patch: Partial<LlmEditDraft>) => void;
   setRowSelected: (idx: number, selected: boolean) => void;
 }
 
@@ -189,9 +193,10 @@ function ReviewRow({
           showDiff={descriptionChanged(r)}
           editing={r.editing && !isSkipped}
           draftValue={r.editDraft?.description ?? ""}
-          onDraftChange={value => updateDraft(idx, {
-            description: value,
-          })}
+          onDraftChange={value =>
+            updateDraft(idx, {
+              description: value,
+            })}
           multiline
         />
       </TableCell>
@@ -206,9 +211,10 @@ function ReviewRow({
         options={quadrants}
         showDiff={quadrantChanged(r)}
         draftId={r.editDraft?.quadrantId ?? ""}
-        onDraftChange={value => updateDraft(idx, {
-          quadrantId: value,
-        })}
+        onDraftChange={value =>
+          updateDraft(idx, {
+            quadrantId: value,
+          })}
       />
 
       <PlacementTableCell
@@ -221,9 +227,10 @@ function ReviewRow({
         options={rings}
         showDiff={ringChanged(r)}
         draftId={r.editDraft?.ringId ?? ""}
-        onDraftChange={value => updateDraft(idx, {
-          ringId: value,
-        })}
+        onDraftChange={value =>
+          updateDraft(idx, {
+            ringId: value,
+          })}
       />
 
       <TableCell className="align-top">
@@ -233,9 +240,10 @@ function ReviewRow({
           showDiff={radarNoteChanged(r)}
           editing={r.editing && !isSkipped && !isRemove}
           draftValue={r.editDraft?.radarNote ?? ""}
-          onDraftChange={value => updateDraft(idx, {
-            radarNote: value,
-          })}
+          onDraftChange={value =>
+            updateDraft(idx, {
+              radarNote: value,
+            })}
           multiline
         />
       </TableCell>
@@ -350,8 +358,8 @@ function PlacementTableCell({
       </TableCell>
     );
   }
-  const existingName = existingId ? byId.get(existingId)?.name ?? "?" : null;
-  const newName = newId ? byId.get(newId)?.name ?? newInput : newInput;
+  const existingName = existingId ? (byId.get(existingId)?.name ?? "?") : null;
+  const newName = newId ? (byId.get(newId)?.name ?? newInput) : newInput;
   return (
     <TableCell className="align-top">
       <PlacementCell
@@ -495,16 +503,14 @@ function ResolutionCell({
               type="checkbox"
               checked={r.deleteTopicOnRemove}
               disabled={!canDeleteTopic}
-              onChange={e => updateEntry(idx, {
-                deleteTopicOnRemove: e.target.checked,
-              })}
+              onChange={e =>
+                updateEntry(idx, {
+                  deleteTopicOnRemove: e.target.checked,
+                })}
             />
             Also delete topic
             {!canDeleteTopic && topic && (
-              <span className="text-[10px]">
-                {" "}
-                (in use)
-              </span>
+              <span className="text-[10px]"> (in use)</span>
             )}
           </label>
         )}
@@ -544,8 +550,8 @@ function DiffCell({
           <span className="text-muted-foreground italic">(none)</span>
         )}
       </span>
-      {editing && (
-        multiline
+      {editing
+        && (multiline
           ? (
             <Textarea
               value={draftValue}
@@ -559,8 +565,7 @@ function DiffCell({
               onChange={e => onDraftChange(e.target.value)}
               className="mt-1"
             />
-          )
-      )}
+          ))}
     </div>
   );
 }
@@ -617,7 +622,8 @@ function PlacementCell({
               <SelectItem
                 key={o.id}
                 value={o.id}
-              >{o.name}
+              >
+                {o.name}
               </SelectItem>
             ))}
           </SelectContent>

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -1,13 +1,13 @@
-import type { EditDraft } from "@/components/radar/BlipEditRow";
+import type { BlipEditDraft } from "@/components/radar/BlipEditRow";
 import type {
   BulkPatch,
-  QuadrantInfo,
-  RingInfo,
   SortDir,
   SortKey,
 } from "@/components/radar/blipTableFilters";
 import type {
   RadarBlip,
+  RadarQuadrant,
+  RadarRing,
   TopicForTopicsPage,
 } from "@emstack/types";
 
@@ -50,15 +50,17 @@ import { useRowSelection } from "@/hooks/useRowSelection";
 
 interface BlipTableProps {
   blips: RadarBlip[];
-  quadrants: QuadrantInfo[];
-  rings: RingInfo[];
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
   topics: TopicForTopicsPage[];
   onSave: (
     blip: RadarBlip,
-    patch: { quadrantId: string | null;
+    patch: {
+      quadrantId: string | null;
       ringId: string | null;
       description: string | null;
-      isIgnored: boolean; },
+      isIgnored: boolean;
+    },
   ) => Promise<void>;
   onRemove: (blip: RadarBlip) => Promise<void>;
   onBulkSave: (ids: string[], patch: BulkPatch) => Promise<void>;
@@ -79,7 +81,7 @@ export function BlipTable({
   const [sortKey, setSortKey] = useState<SortKey>("slice");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
+  const [editDraft, setEditDraft] = useState<BlipEditDraft | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [showItemsColumn, setShowItemsColumn] = useState(false);
   const [bulkQuadrantId, setBulkQuadrantId] = useState<string>(NO_CHANGE);
@@ -94,17 +96,17 @@ export function BlipTable({
     }
     // Incidental similarity to BlipLlmAssist's lookup maps; different domain types.
     // fallow-ignore-next-line code-duplication
-    setSortDir(prev => prev === "asc" ? "desc" : "asc");
+    setSortDir(prev => (prev === "asc" ? "desc" : "asc"));
   }
 
   const quadrantById = useMemo(() => {
-    const map = new Map<string, QuadrantInfo>();
+    const map = new Map<string, RadarQuadrant>();
     quadrants.forEach(q => map.set(q.id, q));
     return map;
   }, [quadrants]);
 
   const ringById = useMemo(() => {
-    const map = new Map<string, RingInfo>();
+    const map = new Map<string, RadarRing>();
     rings.forEach(r => map.set(r.id, r));
     return map;
   }, [rings]);
@@ -115,15 +117,9 @@ export function BlipTable({
     return map;
   }, [topics]);
 
-  const sliceCounts = useMemo(
-    () => countByField(blips, "quadrantId"),
-    [blips],
-  );
+  const sliceCounts = useMemo(() => countByField(blips, "quadrantId"), [blips]);
 
-  const ringCounts = useMemo(
-    () => countByField(blips, "ringId"),
-    [blips],
-  );
+  const ringCounts = useMemo(() => countByField(blips, "ringId"), [blips]);
 
   const topicItemCount = useCallback(
     (topicId: string): number => {
@@ -190,8 +186,12 @@ export function BlipTable({
       return <ChevronsUpDownIcon className="size-3 opacity-50" />;
     }
     return sortDir === "asc"
-      ? <ChevronUpIcon className="size-3" />
-      : <ChevronDownIcon className="size-3" />;
+      ? (
+        <ChevronUpIcon className="size-3" />
+      )
+      : (
+        <ChevronDownIcon className="size-3" />
+      );
   }
 
   function startEdit(blip: RadarBlip) {
@@ -315,15 +315,9 @@ export function BlipTable({
             <SelectValue placeholder="Slice" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>
-              All Slices (
-              {blips.length}
-              )
-            </SelectItem>
+            <SelectItem value={ALL}>All Slices ({blips.length})</SelectItem>
             <SelectItem value={UNASSIGNED}>
-              Unassigned (
-              {sliceCounts.unassigned}
-              )
+              Unassigned ({sliceCounts.unassigned})
             </SelectItem>
             {quadrants.map(q => (
               <SelectItem
@@ -332,8 +326,7 @@ export function BlipTable({
               >
                 {q.name}
                 {" ("}
-                {sliceCounts.counts.get(q.id) ?? 0}
-                )
+                {sliceCounts.counts.get(q.id) ?? 0})
               </SelectItem>
             ))}
           </SelectContent>
@@ -346,15 +339,9 @@ export function BlipTable({
             <SelectValue placeholder="Ring" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>
-              All Rings (
-              {blips.length}
-              )
-            </SelectItem>
+            <SelectItem value={ALL}>All Rings ({blips.length})</SelectItem>
             <SelectItem value={UNASSIGNED}>
-              Unassigned (
-              {ringCounts.unassigned}
-              )
+              Unassigned ({ringCounts.unassigned})
             </SelectItem>
             {rings.map(r => (
               <SelectItem
@@ -363,15 +350,12 @@ export function BlipTable({
               >
                 {r.name}
                 {" ("}
-                {ringCounts.counts.get(r.id) ?? 0}
-                )
+                {ringCounts.counts.get(r.id) ?? 0})
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
-        <label
-          className="flex flex-row items-center gap-2 text-sm"
-        >
+        <label className="flex flex-row items-center gap-2 text-sm">
           <input
             type="checkbox"
             checked={showItemsColumn}

--- a/packages/client/src/components/radar/BlipsTab.tsx
+++ b/packages/client/src/components/radar/BlipsTab.tsx
@@ -1,4 +1,9 @@
-import type { RadarBlip, TopicForTopicsPage } from "@emstack/types";
+import type {
+  RadarBlip,
+  RadarQuadrant,
+  RadarRing,
+  TopicForTopicsPage,
+} from "@emstack/types";
 
 import { Loader2, PlusIcon, TrashIcon } from "lucide-react";
 
@@ -14,19 +19,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-interface PersistedQuadrant {
-  id: string;
-  name: string;
-  position: number;
-}
-
-interface PersistedRing {
-  id: string;
-  name: string;
-  position: number;
-  isAdopted?: boolean;
-}
-
 interface BlipDraft {
   id?: string;
   topicId: string;
@@ -40,8 +32,8 @@ interface BlipsTabProps {
   allConfigPersisted: boolean;
   savedBlipsForTable: RadarBlip[];
   newBlipDrafts: BlipDraft[];
-  persistedQuadrants: PersistedQuadrant[];
-  persistedRings: PersistedRing[];
+  persistedQuadrants: RadarQuadrant[];
+  persistedRings: RadarRing[];
   topics: TopicForTopicsPage[];
   usedTopicIds: Set<string>;
   pendingBlipKey: string | null;
@@ -57,10 +49,12 @@ interface BlipsTabProps {
   onRemoveBlip: (blip: BlipDraft) => void;
   onTableSave: (
     blip: RadarBlip,
-    patch: { quadrantId: string | null;
+    patch: {
+      quadrantId: string | null;
       ringId: string | null;
       description: string | null;
-      isIgnored: boolean; },
+      isIgnored: boolean;
+    },
   ) => Promise<void>;
   onTableRemove: (blip: RadarBlip) => Promise<void>;
   onTableBulkSave: (
@@ -155,8 +149,7 @@ export function BlipsTab({
                         {topics
                           .filter(
                             t =>
-                              t.id === blip.topicId
-                              || !usedTopicIds.has(t.id),
+                              t.id === blip.topicId || !usedTopicIds.has(t.id),
                           )
                           .map(t => (
                             <SelectItem

--- a/packages/client/src/components/radar/RadarLegend.tsx
+++ b/packages/client/src/components/radar/RadarLegend.tsx
@@ -3,10 +3,7 @@ import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types";
 
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import {
-  QUADRANT_PALETTE,
-
-} from "@/components/radar/radarLayout";
+import { QUADRANT_PALETTE } from "@/components/radar/radarLayout";
 import {
   BlipLegendItem,
   SimpleBlipLegendSection,
@@ -124,7 +121,7 @@ export function RadarLegend({
                   onHover={onHover}
                   onBlipClick={onBlipClick}
                   onDescriptionChange={onDescriptionChange}
-                  label={(
+                  label={
                     <>
                       <span
                         className="mr-1 inline-block font-mono text-xs"
@@ -132,17 +129,14 @@ export function RadarLegend({
                           color,
                         }}
                       >
-                        {index}
-                        .
+                        {index}.
                       </span>
                       <span className="font-medium">{blip.topicName}</span>
                       <span className="ml-1 text-xs text-muted-foreground">
-                        (
-                        {ringNameById[blip.ringId ?? ""]}
-                        )
+                        ({ringNameById[blip.ringId ?? ""]})
                       </span>
                     </>
-                  )}
+                  }
                 />
               ))}
             </ul>

--- a/packages/client/src/components/radar/blipLlmReview.ts
+++ b/packages/client/src/components/radar/blipLlmReview.ts
@@ -28,7 +28,7 @@ interface LlmEntry {
   action?: unknown;
 }
 
-export interface EditDraft {
+export interface LlmEditDraft {
   description: string;
   radarNote: string;
   quadrantId: string;
@@ -64,7 +64,7 @@ export interface ResolvedLlmEntry {
   resolution: Resolution;
   deleteTopicOnRemove: boolean;
   editing: boolean;
-  editDraft: EditDraft | null;
+  editDraft: LlmEditDraft | null;
 
   selected: boolean;
 
@@ -72,9 +72,16 @@ export interface ResolvedLlmEntry {
 }
 
 export function computeProblems(
-  entry: Pick<ResolvedLlmEntry,
-  "topicName" | "quadrantInput" | "quadrantId" | "ringInput" | "ringId"
-  | "resolution" | "existingBlipId">,
+  entry: Pick<
+    ResolvedLlmEntry,
+    | "topicName"
+    | "quadrantInput"
+    | "quadrantId"
+    | "ringInput"
+    | "ringId"
+    | "resolution"
+    | "existingBlipId"
+  >,
   excludedNames?: Set<string>,
 ): string[] {
   const problems: string[] = [];
@@ -186,9 +193,7 @@ function asTrimmedString(value: unknown): string {
 }
 
 function normalizeAction(value: unknown): string | null {
-  return typeof value === "string"
-    ? value.trim().toLowerCase() || null
-    : null;
+  return typeof value === "string" ? value.trim().toLowerCase() || null : null;
 }
 
 function lookupByLowerName<T>(
@@ -268,7 +273,7 @@ function resolveLlmEntry(
   const ringMatch = lookupByLowerName(ringByLowerName, ringInput);
   const topicMatch = lookupByLowerName(topicByLowerName, topicName);
   const existingBlip = topicMatch
-    ? existingBlipByTopicId.get(topicMatch.id) ?? null
+    ? (existingBlipByTopicId.get(topicMatch.id) ?? null)
     : null;
 
   const blipState = existingBlipState(existingBlip);

--- a/packages/client/src/components/radar/blipTableFilters.test.ts
+++ b/packages/client/src/components/radar/blipTableFilters.test.ts
@@ -1,13 +1,8 @@
-import type { RadarBlip } from "@emstack/types";
+import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import type {
-  BlipFilterCriteria,
-  BlipFilterLookups,
-  QuadrantInfo,
-  RingInfo,
-} from "./blipTableFilters";
+import type { BlipFilterCriteria, BlipFilterLookups } from "./blipTableFilters";
 
 import {
   ALL,
@@ -29,7 +24,7 @@ function makeBlip(overrides: Partial<RadarBlip> & { id: string }): RadarBlip {
   };
 }
 
-const quadrants: QuadrantInfo[] = [
+const quadrants: RadarQuadrant[] = [
   {
     id: "q1",
     name: "Languages",
@@ -44,7 +39,7 @@ const quadrants: QuadrantInfo[] = [
 
 // Test fixture data; incidental overlap with the production Map-building code.
 // fallow-ignore-next-line code-duplication
-const rings: RingInfo[] = [
+const rings: RadarRing[] = [
   {
     id: "r1",
     name: "Adopt",

--- a/packages/client/src/components/radar/blipTableFilters.ts
+++ b/packages/client/src/components/radar/blipTableFilters.ts
@@ -1,17 +1,4 @@
-import type { RadarBlip } from "@emstack/types";
-
-export interface QuadrantInfo {
-  id: string;
-  name: string;
-  position: number;
-}
-
-export interface RingInfo {
-  id: string;
-  name: string;
-  position: number;
-  isAdopted?: boolean;
-}
+import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types";
 
 export type SortKey = "topic" | "slice" | "ring" | "items";
 export type SortDir = "asc" | "desc";
@@ -34,8 +21,8 @@ export interface BlipFilterCriteria {
 }
 
 export interface BlipFilterLookups {
-  quadrantById: Map<string, QuadrantInfo>;
-  ringById: Map<string, RingInfo>;
+  quadrantById: Map<string, RadarQuadrant>;
+  ringById: Map<string, RadarRing>;
   topicItemCount: (topicId: string) => number;
 }
 
@@ -82,8 +69,12 @@ export function filterAndSortBlips(
       bv = (b.topicName ?? "").toLowerCase();
     }
     else if (sortKey === "slice") {
-      av = quadrantById.get(a.quadrantId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
-      bv = quadrantById.get(b.quadrantId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
+      av
+        = quadrantById.get(a.quadrantId ?? "")?.position
+          ?? Number.MAX_SAFE_INTEGER;
+      bv
+        = quadrantById.get(b.quadrantId ?? "")?.position
+          ?? Number.MAX_SAFE_INTEGER;
     }
     else if (sortKey === "items") {
       av = topicItemCount(a.topicId);

--- a/packages/client/src/components/radar/radarLegendItem.tsx
+++ b/packages/client/src/components/radar/radarLegendItem.tsx
@@ -8,29 +8,29 @@ import { BlipDescriptionPopover } from "@/components/radar/BlipDescriptionPopove
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-interface BlipLegendItemProps {
-  blip: RadarBlip;
-  /** Inner content of the clickable title button (e.g. index + name + ring). */
-  label: ReactNode;
-  isActive: boolean;
-  isSelected: boolean;
+/** Callbacks threaded from a legend section down to each blip row. */
+interface BlipLegendHandlers {
   registerRef: (id: string, el: HTMLLIElement | null) => void;
   onHover: (id: string | null) => void;
   onBlipClick: (blip: RadarBlip) => void;
   onDescriptionChange: (blipId: string, value: string) => void;
 }
 
-interface SimpleBlipLegendSectionProps {
+interface BlipLegendItemProps extends BlipLegendHandlers {
+  blip: RadarBlip;
+  /** Inner content of the clickable title button (e.g. index + name + ring). */
+  label: ReactNode;
+  isActive: boolean;
+  isSelected: boolean;
+}
+
+interface SimpleBlipLegendSectionProps extends BlipLegendHandlers {
   title: string;
   /** className for the section heading (color varies by section). */
   headingClassName: string;
   blips: RadarBlip[];
   activeBlipId: string | null;
   selectedBlipId: string | null;
-  registerRef: (id: string, el: HTMLLIElement | null) => void;
-  onHover: (id: string | null) => void;
-  onBlipClick: (blip: RadarBlip) => void;
-  onDescriptionChange: (blipId: string, value: string) => void;
 }
 
 /**
@@ -138,9 +138,7 @@ export function BlipLegendItem({
         </div>
       </div>
       {description && (
-        <p
-          className="mt-0.5 ml-4 text-xs text-muted-foreground italic"
-        >
+        <p className="mt-0.5 ml-4 text-xs text-muted-foreground italic">
           {description}
         </p>
       )}

--- a/packages/client/src/hooks/useBlipLlmReview.ts
+++ b/packages/client/src/hooks/useBlipLlmReview.ts
@@ -1,5 +1,5 @@
 import type {
-  EditDraft,
+  LlmEditDraft,
   Resolution,
   ResolvedLlmEntry,
 } from "@/components/radar/blipLlmReview";
@@ -52,7 +52,7 @@ export function useBlipLlmReview({
         if (i !== idx) {
           return entry;
         }
-        const draft: EditDraft = {
+        const draft: LlmEditDraft = {
           description: entry.description ?? "",
           radarNote: entry.radarNote ?? "",
           quadrantId: entry.quadrantId ?? "",
@@ -79,7 +79,9 @@ export function useBlipLlmReview({
         const draft = entry.editDraft;
         const next: ResolvedLlmEntry = {
           ...entry,
-          description: draft.description.trim() ? draft.description.trim() : null,
+          description: draft.description.trim()
+            ? draft.description.trim()
+            : null,
           radarNote: draft.radarNote.trim() ? draft.radarNote.trim() : null,
           quadrantId: draft.quadrantId || null,
           ringId: draft.ringId || null,
@@ -101,7 +103,7 @@ export function useBlipLlmReview({
     });
   }
 
-  function updateDraft(idx: number, patch: Partial<EditDraft>) {
+  function updateDraft(idx: number, patch: Partial<LlmEditDraft>) {
     setResolved((prev) => {
       if (!prev) {
         return prev;
@@ -153,8 +155,10 @@ export function useBlipLlmReview({
   function bulkApplyPlacement(
     match: { id: string;
       name: string; } | undefined,
-    toFields: (match: { id: string;
-      name: string; }) => Partial<ResolvedLlmEntry>,
+    toFields: (match: {
+      id: string;
+      name: string;
+    }) => Partial<ResolvedLlmEntry>,
   ) {
     setResolved((prev) => {
       if (!prev) {

--- a/packages/middleware/src/db/schema/radar.ts
+++ b/packages/middleware/src/db/schema/radar.ts
@@ -1,13 +1,13 @@
+import type { RadarConfigEntry } from "@emstack/types";
+
 import { boolean, jsonb, pgTable, primaryKey, unique, varchar } from "drizzle-orm/pg-core";
 
 import { topics } from "./topics";
 
-export interface RadarConfigEntry {
-  id: string;
-  name: string;
-  position: number;
-  isAdopted?: boolean;
-}
+// JSONB column shape comes from the shared types package — the single source of
+// truth the client uses too (type-only re-export, erased at build time). The
+// local copy this replaces had drifted from @emstack/types.
+export type { RadarConfigEntry };
 
 export interface RadarConfig {
   quadrants: RadarConfigEntry[];


### PR DESCRIPTION
## Overview

Removes redundant TypeScript type declarations in the radar feature and codifies the workflow as a reusable skill. Type-only / no behavior changes.

## Changes

**1. Consolidate duplicate config types (`0ce1d2a`)**
- Four locally re-declared quadrant/ring shapes — `QuadrantInfo`, `RingInfo` (`blipTableFilters.ts`) and `PersistedQuadrant`, `PersistedRing` (`BlipsTab.tsx`) — were structurally identical to the shared `RadarQuadrant`/`RadarRing` (`RadarConfigEntry`) in `@emstack/types`. Replaced with imports of the shared types and updated all consumers (`BlipTable`, `BlipEditRow`, `BlipBulkBar`, `BlipDisplayRow`, `BlipsTab`, `blipTableFilters.test.ts`).
- Fixed the same drift in the middleware: `packages/middleware/src/db/schema/radar.ts` re-declared `RadarConfigEntry` locally, which `packages/middleware/CLAUDE.md` forbids ("never re-declare [JSONB shapes] locally; the old local copies drifted"). Switched to a type-only re-export from `@emstack/types`, matching the `enums.ts` pattern.
- Resolved an `EditDraft` name collision: two distinct exported shapes shared the name. Renamed to `LlmEditDraft` (`blipLlmReview.ts`) and `BlipEditDraft` (`BlipEditRow.tsx`).

**2. Extract shared `BlipLegendHandlers` base interface (`96c012b`)**
- `BlipLegendItemProps` and `SimpleBlipLegendSectionProps` repeated the same four handler props that a section threads straight through to each item. Extracted a `BlipLegendHandlers` base both extend.
- `RadarLegend` intentionally does **not** extend it — it builds `registerRef` internally rather than receiving it as a prop.

**3. Add `condense-types` skill (`c10fbc6`)**
- New project skill (`.claude/skills/condense-types/SKILL.md`) capturing this workflow for reuse elsewhere in the app: inventory → classify (dedupe shared shapes / rename collisions / extract base) → apply → verify, with the project-specific guardrails learned here.

## Verification
- `pnpm typecheck` — clean across all packages.
- Radar tests (`blipTableFilters.test.ts`, `blipLlmReview.test.ts`) — 48/48 pass.
- `pnpm exec eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)