### PR TITLE
refactor(client): condense layout component types

### DIFF
--- a/packages/client/src/components/layout/InfoArea.tsx
+++ b/packages/client/src/components/layout/InfoArea.tsx
@@ -1,12 +1,13 @@
-interface InfoAreaProps {
-  header?: string;
-  condition?: boolean;
-  children?: React.ReactNode;
+import type { InfoRowProps } from "@/components/layout/InfoRow";
+
+interface InfoAreaProps extends InfoRowProps {
   className?: string;
 }
 
 export function InfoArea({
-  header, condition = true, children,
+  header,
+  condition = true,
+  children,
 }: InfoAreaProps) {
   if (!condition) {
     return null;
@@ -15,10 +16,7 @@ export function InfoArea({
   return (
     <div className="flex flex-col">
       {header && (
-        <h6
-          className="text-xs font-bold text-black/70 uppercase"
-        >{header}
-        </h6>
+        <h6 className="text-xs font-bold text-black/70 uppercase">{header}</h6>
       )}
       {children}
     </div>

--- a/packages/client/src/components/layout/InfoRow.tsx
+++ b/packages/client/src/components/layout/InfoRow.tsx
@@ -1,4 +1,4 @@
-interface InfoRowProps {
+export interface InfoRowProps {
   header?: string;
   condition?: boolean;
   children?: React.ReactNode;
@@ -13,10 +13,12 @@ export function InfoRow({
 
   return (
     <div className="flex flex-col">
-      {header && (<h6 className="mb-2 text-lg font-bold text-black/90 uppercase">{header}</h6>)}
-      <div className="flex flex-row gap-8">
-        {children}
-      </div>
+      {header && (
+        <h6 className="mb-2 text-lg font-bold text-black/90 uppercase">
+          {header}
+        </h6>
+      )}
+      <div className="flex flex-row gap-8">{children}</div>
     </div>
   );
 }

--- a/packages/client/src/components/layout/ViewModeToggle.tsx
+++ b/packages/client/src/components/layout/ViewModeToggle.tsx
@@ -2,7 +2,7 @@ import { LayoutGridIcon, ListIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
-type ViewMode = "grid" | "table";
+export type ViewMode = "grid" | "table";
 
 interface ViewModeToggleProps {
   viewMode: ViewMode;

--- a/packages/client/src/routes/resources.index.tsx
+++ b/packages/client/src/routes/resources.index.tsx
@@ -1,14 +1,11 @@
+import type { ViewMode } from "@/components/layout/ViewModeToggle";
 import type { ResourceInResources } from "@emstack/types";
 
 import { useMemo, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import {
-  ArrowDownAZIcon,
-  ArrowUpAZIcon,
-  PlusIcon,
-} from "lucide-react";
+import { ArrowDownAZIcon, ArrowUpAZIcon, PlusIcon } from "lucide-react";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { CourseBox } from "@/components/boxes/CourseBox";
@@ -36,7 +33,6 @@ import { fetchResources, fetchProviders, fetchTopics } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
 type SortOption = "alpha" | "progress" | "provider" | "topic";
-type ViewMode = "grid" | "table";
 
 const VIEW_MODE_STORAGE_KEY = "resources:viewMode";
 // Pre-rename key; fall back to it so existing preferences survive.

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -1,14 +1,12 @@
 import type { TopicsTableSort } from "@/components/boxes/TopicsTable";
+import type { ViewMode } from "@/components/layout/ViewModeToggle";
 import type { TopicForTopicsPage } from "@emstack/types";
 
 import { useEffect, useMemo, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import {
-  PlusIcon,
-  Trash2Icon,
-} from "lucide-react";
+import { PlusIcon, Trash2Icon } from "lucide-react";
 import { toast } from "sonner";
 
 import { ContentBox } from "@/components/boxes/ContentBox";
@@ -42,7 +40,6 @@ type SortOption
     | "tasks-desc"
     | "dailies-desc"
     | "custom";
-type ViewMode = "grid" | "table";
 
 const DEFAULT_SORT: TopicsTableSort = {
   column: "name",
@@ -137,14 +134,20 @@ function sortTopics(
         return cmp !== 0 ? cmp * dir : a.name.localeCompare(b.name);
       }
       case "resources":
-        return ((a.resourceCount ?? 0) - (b.resourceCount ?? 0)) * dir
-          || a.name.localeCompare(b.name);
+        return (
+          ((a.resourceCount ?? 0) - (b.resourceCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
       case "tasks":
-        return ((a.taskCount ?? 0) - (b.taskCount ?? 0)) * dir
-          || a.name.localeCompare(b.name);
+        return (
+          ((a.taskCount ?? 0) - (b.taskCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
       case "dailies":
-        return ((a.dailyCount ?? 0) - (b.dailyCount ?? 0)) * dir
-          || a.name.localeCompare(b.name);
+        return (
+          ((a.dailyCount ?? 0) - (b.dailyCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
     }
   });
 }
@@ -263,9 +266,7 @@ function Topics() {
       setSelectedIds(new Set());
       setConfirmOpen(false);
       toast.success(
-        ids.length === 1
-          ? "1 topic deleted."
-          : `${ids.length} topics deleted.`,
+        ids.length === 1 ? "1 topic deleted." : `${ids.length} topics deleted.`,
       );
     }
     catch {
@@ -430,9 +431,7 @@ function Topics() {
                   "
                 >
                   <span className="text-sm text-muted-foreground">
-                    {selectedIds.size > 0
-                      ? `${selectedIds.size} selected`
-                      : ""}
+                    {selectedIds.size > 0 ? `${selectedIds.size} selected` : ""}
                   </span>
                   {selectedIds.size > 0 && (
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## ELI5
Some bits of code described the same thing in more than one place. This tidies them up so each idea is written down once, which makes the code easier to change later. Nothing about how the app looks or behaves changes.

## Summary
- Export the `ViewMode` (`"grid" | "table"`) union from `ViewModeToggle` and import it into the resources and topics list routes, removing two verbatim copies.
- Make `InfoAreaProps` extend `InfoRowProps` instead of repeating the shared `header`/`condition`/`children` props.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec eslint` on the touched files — only pre-existing `import/max-dependencies` warnings (confirmed they predate the change)
- [ ] Resources and Topics pages still toggle between grid and table views
- [ ] Detail-page `InfoArea`/`InfoRow` sections still render headers and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)