### PR TITLE
refactor(client): consolidate EntityKind route-segment union

### DIFF
--- a/packages/client/src/components/boxElements/EntityLink.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 
-type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
+export type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
 
 const TO_BY_KIND: Record<EntityKind, string> = {
   resources: "/resources/$id",

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -1,3 +1,4 @@
+import type { EntityKind } from "@/components/boxElements/EntityLink";
 import type { ResourceStatus } from "@emstack/types";
 
 import { Link } from "@tanstack/react-router";
@@ -7,7 +8,7 @@ import { cn } from "@/lib/utils";
 
 interface PageHeaderProps {
   pageTitle?: string;
-  pageSection?: "" | "resources" | "topics" | "providers" | "domains" | "dailies" | "routines" | "tasks";
+  pageSection?: EntityKind | "dailies" | "routines" | "";
   description?: React.ReactNode;
   children?: React.ReactNode;
   progressCurrent?: number;

--- a/packages/client/src/utils/routineConnections.ts
+++ b/packages/client/src/utils/routineConnections.ts
@@ -1,14 +1,15 @@
 import type { SelectOption } from "./selectOptions";
+import type { EntityKind } from "@/components/boxElements/EntityLink";
 import type { RoutineConnectionType } from "@emstack/types";
 
 import { toOptions } from "./selectOptions";
 
 // EntityLink's entity kind (plural route segment) for each connection type.
-const ENTITY_KIND_BY_TYPE = {
+const ENTITY_KIND_BY_TYPE: Record<RoutineConnectionType, EntityKind> = {
   topic: "topics",
   task: "tasks",
   resource: "resources",
-} as const;
+};
 
 export function connectionEntityKind(type: RoutineConnectionType) {
   return ENTITY_KIND_BY_TYPE[type];


### PR DESCRIPTION
## ELI5
The app has a fixed list of section names ("resources", "topics", "tasks", etc.) used to build links and page headers. That list was written out by hand in a couple of different places, which is easy to let drift apart over time. This change writes it down once and has the other places point at it, so they can never disagree.

## Summary
- Export `EntityKind` from `EntityLink.tsx` (its natural owner — it pairs the union with the `TO_BY_KIND` route map) instead of keeping it file-local.
- `PageHeader.tsx` now composes that shared type (`EntityKind | "dailies" | "routines" | ""`) rather than re-listing the same literals inline.
- `routineConnections.ts` types its `ENTITY_KIND_BY_TYPE` map as `Record<RoutineConnectionType, EntityKind>`, enforcing the relationship a comment previously only described.
- Pure type-level refactor — no runtime behavior change (identical literal member sets).

## Test plan
- [x] `pnpm typecheck` clean across the repo
- [x] `pnpm exec eslint` clean on the three changed files
- [x] `routineConnections.test.ts` passes (9/9)
- [ ] Smoke-check: page headers render their section breadcrumb and entity links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)