### PR TITLE
refactor(client): dedupe resource link-option type in tasks components

### DIFF
--- a/packages/client/src/components/tasks/ResourceLinksPicker.tsx
+++ b/packages/client/src/components/tasks/ResourceLinksPicker.tsx
@@ -1,3 +1,4 @@
+import type { LinkOptionResource } from "./resourceMeta";
 import type { Module, ModuleGroup } from "@emstack/types";
 
 import { useMemo } from "react";
@@ -15,15 +16,10 @@ interface ResourceLinkInput {
   moduleId: string | null;
 }
 
-interface ResourceSummary {
-  id: string;
-  name: string;
-}
-
 interface ResourceLinksPickerProps {
   value: ResourceLinkInput[];
   onChange: (next: ResourceLinkInput[]) => void;
-  courses: ResourceSummary[];
+  courses: LinkOptionResource[];
   moduleGroups: ModuleGroup[];
   modules: Module[];
 }

--- a/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
+++ b/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
@@ -1,3 +1,4 @@
+import type { LinkOptionResource } from "./resourceMeta";
 import type {
   Module,
   ModuleGroup,
@@ -10,11 +11,6 @@ import { EditFormActions } from "@/components/EditFormActions";
 import { Input } from "@/components/input";
 
 export const COLUMN_COUNT = 8;
-
-export interface LinkOptionResource {
-  id: string;
-  name: string;
-}
 
 export function EditingRow({
   resource,

--- a/packages/client/src/components/tasks/resourceMeta.ts
+++ b/packages/client/src/components/tasks/resourceMeta.ts
@@ -48,6 +48,12 @@ export function getResourceLevelClass(
 export type ResourceLevelKey
   = "easeOfStarting" | "timeNeeded" | "interactivity";
 
+// A Resource reduced to its identity for a resource-link <select>.
+export interface LinkOptionResource {
+  id: string;
+  name: string;
+}
+
 // The ease/time/interactivity values live on Resource / ModuleGroup / Module.
 // Resolve from most-specific to least-specific:
 //   Module → its parent ModuleGroup → Resource.


### PR DESCRIPTION
Closes #280

## ELI5
Two different parts of the app were each keeping their own little note that said "a resource is just an id and a name" for their dropdown menus. This PR replaces those two identical notes with a single shared one, so there's one definition instead of two copies that could drift apart.

## Summary
- Consolidated the duplicate `{ id: string; name: string }` resource-link option type: deleted `ResourceSummary` (in `ResourceLinksPicker.tsx`) and the locally-exported `LinkOptionResource` (in `TaskResourceEditingRow.tsx`).
- Defined a single canonical `LinkOptionResource` in `resourceMeta.ts` (the tasks folder's shared helpers module); both components now import it from there, so the topic-edit picker no longer depends on a task-table row component for its type.
- Behavior-preserving, type-only change — call sites pass object literals and were untouched.

## Test plan
- [ ] `pnpm typecheck` is clean
- [ ] `pnpm exec eslint` clean on the three changed files
- [ ] `resourceMeta.test.ts` passes (11/11)
- [ ] Manually: task resource edit row and topic-edit resource-link picker still render and select resources correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
