### PR TITLE
fix(client): forward grid props to GridTile to enable positioning and dragging

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DndGrid } from "@dnd-grid/react";
+import { expect, waitFor } from "@storybook/test";
+
+import { GridTile } from "./-DashboardGrid";
+
+// Regression guard for the dashboard grid: @dnd-grid clones each child to inject
+// the `dnd-grid-item` class, the inline geometry (position/width/transform), drag
+// handlers, and a ref. GridTile must forward all of them — a previous version
+// swallowed them, leaving tiles unpositioned (full-width, no gap), undraggable,
+// and with a stray always-visible handle in the bottom-left.
+//
+// A fixed-height tile keeps its SE resize handle, so we can assert the injected
+// class + geometry + handle all reach the DOM and the hover toggle works.
+function GridTileHarness() {
+  return (
+    <div className="w-[640px]">
+      <DndGrid
+        layout={[
+          {
+            id: "todoist",
+            x: 0,
+            y: 0,
+            w: 2,
+            h: 4,
+            resizable: true,
+          },
+        ]}
+        cols={4}
+        rowHeight={64}
+        gap={12}
+        resizeHandles={["se"]}
+      >
+        <GridTile
+          key="todoist"
+          tileId="todoist"
+          autoHeight={false}
+          rowHeightPx={64}
+          onMeasure={() => {
+            // no-op: this fixed-height tile never reports a measured row count
+          }}
+        >
+          <div data-testid="tile-content">Tile content</div>
+        </GridTile>
+      </DndGrid>
+    </div>
+  );
+}
+
+const meta = {
+  component: GridTileHarness,
+} satisfies Meta<typeof GridTileHarness>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ForwardsGridProps: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    // The grid's injected class must reach the rendered tile element.
+    const item = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLElement>(".dnd-grid-item");
+      if (!el) throw new Error("tile did not receive the dnd-grid-item class");
+      return el;
+    });
+
+    // Geometry is applied inline by the grid (position:absolute + a pixel width
+    // narrower than the container) — proof the cloned `style` was forwarded.
+    await waitFor(() =>
+      expect(getComputedStyle(item).position).toBe("absolute"));
+    await expect(item.getBoundingClientRect().width).toBeLessThan(640);
+
+    // The SE (bottom-right) resize handle exists and is hidden by default — the
+    // regression showed an always-visible handle because the scoped
+    // `.dnd-grid-item > .react-resizable-handle { opacity: 0 }` rule never
+    // matched once the class was swallowed. (Hover reveal is a CSS :hover that
+    // synthetic events can't reliably trigger in-browser, so it isn't asserted.)
+    const handle = item.querySelector<HTMLElement>(
+      ".react-resizable-handle-se",
+    );
+    if (!handle) throw new Error("SE resize handle was not rendered");
+    await expect(getComputedStyle(handle).opacity).toBe("0");
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -116,26 +116,42 @@ function applyGeometryToTiles(
  * Wraps a single tile. Auto-height tiles render at their natural height and
  * report it (via ResizeObserver) so the grid can size their row span; fixed
  * tiles fill the grid cell and scroll internally.
+ *
+ * The grid clones this element to inject the `dnd-grid-item` class, the inline
+ * geometry style, drag handlers, and its own ref — so we must forward every
+ * received prop (and merge its ref with our measuring ref). Swallowing them
+ * leaves tiles unpositioned, undraggable, and with stray always-on handles.
  */
-function GridTile({
+export function GridTile({
   tileId,
   autoHeight,
   rowHeightPx,
   onMeasure,
+  className,
+  ref,
   children,
+  ...props
 }: {
   tileId: DashboardTileId;
   autoHeight: boolean;
   rowHeightPx: number;
   onMeasure: (tileId: DashboardTileId, rows: number) => void;
-  children: React.ReactNode;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
+} & React.ComponentProps<"div">) {
+  const innerRef = useRef<HTMLDivElement>(null);
   const minH = TILE_META[tileId].minH;
+
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      innerRef.current = node;
+      if (typeof ref === "function") ref(node);
+      else if (ref) ref.current = node;
+    },
+    [ref],
+  );
 
   useEffect(() => {
     if (!autoHeight) return;
-    const el = ref.current;
+    const el = innerRef.current;
     if (!el) return;
     const measure = () =>
       onMeasure(tileId, rowsForContent(el.offsetHeight, rowHeightPx, minH));
@@ -147,11 +163,12 @@ function GridTile({
 
   return (
     <div
-      ref={ref}
+      ref={setRef}
       className={cn("min-w-0", !autoHeight && `
         h-full min-h-0
         *:h-full
-      `)}
+      `, className)}
+      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary

Fixed a regression in the `GridTile` component where it was not forwarding props injected by the `@dnd-grid` library, causing tiles to be unpositioned, undraggable, and displaying stray resize handles.

## Changes

- **Export `GridTile`** and accept all `div` element props (`className`, `ref`, and spread `...props`) to allow the grid library to inject its required attributes
- **Forward the `dnd-grid-item` class** and inline geometry styles (position, width, transform) that the grid clones onto each child
- **Implement proper ref forwarding** using a callback ref that merges the grid's ref with the component's internal measuring ref, enabling both drag handlers and height measurement to work correctly
- **Add Storybook regression test** (`-DashboardGrid.stories.tsx`) that verifies:
  - The injected `dnd-grid-item` class reaches the DOM
  - Inline geometry styles are applied (position: absolute, constrained width)
  - The SE resize handle is rendered and hidden by default (not always-visible as in the regression)

## Implementation Details

The grid library clones each child element to inject the `dnd-grid-item` class, drag handlers, a ref, and computed inline styles. The previous implementation swallowed these by not accepting or forwarding them, leaving tiles full-width with no gaps, unable to be dragged, and with a permanently visible resize handle.

The fix uses a callback ref pattern to merge the grid's ref with the component's internal `innerRef` used for ResizeObserver-based height measurement, ensuring both concerns work together.

https://claude.ai/code/session_012mG7UYcoHVsqLRnM81wEqi