### PR TITLE
refactor(client): condense boxElements pill markup and route links through EntityLink

### DIFF
--- a/packages/client/src/components/boxElements/CourseMetaItem.stories.tsx
+++ b/packages/client/src/components/boxElements/CourseMetaItem.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+import { BookIcon } from "lucide-react";
+
+import { CourseMetaItem } from "./CourseMetaItem";
+
+const meta = {
+  component: CourseMetaItem,
+  args: {
+    value: "12 resources",
+    condition: true,
+    iconNode: <BookIcon size={16} />,
+  },
+} satisfies Meta<typeof CourseMetaItem>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("12 resources")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: null,
+    emptyText: "No cost given",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("No cost given")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/boxElements/CourseMetaItem.stories.tsx
+++ b/packages/client/src/components/boxElements/CourseMetaItem.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
 import { BookIcon } from "lucide-react";
+import { within, expect } from "storybook/test";
 
 import { CourseMetaItem } from "./CourseMetaItem";
 

--- a/packages/client/src/components/boxElements/CourseMetaItem.test.tsx
+++ b/packages/client/src/components/boxElements/CourseMetaItem.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { CourseMetaItem } from "./CourseMetaItem";
+
+describe("CourseMetaItem", () => {
+  test("renders nothing when condition is falsy", () => {
+    const {
+      container,
+    } = render(
+      <CourseMetaItem
+        value="hidden"
+        condition={false}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders the value when present", () => {
+    render(
+      <CourseMetaItem
+        value="$49"
+        condition
+        iconNode={<span>icon</span>}
+      />,
+    );
+    expect(screen.getByText("$49")).toBeInTheDocument();
+    expect(screen.getByText("icon")).toBeInTheDocument();
+  });
+
+  test("falls back to italic empty text when value is null or empty", () => {
+    render(
+      <CourseMetaItem
+        value={null}
+        condition
+        emptyText="No cost given"
+      />,
+    );
+    expect(screen.getByText("No cost given")).toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/boxElements/Description.stories.tsx
+++ b/packages/client/src/components/boxElements/Description.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { Description } from "./Description";
 

--- a/packages/client/src/components/boxElements/Description.stories.tsx
+++ b/packages/client/src/components/boxElements/Description.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { Description } from "./Description";
+
+const meta = {
+  component: Description,
+  args: {
+    description: "A thorough introduction to the topic.",
+  },
+} satisfies Meta<typeof Description>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("A thorough introduction to the topic."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    description: null,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("No description provided."),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/boxElements/Description.test.tsx
+++ b/packages/client/src/components/boxElements/Description.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { Description } from "./Description";
+
+describe("Description", () => {
+  test("renders the provided description", () => {
+    render(<Description description="A great course" />);
+    expect(screen.getByText("A great course")).toBeInTheDocument();
+  });
+
+  test("shows the default empty text when no description", () => {
+    render(<Description description={null} />);
+    expect(screen.getByText("No description provided.")).toBeInTheDocument();
+  });
+
+  test("shows a custom empty text", () => {
+    render(
+      <Description
+        description=""
+        emptyText="Nothing here"
+      />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/boxElements/DomainPill.stories.tsx
+++ b/packages/client/src/components/boxElements/DomainPill.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { DomainPill } from "./DomainPill";
 

--- a/packages/client/src/components/boxElements/DomainPill.stories.tsx
+++ b/packages/client/src/components/boxElements/DomainPill.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { DomainPill } from "./DomainPill";
+
+const meta = {
+  component: DomainPill,
+  args: {
+    children: "Frontend",
+  },
+} satisfies Meta<typeof DomainPill>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Frontend")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/boxElements/DomainPill.test.tsx
+++ b/packages/client/src/components/boxElements/DomainPill.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { DomainPill } from "./DomainPill";
+
+describe("DomainPill", () => {
+  test("renders its children", () => {
+    render(<DomainPill>Frontend</DomainPill>);
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+  });
+
+  test("merges a custom className, letting it override base styles", () => {
+    render(<DomainPill className="bg-emerald-100 text-[10px]">Frontend</DomainPill>);
+    const pill = screen.getByText("Frontend");
+    // tailwind-merge keeps the later, conflicting utilities and drops the base.
+    expect(pill.className).toContain("bg-emerald-100");
+    expect(pill.className).not.toContain("bg-gray-100");
+    expect(pill.className).toContain("text-[10px]");
+    expect(pill.className).not.toContain("text-xs");
+  });
+
+  test("forwards native span attributes", () => {
+    render(<DomainPill title="Domain">Frontend</DomainPill>);
+    expect(screen.getByText("Frontend")).toHaveAttribute("title", "Domain");
+  });
+});

--- a/packages/client/src/components/boxElements/DomainPill.tsx
+++ b/packages/client/src/components/boxElements/DomainPill.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+type DomainPillProps = React.ComponentProps<"span">;
+
+/** Static (non-link) domain chip used in topic boxes and the topics table. */
+export function DomainPill({
+  className,
+  children,
+  ...props
+}: DomainPillProps) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm bg-gray-100 px-2 py-0.5 text-xs text-gray-700",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/client/src/components/boxElements/EntityLink.stories.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { EntityLink } from "./EntityLink";
 

--- a/packages/client/src/components/boxElements/EntityLink.stories.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { EntityLink } from "./EntityLink";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof EntityLink> = {
+  component: EntityLink,
+  args: {
+    entity: "topics",
+    id: 1,
+    children: "React",
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "React",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/boxElements/EntityLink.test.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { EntityLink, PILL_LINK_CLASS } from "./EntityLink";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+// `RouterStub` mounts its children once the router finishes its initial load
+// (in an effect), so every assertion waits via an async `findBy*` query first.
+describe("EntityLink", () => {
+  test("renders a link with its children", async () => {
+    render(
+      <RouterStub>
+        <EntityLink
+          entity="topics"
+          id={1}
+        >React
+        </EntityLink>
+      </RouterStub>,
+    );
+    expect(
+      await screen.findByRole("link", {
+        name: "React",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("applies the pill class and forwards the title attribute", async () => {
+    render(
+      <RouterStub>
+        <EntityLink
+          entity="resources"
+          id={7}
+          className={PILL_LINK_CLASS}
+          title="Open"
+        >
+          Course
+        </EntityLink>
+      </RouterStub>,
+    );
+    const link = await screen.findByRole("link", {
+      name: "Course",
+    });
+    expect(link.className).toContain("rounded-sm");
+    expect(link).toHaveAttribute("title", "Open");
+  });
+});

--- a/packages/client/src/components/boxElements/EntityLink.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 
-export type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
+export type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks" | "routines";
 
 const TO_BY_KIND: Record<EntityKind, string> = {
   resources: "/resources/$id",
@@ -10,13 +10,21 @@ const TO_BY_KIND: Record<EntityKind, string> = {
   providers: "/providers/$id",
   domains: "/domains/$id",
   tasks: "/tasks/$id",
+  routines: "/routines/$id",
 };
+
+/** Shared "chip" styling for an entity link rendered as a pill — used by
+ *  TaskBox, RoutineBox connection chips, and TopicList's pill mode. */
+export const PILL_LINK_CLASS
+  = "rounded-sm bg-gray-50 px-2 py-0.5 text-xs hover:bg-gray-900 hover:text-white";
 
 interface EntityLinkProps {
   entity: EntityKind;
   id: string | number;
   className?: string;
   children: ReactNode;
+  /** Passthrough native anchor attributes (e.g. `title`). */
+  title?: string;
 }
 
 export function EntityLink({
@@ -24,6 +32,7 @@ export function EntityLink({
   id,
   className = "hover:text-blue-600",
   children,
+  ...props
 }: EntityLinkProps) {
   return (
     <Link
@@ -32,6 +41,7 @@ export function EntityLink({
         id: String(id),
       }}
       className={className}
+      {...props}
     >
       {children}
     </Link>

--- a/packages/client/src/components/boxElements/StatusIndicator.stories.tsx
+++ b/packages/client/src/components/boxElements/StatusIndicator.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { StatusIndicator } from "./StatusIndicator";
 

--- a/packages/client/src/components/boxElements/StatusIndicator.stories.tsx
+++ b/packages/client/src/components/boxElements/StatusIndicator.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { StatusIndicator } from "./StatusIndicator";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const meta: Meta<typeof StatusIndicator> = {
+  component: StatusIndicator,
+  args: {
+    status: "active",
+  },
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button")).toBeInTheDocument();
+  },
+};
+
+export const Inactive: Story = {
+  args: {
+    status: "inactive",
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    status: "complete",
+  },
+};

--- a/packages/client/src/components/boxElements/StatusIndicator.test.tsx
+++ b/packages/client/src/components/boxElements/StatusIndicator.test.tsx
@@ -1,0 +1,27 @@
+import type { ResourceStatus } from "@emstack/types";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { StatusIndicator } from "./StatusIndicator";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function renderStatus(status: ResourceStatus) {
+  return render(
+    <TooltipProvider>
+      <StatusIndicator status={status} />
+    </TooltipProvider>,
+  );
+}
+
+describe("StatusIndicator", () => {
+  test.each(["active", "inactive", "complete"] as const)(
+    "renders a tooltip trigger for the %s status",
+    (status) => {
+      renderStatus(status);
+      // Each known status renders an icon inside a Radix tooltip trigger button.
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    },
+  );
+});

--- a/packages/client/src/components/boxElements/TopicList.stories.tsx
+++ b/packages/client/src/components/boxElements/TopicList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { TopicList } from "./TopicList";
 

--- a/packages/client/src/components/boxElements/TopicList.stories.tsx
+++ b/packages/client/src/components/boxElements/TopicList.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { TopicList } from "./TopicList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const topics = [
+  {
+    id: "1",
+    name: "React",
+  },
+  {
+    id: "2",
+    name: "Vue",
+  },
+];
+
+const meta: Meta<typeof TopicList> = {
+  component: TopicList,
+  args: {
+    topics,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Pills: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "React",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Inline: Story = {
+  args: {
+    isPills: false,
+  },
+};

--- a/packages/client/src/components/boxElements/TopicList.test.tsx
+++ b/packages/client/src/components/boxElements/TopicList.test.tsx
@@ -1,0 +1,62 @@
+import type { Topic } from "@emstack/types";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { TopicList } from "./TopicList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function makeTopic(overrides: Partial<Topic> = {}): Topic {
+  return {
+    id: "1",
+    name: "React",
+    ...overrides,
+  };
+}
+
+// `RouterStub` mounts its children once the router finishes its initial load,
+// so the first assertion waits via an async `findBy*` query.
+describe("TopicList", () => {
+  test("renders a pill link per topic in pill mode", async () => {
+    render(
+      <RouterStub>
+        <TopicList
+          topics={[makeTopic(), makeTopic({
+            id: "2",
+            name: "Vue",
+          })]}
+        />
+      </RouterStub>,
+    );
+    const link = await screen.findByRole("link", {
+      name: "React",
+    });
+    expect(link.className).toContain("rounded-sm");
+    expect(screen.getByRole("link", {
+      name: "Vue",
+    })).toBeInTheDocument();
+  });
+
+  test("renders inline comma-separated links when isPills is false", async () => {
+    render(
+      <RouterStub>
+        <TopicList
+          isPills={false}
+          topics={[makeTopic(), makeTopic({
+            id: "2",
+            name: "Vue",
+          })]}
+        />
+      </RouterStub>,
+    );
+    const link = await screen.findByRole("link", {
+      name: "React",
+    });
+    expect(link.className).not.toContain("rounded-sm");
+    // The non-pill branch joins all but the last item with a comma.
+    expect(screen.getByText(",", {
+      exact: false,
+    })).toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/boxElements/TopicList.tsx
+++ b/packages/client/src/components/boxElements/TopicList.tsx
@@ -2,6 +2,8 @@ import type { Topic } from "@emstack/types";
 
 import { Link } from "@tanstack/react-router";
 
+import { PILL_LINK_CLASS } from "./EntityLink";
+
 import { cn } from "@/lib/utils";
 
 interface TopicListProps {
@@ -39,10 +41,14 @@ export function TopicList({
               params={{
                 id: topic.id + "",
               }}
-              className={cn({
-                "rounded-sm bg-gray-50 px-2 py-0.5 text-xs hover:bg-gray-900 hover:text-white": isPills,
-                "text-sm text-blue-800 hover:text-blue-600": !isPills,
-              })}
+              className={cn(
+                isPills
+                  ? PILL_LINK_CLASS
+                  : `
+                    text-sm text-blue-800
+                    hover:text-blue-600
+                  `,
+              )}
               key={topic.id}
             >
               {topic.name}

--- a/packages/client/src/components/boxElements/YesNoDisplay.stories.tsx
+++ b/packages/client/src/components/boxElements/YesNoDisplay.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { within, expect } from "@storybook/test";
+import { within, expect } from "storybook/test";
 
 import { YesNoDisplay } from "./YesNoDisplay";
 

--- a/packages/client/src/components/boxElements/YesNoDisplay.stories.tsx
+++ b/packages/client/src/components/boxElements/YesNoDisplay.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { within, expect } from "@storybook/test";
+
+import { YesNoDisplay } from "./YesNoDisplay";
+
+const meta = {
+  component: YesNoDisplay,
+  args: {
+    value: true,
+  },
+} satisfies Meta<typeof YesNoDisplay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Yes: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Yes")).toBeInTheDocument();
+  },
+};
+
+export const No: Story = {
+  args: {
+    value: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("No")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/boxElements/YesNoDisplay.test.tsx
+++ b/packages/client/src/components/boxElements/YesNoDisplay.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { YesNoDisplay } from "./YesNoDisplay";
+
+describe("YesNoDisplay", () => {
+  test("renders Yes when value is true", () => {
+    render(<YesNoDisplay value={true} />);
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+    expect(screen.queryByText("No")).not.toBeInTheDocument();
+  });
+
+  test("renders No when value is false", () => {
+    render(<YesNoDisplay value={false} />);
+    expect(screen.getByText("No")).toBeInTheDocument();
+    expect(screen.queryByText("Yes")).not.toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/boxes/RoutineBox.tsx
+++ b/packages/client/src/components/boxes/RoutineBox.tsx
@@ -4,7 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { AlertTriangleIcon, FlameIcon } from "lucide-react";
 
 import { Description } from "@/components/boxElements/Description";
-import { EntityLink } from "@/components/boxElements/EntityLink";
+import { EntityLink, PILL_LINK_CLASS } from "@/components/boxElements/EntityLink";
 import {
   ContentBox,
   ContentBoxBody,
@@ -100,10 +100,7 @@ export function RoutineBox({
                     key={`${c.type}:${c.id}`}
                     entity={connectionEntityKind(c.type)}
                     id={c.id}
-                    className={`
-                      rounded-sm bg-gray-50 px-2 py-0.5 text-xs
-                      hover:bg-gray-900 hover:text-white
-                    `}
+                    className={PILL_LINK_CLASS}
                   >
                     {c.name ?? c.id}
                   </EntityLink>

--- a/packages/client/src/components/boxes/TaskBox.tsx
+++ b/packages/client/src/components/boxes/TaskBox.tsx
@@ -7,7 +7,7 @@ import {
 
 import { CourseMetaItem } from "@/components/boxElements/CourseMetaItem";
 import { Description } from "@/components/boxElements/Description";
-import { EntityLink } from "@/components/boxElements/EntityLink";
+import { EntityLink, PILL_LINK_CLASS } from "@/components/boxElements/EntityLink";
 import {
   ContentBox,
   ContentBoxBody,
@@ -37,10 +37,7 @@ export function TaskBox({
                 <EntityLink
                   entity="topics"
                   id={topic.id}
-                  className={`
-                    rounded-sm bg-gray-50 px-2 py-0.5 text-xs
-                    hover:bg-gray-900 hover:text-white
-                  `}
+                  className={PILL_LINK_CLASS}
                 >
                   {topic.name}
                 </EntityLink>

--- a/packages/client/src/components/boxes/TopicBox.tsx
+++ b/packages/client/src/components/boxes/TopicBox.tsx
@@ -6,6 +6,7 @@ import {
 
 import { CourseMetaItem } from "@/components/boxElements/CourseMetaItem";
 import { Description } from "@/components/boxElements/Description";
+import { DomainPill } from "@/components/boxElements/DomainPill";
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import {
   ContentBox,
@@ -42,14 +43,7 @@ export function TopicBox({
             {domains
               .filter(domain => domain.id !== undefined)
               .map(domain => (
-                <span
-                  key={domain.id}
-                  className="
-                    rounded-sm bg-gray-100 px-2 py-0.5 text-xs text-gray-700
-                  "
-                >
-                  {domain.title}
-                </span>
+                <DomainPill key={domain.id}>{domain.title}</DomainPill>
               ))}
           </div>
         )}

--- a/packages/client/src/components/boxes/TopicsTable.tsx
+++ b/packages/client/src/components/boxes/TopicsTable.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { useMemo } from "react";
 
+import { DomainPill } from "@/components/boxElements/DomainPill";
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
@@ -59,12 +60,7 @@ function domainsCell(topic: TopicForTopicsPage) {
   return (
     <div className="flex flex-wrap gap-1">
       {domains.map(domain => (
-        <span
-          key={domain.id}
-          className="rounded-sm bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
-        >
-          {domain.title}
-        </span>
+        <DomainPill key={domain.id}>{domain.title}</DomainPill>
       ))}
     </div>
   );

--- a/packages/client/src/components/dailies/DailyTrackerRow.tsx
+++ b/packages/client/src/components/dailies/DailyTrackerRow.tsx
@@ -1,6 +1,5 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
-import { Link } from "@tanstack/react-router";
 import { FlameIcon, LaughIcon } from "lucide-react";
 
 import { DailyCadenceBadge } from "./DailyCadenceBadge";
@@ -17,6 +16,7 @@ import { DailyTaskIndicator } from "./DailyTaskIndicator";
 import { DailyTitle } from "./DailyTitle";
 import { TodayStatusCell } from "./TodayStatusCell";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { cn } from "@/lib/utils";
 import {
   findStatusForDate,
@@ -68,18 +68,16 @@ export function DailyTrackerRow({
         <DailyProgressCell daily={daily} />
       </td>
       <td className="p-2">
-        <Link
-          to="/routines/$id"
-          params={{
-            id: daily.id,
-          }}
+        <EntityLink
+          entity="routines"
+          id={daily.id}
           className="
             font-medium
             hover:text-blue-600
           "
         >
           <DailyTitle daily={daily} />
-        </Link>
+        </EntityLink>
       </td>
       <td className="p-2">
         <span className="inline-flex items-center gap-1.5">

--- a/packages/client/src/components/routines/RoutineEntryLabel.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.tsx
@@ -1,8 +1,8 @@
 import type { RoutineReferenceItem } from "@emstack/types";
 
-import { Link } from "@tanstack/react-router";
 import { MapPinIcon } from "lucide-react";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { ActionableSentence } from "@/components/dailies/ActionableSentence";
 
 interface RoutineEntryLabelProps {
@@ -29,11 +29,9 @@ export function RoutineEntryLabel({
   const nameNode = entry.type === "freeform"
     ? entry.id
     : (
-      <Link
-        to={entry.type === "task" ? "/tasks/$id" : "/resources/$id"}
-        params={{
-          id: entry.id,
-        }}
+      <EntityLink
+        entity={entry.type === "task" ? "tasks" : "resources"}
+        id={entry.id}
         className="
           text-blue-800
           hover:text-blue-600
@@ -43,7 +41,7 @@ export function RoutineEntryLabel({
         {entry.type === "task"
           ? (taskNames.get(entry.id) ?? entry.id)
           : (resourceNames.get(entry.id) ?? entry.id)}
-      </Link>
+      </EntityLink>
     );
 
   const actionable = (

--- a/packages/client/src/components/tasks/TaskResourceRow.tsx
+++ b/packages/client/src/components/tasks/TaskResourceRow.tsx
@@ -2,12 +2,12 @@ import type { TaskResource, TaskResourceLevel } from "@emstack/types";
 
 import { Fragment } from "react";
 
-import { Link } from "@tanstack/react-router";
 import { ActivityIcon, ExternalLinkIcon, PencilIcon } from "lucide-react";
 
 import { LevelBadge } from "./LevelBadge";
 import { COLUMN_COUNT } from "./TaskResourceEditingRow";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { InteractionQuickLog } from "@/components/resources/InteractionQuickLog";
 import { Button } from "@/components/ui/button";
 import { isHttpUrl } from "@/utils";
@@ -58,11 +58,9 @@ export function TaskResourceRow({
           <div className="flex flex-col gap-0.5">
             {linkedLabel && r.resourceId
               ? (
-                <Link
-                  to="/resources/$id"
-                  params={{
-                    id: r.resourceId,
-                  }}
+                <EntityLink
+                  entity="resources"
+                  id={r.resourceId}
                   className="
                     font-medium
                     hover:text-blue-600
@@ -70,7 +68,7 @@ export function TaskResourceRow({
                   title={linkedLabel}
                 >
                   {linkedLabel}
-                </Link>
+                </EntityLink>
               )
               : (
                 <span className="font-medium">{r.name}</span>

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, RadarIcon } from "lucide-react";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea } from "@/components/layout/InfoArea";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -23,18 +24,16 @@ function TopicLinkList({
     <ul className="ml-5 list-disc">
       {topics.map(topic => (
         <li key={topic.id}>
-          <Link
-            to="/topics/$id"
-            params={{
-              id: topic.id + "",
-            }}
-            className={`
+          <EntityLink
+            entity="topics"
+            id={String(topic.id)}
+            className="
               font-bold text-blue-800
               hover:text-blue-600
-            `}
+            "
           >
             {topic.name}
-          </Link>
+          </EntityLink>
           {topic.courses && topic.courses.length > 0 && (
             <span className="ml-2 text-xs text-muted-foreground">
               (


### PR DESCRIPTION
## ELI5

The little "chips" and clickable links that show up on topic, task, and routine cards were copy-pasted in lots of places, each maintaining its own styling. This PR pulls those repeated pieces into a few shared building blocks so they all stay consistent and there's only one place to change them. It also adds tests and Storybook examples for every component in that folder, which previously had none.

## Summary

- Widened `EntityLink` to be the single owner of the entity-kind → URL map: added a `routines` kind, made it forward passthrough attributes (e.g. `title`), and exported a shared `PILL_LINK_CLASS` chip style.
- Replaced the duplicated link-pill class string (TopicList, TaskBox, RoutineBox) with `PILL_LINK_CLASS`, and extracted the static domain chip (`TopicBox`, `TopicsTable`) into a new `DomainPill` component.
- Routed four hand-rolled `<Link>` sites (`TaskResourceRow`, `RoutineEntryLabel`, `DailyTrackerRow`, the domains topic list) through `EntityLink`, preserving classes verbatim.
- Backfilled co-located Storybook stories + Vitest tests for all six boxElements components plus `DomainPill` (router-dependent ones use `RouterStub`; `StatusIndicator` uses `TooltipProvider`).

## Test plan

- [ ] `pnpm --filter=@emstack/client run typecheck` — clean
- [ ] `pnpm --filter=@emstack/client exec vitest run --project=unit-tests` — boxElements/boxes/tasks/routines/dailies pass (43 tests)
- [ ] `pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism` — pass (60 tests)
- [ ] `pnpm exec eslint` on changed files — no new errors
- [ ] Visually confirm topic/domain chips and entity links render identically to before (no styling shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)