### PR TITLE
refactor(client): expose resize handles per tile instead of global resizable flag

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -19,6 +19,7 @@ import {
   GRID_EM_PER_ROW,
   GRID_GAP,
   isAutoHeight,
+  resizeHandlesForTile,
   rowsForContent,
   sortTilesForMobile,
   TILE_META,
@@ -65,9 +66,10 @@ function rootFontSizePx(): number {
 }
 
 /**
- * Builds the layout fed to the grid: auto-height tiles take their measured row
- * count and lose the resize handle; fixed tiles keep their stored height and
- * stay resizable.
+ * Builds the layout fed to the grid. Every tile is resizable and carries its own
+ * handles (see `resizeHandlesForTile`): all tiles get a width-only east edge, and
+ * fixed tiles also get the SE corner for height. Auto-height tiles take their
+ * measured row count so the east-edge drag only ever changes their width.
  */
 function buildDisplayLayout(
   tiles: DashboardLayoutTile[],
@@ -78,12 +80,14 @@ function buildDisplayLayout(
       return {
         ...item,
         resizable: true,
+        resizeHandles: resizeHandlesForTile(item),
       };
     }
     return {
       ...item,
       h: measured.get(item.id) ?? item.h,
-      resizable: false,
+      resizable: true,
+      resizeHandles: resizeHandlesForTile(item),
     };
   });
 }
@@ -197,8 +201,9 @@ export function GridTile({
 
 /**
  * The 4-column drag-and-drop tile grid. Dragging is restricted to the card
- * headers; fixed-height tiles resize via the SE handle while auto-height tiles
- * grow to fit their content. On mobile the tiles render as a plain stack.
+ * headers; every tile resizes its width via a right-edge handle, and fixed-height
+ * tiles additionally resize their height via the SE corner. Auto-height tiles
+ * still grow to fit their content. On mobile the tiles render as a plain stack.
  */
 export function DashboardGrid({
   tiles,

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.test.ts
@@ -8,6 +8,7 @@ import {
   layoutItemsToTiles,
   needsNormalization,
   normalizeTiles,
+  resizeHandlesForTile,
   sortTilesForMobile,
   tilesEqual,
   tilesToLayoutItems,
@@ -300,5 +301,20 @@ describe("needsNormalization", () => {
         },
       ]),
     ).toBe(true);
+  });
+});
+
+describe("resizeHandlesForTile", () => {
+  test("auto-height tiles get only the width (east) handle", () => {
+    expect(resizeHandlesForTile({})).toEqual(["e"]);
+    expect(resizeHandlesForTile({
+      heightMode: "auto",
+    })).toEqual(["e"]);
+  });
+
+  test("fixed-height tiles also get the SE corner for height", () => {
+    expect(resizeHandlesForTile({
+      heightMode: "fixed",
+    })).toEqual(["e", "se"]);
   });
 });

--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
@@ -89,6 +89,23 @@ export function isAutoHeight(tile: Pick<DashboardLayoutTile, "heightMode">): boo
   return (tile.heightMode ?? "auto") === "auto";
 }
 
+/** Mirrors @dnd-grid's ResizeHandleAxis; its published d.ts re-exports the core
+ * types through a broken relative path, so the imported type resolves to `any`
+ * (the same reason GridLayoutItem below is hand-rolled). */
+export type ResizeHandleAxis = "s" | "w" | "e" | "n" | "sw" | "nw" | "se" | "ne";
+
+/**
+ * Resize handles a tile exposes. Every tile gets the east (right-edge) handle so
+ * its width is always adjustable; fixed-height tiles additionally get the SE
+ * corner so the same drag can set their height. Auto-height tiles omit the corner
+ * because their height is content-driven, not handle-driven.
+ */
+export function resizeHandlesForTile(
+  tile: Pick<DashboardLayoutTile, "heightMode">,
+): ResizeHandleAxis[] {
+  return isAutoHeight(tile) ? ["e"] : ["e", "se"];
+}
+
 /**
  * Smallest row count (`h`) whose pixel height fits `contentPx`, given the row
  * height and the inter-row gap. Clamped to `minH`.
@@ -260,7 +277,8 @@ export function tilesEqual(
 }
 
 // Per-item settings carried through the grid so a drag/resize round-trip never
-// drops them. `resizable` is consumed by @dnd-grid to hide the SE handle.
+// drops them. `resizable` and `resizeHandles` are consumed by @dnd-grid to
+// control which resize handles a tile shows (width edge vs. SE corner).
 interface GridItemSettings {
   heightMode?: DashboardLayoutTile["heightMode"];
   showProject?: boolean;
@@ -278,6 +296,7 @@ export interface GridLayoutItem extends GridItemSettings {
   minW?: number;
   minH?: number;
   resizable?: boolean;
+  resizeHandles?: ResizeHandleAxis[];
 }
 
 function pickSettings(source: GridItemSettings): GridItemSettings {


### PR DESCRIPTION
## Summary

Replaces the coarse `resizable: boolean` flag with a fine-grained `resizeHandles` array that specifies which edges/corners each tile can resize from. This allows auto-height tiles to expose only the east (width) handle while fixed-height tiles expose both east and SE (corner) handles, eliminating the need for a separate `resizable` flag.

## Key Changes

- **New type & utility:** Added `ResizeHandleAxis` type (mirrors `@dnd-grid`'s enum) and `resizeHandlesForTile()` function to determine which handles a tile should expose based on its `heightMode`
- **GridLayoutItem interface:** Added `resizeHandles?: ResizeHandleAxis[]` field to carry handle configuration through the grid
- **buildDisplayLayout():** Now sets `resizeHandles` for all tiles (both auto and fixed) and marks all tiles as `resizable: true` (the handles array controls visibility)
- **Documentation:** Updated comments in `DashboardGrid` and `buildDisplayLayout` to reflect the new handle-per-tile model
- **Tests:** Added comprehensive test coverage for `resizeHandlesForTile()` with both auto-height and fixed-height cases

## Implementation Details

- Auto-height tiles get `["e"]` (east edge only) so width-only drags don't affect their content-driven height
- Fixed-height tiles get `["e", "se"]` (east edge + SE corner) for independent width and height control
- The `resizable: boolean` flag is retained for backward compatibility but is now always `true`; `@dnd-grid` uses the `resizeHandles` array to determine which handles to render

https://claude.ai/code/session_014fGGCwFYsHqmHb1sZD6VyQ