### PR TITLE
refactor(client): share resource-progress prop slice across ProgressBar and PageHeader

### DIFF
--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -1,19 +1,16 @@
 import type { EntityKind } from "@/components/boxElements/EntityLink";
-import type { ResourceStatus } from "@emstack/types";
+import type { ResourceProgress } from "@/components/ui/ProgressBar";
 
 import { Link } from "@tanstack/react-router";
 
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { cn } from "@/lib/utils";
 
-interface PageHeaderProps {
+interface PageHeaderProps extends ResourceProgress {
   pageTitle?: string;
   pageSection?: EntityKind | "dailies" | "routines" | "";
   description?: React.ReactNode;
   children?: React.ReactNode;
-  progressCurrent?: number;
-  progressTotal?: number;
-  status?: ResourceStatus;
 }
 
 export function PageHeader({

--- a/packages/client/src/components/ui/ProgressBar.tsx
+++ b/packages/client/src/components/ui/ProgressBar.tsx
@@ -1,13 +1,14 @@
-import type { ResourceStatus } from "@emstack/types";
+import type { Resource } from "@emstack/types";
 
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-interface ContentBoxProgressProps {
-  progressCurrent?: number;
-  progressTotal?: number;
-  status?: ResourceStatus;
+export type ResourceProgress = Partial<
+  Pick<Resource, "progressCurrent" | "progressTotal" | "status">
+>;
+
+interface ContentBoxProgressProps extends ResourceProgress {
   isRounded?: boolean;
 }
 export function ProgressBar({


### PR DESCRIPTION
## ELI5
Two components were each independently describing the same little bundle of "progress" details (how far along something is and its status). This PR writes that bundle down in one place and points both components at it, so they can never drift apart.

## Summary
- Extract a `ResourceProgress` type in `ui/ProgressBar.tsx` — a `Partial<Pick<Resource, "progressCurrent" | "progressTotal" | "status">>` slice of the shared `@emstack/types` `Resource` shape.
- `ContentBoxProgressProps` (ProgressBar) and `PageHeaderProps` (PageHeader) now `extend` it instead of re-declaring the three fields, removing the duplicated cluster and the standalone `ResourceStatus` imports.
- Type-only refactor, no behavior change.

## Test plan
- [x] `pnpm typecheck` clean repo-wide
- [x] `pnpm exec eslint` clean on both changed files
- [ ] Visually confirm the page-header progress bar and content-box progress bar still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)