### PR TITLE
refactor(client): Condense types in client boxes folder

### DIFF
--- a/packages/client/src/components/boxes/RoutineBox.tsx
+++ b/packages/client/src/components/boxes/RoutineBox.tsx
@@ -1,4 +1,4 @@
-import type { Routine, RoutineWeekday } from "@emstack/types";
+import type { Routine, RoutineTodayAction, RoutineWeekday } from "@emstack/types";
 
 import { Link } from "@tanstack/react-router";
 import { AlertTriangleIcon, FlameIcon } from "lucide-react";
@@ -54,15 +54,6 @@ const DAY_STRIP: { day: RoutineWeekday;
     letter: "S",
   },
 ];
-
-// The resolved entry a weekly routine schedules for today (task / resource /
-// freeform name plus any affixes), computed by the parent so the card can show
-// today's task in place of the routine name.
-export interface RoutineTodayAction {
-  name: string;
-  prependText?: string | null;
-  appendText?: string | null;
-}
 
 export function RoutineBox({
   id,

--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -34,18 +34,19 @@ interface TopicsTableSelection {
   onToggleAll: (selectAll: boolean) => void;
 }
 
-interface TopicsTableProps {
-  topics: TopicForTopicsPage[];
-  selection?: TopicsTableSelection;
+interface TopicsTableSortControl {
   sort?: TopicsTableSort;
   onSortChange?: (sort: TopicsTableSort) => void;
 }
 
-interface SortableHeaderProps {
+interface TopicsTableProps extends TopicsTableSortControl {
+  topics: TopicForTopicsPage[];
+  selection?: TopicsTableSelection;
+}
+
+interface SortableHeaderProps extends TopicsTableSortControl {
   column: TopicsTableSortColumn;
   label: string;
-  sort?: TopicsTableSort;
-  onSortChange?: (sort: TopicsTableSort) => void;
   align?: "left" | "right";
 }
 

--- a/packages/client/src/routes/routines.index.tsx
+++ b/packages/client/src/routes/routines.index.tsx
@@ -1,7 +1,7 @@
-import type { RoutineTodayAction } from "@/components/boxes/RoutineBox";
 import type {
   Routine,
   RoutineConnectionType,
+  RoutineTodayAction,
   RoutineWeekday,
 } from "@emstack/types";
 

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -57,3 +57,12 @@ export interface Routine {
   // Null/absent means no target (every day). Only goal/exceeded days count.
   weeklyTarget?: number | null;
 }
+
+// The resolved entry a weekly routine schedules for today (task / resource /
+// freeform name plus any affixes), computed by the client so a card can show
+// today's task in place of the routine name.
+export interface RoutineTodayAction {
+  name: string;
+  prependText?: string | null;
+  appendText?: string | null;
+}


### PR DESCRIPTION
## ELI5
This is a tidy-up of the code's type definitions in one folder. Two small bits of repeated description were merged into a single shared definition, so future changes only need to happen in one place. Nothing about how the app behaves changes.

## Summary
- Extract a shared `TopicsTableSortControl` base interface in `TopicsTable.tsx` so `TopicsTableProps` and `SortableHeaderProps` no longer repeat the `sort?`/`onSortChange?` cluster.
- Move `RoutineTodayAction` out of the client (`RoutineBox.tsx`) and into `@emstack/types` alongside the other `Routine*` types; update both importers to pull from the shared package.
- Type-only refactors — no runtime behavior change.

## Test plan
- [ ] `pnpm typecheck` is clean across all packages
- [ ] `pnpm exec eslint` clean on the changed files (`TopicsTable.tsx`, `RoutineBox.tsx`, `routines.index.tsx`, `Routine.ts`)
- [ ] Routines page still renders today's resolved action in place of the routine name
- [ ] Topics table sorting (click column headers) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)