### PR TITLE
refactor(client): reduce imports in list/index route pages

### DIFF
--- a/packages/client/src/components/boxes/index.ts
+++ b/packages/client/src/components/boxes/index.ts
@@ -1,0 +1,15 @@
+// Barrel for the box / table components so a page that renders two or three of
+// them imports from one module. Boxes import their siblings via direct file
+// paths (never this index), so this re-export barrel introduces no cycle.
+/* eslint-disable import/max-dependencies -- aggregator barrel; re-exports only */
+export { ContentBox } from "./ContentBox";
+export { CourseBox } from "./CourseBox";
+export { CoursesTable } from "./CoursesTable";
+export { DashboardCard } from "./DashboardCard";
+export { DomainBox } from "./DomainBox";
+export { OverviewCardGrid } from "./OverviewCardGrid";
+export { ProviderBox } from "./ProviderBox";
+export { RoutineBox } from "./RoutineBox";
+export { TaskBox } from "./TaskBox";
+export { TopicBox } from "./TopicBox";
+export { TopicsTable, type TopicsTableSort } from "./TopicsTable";

--- a/packages/client/src/components/boxes/index.ts
+++ b/packages/client/src/components/boxes/index.ts
@@ -1,13 +1,10 @@
 // Barrel for the box / table components so a page that renders two or three of
 // them imports from one module. Boxes import their siblings via direct file
 // paths (never this index), so this re-export barrel introduces no cycle.
-/* eslint-disable import/max-dependencies -- aggregator barrel; re-exports only */
 export { ContentBox } from "./ContentBox";
 export { CourseBox } from "./CourseBox";
 export { CoursesTable } from "./CoursesTable";
-export { DashboardCard } from "./DashboardCard";
 export { DomainBox } from "./DomainBox";
-export { OverviewCardGrid } from "./OverviewCardGrid";
 export { ProviderBox } from "./ProviderBox";
 export { RoutineBox } from "./RoutineBox";
 export { TaskBox } from "./TaskBox";

--- a/packages/client/src/components/listControls/index.ts
+++ b/packages/client/src/components/listControls/index.ts
@@ -1,0 +1,19 @@
+// Single import surface for the chrome shared by list/index route pages
+// (page header, route loading/error/empty states, view toggle, and the filter
+// bar primitives). Aggregates components that live elsewhere — keep the
+// implementations in their original homes; this only re-exports them so a list
+// page pulls them from one module instead of five.
+export { EntityError, EntityPending } from "@/components/EntityStates";
+export { OnboardingEmptyState } from "@/components/layout/OnboardingEmptyState";
+export { PageHeader } from "@/components/layout/PageHeader";
+export {
+  ViewModeToggle,
+  type ViewMode,
+} from "@/components/layout/ViewModeToggle";
+export {
+  ClearFiltersButton,
+  FilterSelect,
+  type FilterSelectOption,
+  ListEmptyStates,
+  ListSearchInput,
+} from "@/components/ListPageControls";

--- a/packages/client/src/components/listControls/index.ts
+++ b/packages/client/src/components/listControls/index.ts
@@ -13,7 +13,6 @@ export {
 export {
   ClearFiltersButton,
   FilterSelect,
-  type FilterSelectOption,
   ListEmptyStates,
   ListSearchInput,
 } from "@/components/ListPageControls";

--- a/packages/client/src/routes/domains.index.tsx
+++ b/packages/client/src/routes/domains.index.tsx
@@ -4,10 +4,12 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
-import { ContentBox } from "@/components/boxes/ContentBox";
-import { DomainBox } from "@/components/boxes/DomainBox";
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { PageHeader } from "@/components/layout/PageHeader";
+import { ContentBox, DomainBox } from "@/components/boxes";
+import {
+  EntityError,
+  EntityPending,
+  PageHeader,
+} from "@/components/listControls";
 import { Button } from "@/components/ui/button";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchDomains, fetchSettings } from "@/utils";

--- a/packages/client/src/routes/providers.index.tsx
+++ b/packages/client/src/routes/providers.index.tsx
@@ -4,11 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
-import { ContentBox } from "@/components/boxes/ContentBox";
-import { ProviderBox } from "@/components/boxes/ProviderBox";
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { OnboardingEmptyState } from "@/components/layout/OnboardingEmptyState";
-import { PageHeader } from "@/components/layout/PageHeader";
+import { ContentBox, ProviderBox } from "@/components/boxes";
+import {
+  EntityError,
+  EntityPending,
+  OnboardingEmptyState,
+  PageHeader,
+} from "@/components/listControls";
 import { Button } from "@/components/ui/button";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchProviders } from "@/utils";

