### PR TITLE
refactor(client): extract EditRowBaseProps base for edit-row props

### DIFF
--- a/packages/client/src/components/TagGroupsAdmin.tsx
+++ b/packages/client/src/components/TagGroupsAdmin.tsx
@@ -1,3 +1,4 @@
+import type { EditRowBaseProps } from "@/components/editRowProps";
 import type { Tag, TagGroup } from "@emstack/types";
 
 import { useState } from "react";
@@ -262,13 +263,9 @@ export function TagGroupsAdmin() {
   );
 }
 
-interface GroupEditRowProps {
+interface GroupEditRowProps extends EditRowBaseProps {
   draft: TagGroupDraft;
-  isNew?: boolean;
-  isSaving?: boolean;
   onSave: (draft: TagGroupDraft) => void;
-  onCancel: () => void;
-  onDelete?: () => void;
   deleteDisabled?: boolean;
   deleteDisabledReason?: string;
 }
@@ -505,13 +502,9 @@ function TagDisplayRow({
   );
 }
 
-interface TagEditRowProps {
+interface TagEditRowProps extends EditRowBaseProps {
   draft: TagDraft;
-  isNew?: boolean;
-  isSaving?: boolean;
   onSave: (draft: TagDraft) => void;
-  onCancel: () => void;
-  onDelete?: () => void;
 }
 
 function TagEditRow({

--- a/packages/client/src/components/TaskTypeEditRow.tsx
+++ b/packages/client/src/components/TaskTypeEditRow.tsx
@@ -1,3 +1,4 @@
+import type { EditRowBaseProps } from "@/components/editRowProps";
 import type { TaskType } from "@emstack/types";
 
 import { useState } from "react";
@@ -7,13 +8,9 @@ import { Input } from "@/components/input";
 import { TagsInput } from "@/components/tasks/TagsInput";
 import { Textarea } from "@/components/textarea";
 
-interface TaskTypeEditRowProps {
+interface TaskTypeEditRowProps extends EditRowBaseProps {
   taskType: TaskType;
-  isNew?: boolean;
-  isSaving?: boolean;
   onSave: (next: TaskType) => void;
-  onCancel: () => void;
-  onDelete?: () => void;
   deleteDisabled?: boolean;
   deleteDisabledReason?: string;
 }

--- a/packages/client/src/components/editRowProps.ts
+++ b/packages/client/src/components/editRowProps.ts
@@ -1,0 +1,9 @@
+// Shared prop cluster for inline "edit row" components (tag groups, tags, task
+// types). Each row's props interface extends this; row-specific fields and any
+// delete-disabled props are added by the leaf interfaces.
+export interface EditRowBaseProps {
+  isNew?: boolean;
+  isSaving?: boolean;
+  onCancel: () => void;
+  onDelete?: () => void;
+}


### PR DESCRIPTION
## ELI5
Several small inline "edit a row" forms (for tag groups, tags, and task types) each repeated the same list of buttons-and-state options. This pulls that shared list into one definition they all reuse, so future tweaks happen in one spot. Nothing about how the app behaves changes.

## Summary
- Add a shared `EditRowBaseProps` (in a new `components/editRowProps.ts`, mirroring the existing `dialogProps.ts` pattern) holding the common `isNew`/`isSaving`/`onCancel`/`onDelete` props.
- Have `GroupEditRowProps`, `TagEditRowProps`, and `TaskTypeEditRowProps` extend it; the `deleteDisabled`/`deleteDisabledReason` pair stays inline in the two rows that use it.
- Type-only refactor — resulting prop shapes are unchanged, so the row components and their call sites are untouched.

## Test plan
- [ ] `pnpm typecheck` is clean across all packages
- [ ] `pnpm exec eslint` clean on `editRowProps.ts`, `TagGroupsAdmin.tsx`, `TaskTypeEditRow.tsx`
- [ ] Tag groups / tags admin and task-type editing still save, cancel, and delete correctly (delete-disabled state still honored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)