### PR TITLE
Fixes #290: Condense redundant types in routines components

### DIFF
--- a/packages/client/src/components/routines/WeeklyEntryEditor.tsx
+++ b/packages/client/src/components/routines/WeeklyEntryEditor.tsx
@@ -1,19 +1,12 @@
 import type { WeeklyRowType } from "@/components/routines/weekly";
+import type { SelectOption } from "@/utils";
 
 import { useMemo } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
-import {
-  Combobox,
-  ComboboxInput,
-} from "@/components/combobox";
+import { Combobox, ComboboxInput } from "@/components/combobox";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
-
-interface ItemOption {
-  value: string;
-  label: string;
-}
 
 interface EntryValue {
   type: WeeklyRowType;
@@ -26,8 +19,8 @@ interface EntryValue {
 
 interface WeeklyEntryEditorProps extends EntryValue {
   onChange: (next: EntryValue) => void;
-  taskOptions: ItemOption[];
-  resourceOptions: ItemOption[];
+  taskOptions: SelectOption[];
+  resourceOptions: SelectOption[];
 }
 
 // A single task / resource / freeform picker — the same control the weekly grid
@@ -46,11 +39,7 @@ export function WeeklyEntryEditor({
   resourceOptions,
 }: WeeklyEntryEditorProps) {
   const itemOptions
-    = type === "task"
-      ? taskOptions
-      : type === "resource"
-        ? resourceOptions
-        : [];
+    = type === "task" ? taskOptions : type === "resource" ? resourceOptions : [];
   const optionsMap = useMemo(
     () => new Map(itemOptions.map(o => [o.value, o.label])),
     [itemOptions],
@@ -68,7 +57,7 @@ export function WeeklyEntryEditor({
     });
   }
 
-  const itemName = type === "freeform" ? id : optionsMap.get(id) ?? "";
+  const itemName = type === "freeform" ? id : (optionsMap.get(id) ?? "");
   const showPreview
     = !!itemName && (!!prependText.trim() || !!appendText.trim());
   const preview = buildActionableSentence({

--- a/packages/client/src/components/routines/WeeklyEntryEditor.tsx
+++ b/packages/client/src/components/routines/WeeklyEntryEditor.tsx
@@ -1,4 +1,4 @@
-import type { WeeklyRowType } from "@/components/routines/weekly";
+import type { WeeklyEntry, WeeklyRowType } from "@/components/routines/weekly";
 import type { SelectOption } from "@/utils";
 
 import { useMemo } from "react";
@@ -8,17 +8,8 @@ import { buildActionableSentence } from "@emstack/types";
 import { Combobox, ComboboxInput } from "@/components/combobox";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 
-interface EntryValue {
-  type: WeeklyRowType;
-  id: string;
-  notes: string;
-  location: string;
-  prependText: string;
-  appendText: string;
-}
-
-interface WeeklyEntryEditorProps extends EntryValue {
-  onChange: (next: EntryValue) => void;
+interface WeeklyEntryEditorProps extends WeeklyEntry {
+  onChange: (next: WeeklyEntry) => void;
   taskOptions: SelectOption[];
   resourceOptions: SelectOption[];
 }
@@ -45,7 +36,7 @@ export function WeeklyEntryEditor({
     [itemOptions],
   );
 
-  function emit(patch: Partial<EntryValue>) {
+  function emit(patch: Partial<WeeklyEntry>) {
     onChange({
       type,
       id,

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -1,27 +1,20 @@
 import type { WeeklyRow, WeeklyRowType } from "@/components/routines/weekly";
+import type { SelectOption } from "@/utils";
 import type { RoutineWeekday } from "@emstack/types";
 
 import { useMemo } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
-import {
-  Combobox,
-  ComboboxInput,
-} from "@/components/combobox";
+import { Combobox, ComboboxInput } from "@/components/combobox";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { DAY_LABELS, DAY_ORDER } from "@/components/routines/weekly";
-
-interface ItemOption {
-  value: string;
-  label: string;
-}
 
 interface WeeklyScheduleFieldProps {
   value: WeeklyRow[];
   onChange: (next: WeeklyRow[]) => void;
-  taskOptions: ItemOption[];
-  resourceOptions: ItemOption[];
+  taskOptions: SelectOption[];
+  resourceOptions: SelectOption[];
 }
 
 export function WeeklyScheduleField({
@@ -36,12 +29,15 @@ export function WeeklyScheduleField({
   );
 
   function update(day: RoutineWeekday, patch: Partial<WeeklyRow>) {
-    onChange(value.map(r => (r.day === day
-      ? {
-        ...r,
-        ...patch,
-      }
-      : r)));
+    onChange(
+      value.map(r =>
+        r.day === day
+          ? {
+            ...r,
+            ...patch,
+          }
+          : r),
+    );
   }
 
   return (
@@ -63,12 +59,13 @@ export function WeeklyScheduleField({
               : row.type === "resource"
                 ? resourceOptions
                 : [];
-          const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
+          const optionsMap = new Map(
+            itemOptions.map(o => [o.value, o.label]),
+          );
           const itemName
-            = row.type === "freeform" ? row.id : optionsMap.get(row.id) ?? "";
+            = row.type === "freeform" ? row.id : (optionsMap.get(row.id) ?? "");
           const showPreview
-            = !!itemName
-              && (!!row.prependText.trim() || !!row.appendText.trim());
+            = !!itemName && (!!row.prependText.trim() || !!row.appendText.trim());
           const preview = buildActionableSentence({
             prependText: row.prependText,
             name: itemName,
@@ -116,9 +113,10 @@ export function WeeklyScheduleField({
                     <input
                       aria-label={`${DAY_LABELS[day]} description`}
                       value={row.id}
-                      onChange={e => update(day, {
-                        id: e.target.value,
-                      })}
+                      onChange={e =>
+                        update(day, {
+                          id: e.target.value,
+                        })}
                       placeholder="Describe the activity…"
                       className="
                         flex h-9 w-full rounded-md border bg-background px-2
@@ -130,10 +128,12 @@ export function WeeklyScheduleField({
                     <Combobox
                       items={itemOptions.map(o => o.value)}
                       value={row.id || null}
-                      onValueChange={val => update(day, {
-                        id: val ?? "",
-                      })}
-                      itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+                      onValueChange={val =>
+                        update(day, {
+                          id: val ?? "",
+                        })}
+                      itemToStringLabel={(val: string) =>
+                        optionsMap.get(val) ?? ""}
                     >
                       <ComboboxInput
                         placeholder={
@@ -156,9 +156,10 @@ export function WeeklyScheduleField({
                   <input
                     aria-label={`${DAY_LABELS[day]} notes`}
                     value={row.notes}
-                    onChange={e => update(day, {
-                      notes: e.target.value,
-                    })}
+                    onChange={e =>
+                      update(day, {
+                        notes: e.target.value,
+                      })}
                     placeholder="Notes (optional)…"
                     className="
                       flex h-9 w-full rounded-md border bg-background px-2
@@ -168,9 +169,10 @@ export function WeeklyScheduleField({
                   <input
                     aria-label={`${DAY_LABELS[day]} location`}
                     value={row.location}
-                    onChange={e => update(day, {
-                      location: e.target.value,
-                    })}
+                    onChange={e =>
+                      update(day, {
+                        location: e.target.value,
+                      })}
                     placeholder="Location (e.g. gym, Spanish app, or a URL)…"
                     className="
                       flex h-9 w-full rounded-md border bg-background px-2
@@ -186,9 +188,10 @@ export function WeeklyScheduleField({
                     <input
                       aria-label={`${DAY_LABELS[day]} prepend text`}
                       value={row.prependText}
-                      onChange={e => update(day, {
-                        prependText: e.target.value,
-                      })}
+                      onChange={e =>
+                        update(day, {
+                          prependText: e.target.value,
+                        })}
                       placeholder="Prepend text (e.g. Review)…"
                       className="
                         flex h-9 w-full rounded-md border bg-background px-2
@@ -198,9 +201,10 @@ export function WeeklyScheduleField({
                     <input
                       aria-label={`${DAY_LABELS[day]} append text`}
                       value={row.appendText}
-                      onChange={e => update(day, {
-                        appendText: e.target.value,
-                      })}
+                      onChange={e =>
+                        update(day, {
+                          appendText: e.target.value,
+                        })}
                       placeholder="Append text (e.g. for 10 minutes)…"
                       className="
                         flex h-9 w-full rounded-md border bg-background px-2

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -22,6 +22,10 @@ export interface WeeklyRow {
   appendText: string;
 }
 
+// A weekly entry without its day key — the shared item shape Daily Task mode
+// reads/writes (the same entry applies to every weekday).
+export type WeeklyEntry = Omit<WeeklyRow, "day">;
+
 // Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.
 const ALL_DAYS: RoutineWeekday[] = ["0", "1", "2", "3", "4", "5", "6"];
 
@@ -101,14 +105,7 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
 // `type && id` — so a half-chosen entry (a type picked before its item) still
 // surfaces; otherwise the controlled type <select> would snap back to "None" and
 // the item picker would never enable.
-export function representativeRow(rows: WeeklyRow[]): {
-  type: WeeklyRowType;
-  id: string;
-  notes: string;
-  location: string;
-  prependText: string;
-  appendText: string;
-} {
+export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
   const found = rows.find(r => r.type !== "");
   return found
     ? {


### PR DESCRIPTION
## ELI5
The weekly-routine editing screens had a few small type definitions copied in more than one place, plus one that just restated another type with one field removed. This tidies those up so each shape is defined once and reused, making the code easier to change later. Nothing about how the app behaves changes.

## Summary
- Replaced the duplicated local `ItemOption` interface in `WeeklyScheduleField` and `WeeklyEntryEditor` with the shared `SelectOption` type (which the callers already pass in).
- Extracted `WeeklyEntry = Omit<WeeklyRow, "day">` in `weekly.ts`, replacing `WeeklyEntryEditor`'s local `EntryValue` and `representativeRow`'s inline return literal.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `weekly.test.ts` — 14/14 pass
- [x] `eslint` on changed files — no new errors
- [ ] Smoke-check the routine template editor and the Daily Task editor render and save unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)