### PR TITLE
style(client): add text-sm to dashboard article and task titles

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
@@ -72,14 +72,18 @@ function ArticleList({
                   target="_blank"
                   rel="noreferrer"
                   className="
-                    truncate font-medium
+                    truncate text-sm font-medium
                     hover:text-blue-600
                   "
                 >
                   {doc.title}
                 </a>
               )
-              : <span className="truncate font-medium">{doc.title}</span>}
+              : (
+                <span className="truncate text-sm font-medium">
+                  {doc.title}
+                </span>
+              )}
             <ArticleMeta doc={doc} />
           </div>
           {!!doc.url && (

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
@@ -85,7 +85,7 @@ function TaskList({
                 target="_blank"
                 rel="noreferrer"
                 className="
-                  truncate font-medium
+                  truncate text-sm font-medium
                   hover:text-blue-600
                 "
               >


### PR DESCRIPTION
## Summary
Adds consistent `text-sm` font sizing to article and task titles in the dashboard components to improve visual hierarchy and readability.

## Changes
- **DashboardReadwise.tsx:** Added `text-sm` class to both linked and non-linked article title elements
- **DashboardTodoist.tsx:** Added `text-sm` class to task title link element
- Improved code formatting in DashboardReadwise by wrapping the non-linked title span in parentheses for consistency

## Details
These changes ensure that article and task titles throughout the dashboard maintain a consistent, slightly smaller font size (`text-sm`) while preserving the existing `font-medium` weight and `truncate` behavior. This creates better visual distinction between titles and metadata/supporting information.

https://claude.ai/code/session_019Htas3jUzQbCck6cBRtER5