### PR TITLE
style(client): improve dashboard grid layout responsiveness

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
@@ -74,15 +74,13 @@ function ItemList({
   return (
     <ul
       className="
-        grid grid-cols-[repeat(auto-fill,minmax(min(100%,260px),300px))] gap-2
+        grid grid-cols-[repeat(auto-fit,minmax(min(100%,260px),1fr))] gap-2
       "
     >
       {items.map(item => (
         <li
           key={`${item.domainId}:${item.topicId}`}
-          className="
-            flex max-w-[300px] min-w-0 flex-col gap-1 rounded-md border p-2
-          "
+          className="flex min-w-0 flex-col gap-1 rounded-md border p-2"
         >
           <div className="flex min-w-0 flex-col">
             <Link


### PR DESCRIPTION
## Summary
Refactored the dashboard explore item grid layout to improve responsiveness and remove unnecessary width constraints on individual items.

## Changes
- Changed grid from `auto-fill` to `auto-fit` for better space utilization when items don't fill the viewport
- Updated grid column sizing from fixed `300px` max-width to flexible `1fr` to allow items to expand and fill available space
- Removed `max-w-[300px]` constraint from list items, allowing them to scale with the grid layout

## Details
The `auto-fit` algorithm collapses empty tracks, preventing unnecessary gaps when there are fewer items than grid columns can accommodate. Combined with the `1fr` sizing, items now properly expand to fill available space while maintaining the responsive `minmax(min(100%,260px),1fr)` behavior. This provides a cleaner, more flexible layout that adapts better to different viewport sizes.

https://claude.ai/code/session_01YYuHZgpYg7BVKvJRdjjAt2