### PR TITLE
fix(client): prevent auto-height tiles from clamping to layout height

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
@@ -85,3 +85,77 @@ export const ForwardsGridProps: Story = {
     await expect(getComputedStyle(handle).opacity).toBe("0");
   },
 };
+
+// Regression guard for the auto-height path: the grid injects a fixed pixel
+// `height` (layout rows × rowHeight) into each item's `style`. For an
+// auto-height tile that height must NOT pin the measured element — otherwise
+// the ResizeObserver reads its own clamped height (freezing the row count) and
+// taller content overflows into the tile below, which is what made every card
+// overlap. Here the layout reserves 4 rows × 64px ≈ 256px but the content is
+// 600px tall, so a correct tile grows to its content instead of clamping.
+const TALL_CONTENT_PX = 600;
+
+function AutoHeightHarness() {
+  return (
+    <div className="w-[640px]">
+      <DndGrid
+        layout={[
+          {
+            id: "todoist",
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 4,
+          },
+        ]}
+        cols={4}
+        rowHeight={64}
+        gap={12}
+      >
+        <GridTile
+          key="todoist"
+          tileId="todoist"
+          autoHeight={true}
+          rowHeightPx={64}
+          onMeasure={() => {
+            // no-op: this harness asserts on the rendered height directly
+          }}
+        >
+          <div
+            data-testid="tall-content"
+            style={{
+              height: TALL_CONTENT_PX,
+            }}
+          >
+            Tall content
+          </div>
+        </GridTile>
+      </DndGrid>
+    </div>
+  );
+}
+
+export const AutoHeightSizesToContent: Story = {
+  render: () => <AutoHeightHarness />,
+  play: async ({
+    canvasElement,
+  }) => {
+    const item = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLElement>(".dnd-grid-item");
+      if (!el) throw new Error("tile did not receive the dnd-grid-item class");
+      return el;
+    });
+
+    // Still positioned by the forwarded geometry (the #279 fix must hold).
+    await waitFor(() =>
+      expect(getComputedStyle(item).position).toBe("absolute"));
+
+    // The tile grows to its ~600px content rather than being clamped to the
+    // layout's 4-row (~256px) imposed height. A regressed build leaves the
+    // inline height in place, so the element stays ~256px and the content
+    // overflows into neighbouring tiles.
+    await waitFor(() =>
+      expect(item.getBoundingClientRect().height)
+        .toBeGreaterThan(TALL_CONTENT_PX - 50));
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -123,6 +123,13 @@ function applyGeometryToTiles(
  * geometry style, drag handlers, and its own ref — so we must forward every
  * received prop (and merge its ref with our measuring ref). Swallowing them
  * leaves tiles unpositioned, undraggable, and with stray always-on handles.
+ *
+ * One exception: the grid's geometry `style` carries a fixed pixel `height`
+ * (the layout row count × rowHeight). For auto-height tiles that height must
+ * not reach the measured element — it would feed the element's own height back
+ * into the ResizeObserver (freezing the row count) and let taller content
+ * overflow into the tile below. So we keep position/transform/width but drop
+ * the imposed height for auto tiles, letting them size to their content.
  */
 export function GridTile({
   tileId,
@@ -130,6 +137,7 @@ export function GridTile({
   rowHeightPx,
   onMeasure,
   className,
+  style,
   ref,
   children,
   ...props
@@ -163,6 +171,15 @@ export function GridTile({
     return () => observer.disconnect();
   }, [autoHeight, tileId, rowHeightPx, minH, onMeasure]);
 
+  // Drop the grid's imposed height for auto tiles so the measured element
+  // sizes to its content (see the note above); fixed tiles keep it.
+  const itemStyle = autoHeight && style
+    ? {
+      ...style,
+      height: undefined,
+    }
+    : style;
+
   return (
     <div
       ref={setRef}
@@ -171,6 +188,7 @@ export function GridTile({
         *:h-full
       `, className)}
       {...props}
+      style={itemStyle}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary

Fixes a regression where auto-height grid tiles were clamped to their layout-imposed height, causing taller content to overflow into neighbouring tiles. The grid now correctly allows auto-height tiles to size to their content while preserving the geometry positioning for all tiles.

## Changes

- **GridTile component:** Added logic to strip the `height` style property from auto-height tiles while preserving position, transform, and width styles. This prevents the ResizeObserver from reading its own clamped height and freezing the row count.
- **Storybook test:** Added `AutoHeightSizesToContent` regression guard that verifies:
  - Auto-height tiles remain absolutely positioned (preserving the #279 fix)
  - Tiles grow to their content height (~600px) rather than being constrained by the layout's imposed height (~256px for 4 rows × 64px)

## Implementation Details

The grid's geometry `style` includes a fixed pixel `height` calculated as `layout rows × rowHeight`. For auto-height tiles, this height was being applied to the measured element itself, which caused the ResizeObserver to read the clamped height and prevent further growth. By conditionally dropping the `height` property for auto tiles (while keeping position/transform/width), tiles now correctly expand to accommodate their content.

https://claude.ai/code/session_01PVAYB5Q5f8jo3EEmN864Sr