### PR TITLE
refactor(radar): consolidate duplicated UI and add full Storybook coverage

### DIFF
--- a/.claude/skills/condense-components/SKILL.md
+++ b/.claude/skills/condense-components/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: condense-components
+description: >-
+  Audit a folder or area of the app for redundant React components and condense
+  them — reuse an existing primitive instead of a hand-rolled element, extract a
+  shared component for a control that's duplicated across files, and collapse
+  sibling render blocks that differ only in data into one component. Use when
+  asked to "condense/consolidate/dedupe components", "combine/merge these
+  components", or "can these components be shared/unified". Pairs with
+  `condense-types` (types) — use that for type/interface dedupe.
+---
+
+# Condense components (course-tracker)
+
+Reduce duplicate and overlapping React component markup in a target area (a
+folder, a feature, or a single file) **without changing behavior**. Quality
+only — for behavior cleanups use `/simplify`, for bugs use `/code-review`. This
+is the component-level sibling of `condense-types`; if you're also seeing
+duplicate type/interface declarations, run that too.
+
+Shared primitives live in `packages/client/src/components/ui/` (shadcn-derived)
+and the root-level `components/*.tsx` vendored files. Feature components live in
+`components/<feature>/` (`radar/`, `dailies/`, `tasks/`, …). Most condensing is
+pulling hand-rolled markup back toward a primitive, or lifting a copy-pasted
+block into one shared component.
+
+## 1. Inventory the target area
+
+List the components in scope and look for repeated JSX structure across files —
+the same element with the same class soup, the same control wired up more than
+once, sibling blocks that differ only in their data:
+
+```bash
+grep -rn "^export function\|^export const\|^function " <target-dir>/*.tsx
+```
+
+For a wide sweep ("across the app"), delegate to an **Explore agent** — ask it
+for `file:line`, what the duplicated block renders, and which existing primitive
+(if any) already covers it. Also lean on **fallow**, which flags duplication in
+this repo:
+
+```bash
+pnpm exec fallow dupes        # duplicate code/markup
+pnpm exec fallow dead-code    # components/exports now unused — delete outright
+```
+
+Read the actual markup of each candidate before deciding, and check whether a
+primitive already exists (`grep -rn "export function" components/ui`). Don't
+classify from the name alone.
+
+## 2. Classify each candidate into a pattern
+
+### Pattern A — hand-rolled element that a primitive already covers → reuse it
+A `<span>`/`<button>`/`<div>` with the same class string as an existing
+primitive. Replace it with the primitive. `cn()` uses **tailwind-merge**
+(`lib/utils.ts`), so a primitive can absorb a variant via `className` —
+later, conflicting utilities win:
+- Example: the `rounded-sm … text-[10px]` status-badge `<span>`s in
+  `BlipLlmReviewTable` / `RadarConfigTab` became `<Pill className="rounded-sm
+  px-1.5 text-[10px] …">` — twMerge resolves `rounded-full→rounded-sm`,
+  `text-xs→text-[10px]`, `px-2→px-1.5`.
+- If the primitive needs to forward an attribute it didn't before (e.g. `title`),
+  widen its props to `React.ComponentProps<"el">` and spread `...props` — don't
+  fork it.
+
+### Pattern B — same stateful control wired up in 2+ places → extract a shared component
+A control with imperative or fiddly wiring repeated across files. Extract it to
+`components/ui/`; expose the per-call-site variation as an explicit prop rather
+than re-deriving it inside.
+- Example: the "select all" `<input type="checkbox">` whose `indeterminate` flag
+  is set via a `ref` callback appeared 3× (`BlipLlmReviewTable`, `BlipTable`,
+  `boxes/TopicsTable`). It became `SelectAllCheckbox` with `indeterminate` as a
+  **boolean prop** — the sites compute it differently (`!all && some` vs a plain
+  `some`), so deriving it inside would have been wrong.
+
+### Pattern C — sibling render blocks differ only in data/labels → one component with slots
+2+ blocks with identical structure (heading + list, card + rows) that vary only
+in their content. Collapse them into one component that takes pre-built
+content/render slots so it stays dumb.
+- Example: `RadarLegend` inlined a heading-+`<ul>`-of-`BlipLegendItem` block that
+  duplicated `SimpleBlipLegendSection`. They merged into one `BlipLegendSection`
+  taking `items: { blip; label }[]` (callers pre-build each row's `label`), an
+  optional `emptyMessage`, and an optional `headingStyle` — now one definition
+  renders the quadrant lists, the adopted group, and the ignored group.
+
+## 3. Guardrails (when NOT to condense)
+
+- **Similar markup ≠ same component.** Two bars/cards that look alike but have
+  different *interaction models* must stay separate. `BlipBulkBar` (controlled,
+  single shared Apply, `NO_CHANGE` sentinel) and `BulkEditBar` (internal pending
+  state, per-control Apply, placeholder) were deliberately **not** merged — one
+  configurable component would need a flag for every divergence and read worse
+  than two. If unifying needs an ever-growing pile of `variant`/boolean props,
+  stop and leave them apart.
+- **Don't over-parameterize.** A "shared" component with one caller, or three
+  render-slot props that each fire once, earns nothing — inline it.
+- **Keep the home right.** Cross-cutting primitives go in `components/ui/`;
+  feature-only pieces stay in `components/<feature>/`. Don't drag a radar-specific
+  component into `ui/` just because it was extracted.
+- **Match existing layout/styling.** A reuse that shifts padding, rounding, or
+  font size is a behavior change — verify the merged classes render the same.
+- **Skip generated files**: `routeTree.gen.ts`, anything under `dist/`.
+
+## 4. Apply
+
+- Update the markup, then every importer (grep the whole package, not just the
+  folder — consumers live in routes/other features). After removing an export,
+  re-grep the package for its name; the typecheck surfaces stragglers.
+- The lint-staged formatter reorders/normalizes imports on save — don't
+  hand-fuss import ordering.
+
+## 5. Stories + tests for the resulting components
+
+Every extracted/widened shared component gets a co-located Storybook story and a
+test. Stories stay next to the component; **tests go in a `__tests__/` folder**
+when the caller asks (this repo otherwise co-locates `*.test.ts(x)` — follow the
+caller's convention).
+
+- **Story** — mirror `components/Text.stories.tsx`: `Meta`/`StoryObj` from
+  `@storybook/react-vite`, `within`/`expect`/`fn`/`userEvent` from
+  `@storybook/test`, a `play` assertion. Stories run as browser interaction tests
+  via the `storybook` vitest project, so each one also smoke-tests rendering.
+- **Test** — Vitest + Testing Library (`render`/`screen`/`fireEvent` from
+  `@testing-library/react`; no `user-event` dep). jsdom env + jest-dom matchers
+  are set up in `setupTests.js`.
+- **Router-dependent components**: anything rendering a TanStack `<Link>` needs a
+  router context. Use `@/test-utils/RouterStub` (a memory-router context-only
+  wrapper) as a story decorator and a test wrapper. It mounts children after the
+  router's initial load, so assert with **async `findBy*`** queries, not `getBy*`.
+- **jsdom gotcha**: `fireEvent.click` fires `onChange` even on a `disabled`
+  input, so don't assert "disabled ⇒ handler not called" in jsdom — assert the
+  `disabled` attribute instead.
+
+## 6. Verify
+
+```bash
+pnpm --filter=@emstack/client exec tsc --noEmit -p tsconfig.app.json   # client typecheck
+pnpm --filter=@emstack/client exec vitest run --project=unit-tests <changed dirs/files>
+pnpm --filter=@emstack/client exec vitest run --project=storybook      # runs the new stories
+pnpm exec eslint <changed files>                                       # run from repo ROOT —
+                                                                       # the tailwind plugin
+                                                                       # needs the root cwd
+```
+
+Use `pnpm --filter=@emstack/client run typecheck` (or `pnpm typecheck` for the
+whole repo) rather than a bare `tsc` at the root — the root has stale incremental
+build artifacts that produce spurious `TS6305` errors. The typecheck must be
+clean apart from pre-existing, unrelated errors (confirm with `git stash` if
+unsure one predates your change).
+
+Commit with a `refactor(<scope>):` Conventional Commit, one logical change per
+commit (each consolidation, plus the stories/tests, read better split).

--- a/.claude/skills/condense-components/SKILL.md
+++ b/.claude/skills/condense-components/SKILL.md
@@ -112,35 +112,69 @@ content/render slots so it stays dumb.
 ## 5. Stories + tests for the resulting components
 
 Every extracted/widened shared component gets a co-located Storybook story and a
-test. Stories stay next to the component; **tests go in a `__tests__/` folder**
-when the caller asks (this repo otherwise co-locates `*.test.ts(x)` — follow the
-caller's convention).
+test. **Both stay next to the component** — this repo co-locates `*.stories.tsx`
+and `*.test.ts(x)` (no `__tests__/` folder). If a caller asks for a `__tests__/`
+folder, follow that, but co-location is the default. Vitest's `unit-tests`
+include (`**/*.test.{ts,tsx}`) finds tests either way.
+
+If the ask is broader than the components you touched — e.g. "every component in
+this folder needs a story" — first reuse the mock-data factories: extract shared
+`make*` builders into `test-utils/radarFixtures.ts` (blips/quadrants/rings/topics
++ a `byId` map helper) instead of re-rolling args in each story. One
+`*.stories.tsx` per component file covering the primary export (plus meaningful
+siblings — e.g. both illustrations); heavy containers get a single representative
+render story. A render-only story (no `play`) still smoke-tests rendering.
 
 - **Story** — mirror `components/Text.stories.tsx`: `Meta`/`StoryObj` from
   `@storybook/react-vite`, `within`/`expect`/`fn`/`userEvent` from
-  `@storybook/test`, a `play` assertion. Stories run as browser interaction tests
-  via the `storybook` vitest project, so each one also smoke-tests rendering.
+  `@storybook/test`, an optional `play` assertion. Stories run as browser
+  interaction tests via the `storybook` vitest project, so each one also
+  smoke-tests rendering.
 - **Test** — Vitest + Testing Library (`render`/`screen`/`fireEvent` from
   `@testing-library/react`; no `user-event` dep). jsdom env + jest-dom matchers
-  are set up in `setupTests.js`.
-- **Router-dependent components**: anything rendering a TanStack `<Link>` needs a
-  router context. Use `@/test-utils/RouterStub` (a memory-router context-only
-  wrapper) as a story decorator and a test wrapper. It mounts children after the
-  router's initial load, so assert with **async `findBy*`** queries, not `getBy*`.
+  are set up in `setupTests.js`. The first component test in a package may need
+  `src/vitest.d.ts` (`import "@testing-library/jest-dom/vitest"`) so the matchers
+  (`toBeInTheDocument`, …) are typed.
+
+### Story authoring gotchas (learned the hard way)
+- **Annotate `meta` explicitly** — `const meta: Meta<typeof X> = {…}`, NOT
+  `satisfies Meta<…>` — whenever args use `fn()`. The inferred meta type embeds
+  the `@vitest/spy` Mock type and isn't portable (TS2742). Likewise, if `meta`
+  references a component prop whose interface isn't exported, export it (TS4023).
+- **Async handler args**: `fn(async () => {})` trips
+  `@typescript-eslint/no-empty-function`. Use `fn(() => Promise.resolve())`.
+- **Host-element wrappers**: a component that returns a non-standalone fragment
+  needs its parent supplied by a story decorator — wrap SVG `<g>`/`<circle>`
+  components in `<svg>` (and in `<TooltipProvider>` if they use a Radix
+  `Tooltip`), and `TableRow` components in `<Table><TableBody>`.
+- **Router-dependent components**: anything rendering a TanStack `<Link>` (often
+  transitively — a legend, a table, a chart that renders a legend) needs router
+  context. Use `@/test-utils/RouterStub` (memory-router, context-only) as a story
+  decorator and a test wrapper. It mounts children after the router's initial
+  load, so assert with **async `findBy*`** queries, not `getBy*`. Don't add a
+  global decorator in `preview.ts` — the async mount breaks existing sync `play`s.
 - **jsdom gotcha**: `fireEvent.click` fires `onChange` even on a `disabled`
   input, so don't assert "disabled ⇒ handler not called" in jsdom — assert the
   `disabled` attribute instead.
+- **Story file naming need not match the component file** (e.g. `radarLegendItem.tsx`
+  → `BlipLegendItem.stories.tsx`). Don't audit coverage by filename match alone;
+  grep each component's export for a referencing `.stories.tsx`.
 
 ## 6. Verify
 
 ```bash
 pnpm --filter=@emstack/client exec tsc --noEmit -p tsconfig.app.json   # client typecheck
 pnpm --filter=@emstack/client exec vitest run --project=unit-tests <changed dirs/files>
-pnpm --filter=@emstack/client exec vitest run --project=storybook      # runs the new stories
+pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism
 pnpm exec eslint <changed files>                                       # run from repo ROOT —
                                                                        # the tailwind plugin
                                                                        # needs the root cwd
 ```
+
+The `storybook` project runs stories in a headless browser and is **flaky under
+parallelism** — it intermittently throws bare `TypeError`s across arbitrary story
+files (even ones you didn't touch), while each passes in isolation. Run it with
+`--no-file-parallelism` for a deterministic signal before trusting a failure.
 
 Use `pnpm --filter=@emstack/client run typecheck` (or `pnpm typecheck` for the
 whole repo) rather than a bare `tsc` at the root — the root has stale incremental

--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
+import { SelectAllCheckbox } from "@/components/ui/SelectAllCheckbox";
 import {
   Table,
   TableBody,
@@ -155,15 +156,12 @@ export function TopicsTable({
           <TableRow>
             {selection && (
               <TableHead className="w-10">
-                <input
-                  type="checkbox"
+                <SelectAllCheckbox
                   className="size-4"
                   aria-label="Select all topics"
                   checked={allSelected}
-                  ref={(el) => {
-                    if (el) el.indeterminate = !allSelected && someSelected;
-                  }}
-                  onChange={e => selection.onToggleAll(e.target.checked)}
+                  indeterminate={!allSelected && someSelected}
+                  onCheckedChange={selection.onToggleAll}
                 />
               </TableHead>
             )}

--- a/packages/client/src/components/radar/BlipBulkBar.stories.tsx
+++ b/packages/client/src/components/radar/BlipBulkBar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipBulkBar } from "./BlipBulkBar";
+import { NO_CHANGE } from "./blipTableFilters";
+
+import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof BlipBulkBar> = {
+  component: BlipBulkBar,
+  args: {
+    selectedCount: 3,
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    bulkQuadrantId: NO_CHANGE,
+    bulkRingId: NO_CHANGE,
+    bulkPending: false,
+    onBulkQuadrantChange: fn(),
+    onBulkRingChange: fn(),
+    onApply: fn(),
+    onClear: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("3 selected")).toBeInTheDocument();
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    bulkPending: true,
+    bulkQuadrantId: "q1",
+  },
+};

--- a/packages/client/src/components/radar/BlipDescriptionPopover.stories.tsx
+++ b/packages/client/src/components/radar/BlipDescriptionPopover.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipDescriptionPopover } from "./BlipDescriptionPopover";
+
+const meta: Meta<typeof BlipDescriptionPopover> = {
+  component: BlipDescriptionPopover,
+  args: {
+    value: "Container orchestration",
+    onChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Edit blip description",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipDisplayRow.stories.tsx
+++ b/packages/client/src/components/radar/BlipDisplayRow.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipDisplayRow } from "./BlipDisplayRow";
+
+import { Table, TableBody } from "@/components/ui/table";
+import {
+  byId,
+  makeBlip,
+  makeQuadrants,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof BlipDisplayRow> = {
+  component: BlipDisplayRow,
+  args: {
+    blip: makeBlip({
+      id: "blip-0",
+      topicId: "topic-0",
+      topicName: "Kubernetes",
+      quadrantId: "q1",
+      ringId: "r0",
+      description: "Standardized across teams",
+    }),
+    topic: makeTopics()[0],
+    quadrantById: byId(makeQuadrants()),
+    ringById: byId(makeRings()),
+    isSelected: false,
+    isPending: false,
+    editingLocked: false,
+    showItemsColumn: true,
+    onToggleSelected: fn(),
+    onStartEdit: fn(),
+    onToggleIgnore: fn(),
+    onRemove: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Table>
+          <TableBody>
+            <Story />
+          </TableBody>
+        </Table>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    isSelected: true,
+  },
+};
+
+export const Ignored: Story = {
+  args: {
+    blip: makeBlip({
+      id: "blip-0",
+      topicId: "topic-0",
+      topicName: "Kubernetes",
+      quadrantId: "q1",
+      ringId: "r0",
+      isIgnored: true,
+    }),
+  },
+};

--- a/packages/client/src/components/radar/BlipEditRow.stories.tsx
+++ b/packages/client/src/components/radar/BlipEditRow.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipEditRow } from "./BlipEditRow";
+
+import { Table, TableBody } from "@/components/ui/table";
+import { makeBlip, makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof BlipEditRow> = {
+  component: BlipEditRow,
+  args: {
+    blip: makeBlip({
+      id: "blip-0",
+      topicName: "Kubernetes",
+    }),
+    topicDescription: "Container orchestration",
+    draft: {
+      quadrantId: "q1",
+      ringId: "r0",
+      description: "Standardized across teams",
+      isIgnored: false,
+    },
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    isPending: false,
+    colCount: 6,
+    onDraftChange: fn(),
+    onCommit: fn(),
+    onCancel: fn(),
+  },
+  decorators: [
+    Story => (
+      <Table>
+        <TableBody>
+          <Story />
+        </TableBody>
+      </Table>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Kubernetes",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Ignored: Story = {
+  args: {
+    draft: {
+      quadrantId: "",
+      ringId: "",
+      description: "Out of scope for now",
+      isIgnored: true,
+    },
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    isPending: true,
+  },
+};

--- a/packages/client/src/components/radar/BlipLegendItem.stories.tsx
+++ b/packages/client/src/components/radar/BlipLegendItem.stories.tsx
@@ -1,0 +1,116 @@
+import type { RadarBlip } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipLegendItem, BlipLegendSection } from "./radarLegendItem";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function makeBlip(id: string, topicName: string, description?: string): RadarBlip {
+  return {
+    id,
+    domainId: "domain-1",
+    quadrantId: "q-1",
+    ringId: "r-1",
+    topicId: `topic-${id}`,
+    topicName,
+    description,
+  };
+}
+
+const blips = [
+  makeBlip("a", "Kubernetes", "Container orchestration"),
+  makeBlip("b", "Terraform"),
+  makeBlip("c", "Prometheus", "Metrics + alerting"),
+];
+
+const meta: Meta<typeof BlipLegendSection> = {
+  component: BlipLegendSection,
+  args: {
+    title: "Tools",
+    headingClassName: "text-sm font-semibold uppercase",
+    activeBlipId: null,
+    selectedBlipId: null,
+    registerRef: fn(),
+    onHover: fn(),
+    onBlipClick: fn(),
+    onDescriptionChange: fn(),
+    items: blips.map((blip, idx) => ({
+      blip,
+      label: (
+        <>
+          <span className="mr-1 inline-block font-mono text-xs">
+            {idx + 1}
+            .
+          </span>
+          <span className="font-medium">{blip.topicName}</span>
+        </>
+      ),
+    })),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Section: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+    await expect(canvas.getByText("Terraform")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    emptyMessage: "No blips yet.",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("No blips yet.")).toBeInTheDocument();
+  },
+};
+
+/** A single legend row in isolation (selected, so its actions are visible). */
+export const SingleItem: StoryObj<typeof BlipLegendItem> = {
+  render: args => (
+    <RouterStub>
+      <ul>
+        <BlipLegendItem {...args} />
+      </ul>
+    </RouterStub>
+  ),
+  args: {
+    blip: makeBlip("solo", "Kubernetes", "Container orchestration"),
+    label: <span className="font-medium">Kubernetes</span>,
+    isActive: false,
+    isSelected: true,
+    registerRef: fn(),
+    onHover: fn(),
+    onBlipClick: fn(),
+    onDescriptionChange: fn(),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Container orchestration"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipLlmAssist.stories.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "@storybook/test";
+
+import { BlipLlmAssist } from "./BlipLlmAssist";
+
+import {
+  makeBlips,
+  makeQuadrants,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof BlipLlmAssist> = {
+  component: BlipLlmAssist,
+  args: {
+    domainId: "domain-1",
+    domainTitle: "Backend Platform",
+    domainDescription: "Services, infra, and tooling owned by the platform team.",
+    domainTopics: [],
+    excludedTopics: [],
+    withinScopeDescription: "Anything the platform team operates.",
+    outOfScopeDescription: "Frontend frameworks.",
+    withinScopeTopicNames: ["Kubernetes", "Terraform"],
+    outOfScopeTopicNames: ["React"],
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    topics: makeTopics(),
+    existingBlips: makeBlips(4),
+    onComplete: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Render-only smoke story — the setup view renders the prompt builder and a
+// JSON input. (Story execution itself fails if the component throws on render.)
+export const Setup: Story = {};

--- a/packages/client/src/components/radar/BlipLlmBulkEditBar.stories.tsx
+++ b/packages/client/src/components/radar/BlipLlmBulkEditBar.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BulkEditBar } from "./BlipLlmBulkEditBar";
+
+import {
+  makeQuadrants,
+  makeResolvedEntry,
+  makeRings,
+} from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof BulkEditBar> = {
+  component: BulkEditBar,
+  args: {
+    resolved: [
+      makeResolvedEntry({
+        topicName: "Kubernetes",
+        selected: true,
+      }),
+      makeResolvedEntry({
+        topicName: "Terraform",
+        selected: true,
+      }),
+      makeResolvedEntry({
+        topicName: "Rust",
+        selected: false,
+      }),
+    ],
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    onBulkQuadrant: fn(),
+    onBulkRing: fn(),
+    onBulkResolution: fn(),
+    onClearDescriptions: fn(),
+    onClearRadarNotes: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Bulk edit/)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipLlmReviewTable.stories.tsx
+++ b/packages/client/src/components/radar/BlipLlmReviewTable.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { ReviewTable } from "./BlipLlmReviewTable";
+
+import {
+  byId,
+  makeQuadrants,
+  makeResolvedEntry,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+
+const quadrants = makeQuadrants();
+const rings = makeRings();
+const topics = makeTopics();
+
+const meta: Meta<typeof ReviewTable> = {
+  component: ReviewTable,
+  args: {
+    resolved: [
+      makeResolvedEntry({
+        topicName: "Kubernetes",
+        selected: true,
+      }),
+      makeResolvedEntry({
+        topicName: "Terraform",
+        resolution: "updateBlip",
+        existingBlipId: "blip-1",
+      }),
+      makeResolvedEntry({
+        topicName: "Rust",
+        willCreateTopic: true,
+        matchedTopicId: null,
+        resolution: "create",
+      }),
+      makeResolvedEntry({
+        topicName: "Vitest",
+        resolution: "skip",
+      }),
+    ],
+    quadrants,
+    rings,
+    quadrantById: byId(quadrants),
+    ringById: byId(rings),
+    topicById: byId(topics),
+    updateEntry: fn(),
+    startEdit: fn(),
+    commitEdit: fn(),
+    cancelEdit: fn(),
+    updateDraft: fn(),
+    setRowSelected: fn(),
+    setAllSelected: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("columnheader", {
+        name: "Topic",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Kubernetes")).toBeInTheDocument();
+    await expect(canvas.getByText("New topic")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipLlmReviewTable.tsx
+++ b/packages/client/src/components/radar/BlipLlmReviewTable.tsx
@@ -19,6 +19,7 @@ import {
 } from "./blipLlmReview";
 
 import { Input } from "@/components/input";
+import { Pill } from "@/components/radar/Pill";
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { SelectAllCheckbox } from "@/components/ui/SelectAllCheckbox";
 import {
   Table,
   TableBody,
@@ -77,16 +79,11 @@ export function ReviewTable({
       <TableHeader>
         <TableRow>
           <TableHead className="w-8">
-            <input
-              type="checkbox"
+            <SelectAllCheckbox
               aria-label={allSelected ? "Deselect all" : "Select all"}
               checked={allSelected}
-              ref={(el) => {
-                if (el) {
-                  el.indeterminate = !allSelected && someSelected;
-                }
-              }}
-              onChange={e => setAllSelected(e.target.checked)}
+              indeterminate={!allSelected && someSelected}
+              onCheckedChange={setAllSelected}
             />
           </TableHead>
           <TableHead className="min-w-32">Topic</TableHead>
@@ -286,32 +283,31 @@ function TopicCell({
         <span className="font-medium">{r.topicName || "(no topic)"}</span>
         <div className="flex flex-row flex-wrap gap-1">
           {r.willCreateTopic && (
-            <span
-              className={`
-                rounded-sm bg-emerald-100 px-1.5 py-0.5 text-[10px]
-                text-emerald-800
-              `}
+            <Pill
+              className="
+                rounded-sm bg-emerald-100 px-1.5 text-[10px] text-emerald-800
+              "
             >
               New topic
-            </span>
+            </Pill>
           )}
           {!r.willCreateTopic && r.matchedTopicId && (
-            <span
-              className={`
-                rounded-sm bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800
-              `}
+            <Pill
+              className="
+                rounded-sm bg-blue-100 px-1.5 text-[10px] text-blue-800
+              "
             >
               Existing topic
-            </span>
+            </Pill>
           )}
           {conflicts && (
-            <span
-              className={`
-                rounded-sm bg-amber-200 px-1.5 py-0.5 text-[10px] text-amber-900
-              `}
+            <Pill
+              className="
+                rounded-sm bg-amber-200 px-1.5 text-[10px] text-amber-900
+              "
             >
               On radar
-            </span>
+            </Pill>
           )}
         </div>
         {r.problems.length > 0 && !isSkipped && (

--- a/packages/client/src/components/radar/BlipPlacementSelect.stories.tsx
+++ b/packages/client/src/components/radar/BlipPlacementSelect.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipPlacementSelect } from "./BlipPlacementSelect";
+
+import { makeQuadrants } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof BlipPlacementSelect> = {
+  component: BlipPlacementSelect,
+  args: {
+    label: "Slice",
+    value: "",
+    placeholder: "Pick a slice",
+    options: makeQuadrants(),
+    onValueChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Slice")).toBeInTheDocument();
+    await expect(canvas.getByText("Pick a slice")).toBeInTheDocument();
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    value: "q1",
+  },
+};

--- a/packages/client/src/components/radar/BlipTable.stories.tsx
+++ b/packages/client/src/components/radar/BlipTable.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipTable } from "./BlipTable";
+
+import {
+  makeBlips,
+  makeQuadrants,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof BlipTable> = {
+  component: BlipTable,
+  args: {
+    blips: makeBlips(6),
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    topics: makeTopics(),
+    onSave: fn(() => Promise.resolve()),
+    onRemove: fn(() => Promise.resolve()),
+    onBulkSave: fn(() => Promise.resolve()),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -38,6 +38,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { SelectAllCheckbox } from "@/components/ui/SelectAllCheckbox";
 import {
   Table,
   TableBody,
@@ -385,14 +386,11 @@ export function BlipTable({
           <TableHeader>
             <TableRow>
               <TableHead className="w-1">
-                <input
-                  type="checkbox"
+                <SelectAllCheckbox
                   aria-label="Select all visible"
                   checked={allVisibleSelected}
-                  ref={(el) => {
-                    if (el) el.indeterminate = someVisibleSelected;
-                  }}
-                  onChange={toggleSelectAllVisible}
+                  indeterminate={someVisibleSelected}
+                  onCheckedChange={toggleSelectAllVisible}
                   disabled={filteredBlips.length === 0}
                 />
               </TableHead>

--- a/packages/client/src/components/radar/BlipsTab.stories.tsx
+++ b/packages/client/src/components/radar/BlipsTab.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { BlipsTab } from "./BlipsTab";
+
+import {
+  makeBlips,
+  makeQuadrants,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const topics = makeTopics();
+
+const meta: Meta<typeof BlipsTab> = {
+  component: BlipsTab,
+  args: {
+    allConfigPersisted: true,
+    savedBlipsForTable: makeBlips(4),
+    newBlipDrafts: [],
+    persistedQuadrants: makeQuadrants(),
+    persistedRings: makeRings(),
+    topics,
+    usedTopicIds: new Set(["topic-0", "topic-1"]),
+    pendingBlipKey: null,
+    topicById: new Map(
+      topics.map(t => [t.id, {
+        name: t.name,
+        description: t.description,
+      }]),
+    ),
+    topicNameById: new Map(topics.map(t => [t.id, t.name])),
+    onAddBlip: fn(),
+    onChangeBlipTopic: fn(),
+    onChangeBlipQuadrant: fn(),
+    onChangeBlipRing: fn(),
+    onChangeBlipDescription: fn(),
+    onSaveBlip: fn(),
+    onRemoveBlip: fn(),
+    onTableSave: fn(() => Promise.resolve()),
+    onTableRemove: fn(() => Promise.resolve()),
+    onTableBulkSave: fn(() => Promise.resolve()),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/LlmEditTab.stories.tsx
+++ b/packages/client/src/components/radar/LlmEditTab.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { LlmEditTab } from "./LlmEditTab";
+
+import {
+  makeBlips,
+  makeQuadrants,
+  makeRings,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof LlmEditTab> = {
+  component: LlmEditTab,
+  args: {
+    allConfigPersisted: true,
+    domainId: "domain-1",
+    domainTitle: "Backend Platform",
+    domainDescription: "Services, infra, and tooling owned by the platform team.",
+    domainTopics: [],
+    excludedTopics: [],
+    withinScopeDescription: "Anything the platform team operates.",
+    outOfScopeDescription: "Frontend frameworks.",
+    withinScopeTopicNames: ["Kubernetes"],
+    outOfScopeTopicNames: ["React"],
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    topics: makeTopics(),
+    existingBlips: makeBlips(4),
+    onComplete: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {};
+
+export const NotConfigured: Story = {
+  args: {
+    allConfigPersisted: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Save your slices and rings/)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/Pill.stories.tsx
+++ b/packages/client/src/components/radar/Pill.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "@storybook/test";
+
+import { Pill } from "./Pill";
+
+const meta = {
+  component: Pill,
+  args: {
+    children: "Pill",
+  },
+} satisfies Meta<typeof Pill>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pill")).toBeInTheDocument();
+  },
+};
+
+/** A status badge: the base pill styles overridden via className (tailwind-merge). */
+export const NewTopicBadge: Story = {
+  args: {
+    children: "New topic",
+    className: "rounded-sm bg-emerald-100 px-1.5 text-[10px] text-emerald-800",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const pill = canvas.getByText("New topic");
+    await expect(pill).toBeInTheDocument();
+    await expect(pill.className).toContain("rounded-sm");
+    await expect(pill.className).not.toContain("rounded-full");
+  },
+};
+
+export const ExistingTopicBadge: Story = {
+  args: {
+    children: "Existing topic",
+    className: "rounded-sm bg-blue-100 px-1.5 text-[10px] text-blue-800",
+  },
+};
+
+export const OnRadarBadge: Story = {
+  args: {
+    children: "On radar",
+    className: "rounded-sm bg-amber-200 px-1.5 text-[10px] text-amber-900",
+  },
+};

--- a/packages/client/src/components/radar/Pill.test.tsx
+++ b/packages/client/src/components/radar/Pill.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { Pill } from "./Pill";
+
+describe("Pill", () => {
+  test("renders its children", () => {
+    render(<Pill>New topic</Pill>);
+    expect(screen.getByText("New topic")).toBeInTheDocument();
+  });
+
+  test("merges a custom className, letting it override base styles", () => {
+    render(
+      <Pill className="rounded-sm bg-emerald-100 text-[10px]">New topic</Pill>,
+    );
+    const pill = screen.getByText("New topic");
+    // tailwind-merge keeps the later, conflicting utilities and drops the base.
+    expect(pill.className).toContain("rounded-sm");
+    expect(pill.className).not.toContain("rounded-full");
+    expect(pill.className).toContain("text-[10px]");
+    expect(pill.className).not.toContain("text-xs");
+  });
+
+  test("forwards native span attributes", () => {
+    render(<Pill title="Hidden from radar chart">Side panel</Pill>);
+    expect(screen.getByText("Side panel")).toHaveAttribute(
+      "title",
+      "Hidden from radar chart",
+    );
+  });
+});

--- a/packages/client/src/components/radar/Pill.tsx
+++ b/packages/client/src/components/radar/Pill.tsx
@@ -1,13 +1,11 @@
 import { cn } from "@/lib/utils";
 
-interface PillProps {
-  className?: string;
-  children: React.ReactNode;
-}
+type PillProps = React.ComponentProps<"span">;
 
 export function Pill({
   className,
   children,
+  ...props
 }: PillProps) {
   return (
     <span
@@ -15,6 +13,7 @@ export function Pill({
         "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
         className,
       )}
+      {...props}
     >
       {children}
     </span>

--- a/packages/client/src/components/radar/RadarBlipDot.stories.tsx
+++ b/packages/client/src/components/radar/RadarBlipDot.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { RadarBlipDot } from "./RadarBlipDot";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { makeBlip } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof RadarBlipDot> = {
+  component: RadarBlipDot,
+  args: {
+    blip: makeBlip({
+      id: "blip-0",
+      topicName: "Kubernetes",
+      description: "Container orchestration",
+    }),
+    x: 100,
+    y: 80,
+    index: 1,
+    color: "#2563eb",
+    dotRadius: 12,
+    haloRadius: 20,
+    fontSize: 12,
+    subtitle: "Tools · Adopt",
+    isActive: false,
+    isSelected: false,
+    onHover: fn(),
+    onClick: fn(),
+  },
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <svg
+          width={200}
+          height={160}
+        >
+          <Story />
+        </svg>
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("1")).toBeInTheDocument();
+  },
+};
+
+export const Active: Story = {
+  args: {
+    isActive: true,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    isSelected: true,
+  },
+};

--- a/packages/client/src/components/radar/RadarBlipDotLayer.stories.tsx
+++ b/packages/client/src/components/radar/RadarBlipDotLayer.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { RadarBlipDotLayer } from "./RadarBlipDotLayer";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  makeBlips,
+  makePositionedBlips,
+  makeQuadrants,
+} from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof RadarBlipDotLayer> = {
+  component: RadarBlipDotLayer,
+  args: {
+    positioned: makePositionedBlips(makeBlips(5)),
+    sortedQuadrants: makeQuadrants(),
+    activeBlipId: null,
+    selectedBlipId: null,
+    dotRadius: 12,
+    haloRadius: 20,
+    fontSize: 12,
+    clampQuadrantIndex: true,
+    renderSubtitle: (quadrantName, blip) => quadrantName ?? blip.topicName,
+    onHover: fn(),
+    onClick: fn(),
+  },
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <svg
+          width={400}
+          height={400}
+        >
+          <Story />
+        </svg>
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("1")).toBeInTheDocument();
+  },
+};
+
+export const WithActiveBlip: Story = {
+  args: {
+    activeBlipId: "blip-0",
+  },
+};

--- a/packages/client/src/components/radar/RadarChart.stories.tsx
+++ b/packages/client/src/components/radar/RadarChart.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { RadarChart } from "./RadarChart";
+
+import { makeBlips, makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof RadarChart> = {
+  component: RadarChart,
+  args: {
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    blips: makeBlips(8),
+    size: 500,
+    showLegend: true,
+    onBlipClick: fn(),
+    onDescriptionChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithLegend: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+  },
+};
+
+export const ChartOnly: Story = {
+  args: {
+    showLegend: false,
+  },
+};

--- a/packages/client/src/components/radar/RadarConfigIllustrations.stories.tsx
+++ b/packages/client/src/components/radar/RadarConfigIllustrations.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "@storybook/test";
+
+import {
+  QuadrantsIllustration,
+  RingsIllustration,
+} from "./RadarConfigIllustrations";
+
+import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof QuadrantsIllustration> = {
+  component: QuadrantsIllustration,
+  args: {
+    names: makeQuadrants().map(q => q.name),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Quadrants: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Techniques")).toBeInTheDocument();
+  },
+};
+
+export const Rings: StoryObj<typeof RingsIllustration> = {
+  render: () => <RingsIllustration names={makeRings().map(r => r.name)} />,
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Adopt")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/RadarConfigTab.stories.tsx
+++ b/packages/client/src/components/radar/RadarConfigTab.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { RadarConfigTab } from "./RadarConfigTab";
+
+import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+
+const quadrantDrafts = makeQuadrants().map((q, i) => ({
+  id: q.id,
+  name: q.name,
+  position: i,
+  localKey: `qk-${i}`,
+}));
+
+const ringDrafts = makeRings().map((r, i) => ({
+  id: r.id,
+  name: r.name,
+  position: i,
+  localKey: `rk-${i}`,
+}));
+
+const meta: Meta<typeof RadarConfigTab> = {
+  component: RadarConfigTab,
+  args: {
+    quadrants: quadrantDrafts,
+    rings: ringDrafts,
+    quadrantCount: quadrantDrafts.length,
+    maxRings: 6,
+    isSaving: false,
+    hasAdoptedSection: false,
+    onChangeQuadrant: fn(),
+    onChangeRing: fn(),
+    onAddRing: fn(),
+    onRemoveRing: fn(),
+    onToggleAdoptedSection: fn(),
+    onSave: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByDisplayValue("Techniques")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save configuration/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+};
+
+export const WithAdoptedSection: Story = {
+  args: {
+    hasAdoptedSection: true,
+  },
+};

--- a/packages/client/src/components/radar/RadarConfigTab.tsx
+++ b/packages/client/src/components/radar/RadarConfigTab.tsx
@@ -1,6 +1,7 @@
 import { Loader2, PlusIcon, TrashIcon } from "lucide-react";
 
 import { Input } from "@/components/input";
+import { Pill } from "@/components/radar/Pill";
 import {
   QuadrantsIllustration,
   RingsIllustration,
@@ -128,15 +129,15 @@ export function RadarConfigTab({
                 />
                 {r.isAdopted
                   ? (
-                    <span
-                      className={`
-                        rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px]
+                    <Pill
+                      className="
+                        rounded-sm bg-amber-100 px-1.5 text-[10px]
                         text-amber-900
-                      `}
+                      "
                       title="Hidden from radar chart, listed on the side"
                     >
                       Side panel
-                    </span>
+                    </Pill>
                   )
                   : (
                     <Button

--- a/packages/client/src/components/radar/RadarLegend.stories.tsx
+++ b/packages/client/src/components/radar/RadarLegend.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { RadarLegend } from "./RadarLegend";
+
+import {
+  makeBlip,
+  makeBlips,
+  makePositionedBlips,
+  makeQuadrants,
+  makeRings,
+} from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof RadarLegend> = {
+  component: RadarLegend,
+  args: {
+    quadrants: makeQuadrants(),
+    rings: makeRings(),
+    positionedBlips: makePositionedBlips(makeBlips(6)),
+    adoptedBlips: [
+      makeBlip({
+        id: "adopted-0",
+        topicName: "Jenkins",
+      }),
+    ],
+    adoptedSectionName: "Adopted",
+    ignoredBlips: [
+      makeBlip({
+        id: "ignored-0",
+        topicName: "Subversion",
+      }),
+    ],
+    activeBlipId: null,
+    selectedBlipId: null,
+    onDescriptionChange: fn(),
+    onHover: fn(),
+    onBlipClick: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+    await expect(canvas.getByText("Adopted")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/RadarLegend.tsx
+++ b/packages/client/src/components/radar/RadarLegend.tsx
@@ -4,10 +4,7 @@ import type { RadarBlip, RadarQuadrant, RadarRing } from "@emstack/types";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { QUADRANT_PALETTE } from "@/components/radar/radarLayout";
-import {
-  BlipLegendItem,
-  SimpleBlipLegendSection,
-} from "@/components/radar/radarLegendItem";
+import { BlipLegendSection } from "@/components/radar/radarLegendItem";
 
 interface RadarLegendProps {
   quadrants: RadarQuadrant[];
@@ -87,67 +84,56 @@ export function RadarLegend({
     >
       {quadrants.map((q, idx) => {
         const color = QUADRANT_PALETTE[idx % QUADRANT_PALETTE.length];
-        const items = positionedBlips.filter(
-          pb => pb.blip.quadrantId === q.id,
-        );
+        const items = positionedBlips
+          .filter(pb => pb.blip.quadrantId === q.id)
+          .map(({
+            blip, index,
+          }) => ({
+            blip,
+            label: (
+              <>
+                <span
+                  className="mr-1 inline-block font-mono text-xs"
+                  style={{
+                    color,
+                  }}
+                >
+                  {index}.
+                </span>
+                <span className="font-medium">{blip.topicName}</span>
+                <span className="ml-1 text-xs text-muted-foreground">
+                  ({ringNameById[blip.ringId ?? ""]})
+                </span>
+              </>
+            ),
+          }));
         return (
-          <div
+          <BlipLegendSection
             key={q.id}
-            className="flex flex-col gap-1"
-          >
-            <h4
-              className="text-sm font-semibold uppercase"
-              style={{
-                color,
-              }}
-            >
-              {q.name}
-            </h4>
-            {items.length === 0 && (
-              <p className="text-xs text-muted-foreground italic">
-                No blips yet.
-              </p>
-            )}
-            <ul className="flex flex-col gap-0.5">
-              {items.map(({
-                blip, index,
-              }) => (
-                <BlipLegendItem
-                  key={blip.id}
-                  blip={blip}
-                  isActive={activeBlipId === blip.id}
-                  isSelected={selectedBlipId === blip.id}
-                  registerRef={registerRef}
-                  onHover={onHover}
-                  onBlipClick={onBlipClick}
-                  onDescriptionChange={onDescriptionChange}
-                  label={
-                    <>
-                      <span
-                        className="mr-1 inline-block font-mono text-xs"
-                        style={{
-                          color,
-                        }}
-                      >
-                        {index}.
-                      </span>
-                      <span className="font-medium">{blip.topicName}</span>
-                      <span className="ml-1 text-xs text-muted-foreground">
-                        ({ringNameById[blip.ringId ?? ""]})
-                      </span>
-                    </>
-                  }
-                />
-              ))}
-            </ul>
-          </div>
+            title={q.name}
+            headingClassName="text-sm font-semibold uppercase"
+            headingStyle={{
+              color,
+            }}
+            items={items}
+            emptyMessage="No blips yet."
+            activeBlipId={activeBlipId}
+            selectedBlipId={selectedBlipId}
+            registerRef={registerRef}
+            onHover={onHover}
+            onBlipClick={onBlipClick}
+            onDescriptionChange={onDescriptionChange}
+          />
         );
       })}
       {adoptedBlips.length > 0 && (
-        <SimpleBlipLegendSection
+        <BlipLegendSection
           title={adoptedSectionName}
           headingClassName="text-sm font-semibold text-amber-700 uppercase"
-          blips={adoptedBlips}
+          items={adoptedBlips.map(blip => ({
+            blip,
+            label: <span className="font-medium">{blip.topicName}</span>,
+          }))}
           activeBlipId={activeBlipId}
           selectedBlipId={selectedBlipId}
           registerRef={registerRef}
@@ -157,10 +143,13 @@ export function RadarLegend({
         />
       )}
       {ignoredBlips.length > 0 && (
-        <SimpleBlipLegendSection
+        <BlipLegendSection
           title="Ignored"
           headingClassName="text-sm font-semibold text-gray-600 uppercase"
-          blips={ignoredBlips}
+          items={ignoredBlips.map(blip => ({
+            blip,
+            label: <span className="font-medium">{blip.topicName}</span>,
+          }))}
           activeBlipId={activeBlipId}
           selectedBlipId={selectedBlipId}
           registerRef={registerRef}

--- a/packages/client/src/components/radar/TopicMultiSelect.stories.tsx
+++ b/packages/client/src/components/radar/TopicMultiSelect.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "@storybook/test";
+
+import { TopicMultiSelect } from "./TopicMultiSelect";
+
+import { makeTopics } from "@/test-utils/radarFixtures";
+
+const options = makeTopics().map(t => ({
+  value: t.id,
+  label: t.name,
+}));
+
+const meta: Meta<typeof TopicMultiSelect> = {
+  component: TopicMultiSelect,
+  args: {
+    options,
+    value: ["topic-0", "topic-1"],
+    placeholder: "Add topics…",
+    onChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithSelection: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Kubernetes")).toBeInTheDocument();
+    await expect(canvas.getByText("Terraform")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: [],
+  },
+};

--- a/packages/client/src/components/radar/radarLegendItem.test.tsx
+++ b/packages/client/src/components/radar/radarLegendItem.test.tsx
@@ -1,0 +1,152 @@
+import type { RadarBlip } from "@emstack/types";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { BlipLegendItem, BlipLegendSection } from "./radarLegendItem";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function makeBlip(overrides: Partial<RadarBlip> = {}): RadarBlip {
+  return {
+    id: "blip-1",
+    domainId: "domain-1",
+    quadrantId: "q-1",
+    ringId: "r-1",
+    topicId: "topic-1",
+    topicName: "Kubernetes",
+    ...overrides,
+  };
+}
+
+const noopHandlers = {
+  registerRef: vi.fn(),
+  onHover: vi.fn(),
+  onBlipClick: vi.fn(),
+  onDescriptionChange: vi.fn(),
+};
+
+function renderSection(
+  props: Partial<React.ComponentProps<typeof BlipLegendSection>> = {},
+) {
+  return render(
+    <RouterStub>
+      <BlipLegendSection
+        title="Tools"
+        headingClassName="heading"
+        items={[]}
+        activeBlipId={null}
+        selectedBlipId={null}
+        {...noopHandlers}
+        {...props}
+      />
+    </RouterStub>,
+  );
+}
+
+// `RouterStub` mounts its children once the router finishes its initial load
+// (in an effect), so every assertion waits via an async `findBy*` query first.
+describe("BlipLegendSection", () => {
+  test("renders the heading and one row per item", async () => {
+    const a = makeBlip({
+      id: "a",
+      topicName: "Alpha",
+    });
+    const b = makeBlip({
+      id: "b",
+      topicName: "Beta",
+    });
+    renderSection({
+      items: [
+        {
+          blip: a,
+          label: <span>Alpha</span>,
+        },
+        {
+          blip: b,
+          label: <span>Beta</span>,
+        },
+      ],
+    });
+    expect(await screen.findByRole("heading", {
+      name: "Tools",
+    })).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
+
+  test("shows the empty message when there are no items", async () => {
+    renderSection({
+      items: [],
+      emptyMessage: "No blips yet.",
+    });
+    expect(await screen.findByText("No blips yet.")).toBeInTheDocument();
+  });
+
+  test("omits the empty message when none is provided", async () => {
+    renderSection({
+      items: [],
+    });
+    await screen.findByRole("heading", {
+      name: "Tools",
+    });
+    expect(screen.queryByText("No blips yet.")).not.toBeInTheDocument();
+  });
+
+  test("applies inline heading styles", async () => {
+    renderSection({
+      title: "Tools",
+      headingStyle: {
+        color: "rgb(255, 0, 0)",
+      },
+    });
+    expect(await screen.findByRole("heading", {
+      name: "Tools",
+    })).toHaveStyle({
+      color: "rgb(255, 0, 0)",
+    });
+  });
+});
+
+describe("BlipLegendItem", () => {
+  test("renders its label and fires onBlipClick", async () => {
+    const onBlipClick = vi.fn();
+    render(
+      <RouterStub>
+        <ul>
+          <BlipLegendItem
+            blip={makeBlip()}
+            label={<span>Kubernetes</span>}
+            isActive={false}
+            isSelected={false}
+            {...noopHandlers}
+            onBlipClick={onBlipClick}
+          />
+        </ul>
+      </RouterStub>,
+    );
+    fireEvent.click(await screen.findByText("Kubernetes"));
+    expect(onBlipClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the description subtext when present", async () => {
+    render(
+      <RouterStub>
+        <ul>
+          <BlipLegendItem
+            blip={makeBlip({
+              description: "A container orchestrator",
+            })}
+            label={<span>Kubernetes</span>}
+            isActive={false}
+            isSelected={false}
+            {...noopHandlers}
+          />
+        </ul>
+      </RouterStub>,
+    );
+    expect(
+      await screen.findByText("A container orchestrator"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/radar/radarLegendItem.tsx
+++ b/packages/client/src/components/radar/radarLegendItem.tsx
@@ -1,5 +1,5 @@
 import type { RadarBlip } from "@emstack/types";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 import { ArrowRightIcon } from "lucide-react";
@@ -24,35 +24,59 @@ interface BlipLegendItemProps extends BlipLegendHandlers {
   isSelected: boolean;
 }
 
-interface SimpleBlipLegendSectionProps extends BlipLegendHandlers {
+/** A blip plus its pre-built legend label, ready to render in a section. */
+export interface BlipLegendSectionItem {
+  blip: RadarBlip;
+  /** Inner content of the row's clickable title button. */
+  label: ReactNode;
+}
+
+interface BlipLegendSectionProps extends BlipLegendHandlers {
   title: string;
   /** className for the section heading (color varies by section). */
   headingClassName: string;
-  blips: RadarBlip[];
+  /** Inline heading styles — quadrant headings colour themselves this way. */
+  headingStyle?: CSSProperties;
+  items: BlipLegendSectionItem[];
+  /** Shown in place of the list when there are no items (e.g. quadrants). */
+  emptyMessage?: string;
   activeBlipId: string | null;
   selectedBlipId: string | null;
 }
 
 /**
- * A legend section that lists blips by topic name only (used by the adopted and
- * ignored groups, which differ solely by their heading text and color).
+ * A legend section: a coloured heading over a list of blip rows. Callers
+ * pre-build each row's `label`, so this renders the quadrant lists (index +
+ * name + ring), the adopted group, and the ignored group from one definition.
  */
-export function SimpleBlipLegendSection({
+export function BlipLegendSection({
   title,
   headingClassName,
-  blips,
+  headingStyle,
+  items,
+  emptyMessage,
   activeBlipId,
   selectedBlipId,
   registerRef,
   onHover,
   onBlipClick,
   onDescriptionChange,
-}: SimpleBlipLegendSectionProps) {
+}: BlipLegendSectionProps) {
   return (
     <div className="flex flex-col gap-1">
-      <h4 className={headingClassName}>{title}</h4>
+      <h4
+        className={headingClassName}
+        style={headingStyle}
+      >
+        {title}
+      </h4>
+      {items.length === 0 && emptyMessage !== undefined && (
+        <p className="text-xs text-muted-foreground italic">{emptyMessage}</p>
+      )}
       <ul className="flex flex-col gap-0.5">
-        {blips.map(blip => (
+        {items.map(({
+          blip, label,
+        }) => (
           <BlipLegendItem
             key={blip.id}
             blip={blip}
@@ -62,7 +86,7 @@ export function SimpleBlipLegendSection({
             onHover={onHover}
             onBlipClick={onBlipClick}
             onDescriptionChange={onDescriptionChange}
-            label={<span className="font-medium">{blip.topicName}</span>}
+            label={label}
           />
         ))}
       </ul>

--- a/packages/client/src/components/ui/SelectAllCheckbox.stories.tsx
+++ b/packages/client/src/components/ui/SelectAllCheckbox.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "@storybook/test";
+
+import { SelectAllCheckbox } from "./SelectAllCheckbox";
+
+const meta: Meta<typeof SelectAllCheckbox> = {
+  component: SelectAllCheckbox,
+  args: {
+    "aria-label": "Select all",
+    "checked": false,
+    "indeterminate": false,
+    "onCheckedChange": fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Unchecked: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole("checkbox", {
+      name: "Select all",
+    });
+    await expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("checkbox")).toBeChecked();
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    indeterminate: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole<HTMLInputElement>("checkbox");
+    await expect(checkbox.indeterminate).toBe(true);
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("checkbox")).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/ui/SelectAllCheckbox.test.tsx
+++ b/packages/client/src/components/ui/SelectAllCheckbox.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { SelectAllCheckbox } from "./SelectAllCheckbox";
+
+function renderCheckbox(props: Partial<React.ComponentProps<typeof SelectAllCheckbox>> = {}) {
+  const onCheckedChange = vi.fn();
+  render(
+    <SelectAllCheckbox
+      aria-label="Select all"
+      checked={false}
+      indeterminate={false}
+      onCheckedChange={onCheckedChange}
+      {...props}
+    />,
+  );
+  const checkbox = screen.getByRole("checkbox", {
+    name: "Select all",
+  }) as HTMLInputElement;
+  return {
+    checkbox,
+    onCheckedChange,
+  };
+}
+
+describe("SelectAllCheckbox", () => {
+  test("reflects the checked prop", () => {
+    const {
+      checkbox,
+    } = renderCheckbox({
+      checked: true,
+    });
+    expect(checkbox.checked).toBe(true);
+  });
+
+  test("applies the indeterminate prop to the DOM node", () => {
+    const {
+      checkbox,
+    } = renderCheckbox({
+      indeterminate: true,
+    });
+    expect(checkbox.indeterminate).toBe(true);
+  });
+
+  test("is not indeterminate when the prop is false", () => {
+    const {
+      checkbox,
+    } = renderCheckbox({
+      indeterminate: false,
+    });
+    expect(checkbox.indeterminate).toBe(false);
+  });
+
+  test("fires onCheckedChange with the next checked value", () => {
+    const {
+      checkbox, onCheckedChange,
+    } = renderCheckbox({
+      checked: false,
+    });
+    fireEvent.click(checkbox);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  test("honours the disabled prop", () => {
+    const {
+      checkbox,
+    } = renderCheckbox({
+      disabled: true,
+    });
+    expect(checkbox.disabled).toBe(true);
+  });
+});

--- a/packages/client/src/components/ui/SelectAllCheckbox.tsx
+++ b/packages/client/src/components/ui/SelectAllCheckbox.tsx
@@ -1,0 +1,42 @@
+interface SelectAllCheckboxProps {
+  "checked": boolean;
+  /**
+   * Whether to show the partial (dash) state. Call sites compute this
+   * differently — some as `!allSelected && someSelected`, some as a plain
+   * `someSelected` — so it's an explicit prop rather than derived here.
+   */
+  "indeterminate": boolean;
+  "onCheckedChange": (checked: boolean) => void;
+  "aria-label": string;
+  "disabled"?: boolean;
+  "className"?: string;
+}
+
+/**
+ * A "select all" header checkbox. The native `indeterminate` flag can only be
+ * set imperatively, so it's applied via a ref callback.
+ */
+export function SelectAllCheckbox({
+  checked,
+  indeterminate,
+  onCheckedChange,
+  disabled,
+  className,
+  "aria-label": ariaLabel,
+}: SelectAllCheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      className={className}
+      aria-label={ariaLabel}
+      checked={checked}
+      disabled={disabled}
+      ref={(el) => {
+        if (el) {
+          el.indeterminate = indeterminate;
+        }
+      }}
+      onChange={e => onCheckedChange(e.target.checked)}
+    />
+  );
+}

--- a/packages/client/src/test-utils/RouterStub.tsx
+++ b/packages/client/src/test-utils/RouterStub.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+/**
+ * Wraps `children` in a minimal in-memory TanStack Router so components that
+ * render `<Link>` can be exercised in isolation (tests and Storybook). It only
+ * provides router context — it does not match the app's real route tree, so
+ * navigation is a no-op; assert on rendered output and handlers, not routing.
+ */
+export function RouterStub({
+  children,
+}: { children: ReactNode }) {
+  const rootRoute = createRootRoute({
+    component: () => <>{children}</>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({
+      initialEntries: ["/"],
+    }),
+  });
+  // The stub router's tree is intentionally narrower than the registered app
+  // tree that types `<Link to>`, so the instance type won't line up — that's
+  // fine for a context-only provider.
+  return <RouterProvider router={router as never} />;
+}

--- a/packages/client/src/test-utils/radarFixtures.ts
+++ b/packages/client/src/test-utils/radarFixtures.ts
@@ -1,0 +1,142 @@
+import type { ResolvedLlmEntry } from "@/components/radar/blipLlmReview";
+import type { PositionedBlip } from "@/components/radar/radarLayout";
+import type {
+  RadarBlip,
+  RadarQuadrant,
+  RadarRing,
+  TopicForTopicsPage,
+} from "@emstack/types";
+
+/**
+ * Mock-data factories for radar Storybook stories and tests. Kept here (rather
+ * than duplicated per file) so every story builds blips/quadrants/rings the
+ * same way.
+ */
+
+const QUADRANT_NAMES = ["Techniques", "Tools", "Platforms", "Languages"];
+const RING_NAMES = ["Adopt", "Trial", "Assess", "Hold"];
+const TOPIC_NAMES = [
+  "Kubernetes",
+  "Terraform",
+  "Prometheus",
+  "GraphQL",
+  "Rust",
+  "Vitest",
+  "Playwright",
+  "OpenTelemetry",
+];
+
+export function makeQuadrants(count = 4): RadarQuadrant[] {
+  return Array.from({
+    length: count,
+  }, (_q, i) => ({
+    id: `q${i}`,
+    name: QUADRANT_NAMES[i] ?? `Quadrant ${i + 1}`,
+    position: i,
+  }));
+}
+
+export function makeRings(count = 4): RadarRing[] {
+  return Array.from({
+    length: count,
+  }, (_r, i) => ({
+    id: `r${i}`,
+    name: RING_NAMES[i] ?? `Ring ${i + 1}`,
+    position: i,
+  }));
+}
+
+export function makeBlip(
+  overrides: Partial<RadarBlip> & { id: string },
+): RadarBlip {
+  return {
+    domainId: "domain-1",
+    quadrantId: "q0",
+    ringId: "r0",
+    topicId: "topic-1",
+    topicName: "Kubernetes",
+    description: null,
+    ...overrides,
+  };
+}
+
+/** A spread of blips across the given quadrants/rings, with stable ids. */
+export function makeBlips(
+  count = 6,
+  quadrants = makeQuadrants(),
+  rings = makeRings(),
+): RadarBlip[] {
+  return Array.from({
+    length: count,
+  }, (_b, i) => makeBlip({
+    id: `blip-${i}`,
+    topicId: `topic-${i}`,
+    topicName: TOPIC_NAMES[i] ?? `Topic ${i + 1}`,
+    quadrantId: quadrants[i % quadrants.length]?.id ?? null,
+    ringId: rings[i % rings.length]?.id ?? null,
+    description: i % 2 === 0 ? `Notes about ${TOPIC_NAMES[i] ?? "topic"}` : null,
+  }));
+}
+
+export function makeTopics(count = 6): TopicForTopicsPage[] {
+  return Array.from({
+    length: count,
+  }, (_t, i) => ({
+    id: `topic-${i}`,
+    name: TOPIC_NAMES[i] ?? `Topic ${i + 1}`,
+    description: `Description for ${TOPIC_NAMES[i] ?? `topic ${i + 1}`}`,
+    resourceCount: i,
+    taskCount: i % 3,
+    dailyCount: i % 2,
+  }));
+}
+
+/** Lays the blips out on a simple grid so SVG/legend stories have positions. */
+export function makePositionedBlips(
+  blips = makeBlips(),
+  size = 400,
+): PositionedBlip[] {
+  const center = size / 2;
+  return blips.map((blip, index) => ({
+    blip,
+    x: center + (index % 2 === 0 ? 1 : -1) * (40 + index * 12),
+    y: center + (index % 3 === 0 ? 1 : -1) * (30 + index * 10),
+    index: index + 1,
+  }));
+}
+
+export function makeResolvedEntry(
+  overrides: Partial<ResolvedLlmEntry> = {},
+): ResolvedLlmEntry {
+  return {
+    topicName: "Kubernetes",
+    matchedTopicId: "topic-0",
+    willCreateTopic: false,
+    quadrantInput: "Tools",
+    ringInput: "Adopt",
+    description: "Container orchestration",
+    radarNote: "Standardized across teams",
+    quadrantId: "q1",
+    ringId: "r0",
+    existingBlipId: null,
+    existingQuadrantId: null,
+    existingRingId: null,
+    existingRadarNote: null,
+    existingTopicDescription: null,
+    topicCourseCount: 0,
+    topicTaskCount: 0,
+    topicDailyCount: 0,
+    resolution: "create",
+    deleteTopicOnRemove: false,
+    editing: false,
+    editDraft: null,
+    selected: false,
+    problems: [],
+    ...overrides,
+  };
+}
+
+/** Build an id→item lookup map (quadrantById / ringById / topicById). */
+export function byId<T extends { id: string }>(items: T[]): Map<string, T> {
+  return new Map(items.map(item => [item.id, item]));
+}

--- a/packages/client/src/vitest.d.ts
+++ b/packages/client/src/vitest.d.ts
@@ -1,0 +1,5 @@
+// Augments Vitest's `expect` with the jest-dom matchers (toBeInTheDocument,
+// toHaveStyle, …). The matchers are registered at runtime in setupTests.js;
+// this brings their types into the test files.
+// eslint-disable-next-line import/no-unassigned-import
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## ELI5
The radar feature had several bits of look-alike code copy-pasted across files. This tidies those up into a few shared pieces so there's one place to change each, and adds a "living catalog" entry (a Storybook story) for every radar component so you can see and exercise each one in isolation.

## Summary
- **Consolidate duplicated UI**: extract a shared `SelectAllCheckbox` primitive (the indeterminate header checkbox was duplicated in `BlipLlmReviewTable`, `BlipTable`, and `boxes/TopicsTable`), generalize `SimpleBlipLegendSection` → one `BlipLegendSection` for the quadrant/adopted/ignored lists, and collapse hand-rolled mini-badges onto the existing `Pill` (widened to forward native span props).
- **Full story + test coverage**: every component in `components/radar` now has a co-located Storybook story (which run as browser smoke tests), plus unit tests for the extracted pieces. Adds shared `test-utils` (`RouterStub`, `radarFixtures`) and `vitest.d.ts` to type jest-dom matchers. Tests are co-located per the package convention.
- **New `condense-components` skill** documenting the workflow and the gotchas learned here (host-element wrappers, `meta` typing for `fn()`, the storybook runner `--no-file-parallelism` flake).

## Test plan
- [ ] `pnpm --filter=@emstack/client exec tsc --noEmit -p tsconfig.app.json` — clean
- [ ] `pnpm --filter=@emstack/client exec vitest run --project=unit-tests src/components` — 121 passing
- [ ] `pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism` — all stories render (23 files / 47 tests)
- [ ] `pnpm exec eslint` (from repo root) on the changed files — clean
- [ ] `pnpm storybook` — eyeball the new radar stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)