### PR TITLE
refactor(client): extract BaseModuleEditDraft base for resource drafts

### DIFF
--- a/packages/client/src/components/resources/LevelAndTagsFields.tsx
+++ b/packages/client/src/components/resources/LevelAndTagsFields.tsx
@@ -1,16 +1,10 @@
-import type { TagGroup, TaskResourceLevel } from "@emstack/types";
+import type { LevelAndTagsValue } from "./moduleDrafts";
+import type { TagGroup } from "@emstack/types";
 
 import { LevelTriad } from "./LevelTriad";
 import { lookupTagsByIds } from "./moduleDrafts";
 
 import { TagPicker } from "@/components/tasks/TagPicker";
-
-export interface LevelAndTagsValue {
-  easeOfStarting: TaskResourceLevel | "";
-  timeNeeded: TaskResourceLevel | "";
-  interactivity: TaskResourceLevel | "";
-  tagIds: string[];
-}
 
 /**
  * The shared "effort levels + tag picker" fields rendered at the bottom of the

--- a/packages/client/src/components/resources/moduleDrafts.ts
+++ b/packages/client/src/components/resources/moduleDrafts.ts
@@ -10,33 +10,36 @@ import type {
 
 import { parseModuleLength } from "@emstack/types";
 
-export interface GroupDraft {
-  id: string;
-  name: string;
-  description: string;
-  url: string;
-  totalCount: string;
-  completedCount: string;
+// The shared "effort levels + tag picker" block rendered at the bottom of both
+// the module and module-group edit cards (see LevelAndTagsFields). Both draft
+// shapes below extend it, so the cards can pass a draft straight through.
+export interface LevelAndTagsValue {
   easeOfStarting: TaskResourceLevel | "";
   timeNeeded: TaskResourceLevel | "";
   interactivity: TaskResourceLevel | "";
   tagIds: string[];
 }
 
-export type DurationMode = "minutes" | "bucket";
-
-export interface ModuleDraft {
+// Fields common to both edit drafts (the editable header plus the level/tag
+// block). Group- and module-specific fields are added by the leaf interfaces.
+interface BaseModuleEditDraft extends LevelAndTagsValue {
   id: string;
   name: string;
   description: string;
   url: string;
+}
+
+export interface GroupDraft extends BaseModuleEditDraft {
+  totalCount: string;
+  completedCount: string;
+}
+
+export type DurationMode = "minutes" | "bucket";
+
+export interface ModuleDraft extends BaseModuleEditDraft {
   durationMode: DurationMode;
   minutesValue: string;
   bucketValue: ModuleDurationBucket | "";
-  easeOfStarting: TaskResourceLevel | "";
-  timeNeeded: TaskResourceLevel | "";
-  interactivity: TaskResourceLevel | "";
-  tagIds: string[];
 }
 
 const NEW_ID = "__new__";


### PR DESCRIPTION
## ELI5
Two "edit form" data shapes in the resources area were describing the same set of fields twice. This tidies them up so the shared fields are written down once and reused, which means future changes only need to happen in one place. Nothing about how the app works changes.

## Summary
- Extract a `BaseModuleEditDraft` interface (the common editable header: `id`/`name`/`description`/`url`) that extends the existing `LevelAndTagsValue`; `GroupDraft` and `ModuleDraft` now extend it, so all 8 previously-duplicated fields live in one place.
- Relocate `LevelAndTagsValue` into `moduleDrafts.ts` (alongside the other draft types; its only consumer already imports from there), keeping the module dependency one-directional.
- Type-only refactor — the resulting `GroupDraft`/`ModuleDraft` shapes are unchanged, so factories and consumers are untouched.

## Test plan
- [ ] `pnpm typecheck` is clean across all packages
- [ ] `pnpm exec eslint` clean on `moduleDrafts.ts` and `LevelAndTagsFields.tsx`
- [ ] Resource module/group edit cards still render the effort-level triad + tag picker and save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)