### PR TITLE
feat(client): extract tile visibility picker into modal dialog

### DIFF
--- a/packages/client/src/components/ui/checkbox.tsx
+++ b/packages/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { CheckIcon } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        `
+          peer size-4 shrink-0 rounded-sm border border-input shadow-xs
+          transition-shadow outline-none
+          focus-visible:border-ring focus-visible:ring-[3px]
+          focus-visible:ring-ring/50
+          disabled:cursor-not-allowed disabled:opacity-50
+          data-[state=checked]:border-primary data-[state=checked]:bg-primary
+          data-[state=checked]:text-primary-foreground
+        `,
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.tsx
@@ -1,0 +1,73 @@
+import type { ControlledDialogProps } from "@/components/dialogProps";
+import type { DashboardLayout, DashboardTileId } from "@emstack/types";
+
+import { DASHBOARD_TILE_IDS } from "@emstack/types";
+
+import { TILE_META } from "./-dashboardTileMeta";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+
+interface VisibleTilesDialogProps extends ControlledDialogProps {
+  /** The layout whose tiles are being toggled, or null when closed. */
+  layout: DashboardLayout | null;
+  onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) => void;
+}
+
+/**
+ * Tile-visibility picker. Replaces the long inline checkbox list that used to
+ * live in the dashboard tab's "More" menu. Toggling is live: each change calls
+ * `onToggleTile`, which persists optimistically so the grid updates behind the
+ * modal and the checkmarks reflect the cache on the next render.
+ */
+export function VisibleTilesDialog({
+  open,
+  layout,
+  onOpenChange,
+  onToggleTile,
+}: VisibleTilesDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Visible tiles</DialogTitle>
+          <DialogDescription>
+            {`Choose which tiles appear on ${layout?.name ?? "this layout"}.`}
+          </DialogDescription>
+        </DialogHeader>
+        {layout && (
+          <div className="flex flex-col gap-1">
+            {DASHBOARD_TILE_IDS.map((tileId) => {
+              const checked = layout.tiles.some(t => t.tileId === tileId);
+              return (
+                <Label
+                  key={tileId}
+                  className={`
+                    cursor-pointer rounded-md p-2 font-normal
+                    hover:bg-accent
+                  `}
+                >
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={() => onToggleTile(layout, tileId)}
+                  />
+                  {TILE_META[tileId].title}
+                </Label>
+              );
+            })}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -2,12 +2,12 @@ import type { DashboardLayout, DashboardLayoutTile, DashboardTileId } from "@ems
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   BookmarkIcon,
   CopyIcon,
+  LayoutGridIcon,
   MoreHorizontalIcon,
   PencilIcon,
   PlusIcon,
@@ -22,9 +22,9 @@ import {
   needsNormalization,
   normalizeTiles,
   tilesEqual,
-  TILE_META,
   toggleTile,
 } from "./dashboard.-components/-dashboardTileMeta";
+import { VisibleTilesDialog } from "./dashboard.-components/-VisibleTilesDialog";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -32,10 +32,8 @@ import { LayoutNameDialog } from "@/components/LayoutNameDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -58,7 +56,7 @@ const SAVE_DEBOUNCE_MS = 600;
 
 interface LayoutTabProps {
   layout: DashboardLayout;
-  onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) => void;
+  onEditTiles: (layout: DashboardLayout) => void;
   onRename: (layout: DashboardLayout) => void;
   onDuplicate: (layout: DashboardLayout) => void;
   onSaveAs: (layout: DashboardLayout) => void;
@@ -70,7 +68,7 @@ interface LayoutTabProps {
  * button-in-button) and is always visible on touch where hover doesn't fire. */
 function LayoutTab({
   layout,
-  onToggleTile,
+  onEditTiles,
   onRename,
   onDuplicate,
   onSaveAs,
@@ -105,18 +103,10 @@ function LayoutTab({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuLabel>Visible tiles</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {DASHBOARD_TILE_IDS.map(tileId => (
-            <DropdownMenuCheckboxItem
-              key={tileId}
-              checked={layout.tiles.some(t => t.tileId === tileId)}
-              onCheckedChange={() => onToggleTile(layout, tileId)}
-              onSelect={e => e.preventDefault()}
-            >
-              {TILE_META[tileId].title}
-            </DropdownMenuCheckboxItem>
-          ))}
+          <DropdownMenuItem onSelect={() => onEditTiles(layout)}>
+            <LayoutGridIcon />
+            Visible tiles…
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => onRename(layout)}>
             <PencilIcon />
@@ -147,6 +137,7 @@ function LayoutTab({
 function Dashboard() {
   const queryClient = useQueryClient();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [tilesTargetId, setTilesTargetId] = useState<string | null>(null);
   const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
   const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
@@ -183,6 +174,7 @@ function Dashboard() {
     [activeLayout],
   );
 
+  const tilesTarget = layouts?.find(l => l.id === tilesTargetId) ?? null;
   const renameTarget = layouts?.find(l => l.id === renameTargetId) ?? null;
   const saveAsTarget = layouts?.find(l => l.id === saveAsTargetId) ?? null;
   const deleteTarget = layouts?.find(l => l.id === deleteTargetId) ?? null;
@@ -413,7 +405,7 @@ function Dashboard() {
                     <LayoutTab
                       key={layout.id}
                       layout={layout}
-                      onToggleTile={handleToggleTile}
+                      onEditTiles={l => setTilesTargetId(l.id)}
                       onRename={l => setRenameTargetId(l.id)}
                       onDuplicate={l => duplicateMutation.mutate(l.id)}
                       onSaveAs={l => setSaveAsTargetId(l.id)}
@@ -447,6 +439,15 @@ function Dashboard() {
           </>
         )}
       </div>
+
+      <VisibleTilesDialog
+        open={tilesTarget !== null}
+        layout={tilesTarget}
+        onToggleTile={handleToggleTile}
+        onOpenChange={(open) => {
+          if (!open) setTilesTargetId(null);
+        }}
+      />
 
       <AddLayoutDialog
         open={addDialogOpen}


### PR DESCRIPTION
## Summary

Refactors the dashboard's tile visibility controls from an inline checkbox list in the "More" dropdown menu into a dedicated modal dialog. This improves UX by providing a cleaner, more discoverable interface for managing visible tiles.

## Changes

- **New component:** `VisibleTilesDialog` — a controlled modal that displays all available dashboard tiles with checkboxes, replacing the previous dropdown menu items
- **New UI primitive:** `Checkbox` component wrapping Radix UI's checkbox primitive with Tailwind styling
- **Updated dashboard flow:** 
  - Removed `DropdownMenuCheckboxItem` entries from the "More" menu
  - Added "Visible tiles…" menu item that opens the modal
  - Tile toggling remains live (optimistic updates persist via `onToggleTile`)
  - Modal state managed via `tilesTargetId` in the Dashboard component
- **Cleaner API:** `LayoutTab` now receives `onEditTiles` callback instead of `onToggleTile`, decoupling the UI trigger from the mutation logic

## Implementation Details

- The modal displays the layout name in its description for context
- Checkbox state is derived from the layout's current tile list on each render, so changes are reflected immediately as the grid updates behind the modal
- The dialog uses `max-w-sm` constraint and maintains consistent spacing with `gap-1` between tile options
- Hover states on labels improve discoverability of the interactive elements

https://claude.ai/code/session_01HVateohgg4aiKdZdFCrjtF