--- a/packages/client/src/routes/resources.-components/-ResourcesList.stories.tsx
+++ b/packages/client/src/routes/resources.-components/-ResourcesList.stories.tsx
@@ -1,0 +1,122 @@
+import type { CourseProvider, ResourceInResources } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { ResourcesList } from "./-ResourcesList";
+
+import { makeTopics } from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const cost = {
+  cost: "100",
+  isCostFromPlatform: false,
+  splitBy: 1,
+};
+
+const resources: ResourceInResources[] = [
+  {
+    id: "r1",
+    name: "React Fundamentals",
+    url: "https://example.com/react",
+    dateExpires: "",
+    cost,
+    progressCurrent: 3,
+    progressTotal: 10,
+    status: "active",
+    provider: {
+      id: "p1",
+      name: "Frontend Masters",
+    },
+    topics: [
+      {
+        id: "t1",
+        name: "React",
+      },
+    ],
+  },
+  {
+    id: "r2",
+    name: "Advanced TypeScript",
+    url: "",
+    dateExpires: "",
+    cost,
+    progressCurrent: 10,
+    progressTotal: 10,
+    status: "complete",
+    topics: [],
+  },
+];
+
+const providers: CourseProvider[] = [
+  {
+    id: "p1",
+    name: "Frontend Masters",
+    url: "https://frontendmasters.com",
+    resourceCount: 1,
+  },
+];
+
+const topics = makeTopics(3);
+
+const meta: Meta<typeof ResourcesList> = {
+  component: ResourcesList,
+  args: {
+    resources,
+    providers,
+    topics,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+  // Reset persisted view-mode so each story starts in grid view.
+  beforeEach: () => {
+    window.localStorage.clear();
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("React Fundamentals")).toBeInTheDocument();
+    await expect(canvas.getByText("Advanced TypeScript")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    resources: [],
+    providers: [],
+    topics: [],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("No resources yet!")).toBeInTheDocument();
+  },
+};
+
+export const TableView: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Table view",
+      }),
+    );
+    await expect(canvas.getByRole("table")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/resources.-components/-ResourcesList.tsx
+++ b/packages/client/src/routes/resources.-components/-ResourcesList.tsx
@@ -1,0 +1,300 @@
+import type { ViewMode } from "@/components/listControls";
+import type {
+  CourseProvider,
+  ResourceInResources,
+  TopicForTopicsPage,
+} from "@emstack/types";
+
+import { useMemo, useState } from "react";
+
+import { Link } from "@tanstack/react-router";
+import { ArrowDownAZIcon, ArrowUpAZIcon, PlusIcon } from "lucide-react";
+
+import { ContentBox, CourseBox, CoursesTable } from "@/components/boxes";
+import {
+  ClearFiltersButton,
+  FilterSelect,
+  ListSearchInput,
+  OnboardingEmptyState,
+
+  ViewModeToggle,
+} from "@/components/listControls";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type SortOption = "alpha" | "progress" | "provider" | "topic";
+
+const VIEW_MODE_STORAGE_KEY = "resources:viewMode";
+// Pre-rename key; fall back to it so existing preferences survive.
+const LEGACY_VIEW_MODE_STORAGE_KEY = "courses:viewMode";
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === "undefined") return "grid";
+  const stored
+    = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
+      ?? window.localStorage.getItem(LEGACY_VIEW_MODE_STORAGE_KEY);
+  return stored === "table" ? "table" : "grid";
+}
+
+function getProgressPercent(course: ResourceInResources): number {
+  if (course.progressTotal === 0) return 0;
+  return course.progressCurrent / course.progressTotal;
+}
+
+function sortCourses(
+  courses: ResourceInResources[],
+  sortBy: SortOption,
+): ResourceInResources[] {
+  return [...courses].sort((a, b) => {
+    switch (sortBy) {
+      case "alpha":
+        return a.name.localeCompare(b.name);
+      case "progress":
+        return getProgressPercent(b) - getProgressPercent(a);
+      case "provider":
+        return (a.provider?.name ?? "").localeCompare(b.provider?.name ?? "");
+      case "topic":
+        return (a.topics?.[0]?.name ?? "").localeCompare(
+          b.topics?.[0]?.name ?? "",
+        );
+    }
+  });
+}
+
+export interface ResourcesListProps {
+  resources: ResourceInResources[];
+  providers: CourseProvider[];
+  topics: TopicForTopicsPage[];
+  initialTopicId?: string;
+}
+
+export function ResourcesList({
+  resources,
+  providers,
+  topics,
+  initialTopicId,
+}: ResourcesListProps) {
+  const [search, setSearch] = useState("");
+  const [filterProvider, setFilterProvider] = useState<string | undefined>();
+  const [filterTopic, setFilterTopic] = useState<string | undefined>(
+    initialTopicId,
+  );
+  const [sortBy, setSortBy] = useState<SortOption>("alpha");
+  const [sortAsc, setSortAsc] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+
+  const updateViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    }
+  };
+
+  const filteredAndSorted = useMemo(() => {
+    let result = resources;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(c => c.name.toLowerCase().includes(q));
+    }
+
+    if (filterProvider === "none") {
+      result = result.filter(c => !c.provider);
+    }
+    else if (filterProvider) {
+      result = result.filter(c => c.provider?.id === filterProvider);
+    }
+
+    if (filterTopic === "none") {
+      result = result.filter(c => !c.topics || c.topics.length === 0);
+    }
+    else if (filterTopic) {
+      result = result.filter(c =>
+        c.topics?.some(t => t.id === filterTopic));
+    }
+
+    const sorted = sortCourses(result, sortBy);
+    return sortAsc ? sorted : sorted.reverse();
+  }, [resources, search, filterProvider, filterTopic, sortBy, sortAsc]);
+
+  const hasActiveFilters = filterProvider || filterTopic;
+
+  const totalCourseCount = resources.length;
+  const noProviderCount = useMemo(
+    () => resources.filter(c => !c.provider).length,
+    [resources],
+  );
+  const noTopicCount = useMemo(
+    () => resources.filter(c => !c.topics || c.topics.length === 0).length,
+    [resources],
+  );
+
+  return (
+    <div className="container flex flex-col gap-4">
+      <div>
+        {resources.length > 0 && (
+          <div
+            className="mb-4 flex flex-wrap items-center justify-between gap-3"
+          >
+            <div className="flex flex-wrap items-center gap-3">
+              <ListSearchInput
+                placeholder="Search resources..."
+                value={search}
+                onChange={setSearch}
+              />
+              <FilterSelect
+                placeholder="Provider"
+                value={filterProvider}
+                onChange={setFilterProvider}
+                allLabel="All Providers"
+                totalCount={totalCourseCount}
+                noneLabel="No Provider"
+                noneCount={noProviderCount}
+                options={providers
+                  .filter(p => (p.resourceCount ?? 0) > 0)
+                  .map(p => ({
+                    value: p.id,
+                    label: p.name,
+                    count: p.resourceCount ?? 0,
+                  }))}
+              />
+
+              <FilterSelect
+                placeholder="Topic"
+                value={filterTopic}
+                onChange={setFilterTopic}
+                allLabel="All Topics"
+                totalCount={totalCourseCount}
+                noneLabel="No Topic"
+                noneCount={noTopicCount}
+                options={topics
+                  .filter(t => (t.resourceCount ?? 0) > 0)
+                  .map(t => ({
+                    value: t.id,
+                    label: t.name,
+                    count: t.resourceCount ?? 0,
+                  }))}
+              />
+
+              {hasActiveFilters && (
+                <ClearFiltersButton
+                  onClick={() => {
+                    setFilterProvider(undefined);
+                    setFilterTopic(undefined);
+                  }}
+                />
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Sort</span>
+              <Select
+                value={sortBy}
+                onValueChange={v => setSortBy(v as SortOption)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Sort by" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="alpha">A-Z</SelectItem>
+                  <SelectItem value="progress">Progress</SelectItem>
+                  <SelectItem value="provider">Provider</SelectItem>
+                  <SelectItem value="topic">Topic</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setSortAsc(prev => !prev)}
+              >
+                {sortAsc
+                  ? (
+                    <ArrowDownAZIcon className="size-4" />
+                  )
+                  : (
+                    <ArrowUpAZIcon className="size-4" />
+                  )}
+              </Button>
+              <ViewModeToggle
+                viewMode={viewMode}
+                onChange={updateViewMode}
+                gridLabel="Grid view"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+      {resources.length === 0 && (
+        <OnboardingEmptyState message="No resources yet!" />
+      )}
+
+      {resources.length > 0 && filteredAndSorted.length === 0 && (
+        <div className="text-muted-foreground">
+          <i>No resources match your filters.</i>
+        </div>
+      )}
+
+      {viewMode === "grid" && (
+        <div className="card-grid">
+          {filteredAndSorted.length > 0
+            && filteredAndSorted.map((course: ResourceInResources) => {
+              if (!course) {
+                return <></>;
+              }
+              return (
+                <CourseBox
+                  {...course}
+                  key={course.id}
+                />
+              );
+            })}
+
+          <Link
+            to="/resources/$id/edit"
+            params={{
+              id: "new",
+            }}
+          >
+            <ContentBox
+              className="
+                h-full items-center justify-center border-dashed p-8
+                text-muted-foreground transition-colors
+                hover:border-solid hover:bg-accent hover:text-accent-foreground
+              "
+            >
+              <PlusIcon size={32} />
+              <span className="text-lg font-medium">Add New Resource</span>
+            </ContentBox>
+          </Link>
+        </div>
+      )}
+
+      {viewMode === "table" && (
+        <div className="flex flex-col gap-4">
+          {filteredAndSorted.length > 0 && (
+            <CoursesTable courses={filteredAndSorted} />
+          )}
+          <div>
+            <Link
+              to="/resources/$id/edit"
+              params={{
+                id: "new",
+              }}
+            >
+              <Button variant="outline">
+                <PlusIcon className="size-4" />
+                Add New Course
+              </Button>
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/routes/resources.index.tsx
+++ b/packages/client/src/routes/resources.index.tsx
@@ -1,50 +1,18 @@
-import type { ViewMode } from "@/components/layout/ViewModeToggle";
-import type { ResourceInResources } from "@emstack/types";
-
-import { useMemo, useState } from "react";
-
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowDownAZIcon, ArrowUpAZIcon, PlusIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 
-import { ContentBox } from "@/components/boxes/ContentBox";
-import { CourseBox } from "@/components/boxes/CourseBox";
-import { CoursesTable } from "@/components/boxes/CoursesTable";
-// fallow-ignore-next-line code-duplication
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { OnboardingEmptyState } from "@/components/layout/OnboardingEmptyState";
-import { PageHeader } from "@/components/layout/PageHeader";
-import { ViewModeToggle } from "@/components/layout/ViewModeToggle";
+import { ResourcesList } from "./resources.-components/-ResourcesList";
+
 import {
-  ClearFiltersButton,
-  FilterSelect,
-  ListSearchInput,
-} from "@/components/ListPageControls";
+  EntityError,
+  EntityPending,
+  PageHeader,
+} from "@/components/listControls";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
-import { fetchResources, fetchProviders, fetchTopics } from "@/utils";
+import { fetchProviders, fetchResources, fetchTopics } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
-
-type SortOption = "alpha" | "progress" | "provider" | "topic";
-
-const VIEW_MODE_STORAGE_KEY = "resources:viewMode";
-// Pre-rename key; fall back to it so existing preferences survive.
-const LEGACY_VIEW_MODE_STORAGE_KEY = "courses:viewMode";
-
-function getInitialViewMode(): ViewMode {
-  if (typeof window === "undefined") return "grid";
-  const stored
-    = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
-      ?? window.localStorage.getItem(LEGACY_VIEW_MODE_STORAGE_KEY);
-  return stored === "table" ? "table" : "grid";
-}
 
 export interface ResourcesSearch {
   topicId?: string;
@@ -70,51 +38,11 @@ function CoursesError() {
   return <EntityError entity="resources" />;
 }
 
-function getProgressPercent(course: ResourceInResources): number {
-  if (course.progressTotal === 0) return 0;
-  return course.progressCurrent / course.progressTotal;
-}
-
-function sortCourses(
-  courses: ResourceInResources[],
-  sortBy: SortOption,
-): ResourceInResources[] {
-  return [...courses].sort((a, b) => {
-    switch (sortBy) {
-      case "alpha":
-        return a.name.localeCompare(b.name);
-      case "progress":
-        return getProgressPercent(b) - getProgressPercent(a);
-      case "provider":
-        return (a.provider?.name ?? "").localeCompare(b.provider?.name ?? "");
-      case "topic":
-        return (a.topics?.[0]?.name ?? "").localeCompare(
-          b.topics?.[0]?.name ?? "",
-        );
-    }
-  });
-}
-
 function Courses() {
   const urlSearch = Route.useSearch();
-  const [search, setSearch] = useState("");
-  const [filterProvider, setFilterProvider] = useState<string | undefined>();
-  const [filterTopic, setFilterTopic] = useState<string | undefined>(
-    urlSearch.topicId,
-  );
-  const [sortBy, setSortBy] = useState<SortOption>("alpha");
-  const [sortAsc, setSortAsc] = useState(true);
-  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-
-  const updateViewMode = (mode: ViewMode) => {
-    setViewMode(mode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
-    }
-  };
 
   const {
-    data,
+    data: resources,
   } = useQuery({
     queryKey: queryKeys.resources.list(),
     queryFn: () => fetchResources(),
@@ -133,47 +61,6 @@ function Courses() {
     queryKey: ["topics"],
     queryFn: () => fetchTopics(),
   });
-
-  const filteredAndSorted = useMemo(() => {
-    if (!data) return [];
-
-    let result = data;
-
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter(c => c.name.toLowerCase().includes(q));
-    }
-
-    if (filterProvider === "none") {
-      result = result.filter(c => !c.provider);
-    }
-    else if (filterProvider) {
-      result = result.filter(c => c.provider?.id === filterProvider);
-    }
-
-    if (filterTopic === "none") {
-      result = result.filter(c => !c.topics || c.topics.length === 0);
-    }
-    else if (filterTopic) {
-      result = result.filter(c =>
-        c.topics?.some(t => t.id === filterTopic));
-    }
-
-    const sorted = sortCourses(result, sortBy);
-    return sortAsc ? sorted : sorted.reverse();
-  }, [data, search, filterProvider, filterTopic, sortBy, sortAsc]);
-
-  const hasActiveFilters = filterProvider || filterTopic;
-
-  const totalCourseCount = data?.length ?? 0;
-  const noProviderCount = useMemo(
-    () => data?.filter(c => !c.provider).length ?? 0,
-    [data],
-  );
-  const noTopicCount = useMemo(
-    () => data?.filter(c => !c.topics || c.topics.length === 0).length ?? 0,
-    [data],
-  );
 
   return (
     <div>
@@ -194,171 +81,12 @@ function Courses() {
           </Button>
         </Link>
       </PageHeader>
-      <div className="container flex flex-col gap-4">
-        <div>
-          {data && data.length > 0 && (
-            <div
-              className="mb-4 flex flex-wrap items-center justify-between gap-3"
-            >
-              <div className="flex flex-wrap items-center gap-3">
-                <ListSearchInput
-                  placeholder="Search resources..."
-                  value={search}
-                  onChange={setSearch}
-                />
-                <FilterSelect
-                  placeholder="Provider"
-                  value={filterProvider}
-                  onChange={setFilterProvider}
-                  allLabel="All Providers"
-                  totalCount={totalCourseCount}
-                  noneLabel="No Provider"
-                  noneCount={noProviderCount}
-                  options={
-                    providers
-                      ?.filter(p => (p.resourceCount ?? 0) > 0)
-                      .map(p => ({
-                        value: p.id,
-                        label: p.name,
-                        count: p.resourceCount ?? 0,
-                      })) ?? []
-                  }
-                />
-
-                <FilterSelect
-                  placeholder="Topic"
-                  value={filterTopic}
-                  onChange={setFilterTopic}
-                  allLabel="All Topics"
-                  totalCount={totalCourseCount}
-                  noneLabel="No Topic"
-                  noneCount={noTopicCount}
-                  options={
-                    topics
-                      ?.filter(t => (t.resourceCount ?? 0) > 0)
-                      .map(t => ({
-                        value: t.id,
-                        label: t.name,
-                        count: t.resourceCount ?? 0,
-                      })) ?? []
-                  }
-                />
-
-                {hasActiveFilters && (
-                  <ClearFiltersButton
-                    onClick={() => {
-                      setFilterProvider(undefined);
-                      setFilterTopic(undefined);
-                    }}
-                  />
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Sort</span>
-                <Select
-                  value={sortBy}
-                  onValueChange={v => setSortBy(v as SortOption)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Sort by" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="alpha">A-Z</SelectItem>
-                    <SelectItem value="progress">Progress</SelectItem>
-                    <SelectItem value="provider">Provider</SelectItem>
-                    <SelectItem value="topic">Topic</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setSortAsc(prev => !prev)}
-                >
-                  {sortAsc
-                    ? (
-                      <ArrowDownAZIcon className="size-4" />
-                    )
-                    : (
-                      <ArrowUpAZIcon className="size-4" />
-                    )}
-                </Button>
-                <ViewModeToggle
-                  viewMode={viewMode}
-                  onChange={updateViewMode}
-                  gridLabel="Grid view"
-                />
-              </div>
-            </div>
-          )}
-        </div>
-        {(!data || data.length === 0) && (
-          <OnboardingEmptyState message="No resources yet!" />
-        )}
-
-        {data && data.length > 0 && filteredAndSorted.length === 0 && (
-          <div className="text-muted-foreground">
-            <i>No resources match your filters.</i>
-          </div>
-        )}
-
-        {viewMode === "grid" && (
-          <div className="card-grid">
-            {filteredAndSorted.length > 0
-              && filteredAndSorted.map((course: ResourceInResources) => {
-                if (!course) {
-                  return <></>;
-                }
-                return (
-                  <CourseBox
-                    {...course}
-                    key={course.id}
-                  />
-                );
-              })}
-
-            <Link
-              to="/resources/$id/edit"
-              params={{
-                id: "new",
-              }}
-            >
-              <ContentBox
-                className="
-                  h-full items-center justify-center border-dashed p-8
-                  text-muted-foreground transition-colors
-                  hover:border-solid hover:bg-accent
-                  hover:text-accent-foreground
-                "
-              >
-                <PlusIcon size={32} />
-                <span className="text-lg font-medium">Add New Resource</span>
-              </ContentBox>
-            </Link>
-          </div>
-        )}
-
-        {viewMode === "table" && (
-          <div className="flex flex-col gap-4">
-            {filteredAndSorted.length > 0 && (
-              <CoursesTable courses={filteredAndSorted} />
-            )}
-            <div>
-              <Link
-                to="/resources/$id/edit"
-                params={{
-                  id: "new",
-                }}
-              >
-                <Button variant="outline">
-                  <PlusIcon className="size-4" />
-                  Add New Course
-                </Button>
-              </Link>
-            </div>
-          </div>
-        )}
-      </div>
+      <ResourcesList
+        resources={resources ?? []}
+        providers={providers ?? []}
+        topics={topics ?? []}
+        initialTopicId={urlSearch.topicId}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes/routines.-components/-RoutinesList.stories.tsx
+++ b/packages/client/src/routes/routines.-components/-RoutinesList.stories.tsx
@@ -1,0 +1,76 @@
+import type { Routine } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { RoutinesList } from "./-RoutinesList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const routines: Routine[] = [
+  {
+    id: "rt1",
+    name: "Morning Reading",
+    mode: "daily",
+    status: "active",
+    connections: [
+      {
+        type: "topic",
+        id: "t1",
+        name: "React",
+      },
+    ],
+    completions: [],
+    weekly: {},
+  },
+  {
+    id: "rt2",
+    name: "Weekly Review",
+    mode: "weekly",
+    status: "active",
+    connections: [],
+    completions: [],
+    weekly: {},
+  },
+];
+
+const meta: Meta<typeof RoutinesList> = {
+  component: RoutinesList,
+  args: {
+    routines,
+    resolveTodayAction: fn(() => null),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Morning Reading")).toBeInTheDocument();
+    await expect(canvas.getByText("Weekly Review")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    routines: [],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No routines yet!/i)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.-components/-RoutinesList.tsx
+++ b/packages/client/src/routes/routines.-components/-RoutinesList.tsx
@@ -1,0 +1,188 @@
+import type {
+  Routine,
+  RoutineConnectionType,
+  RoutineTodayAction,
+} from "@emstack/types";
+
+import { useMemo, useState } from "react";
+
+import { RoutineBox } from "@/components/boxes";
+import {
+  ClearFiltersButton,
+  FilterSelect,
+  ListEmptyStates,
+  ListSearchInput,
+} from "@/components/listControls";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface RoutinesListProps {
+  routines: Routine[];
+  // Today's scheduled action for a weekly routine (display name + affixes), or
+  // null for daily/unscheduled routines. The caller resolves it because it
+  // depends on query-backed task/resource name lookups.
+  resolveTodayAction: (routine: Routine) => RoutineTodayAction | null;
+  initialConnection?: string;
+}
+
+export function RoutinesList({
+  routines,
+  resolveTodayAction,
+  initialConnection,
+}: RoutinesListProps) {
+  const [search, setSearch] = useState("");
+  const [filterConnection, setFilterConnection] = useState<string | undefined>(
+    initialConnection,
+  );
+  const [filterMode, setFilterMode] = useState<"weekly" | "daily" | undefined>(
+    undefined,
+  );
+
+  const filtered = useMemo(() => {
+    let result = routines;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        r =>
+          r.name.toLowerCase().includes(q)
+          || (r.description?.toLowerCase().includes(q) ?? false),
+      );
+    }
+
+    if (filterConnection === "none") {
+      result = result.filter(
+        r => !r.connections || r.connections.length === 0,
+      );
+    }
+    else if (filterConnection) {
+      result = result.filter(r =>
+        (r.connections ?? []).some(
+          c => `${c.type}:${c.id}` === filterConnection,
+        ));
+    }
+
+    if (filterMode) {
+      // Pre-existing routines default to "weekly" when mode is absent.
+      result = result.filter(r => (r.mode ?? "weekly") === filterMode);
+    }
+
+    return result;
+  }, [routines, search, filterConnection, filterMode]);
+
+  const hasActiveFilters = !!filterConnection || !!filterMode;
+
+  // Distinct connections across all routines, each with its display name and
+  // count, for the filter dropdown.
+  const connectionFilterOptions = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        value: string;
+        name: string;
+        type: RoutineConnectionType;
+        count: number;
+      }
+    >();
+    routines.forEach((r) => {
+      r.connections?.forEach((c) => {
+        const value = `${c.type}:${c.id}`;
+        const existing = map.get(value);
+        if (existing) {
+          existing.count += 1;
+        }
+        else {
+          map.set(value, {
+            value,
+            name: c.name ?? c.id,
+            type: c.type,
+            count: 1,
+          });
+        }
+      });
+    });
+    return Array.from(map.values()).sort((a, b) =>
+      a.name.localeCompare(b.name));
+  }, [routines]);
+  const totalRoutineCount = routines.length;
+  const noConnectionCount = useMemo(
+    () =>
+      routines.filter(r => !r.connections || r.connections.length === 0)
+        .length,
+    [routines],
+  );
+
+  return (
+    <div className="container flex flex-col gap-4">
+      {routines.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-3">
+          <ListSearchInput
+            placeholder="Search routines..."
+            value={search}
+            onChange={setSearch}
+          />
+          <FilterSelect
+            placeholder="Connection"
+            value={filterConnection}
+            onChange={setFilterConnection}
+            allLabel="All Connections"
+            totalCount={totalRoutineCount}
+            noneLabel="No Connection"
+            noneCount={noConnectionCount}
+            options={connectionFilterOptions.map(opt => ({
+              value: opt.value,
+              label: opt.name,
+              count: opt.count,
+              prefix: opt.type,
+            }))}
+          />
+          <Select
+            value={filterMode ?? "all"}
+            onValueChange={v =>
+              setFilterMode(v === "all" ? undefined : (v as "weekly" | "daily"))}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="weekly">Weekly Schedule</SelectItem>
+              <SelectItem value="daily">Daily Task</SelectItem>
+            </SelectContent>
+          </Select>
+          {hasActiveFilters && (
+            <ClearFiltersButton
+              onClick={() => {
+                setFilterConnection(undefined);
+                setFilterMode(undefined);
+              }}
+            />
+          )}
+        </div>
+      )}
+
+      <ListEmptyStates
+        entityLabel="routines"
+        total={totalRoutineCount}
+        filteredCount={filtered.length}
+      />
+
+      {filtered.length > 0 && (
+        <div className="card-grid">
+          {filtered.map((routine: Routine) => (
+            <RoutineBox
+              key={routine.id}
+              {...routine}
+              todayAction={resolveTodayAction(routine)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/routes/routines.index.tsx
+++ b/packages/client/src/routes/routines.index.tsx
@@ -5,30 +5,19 @@ import type {
   RoutineWeekday,
 } from "@emstack/types";
 
-import { useMemo, useState } from "react";
-
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { CalendarCheckIcon, PlusIcon } from "lucide-react";
 
-import { RoutineBox } from "@/components/boxes/RoutineBox";
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { PageHeader } from "@/components/layout/PageHeader";
+import { RoutinesList } from "./routines.-components/-RoutinesList";
+
 import {
-  ClearFiltersButton,
-  FilterSelect,
-  ListEmptyStates,
-  ListSearchInput,
-} from "@/components/ListPageControls";
+  EntityError,
+  EntityPending,
+  PageHeader,
+} from "@/components/listControls";
 import { weeklyEntryName } from "@/components/routines/weekly";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
 import { fetchRoutines } from "@/utils";
 
@@ -69,9 +58,6 @@ function RoutinesError() {
   return <EntityError entity="routines" />;
 }
 
-// Pre-existing complexity hotspot (untested route component); suppressed so
-// unrelated edits inside it don't trip the audit gate. Refactor candidate.
-// fallow-ignore-next-line complexity
 function Routines() {
   const urlSearch = Route.useSearch();
   const initialConnection
@@ -80,16 +66,9 @@ function Routines() {
       : urlSearch.topicId
         ? `topic:${urlSearch.topicId}`
         : undefined;
-  const [search, setSearch] = useState("");
-  const [filterConnection, setFilterConnection] = useState<string | undefined>(
-    initialConnection,
-  );
-  const [filterMode, setFilterMode] = useState<"weekly" | "daily" | undefined>(
-    undefined,
-  );
 
   const {
-    data,
+    data: routines,
   } = useQuery({
     queryKey: ["routines"],
     queryFn: () => fetchRoutines(),
@@ -98,8 +77,7 @@ function Routines() {
   // Resolve scheduled task / resource names so a weekly routine can show today's
   // entry in place of its name (freeform entries carry their own text in `id`).
   const {
-    taskNames,
-    resourceNames,
+    taskNames, resourceNames,
   } = useTaskResourceNames();
   const todayWeekday = String(new Date().getDay()) as RoutineWeekday;
 
@@ -120,75 +98,6 @@ function Routines() {
       appendText: entry.appendText,
     };
   }
-
-  const filtered = useMemo(() => {
-    if (!data) return [];
-
-    let result = data;
-
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter(r =>
-        r.name.toLowerCase().includes(q)
-        || (r.description?.toLowerCase().includes(q) ?? false));
-    }
-
-    if (filterConnection === "none") {
-      result = result.filter(r => !r.connections || r.connections.length === 0);
-    }
-    else if (filterConnection) {
-      result = result.filter(r =>
-        (r.connections ?? []).some(
-          c => `${c.type}:${c.id}` === filterConnection,
-        ));
-    }
-
-    if (filterMode) {
-      // Pre-existing routines default to "weekly" when mode is absent.
-      result = result.filter(r => (r.mode ?? "weekly") === filterMode);
-    }
-
-    return result;
-  }, [data, search, filterConnection, filterMode]);
-
-  const hasActiveFilters = !!filterConnection || !!filterMode;
-
-  // Distinct connections across all routines, each with its display name and
-  // count, for the filter dropdown.
-  const connectionFilterOptions = useMemo(() => {
-    const map = new Map<string, {
-      value: string;
-      name: string;
-      type: RoutineConnectionType;
-      count: number;
-    }>();
-    data?.forEach((r) => {
-      r.connections?.forEach((c) => {
-        const value = `${c.type}:${c.id}`;
-        const existing = map.get(value);
-        if (existing) {
-          existing.count += 1;
-        }
-        else {
-          map.set(value, {
-            value,
-            name: c.name ?? c.id,
-            type: c.type,
-            count: 1,
-          });
-        }
-      });
-    });
-    return Array.from(map.values()).sort((a, b) =>
-      a.name.localeCompare(b.name));
-  }, [data]);
-  const totalRoutineCount = data?.length ?? 0;
-  const noConnectionCount = useMemo(
-    () =>
-      data?.filter(r => !r.connections || r.connections.length === 0).length
-      ?? 0,
-    [data],
-  );
 
   return (
     <div>
@@ -214,72 +123,11 @@ function Routines() {
           </Button>
         </Link>
       </PageHeader>
-      <div className="container flex flex-col gap-4">
-        {data && data.length > 0 && (
-          <div className="mb-4 flex flex-wrap items-center gap-3">
-            <ListSearchInput
-              placeholder="Search routines..."
-              value={search}
-              onChange={setSearch}
-            />
-            <FilterSelect
-              placeholder="Connection"
-              value={filterConnection}
-              onChange={setFilterConnection}
-              allLabel="All Connections"
-              totalCount={totalRoutineCount}
-              noneLabel="No Connection"
-              noneCount={noConnectionCount}
-              options={connectionFilterOptions.map(opt => ({
-                value: opt.value,
-                label: opt.name,
-                count: opt.count,
-                prefix: opt.type,
-              }))}
-            />
-            <Select
-              value={filterMode ?? "all"}
-              onValueChange={v =>
-                setFilterMode(v === "all" ? undefined : (v as "weekly" | "daily"))}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Type" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Types</SelectItem>
-                <SelectItem value="weekly">Weekly Schedule</SelectItem>
-                <SelectItem value="daily">Daily Task</SelectItem>
-              </SelectContent>
-            </Select>
-            {hasActiveFilters && (
-              <ClearFiltersButton
-                onClick={() => {
-                  setFilterConnection(undefined);
-                  setFilterMode(undefined);
-                }}
-              />
-            )}
-          </div>
-        )}
-
-        <ListEmptyStates
-          entityLabel="routines"
-          total={totalRoutineCount}
-          filteredCount={filtered.length}
-        />
-
-        {filtered.length > 0 && (
-          <div className="card-grid">
-            {filtered.map((routine: Routine) => (
-              <RoutineBox
-                key={routine.id}
-                {...routine}
-                todayAction={resolveTodayAction(routine)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <RoutinesList
+        routines={routines ?? []}
+        resolveTodayAction={resolveTodayAction}
+        initialConnection={initialConnection}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes/tasks.index.tsx
+++ b/packages/client/src/routes/tasks.index.tsx
@@ -6,15 +6,16 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
-import { TaskBox } from "@/components/boxes/TaskBox";
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { PageHeader } from "@/components/layout/PageHeader";
+import { TaskBox } from "@/components/boxes";
 import {
   ClearFiltersButton,
+  EntityError,
+  EntityPending,
   FilterSelect,
   ListEmptyStates,
   ListSearchInput,
-} from "@/components/ListPageControls";
+  PageHeader,
+} from "@/components/listControls";
 import { Button } from "@/components/ui/button";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchTasks, fetchTopics } from "@/utils";
@@ -71,9 +72,11 @@ function Tasks() {
 
     if (search) {
       const q = search.toLowerCase();
-      result = result.filter(t =>
-        t.name.toLowerCase().includes(q)
-        || (t.description?.toLowerCase().includes(q) ?? false));
+      result = result.filter(
+        t =>
+          t.name.toLowerCase().includes(q)
+          || (t.description?.toLowerCase().includes(q) ?? false),
+      );
     }
 
     if (filterTopic === "none") {

--- a/packages/client/src/routes/topics.-components/-TopicsList.stories.tsx
+++ b/packages/client/src/routes/topics.-components/-TopicsList.stories.tsx
@@ -1,0 +1,84 @@
+import type { Domain } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { TopicsList } from "./-TopicsList";
+
+import { makeTopics } from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const topics = makeTopics(4);
+
+const domains: Domain[] = [
+  {
+    id: "d1",
+    title: "Frontend",
+    topicCount: 2,
+  },
+  {
+    id: "d2",
+    title: "Infrastructure",
+    topicCount: 1,
+  },
+];
+
+const meta: Meta<typeof TopicsList> = {
+  component: TopicsList,
+  args: {
+    topics,
+    domains,
+    onBulkDelete: fn(() => Promise.resolve()),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+  // Reset persisted view-mode so each story starts in card view.
+  beforeEach: () => {
+    window.localStorage.clear();
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Kubernetes")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    topics: [],
+    domains: [],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("No courses yet!")).toBeInTheDocument();
+  },
+};
+
+export const TableView: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Table view",
+      }),
+    );
+    await expect(canvas.getByRole("table")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/topics.-components/-TopicsList.tsx
+++ b/packages/client/src/routes/topics.-components/-TopicsList.tsx
@@ -1,0 +1,443 @@
+import type { TopicsTableSort } from "@/components/boxes";
+import type { ViewMode } from "@/components/listControls";
+import type { Domain, TopicForTopicsPage } from "@emstack/types";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Link } from "@tanstack/react-router";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { ContentBox, TopicBox, TopicsTable } from "@/components/boxes";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import {
+  ClearFiltersButton,
+  FilterSelect,
+  ListSearchInput,
+  OnboardingEmptyState,
+  ViewModeToggle,
+} from "@/components/listControls";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type SortOption
+  = | "alpha-asc"
+    | "alpha-desc"
+    | "resources-desc"
+    | "tasks-desc"
+    | "dailies-desc"
+    | "custom";
+
+const DEFAULT_SORT: TopicsTableSort = {
+  column: "name",
+  direction: "asc",
+};
+
+function sortToOption(sort: TopicsTableSort): SortOption {
+  if (sort.column === "name" && sort.direction === "asc") return "alpha-asc";
+  if (sort.column === "name" && sort.direction === "desc") return "alpha-desc";
+  if (sort.column === "resources" && sort.direction === "desc") {
+    return "resources-desc";
+  }
+  if (sort.column === "tasks" && sort.direction === "desc") {
+    return "tasks-desc";
+  }
+  if (sort.column === "dailies" && sort.direction === "desc") {
+    return "dailies-desc";
+  }
+  return "custom";
+}
+
+function optionToSort(option: SortOption): TopicsTableSort {
+  switch (option) {
+    case "alpha-asc":
+      return {
+        column: "name",
+        direction: "asc",
+      };
+    case "alpha-desc":
+      return {
+        column: "name",
+        direction: "desc",
+      };
+    case "resources-desc":
+      return {
+        column: "resources",
+        direction: "desc",
+      };
+    case "tasks-desc":
+      return {
+        column: "tasks",
+        direction: "desc",
+      };
+    case "dailies-desc":
+      return {
+        column: "dailies",
+        direction: "desc",
+      };
+    case "custom":
+      return DEFAULT_SORT;
+  }
+}
+
+const VIEW_MODE_STORAGE_KEY = "topics:viewMode";
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === "undefined") return "grid";
+  const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+  return stored === "table" ? "table" : "grid";
+}
+
+function firstDomainTitle(topic: TopicForTopicsPage): string {
+  const first = topic.domains?.find(d => d.id !== undefined);
+  return first?.title ?? "";
+}
+
+function sortTopics(
+  topics: TopicForTopicsPage[],
+  sort: TopicsTableSort,
+): TopicForTopicsPage[] {
+  const dir = sort.direction === "asc" ? 1 : -1;
+  return [...topics].sort((a, b) => {
+    switch (sort.column) {
+      case "name":
+        return a.name.localeCompare(b.name) * dir;
+      case "domains": {
+        const cmp = firstDomainTitle(a).localeCompare(firstDomainTitle(b));
+        return cmp !== 0 ? cmp * dir : a.name.localeCompare(b.name);
+      }
+      case "resources":
+        return (
+          ((a.resourceCount ?? 0) - (b.resourceCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
+      case "tasks":
+        return (
+          ((a.taskCount ?? 0) - (b.taskCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
+      case "dailies":
+        return (
+          ((a.dailyCount ?? 0) - (b.dailyCount ?? 0)) * dir
+          || a.name.localeCompare(b.name)
+        );
+    }
+  });
+}
+
+export interface TopicsListProps {
+  topics: TopicForTopicsPage[];
+  domains: Domain[];
+  // Deletes the given topics; the caller owns the network call, query
+  // invalidation, and success/error toast. Rejects on failure so the confirm
+  // dialog stays open for a retry.
+  onBulkDelete: (ids: string[]) => Promise<void>;
+}
+
+export function TopicsList({
+  topics, domains, onBulkDelete,
+}: TopicsListProps) {
+  const [search, setSearch] = useState("");
+  const [filterDomain, setFilterDomain] = useState<string | undefined>();
+  const [sort, setSort] = useState<TopicsTableSort>(DEFAULT_SORT);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const updateViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    }
+  };
+
+  const filteredAndSorted = useMemo(() => {
+    let result = topics.filter(t => t.name !== "");
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter((t) => {
+        const nameMatch = t.name.toLowerCase().includes(q);
+        const domainMatch = t.domains?.some(d =>
+          d.title.toLowerCase().includes(q));
+        return nameMatch || domainMatch;
+      });
+    }
+
+    if (filterDomain === "none") {
+      result = result.filter(t => !t.domains || t.domains.length === 0);
+    }
+    else if (filterDomain) {
+      result = result.filter(t =>
+        t.domains?.some(d => d.id === filterDomain));
+    }
+
+    return sortTopics(result, sort);
+  }, [topics, search, filterDomain, sort]);
+
+  const filteredIds = useMemo(
+    () => filteredAndSorted.map(t => t.id),
+    [filteredAndSorted],
+  );
+
+  useEffect(() => {
+    if (viewMode !== "table" && selectedIds.size > 0) {
+      setSelectedIds(new Set());
+    }
+  }, [viewMode, selectedIds]);
+
+  useEffect(() => {
+    if (selectedIds.size === 0) return;
+    const visible = new Set(filteredIds);
+    let changed = false;
+    const next = new Set<string>();
+    selectedIds.forEach((id) => {
+      if (visible.has(id)) {
+        next.add(id);
+      }
+      else {
+        changed = true;
+      }
+    });
+    if (changed) setSelectedIds(next);
+  }, [filteredIds, selectedIds]);
+
+  const handleBulkDelete = async () => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+    setIsDeleting(true);
+    try {
+      await onBulkDelete(ids);
+      setSelectedIds(new Set());
+      setConfirmOpen(false);
+    }
+    catch {
+      // The caller surfaces the error; keep the dialog open for a retry.
+    }
+    finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const hasActiveFilters = filterDomain;
+
+  const totalTopicCount = useMemo(
+    () => topics.filter(t => t.name !== "").length,
+    [topics],
+  );
+  const noDomainCount = useMemo(
+    () =>
+      topics.filter(
+        t => t.name !== "" && (!t.domains || t.domains.length === 0),
+      ).length,
+    [topics],
+  );
+
+  return (
+    <>
+      <div className="container flex flex-col gap-4">
+        <div>
+          {topics.length > 0 && (
+            <div
+              className="mb-4 flex flex-wrap items-center justify-between gap-3"
+            >
+              <div className="flex flex-wrap items-center gap-3">
+                <ListSearchInput
+                  placeholder="Search topics..."
+                  value={search}
+                  onChange={setSearch}
+                />
+
+                <FilterSelect
+                  placeholder="Domain"
+                  value={filterDomain}
+                  onChange={setFilterDomain}
+                  allLabel="All Domains"
+                  totalCount={totalTopicCount}
+                  noneLabel="No Domain"
+                  noneCount={noDomainCount}
+                  options={domains
+                    .filter(d => (d.topicCount ?? 0) > 0)
+                    .map(d => ({
+                      value: d.id,
+                      label: d.title,
+                      count: d.topicCount ?? 0,
+                    }))}
+                />
+
+                {hasActiveFilters && (
+                  <ClearFiltersButton
+                    onClick={() => {
+                      setFilterDomain(undefined);
+                    }}
+                  />
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">Sort</span>
+                <Select
+                  value={sortToOption(sort)}
+                  onValueChange={(v) => {
+                    const option = v as SortOption;
+                    if (option === "custom") return;
+                    setSort(optionToSort(option));
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sort by" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="alpha-asc">A-Z</SelectItem>
+                    <SelectItem value="alpha-desc">Z-A</SelectItem>
+                    <SelectItem value="resources-desc">
+                      Number of linked resources
+                    </SelectItem>
+                    <SelectItem value="tasks-desc">
+                      Number of linked tasks
+                    </SelectItem>
+                    <SelectItem value="dailies-desc">
+                      Number of linked dailies
+                    </SelectItem>
+                    {sortToOption(sort) === "custom" && (
+                      <SelectItem value="custom">Custom</SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                <ViewModeToggle
+                  viewMode={viewMode}
+                  onChange={updateViewMode}
+                  gridLabel="Card view"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        {topics.length === 0 && (
+          <OnboardingEmptyState message="No courses yet!" />
+        )}
+
+        {topics.length > 0 && filteredAndSorted.length === 0 && (
+          <div className="text-muted-foreground">
+            <i>No topics match your filters.</i>
+          </div>
+        )}
+
+        {viewMode === "grid" && (
+          <div className="card-grid">
+            {filteredAndSorted.length > 0
+              && filteredAndSorted.map((topic: TopicForTopicsPage) => {
+                return (
+                  <TopicBox
+                    {...topic}
+                    key={topic.id}
+                  />
+                );
+              })}
+
+            <Link
+              to="/topics/$id/edit"
+              params={{
+                id: "new",
+              }}
+            >
+              <ContentBox
+                className="
+                  h-full items-center justify-center border-dashed p-8
+                  text-muted-foreground transition-colors
+                  hover:border-solid hover:bg-accent
+                  hover:text-accent-foreground
+                "
+              >
+                <PlusIcon size={32} />
+                <span className="text-lg font-medium">Add New Topic</span>
+              </ContentBox>
+            </Link>
+          </div>
+        )}
+
+        {viewMode === "table" && (
+          <div className="flex flex-col gap-4">
+            {filteredAndSorted.length > 0 && (
+              <>
+                <div
+                  className="
+                    flex min-h-9 flex-wrap items-center justify-between gap-2
+                  "
+                >
+                  <span className="text-sm text-muted-foreground">
+                    {selectedIds.size > 0 ? `${selectedIds.size} selected` : ""}
+                  </span>
+                  {selectedIds.size > 0 && (
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setSelectedIds(new Set())}
+                      >
+                        Clear selection
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setConfirmOpen(true)}
+                      >
+                        <Trash2Icon className="size-4" />
+                        Delete
+                        {" "}
+                        {selectedIds.size}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                <TopicsTable
+                  topics={filteredAndSorted}
+                  selection={{
+                    selectedIds,
+                    onSelectionChange: setSelectedIds,
+                  }}
+                  sort={sort}
+                  onSortChange={setSort}
+                />
+              </>
+            )}
+            <div>
+              <Link
+                to="/topics/$id/edit"
+                params={{
+                  id: "new",
+                }}
+              >
+                <Button variant="outline">
+                  <PlusIcon className="size-4" />
+                  Add New Topic
+                </Button>
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={
+          selectedIds.size === 1
+            ? "Delete 1 topic?"
+            : `Delete ${selectedIds.size} topics?`
+        }
+        description="This will remove the selected topics and any links to courses, domains, and radar blips. This cannot be undone."
+        confirmLabel={isDeleting ? "Deleting..." : "Delete"}
+        cancelLabel="Cancel"
+        onConfirm={handleBulkDelete}
+        onCancel={() => {
+          if (!isDeleting) setConfirmOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/packages/client/src/routes/topics.index.tsx
+++ b/packages/client/src/routes/topics.index.tsx
@@ -1,105 +1,16 @@
-import type { TopicsTableSort } from "@/components/boxes/TopicsTable";
-import type { ViewMode } from "@/components/layout/ViewModeToggle";
-import type { TopicForTopicsPage } from "@emstack/types";
-
-import { useEffect, useMemo, useState } from "react";
-
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { PlusIcon, Trash2Icon } from "lucide-react";
+import { createFileRoute } from "@tanstack/react-router";
 import { toast } from "sonner";
 
-import { ContentBox } from "@/components/boxes/ContentBox";
-import { TopicBox } from "@/components/boxes/TopicBox";
-import { TopicsTable } from "@/components/boxes/TopicsTable";
-import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { EntityError, EntityPending } from "@/components/EntityStates";
-import { OnboardingEmptyState } from "@/components/layout/OnboardingEmptyState";
-import { PageHeader } from "@/components/layout/PageHeader";
-import { ViewModeToggle } from "@/components/layout/ViewModeToggle";
+import { TopicsList } from "./topics.-components/-TopicsList";
+
 import {
-  ClearFiltersButton,
-  FilterSelect,
-  ListSearchInput,
-} from "@/components/ListPageControls";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  EntityError,
+  EntityPending,
+  PageHeader,
+} from "@/components/listControls";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { bulkDeleteTopics, fetchDomains, fetchTopics } from "@/utils";
-
-type SortOption
-  = | "alpha-asc"
-    | "alpha-desc"
-    | "resources-desc"
-    | "tasks-desc"
-    | "dailies-desc"
-    | "custom";
-
-const DEFAULT_SORT: TopicsTableSort = {
-  column: "name",
-  direction: "asc",
-};
-
-function sortToOption(sort: TopicsTableSort): SortOption {
-  if (sort.column === "name" && sort.direction === "asc") return "alpha-asc";
-  if (sort.column === "name" && sort.direction === "desc") return "alpha-desc";
-  if (sort.column === "resources" && sort.direction === "desc") {
-    return "resources-desc";
-  }
-  if (sort.column === "tasks" && sort.direction === "desc") {
-    return "tasks-desc";
-  }
-  if (sort.column === "dailies" && sort.direction === "desc") {
-    return "dailies-desc";
-  }
-  return "custom";
-}
-
-function optionToSort(option: SortOption): TopicsTableSort {
-  switch (option) {
-    case "alpha-asc":
-      return {
-        column: "name",
-        direction: "asc",
-      };
-    case "alpha-desc":
-      return {
-        column: "name",
-        direction: "desc",
-      };
-    case "resources-desc":
-      return {
-        column: "resources",
-        direction: "desc",
-      };
-    case "tasks-desc":
-      return {
-        column: "tasks",
-        direction: "desc",
-      };
-    case "dailies-desc":
-      return {
-        column: "dailies",
-        direction: "desc",
-      };
-    case "custom":
-      return DEFAULT_SORT;
-  }
-}
-
-const VIEW_MODE_STORAGE_KEY = "topics:viewMode";
-
-function getInitialViewMode(): ViewMode {
-  if (typeof window === "undefined") return "grid";
-  const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
-  return stored === "table" ? "table" : "grid";
-}
 
 export const Route = createFileRoute("/topics/")({
   component: Topics,
@@ -115,62 +26,11 @@ function TopicsError() {
   return <EntityError entity="topics" />;
 }
 
-function firstDomainTitle(topic: TopicForTopicsPage): string {
-  const first = topic.domains?.find(d => d.id !== undefined);
-  return first?.title ?? "";
-}
-
-function sortTopics(
-  topics: TopicForTopicsPage[],
-  sort: TopicsTableSort,
-): TopicForTopicsPage[] {
-  const dir = sort.direction === "asc" ? 1 : -1;
-  return [...topics].sort((a, b) => {
-    switch (sort.column) {
-      case "name":
-        return a.name.localeCompare(b.name) * dir;
-      case "domains": {
-        const cmp = firstDomainTitle(a).localeCompare(firstDomainTitle(b));
-        return cmp !== 0 ? cmp * dir : a.name.localeCompare(b.name);
-      }
-      case "resources":
-        return (
-          ((a.resourceCount ?? 0) - (b.resourceCount ?? 0)) * dir
-          || a.name.localeCompare(b.name)
-        );
-      case "tasks":
-        return (
-          ((a.taskCount ?? 0) - (b.taskCount ?? 0)) * dir
-          || a.name.localeCompare(b.name)
-        );
-      case "dailies":
-        return (
-          ((a.dailyCount ?? 0) - (b.dailyCount ?? 0)) * dir
-          || a.name.localeCompare(b.name)
-        );
-    }
-  });
-}
-
 function Topics() {
-  const [search, setSearch] = useState("");
-  const [filterDomain, setFilterDomain] = useState<string | undefined>();
-  const [sort, setSort] = useState<TopicsTableSort>(DEFAULT_SORT);
-  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
   const queryClient = useQueryClient();
 
-  const updateViewMode = (mode: ViewMode) => {
-    setViewMode(mode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
-    }
-  };
-
   const {
-    data,
+    data: topics,
   } = useQuery({
     queryKey: ["topics"],
     queryFn: () => fetchTopics(),
@@ -183,63 +43,7 @@ function Topics() {
     queryFn: () => fetchDomains(),
   });
 
-  const filteredAndSorted = useMemo(() => {
-    if (!data) return [];
-
-    let result = data.filter(t => t.name !== "");
-
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter((t) => {
-        const nameMatch = t.name.toLowerCase().includes(q);
-        const domainMatch = t.domains?.some(d =>
-          d.title.toLowerCase().includes(q));
-        return nameMatch || domainMatch;
-      });
-    }
-
-    if (filterDomain === "none") {
-      result = result.filter(t => !t.domains || t.domains.length === 0);
-    }
-    else if (filterDomain) {
-      result = result.filter(t =>
-        t.domains?.some(d => d.id === filterDomain));
-    }
-
-    return sortTopics(result, sort);
-  }, [data, search, filterDomain, sort]);
-
-  const filteredIds = useMemo(
-    () => filteredAndSorted.map(t => t.id),
-    [filteredAndSorted],
-  );
-
-  useEffect(() => {
-    if (viewMode !== "table" && selectedIds.size > 0) {
-      setSelectedIds(new Set());
-    }
-  }, [viewMode, selectedIds]);
-
-  useEffect(() => {
-    if (selectedIds.size === 0) return;
-    const visible = new Set(filteredIds);
-    let changed = false;
-    const next = new Set<string>();
-    selectedIds.forEach((id) => {
-      if (visible.has(id)) {
-        next.add(id);
-      }
-      else {
-        changed = true;
-      }
-    });
-    if (changed) setSelectedIds(next);
-  }, [filteredIds, selectedIds]);
-
-  const handleBulkDelete = async () => {
-    const ids = Array.from(selectedIds);
-    if (ids.length === 0) return;
-    setIsDeleting(true);
+  const handleBulkDelete = async (ids: string[]) => {
     try {
       await bulkDeleteTopics(ids);
       await queryClient.invalidateQueries({
@@ -248,33 +52,15 @@ function Topics() {
       await queryClient.invalidateQueries({
         queryKey: ["domains"],
       });
-      setSelectedIds(new Set());
-      setConfirmOpen(false);
       toast.success(
         ids.length === 1 ? "1 topic deleted." : `${ids.length} topics deleted.`,
       );
     }
-    catch {
+    catch (error) {
       toast.error("Failed to delete topics. Please try again.");
-    }
-    finally {
-      setIsDeleting(false);
+      throw error;
     }
   };
-
-  const hasActiveFilters = filterDomain;
-
-  const totalTopicCount = useMemo(
-    () => data?.filter(t => t.name !== "").length ?? 0,
-    [data],
-  );
-  const noDomainCount = useMemo(
-    () =>
-      data?.filter(
-        t => t.name !== "" && (!t.domains || t.domains.length === 0),
-      ).length ?? 0,
-    [data],
-  );
 
   return (
     <div>
@@ -283,204 +69,10 @@ function Topics() {
         pageSection=""
         description={ENTITY_DESCRIPTIONS.topics}
       />
-      <div className="container flex flex-col gap-4">
-        <div>
-          {data && data.length > 0 && (
-            <div
-              className="mb-4 flex flex-wrap items-center justify-between gap-3"
-            >
-              <div className="flex flex-wrap items-center gap-3">
-                <ListSearchInput
-                  placeholder="Search topics..."
-                  value={search}
-                  onChange={setSearch}
-                />
-
-                <FilterSelect
-                  placeholder="Domain"
-                  value={filterDomain}
-                  onChange={setFilterDomain}
-                  allLabel="All Domains"
-                  totalCount={totalTopicCount}
-                  noneLabel="No Domain"
-                  noneCount={noDomainCount}
-                  options={
-                    domains
-                      ?.filter(d => (d.topicCount ?? 0) > 0)
-                      .map(d => ({
-                        value: d.id,
-                        label: d.title,
-                        count: d.topicCount ?? 0,
-                      })) ?? []
-                  }
-                />
-
-                {hasActiveFilters && (
-                  <ClearFiltersButton
-                    onClick={() => {
-                      setFilterDomain(undefined);
-                    }}
-                  />
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Sort</span>
-                <Select
-                  value={sortToOption(sort)}
-                  onValueChange={(v) => {
-                    const option = v as SortOption;
-                    if (option === "custom") return;
-                    setSort(optionToSort(option));
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Sort by" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="alpha-asc">A-Z</SelectItem>
-                    <SelectItem value="alpha-desc">Z-A</SelectItem>
-                    <SelectItem value="resources-desc">
-                      Number of linked resources
-                    </SelectItem>
-                    <SelectItem value="tasks-desc">
-                      Number of linked tasks
-                    </SelectItem>
-                    <SelectItem value="dailies-desc">
-                      Number of linked dailies
-                    </SelectItem>
-                    {sortToOption(sort) === "custom" && (
-                      <SelectItem value="custom">Custom</SelectItem>
-                    )}
-                  </SelectContent>
-                </Select>
-                <ViewModeToggle
-                  viewMode={viewMode}
-                  onChange={updateViewMode}
-                  gridLabel="Card view"
-                />
-              </div>
-            </div>
-          )}
-        </div>
-        {(!data || data.length === 0) && (
-          <OnboardingEmptyState message="No courses yet!" />
-        )}
-
-        {data && data.length > 0 && filteredAndSorted.length === 0 && (
-          <div className="text-muted-foreground">
-            <i>No topics match your filters.</i>
-          </div>
-        )}
-
-        {viewMode === "grid" && (
-          <div className="card-grid">
-            {filteredAndSorted.length > 0
-              && filteredAndSorted.map((topic: TopicForTopicsPage) => {
-                return (
-                  <TopicBox
-                    {...topic}
-                    key={topic.id}
-                  />
-                );
-              })}
-
-            <Link
-              to="/topics/$id/edit"
-              params={{
-                id: "new",
-              }}
-            >
-              <ContentBox
-                className="
-                  h-full items-center justify-center border-dashed p-8
-                  text-muted-foreground transition-colors
-                  hover:border-solid hover:bg-accent
-                  hover:text-accent-foreground
-                "
-              >
-                <PlusIcon size={32} />
-                <span className="text-lg font-medium">Add New Topic</span>
-              </ContentBox>
-            </Link>
-          </div>
-        )}
-
-        {viewMode === "table" && (
-          <div className="flex flex-col gap-4">
-            {filteredAndSorted.length > 0 && (
-              <>
-                <div
-                  className="
-                    flex min-h-9 flex-wrap items-center justify-between gap-2
-                  "
-                >
-                  <span className="text-sm text-muted-foreground">
-                    {selectedIds.size > 0 ? `${selectedIds.size} selected` : ""}
-                  </span>
-                  {selectedIds.size > 0 && (
-                    <div className="flex items-center gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => setSelectedIds(new Set())}
-                      >
-                        Clear selection
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => setConfirmOpen(true)}
-                      >
-                        <Trash2Icon className="size-4" />
-                        Delete
-                        {" "}
-                        {selectedIds.size}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-                <TopicsTable
-                  topics={filteredAndSorted}
-                  selection={{
-                    selectedIds,
-                    onSelectionChange: setSelectedIds,
-                  }}
-                  sort={sort}
-                  onSortChange={setSort}
-                />
-              </>
-            )}
-            <div>
-              <Link
-                to="/topics/$id/edit"
-                params={{
-                  id: "new",
-                }}
-              >
-                <Button variant="outline">
-                  <PlusIcon className="size-4" />
-                  Add New Topic
-                </Button>
-              </Link>
-            </div>
-          </div>
-        )}
-      </div>
-      <ConfirmDialog
-        open={confirmOpen}
-        title={
-          selectedIds.size === 1
-            ? "Delete 1 topic?"
-            : `Delete ${selectedIds.size} topics?`
-        }
-        description="This will remove the selected topics and any links to courses, domains, and radar blips. This cannot be undone."
-        confirmLabel={isDeleting ? "Deleting..." : "Delete"}
-        cancelLabel="Cancel"
-        onConfirm={handleBulkDelete}
-        onCancel={() => {
-          if (!isDeleting) setConfirmOpen(false);
-        }}
+      <TopicsList
+        topics={topics ?? []}
+        domains={domains ?? []}
+        onBulkDelete={handleBulkDelete}
       />
     </div>
   );


### PR DESCRIPTION
Fixes #304

## ELI5

Six list pages (resources, topics, routines, tasks, domains, providers) each pulled in lots of separate little pieces, which tripped a code-health warning about importing from too many places. This groups the shared pieces into two tidy "one-stop" import files, and splits the three busiest pages' guts into their own reusable components — which also got picture-card examples (Storybook stories) so they're easy to view and test in isolation. Nothing the user sees changes.

## Summary

- Add two aggregator barrels — `components/listControls/index.ts` (page header, loading/error/empty states, view toggle, filter-bar primitives) and `components/boxes/index.ts` (box/table components) — so each page imports shared chrome from one module instead of five.
- Barrel-swap imports on `tasks`/`domains`/`providers` index routes (already under the limit after barreling).
- Extract the filter/sort/grid bodies of `resources`/`topics`/`routines` into presentational route-private `*-List` components (`resources.-components/`, `topics.-components/`, `routines.-components/`); data fetching and the topics bulk-delete mutation stay in the route and pass down as props.
- Add Storybook stories for each new component (CSF3, `RouterStub` decorator, props-based fixtures) with Default/Empty/TableView variants and light play assertions.
- Result: all six routes and the three new components now have ≤10 value imports.

## Component flow

Route files own data (queries + mutations) and pass it as props to the new presentational `*-List` components. Every page — extracted or barrel-only — pulls shared chrome and boxes from the two barrels instead of importing each piece separately.

```mermaid
flowchart LR
  subgraph routes["Route files — own data (useQuery / mutations)"]
    R["resources.index"]
    T["topics.index"]
    RO["routines.index"]
    SIMPLE["tasks.index<br/>domains.index<br/>providers.index"]
  end

  subgraph lists["Presentational *-List — props only (new)"]
    RL["-ResourcesList"]
    TL["-TopicsList"]
    ROL["-RoutinesList"]
  end

  subgraph barrels["Shared barrels — one import each (new)"]
    LC["@/components/listControls<br/>header · states · filter bar · view toggle"]
    BX["@/components/boxes<br/>cards · tables"]
  end

  R -- "resources, providers,<br/>topics, initialTopicId" --> RL
  T -- "topics, domains,<br/>onBulkDelete" --> TL
  RO -- "routines, resolveTodayAction,<br/>initialConnection" --> ROL

  RL --> LC
  RL --> BX
  TL --> LC
  TL --> BX
  ROL --> LC
  ROL --> BX
  R --> LC
  T --> LC
  RO --> LC
  SIMPLE --> LC
  SIMPLE --> BX
```

## Test plan

- [x] `pnpm --filter=@emstack/client run typecheck` — clean (incl. after rebase onto latest master)
- [x] `pnpm lint` — exit 0, no errors; `grep "Maximum number of dependencies"` no longer lists any of the six routes or the new components
- [x] `pnpm --filter=@emstack/client exec vitest run` — 257 passed, including 8 new story play tests
- [ ] Manual smoke (`pnpm dev`): load `/resources`, `/topics`, `/routines`, `/tasks`, `/domains`, `/providers`; verify search, filters, sort, grid/table toggle (resources/topics), topics bulk-delete, and the `?topicId=` / routines connection URL prefilters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
