### PR TITLE
chore: remove db-push service from compose and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,6 @@ COPY CHANGELOG.md ./
 RUN pnpm --filter @emstack/client build
 
 
-# One-shot stage for pushing the Drizzle schema (compose `db-push` service).
-# DATABASE_URL comes from the environment; no .env file needed.
-FROM build-middleware AS db-push
-
-WORKDIR /app/packages/middleware
-CMD ["pnpm", "push:prod"]
-
-
 # Production stage — fresh install with only production deps (client ships as static files)
 FROM base AS prod-deps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,17 +14,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-  db-push:
-    build:
-      context: ./
-      dockerfile: Dockerfile
-      target: db-push
-    restart: "no"
-    environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-coursetracker}
-    depends_on:
-      db:
-        condition: service_healthy
   gateway:
     build:
       context: ./
@@ -36,8 +25,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      db-push:
-        condition: service_completed_successfully
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Removes the `db-push` Docker Compose service and its corresponding Dockerfile build stage. Schema migrations are now handled exclusively by the gateway during startup, eliminating the need for a separate one-shot service.

## Changes

- **docker-compose.yml:** Removed the `db-push` service definition and its dependency from the `gateway` service
- **Dockerfile:** Removed the `db-push` build stage that ran `pnpm push:prod`

## Implementation Details

The gateway already runs runtime migrations and `drizzle-kit push` on startup (as documented in CLAUDE.md under "Deployment"), making the separate `db-push` service redundant. This simplifies the compose configuration and reduces container startup complexity while maintaining the same schema migration behavior.

https://claude.ai/code/session_0157dTizR5S1bKcAXWQbmVQa