### PR TITLE
refactor(client): consolidate formField prop types onto SelectOption and a shared base

### DIFF
--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -1,4 +1,5 @@
 import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
 import type { SelectOption } from "@/utils";
 
 import {
@@ -20,11 +21,9 @@ import {
 } from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
-interface ComboboxFieldProps {
-  label: string;
+interface ComboboxFieldProps extends BaseFieldProps {
   options: SelectOption[];
   placeholder?: string;
-  className?: string;
   disabled?: boolean;
   create?: CreateConfig;
 }

--- a/packages/client/src/components/formFields/ComboboxField.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.tsx
@@ -1,4 +1,5 @@
 import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { SelectOption } from "@/utils";
 
 import {
   Combobox,
@@ -13,13 +14,15 @@ import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel
 import { useComboboxCreate } from "@/components/formFields/useComboboxCreate";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
 interface ComboboxFieldProps {
   label: string;
-  options: { value: string;
-    label: string; }[];
+  options: SelectOption[];
   placeholder?: string;
   className?: string;
   disabled?: boolean;

--- a/packages/client/src/components/formFields/DatePickerField.tsx
+++ b/packages/client/src/components/formFields/DatePickerField.tsx
@@ -1,3 +1,5 @@
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
+
 import { CalendarIcon } from "lucide-react";
 
 import { Calendar } from "@/components/calendar";
@@ -5,14 +7,15 @@ import { Field, FieldLabel } from "@/components/forms/field";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useFieldContext } from "@/utils/fieldContext";
 
-interface DatePickerFieldProps {
-  label: string;
+interface DatePickerFieldProps extends BaseFieldProps {
   placeholder?: string;
   clearLabel?: string;
-  className?: string;
 }
 
 export function DatePickerField({

--- a/packages/client/src/components/formFields/InputField.tsx
+++ b/packages/client/src/components/formFields/InputField.tsx
@@ -1,12 +1,15 @@
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
+
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
 import { Input } from "@/components/input";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
-interface InputFieldProps {
-  label: string;
-  className?: string;
+interface InputFieldProps extends BaseFieldProps {
   fieldClassName?: string;
   placeholder?: string;
   disabled?: boolean;

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -1,4 +1,5 @@
 import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
 import type { SelectOption } from "@/utils";
 
 import {
@@ -28,11 +29,9 @@ import {
 } from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
-interface MultiComboboxFieldProps {
-  label: string;
+interface MultiComboboxFieldProps extends BaseFieldProps {
   options: SelectOption[];
   placeholder?: string;
-  className?: string;
   create?: CreateConfig;
   /**
    * When true, options are rendered under group headers (and the dropdown filters

--- a/packages/client/src/components/formFields/MultiComboboxField.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.tsx
@@ -1,4 +1,5 @@
 import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { SelectOption } from "@/utils";
 
 import {
   Combobox,
@@ -21,18 +22,15 @@ import { ComboboxCreatePanel } from "@/components/formFields/ComboboxCreatePanel
 import { useComboboxCreate } from "@/components/formFields/useComboboxCreate";
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
-
-interface ComboboxOption {
-  value: string;
-  label: string;
-  group?: string;
-}
 
 interface MultiComboboxFieldProps {
   label: string;
-  options: ComboboxOption[];
+  options: SelectOption[];
   placeholder?: string;
   className?: string;
   create?: CreateConfig;
@@ -50,7 +48,7 @@ interface MultiComboboxFieldProps {
 // this as the combobox `items` lets Base UI filter within each group and hide
 // empty ones. Groups keep first-appearance order, with "Other" forced last.
 function partitionOptions(
-  options: ComboboxOption[],
+  options: SelectOption[],
 ): { value: string;
   items: string[]; }[] {
   const groups = new Map<string, string[]>();
@@ -133,7 +131,9 @@ export function MultiComboboxField({
       <Combobox
         multiple
         items={
-          groupByPrefix ? partitionOptions(options) : options.map(o => o.value)
+          groupByPrefix
+            ? partitionOptions(options)
+            : options.map(o => o.value)
         }
         value={field.state.value || []}
         onValueChange={val => field.handleChange(val)}
@@ -142,9 +142,7 @@ export function MultiComboboxField({
       >
         <ComboboxChips ref={anchor}>
           {(field.state.value || []).map(val => (
-            <ComboboxChip key={val}>
-              {optionsMap.get(val) ?? val}
-            </ComboboxChip>
+            <ComboboxChip key={val}>{optionsMap.get(val) ?? val}</ComboboxChip>
           ))}
           <ComboboxChipsInput
             placeholder={placeholder}

--- a/packages/client/src/components/formFields/NumberField.tsx
+++ b/packages/client/src/components/formFields/NumberField.tsx
@@ -1,12 +1,15 @@
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
+
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
 import { Input } from "@/components/input";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
-interface NumberFieldProps {
-  label: string;
-  className?: string;
+interface NumberFieldProps extends BaseFieldProps {
   min?: number;
   step?: string;
   disabled?: boolean;

--- a/packages/client/src/components/formFields/RadioGroupField.tsx
+++ b/packages/client/src/components/formFields/RadioGroupField.tsx
@@ -1,14 +1,18 @@
+import type { SelectOption } from "@/utils";
+
 import { Field, FieldLabel } from "@/components/forms/field";
 import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useFieldContext } from "@/utils/fieldContext";
 
 interface RadioGroupFieldProps {
   label: string;
-  options: { value: string;
-    label: string; }[];
+  options: SelectOption[];
   className?: string;
   labelClassName?: string;
 }

--- a/packages/client/src/components/formFields/RadioGroupField.tsx
+++ b/packages/client/src/components/formFields/RadioGroupField.tsx
@@ -1,3 +1,4 @@
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
 import type { SelectOption } from "@/utils";
 
 import { Field, FieldLabel } from "@/components/forms/field";
@@ -10,10 +11,8 @@ import {
 } from "@/utils/fieldChangeHighlight";
 import { useFieldContext } from "@/utils/fieldContext";
 
-interface RadioGroupFieldProps {
-  label: string;
+interface RadioGroupFieldProps extends BaseFieldProps {
   options: SelectOption[];
-  className?: string;
   labelClassName?: string;
 }
 

--- a/packages/client/src/components/formFields/TextareaField.tsx
+++ b/packages/client/src/components/formFields/TextareaField.tsx
@@ -1,12 +1,15 @@
+import type { BaseFieldProps } from "@/components/formFields/fieldProps";
+
 import { Field, FieldError, FieldLabel } from "@/components/forms/field";
 import { Textarea } from "@/components/textarea";
 import { cn } from "@/lib/utils";
-import { changedFieldClass, useFieldChangeHighlight } from "@/utils/fieldChangeHighlight";
+import {
+  changedFieldClass,
+  useFieldChangeHighlight,
+} from "@/utils/fieldChangeHighlight";
 import { useIsFieldInvalid } from "@/utils/useIsFieldInvalid";
 
-interface TextareaFieldProps {
-  label: string;
-  className?: string;
+interface TextareaFieldProps extends BaseFieldProps {
   placeholder?: string;
   disabled?: boolean;
   labelIcon?: React.ReactNode;
@@ -34,9 +37,7 @@ export function TextareaField({
         className={className}
       >
         {labelIcon && (
-          <span className="inline-flex shrink-0 items-center">
-            {labelIcon}
-          </span>
+          <span className="inline-flex shrink-0 items-center">{labelIcon}</span>
         )}
         <span>{label}</span>
       </FieldLabel>

--- a/packages/client/src/components/formFields/fieldProps.ts
+++ b/packages/client/src/components/formFields/fieldProps.ts
@@ -1,0 +1,6 @@
+// Shared props common to every TanStack-Form field component in this folder.
+// Each `*FieldProps` interface extends this and adds its own distinctive props.
+export interface BaseFieldProps {
+  label: string;
+  className?: string;
+}

--- a/packages/client/src/components/formFields/useComboboxCreate.ts
+++ b/packages/client/src/components/formFields/useComboboxCreate.ts
@@ -1,4 +1,5 @@
 import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { SelectOption } from "@/utils";
 
 import { useState } from "react";
 
@@ -6,8 +7,7 @@ import { toast } from "sonner";
 
 interface UseComboboxCreateOptions {
   create: CreateConfig | undefined;
-  options: { value: string;
-    label: string; }[];
+  options: SelectOption[];
   /** Applies the newly created option to the field (set / append). */
   onCreated: (newId: string) => void;
 }
@@ -29,8 +29,9 @@ export function useComboboxCreate({
   const [creating, setCreating] = useState(false);
 
   const trimmedInput = inputValue.trim();
-  const hasExactMatch = trimmedInput.length > 0
-    && options.some(o => o.label.toLowerCase() === trimmedInput.toLowerCase());
+  const hasExactMatch
+    = trimmedInput.length > 0
+      && options.some(o => o.label.toLowerCase() === trimmedInput.toLowerCase());
 
   const showAddRow = !!create && trimmedInput.length > 0 && !hasExactMatch;
 


### PR DESCRIPTION
## ELI5
The app's form input components (text boxes, dropdowns, date pickers, etc.) each had their own slightly-different definitions of the same things: what a dropdown option looks like, and the basic "label + styling" every field shares. This tidies those up so they all point at one shared definition instead of copies that could quietly drift apart. Nothing changes for users — it's purely a code-cleanliness change.

## Summary
- Replaced the local `ComboboxOption` interface and inline `{ value, label }[]` option shapes in the combobox/radio fields with the existing shared `SelectOption` type from `@/utils` (the data already flows in as `SelectOption[]` via `toOptions`/`tagGroupsToOptions`).
- Extracted a `BaseFieldProps { label; className? }` base (new `formFields/fieldProps.ts`) that all seven TanStack-Form field prop interfaces now `extend`, removing the repeated `label`/`className` declarations.
- Behavior-preserving, type-only refactor across `packages/client/src/components/formFields`.

## Test plan
- [x] `pnpm typecheck` clean across the repo (real safety net for a type-only change)
- [x] `pnpm exec eslint packages/client/src/components/formFields` clean apart from one pre-existing `no-console` warning in `useComboboxCreate.ts`
- [ ] Smoke-check edit pages that render these fields (resources, providers, topics, tasks, routines) — comboboxes, radio groups, and create-new flows still populate and submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)