### PR TITLE
refactor(dailies): extract DailyStatusChangeProps base

### DIFF
--- a/packages/client/src/components/dailies/DailyStatusModal.tsx
+++ b/packages/client/src/components/dailies/DailyStatusModal.tsx
@@ -1,3 +1,4 @@
+import type { DailyStatusChangeProps } from "./dailyStatusMeta";
 import type { ControlledDialogProps } from "@/components/dialogProps";
 import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
@@ -30,10 +31,8 @@ const CRITERIA_KEY_BY_STATUS: Record<
   freeze: "freeze",
 };
 
-interface DailyStatusModalProps extends ControlledDialogProps {
-  daily: Daily;
-  currentStatus: DailyCompletionStatus | null;
-  onChange: (status: DailyCompletionStatus, note: string | null) => void;
+interface DailyStatusModalProps
+  extends ControlledDialogProps, DailyStatusChangeProps {
   disabled?: boolean;
 }
 

--- a/packages/client/src/components/dailies/TodayStatusCell.tsx
+++ b/packages/client/src/components/dailies/TodayStatusCell.tsx
@@ -1,4 +1,4 @@
-import type { Daily, DailyCompletionStatus } from "@emstack/types";
+import type { DailyStatusChangeProps } from "./dailyStatusMeta";
 
 import { useState } from "react";
 
@@ -7,11 +7,8 @@ import { DailyStatusModal } from "./DailyStatusModal";
 
 import { cn } from "@/lib/utils";
 
-interface TodayStatusCellProps {
-  daily: Daily;
-  currentStatus: DailyCompletionStatus | null;
+interface TodayStatusCellProps extends DailyStatusChangeProps {
   disabled: boolean;
-  onChange: (status: DailyCompletionStatus, note: string | null) => void;
 }
 
 export function TodayStatusCell({
@@ -29,9 +26,11 @@ export function TodayStatusCell({
         type="button"
         disabled={disabled}
         onClick={() => setModalOpen(true)}
-        aria-label={currentStatus
-          ? `Change today's status for ${daily.name}`
-          : `Set today's status for ${daily.name}`}
+        aria-label={
+          currentStatus
+            ? `Change today's status for ${daily.name}`
+            : `Set today's status for ${daily.name}`
+        }
         className={cn(
           `
             flex w-full cursor-pointer items-center justify-center gap-1

--- a/packages/client/src/components/dailies/dailyStatusMeta.tsx
+++ b/packages/client/src/components/dailies/dailyStatusMeta.tsx
@@ -1,4 +1,4 @@
-import type { DailyCompletionStatus } from "@emstack/types";
+import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
 import {
   CircleCheckIcon,
@@ -11,6 +11,13 @@ import {
 /** Tabs shown in the daily / routine detail panel. */
 export const DAILY_DETAIL_TABS = ["details", "entries", "criteria"] as const;
 export type DailyDetailTab = (typeof DAILY_DETAIL_TABS)[number];
+
+/** Props for editing a daily's completion status with an optional note. */
+export interface DailyStatusChangeProps {
+  daily: Daily;
+  currentStatus: DailyCompletionStatus | null;
+  onChange: (status: DailyCompletionStatus, note: string | null) => void;
+}
 
 export interface DailyStatusOption {
   value: DailyCompletionStatus;
@@ -34,32 +41,40 @@ export const DAILY_STATUS_OPTIONS: DailyStatusOption[] = [
     value: "touched",
     label: "Touched",
     icon: <CircleSlashIcon className="size-4" />,
-    circleClass: "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
-    pillClass: "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
+    circleClass:
+      "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
+    pillClass:
+      "bg-amber-100 text-amber-800 border-amber-400 dark:bg-amber-900/40 dark:text-amber-200",
     borderColor: "#fbbf24",
   },
   {
     value: "goal",
     label: "Goal",
     icon: <CircleCheckIcon className="size-4" />,
-    circleClass: "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
-    pillClass: "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
+    circleClass:
+      "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
+    pillClass:
+      "bg-emerald-100 text-emerald-800 border-emerald-500 dark:bg-emerald-900/40 dark:text-emerald-200",
     borderColor: "#10b981",
   },
   {
     value: "exceeded",
     label: "Exceeded",
     icon: <SparklesIcon className="size-4" />,
-    circleClass: "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_8px_2px_rgba(139,92,246,0.5)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_8px_2px_rgba(167,139,250,0.55)]",
-    pillClass: "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_6px_1px_rgba(139,92,246,0.45)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_6px_1px_rgba(167,139,250,0.5)]",
+    circleClass:
+      "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_8px_2px_rgba(139,92,246,0.5)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_8px_2px_rgba(167,139,250,0.55)]",
+    pillClass:
+      "bg-violet-100 text-violet-800 border-violet-500 shadow-[0_0_6px_1px_rgba(139,92,246,0.45)] dark:bg-violet-900/40 dark:text-violet-200 dark:shadow-[0_0_6px_1px_rgba(167,139,250,0.5)]",
     borderColor: "#8b5cf6",
   },
   {
     value: "freeze",
     label: "Freeze",
     icon: <SnowflakeIcon className="size-4" />,
-    circleClass: "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
-    pillClass: "bg-sky-50/60 text-sky-700 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-300 dark:border-sky-900/40",
+    circleClass:
+      "bg-sky-50/60 text-sky-500/70 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-400/60 dark:border-sky-900/40",
+    pillClass:
+      "bg-sky-50/60 text-sky-700 border-sky-200/70 dark:bg-sky-950/20 dark:text-sky-300 dark:border-sky-900/40",
     borderColor: "#bae6fd",
   },
 ];
@@ -68,6 +83,7 @@ export function getDailyStatusOption(
   status: DailyCompletionStatus,
 ): DailyStatusOption {
   return (
-    DAILY_STATUS_OPTIONS.find(o => o.value === status) ?? DAILY_STATUS_OPTIONS[0]
+    DAILY_STATUS_OPTIONS.find(o => o.value === status)
+    ?? DAILY_STATUS_OPTIONS[0]
   );
 }


### PR DESCRIPTION
## ELI5

Two pieces of the daily-habit tracker were describing the exact same set of inputs (which habit, its current status, and what to do when the status changes). This pulls that shared description into one named place so the two pieces point at it instead of repeating it. Nothing the user sees changes — it's a tidy-up.

## Summary

- Extract a shared `DailyStatusChangeProps` base interface (`daily` / `currentStatus` / `onChange`) into `dailyStatusMeta.tsx`.
- `DailyStatusModalProps` and `TodayStatusCellProps` now `extend` it instead of re-declaring the same three fields (`TodayStatusCell` forwards all three straight into `DailyStatusModal`).
- Builds on the controlled-dialog base from #285 (already merged) — `DailyStatusModalProps` extends both `ControlledDialogProps` and the new base.

## Test plan

- [ ] `pnpm typecheck` passes (type-only refactor — primary safety net)
- [ ] `pnpm exec eslint packages/client/src/components/dailies/{dailyStatusMeta,DailyStatusModal,TodayStatusCell}.tsx` clean
- [ ] Daily tracker today-cell still opens the status modal and saves status + note unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)