### PR TITLE
refactor(client): reduce minimum width for dashboard tiles

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
+++ b/packages/client/src/routes/dashboard.-components/-dashboardTileMeta.ts
@@ -21,12 +21,12 @@ export interface DashboardTileMeta {
 export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
   doNow: {
     title: "Do Now",
-    minW: 2,
+    minW: 1,
     minH: 4,
   },
   doneForDay: {
     title: "Done for the Day",
-    minW: 2,
+    minW: 1,
     minH: 4,
   },
   underutilizedProviders: {
@@ -56,7 +56,7 @@ export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
   },
   readwise: {
     title: "Readwise",
-    minW: 2,
+    minW: 1,
     minH: 4,
   },
   todoist: {
@@ -71,7 +71,7 @@ export const TILE_META: Record<DashboardTileId, DashboardTileMeta> = {
   },
   changelog: {
     title: "Changelog",
-    minW: 2,
+    minW: 1,
     minH: 4,
   },
 };


### PR DESCRIPTION
## Summary
Reduces the minimum width constraint for several dashboard tiles to improve layout flexibility and space utilization on smaller screens.

## Changes
- Reduced `minW` from 2 to 1 for the following tiles:
  - "Do Now"
  - "Done for the Day"
  - "Readwise"
  - "Changelog"

## Details
These tiles previously required a minimum width of 2 grid units, which may have been unnecessarily restrictive for responsive layouts. Lowering the constraint to 1 unit allows for more flexible dashboard arrangements while maintaining the minimum height of 4 units for each tile.

https://claude.ai/code/session_01DqEVh6AQutpLQ2WRs8HSUW