### PR TITLE
feat(client): add tile settings and auto-height to changelog card

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
@@ -1,3 +1,4 @@
+import type { DashboardTileProps } from "./-dashboardTileMeta";
 import type { ReactNode } from "react";
 
 // Bundled at build time from the repo-root CHANGELOG.md (the `@root` Vite
@@ -9,6 +10,8 @@ import type { ReactNode } from "react";
 import changelogMarkdown from "@root/CHANGELOG.md?raw";
 
 import { parseChangelog } from "./-changelog";
+import { CardSettingsFlyout } from "./-DashboardCardSettings";
+import { isAutoHeight } from "./-dashboardTileMeta";
 
 import { DashboardCard } from "@/components/boxes/DashboardCard";
 
@@ -86,9 +89,13 @@ function renderInline(text: string): ReactNode[] {
   return nodes;
 }
 
-export function DashboardChangelog() {
+export function DashboardChangelog({
+  tile,
+  onUpdateTile,
+}: DashboardTileProps) {
   return (
     <DashboardCard
+      autoHeight={isAutoHeight(tile)}
       title="Changelog"
       action={(
         <a
@@ -102,6 +109,12 @@ export function DashboardChangelog() {
         >
           View on GitHub
         </a>
+      )}
+      settings={(
+        <CardSettingsFlyout
+          tile={tile}
+          onUpdateTile={onUpdateTile}
+        />
       )}
     >
       {releases.length === 0


### PR DESCRIPTION
## Summary
Adds configurable tile settings and auto-height support to the DashboardChangelog component, bringing it in line with other dashboard cards that support customization.

## Key Changes
- Updated `DashboardChangelog` to accept `DashboardTileProps` (tile configuration and update callback)
- Added `CardSettingsFlyout` to the changelog card's action menu, enabling users to customize tile settings
- Integrated `isAutoHeight` utility to respect the tile's auto-height configuration
- Added necessary imports for tile metadata and settings components

## Implementation Details
The changelog card now participates in the dashboard's tile customization system. The `autoHeight` prop is passed to `DashboardCard` based on the tile's configuration, and the settings flyout allows users to modify tile behavior without requiring code changes.

https://claude.ai/code/session_01Gwq9dtJdaqBUihz9L3yjqy