### PR TITLE
feat: add most-connected entity pills to overview tiles

### DIFF
--- a/packages/client/src/components/boxElements/EntityLink.tsx
+++ b/packages/client/src/components/boxElements/EntityLink.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Link } from "@tanstack/react-router";
 
-export type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks";
+export type EntityKind = "resources" | "topics" | "providers" | "domains" | "tasks" | "routines";
 
 const TO_BY_KIND: Record<EntityKind, string> = {
   resources: "/resources/$id",
@@ -10,6 +10,7 @@ const TO_BY_KIND: Record<EntityKind, string> = {
   providers: "/providers/$id",
   domains: "/domains/$id",
   tasks: "/tasks/$id",
+  routines: "/routines/$id",
 };
 
 interface EntityLinkProps {

--- a/packages/client/src/components/boxes/OverviewCardGrid.tsx
+++ b/packages/client/src/components/boxes/OverviewCardGrid.tsx
@@ -1,7 +1,10 @@
+import type { EntityKind } from "@/components/boxElements/EntityLink";
+import type { TopConnectedItem } from "@/utils/topConnected";
 import type { LucideIcon } from "lucide-react";
 
 import { Link } from "@tanstack/react-router";
 
+import { EntityLink } from "@/components/boxElements/EntityLink";
 import { ContentBox } from "@/components/boxes/ContentBox";
 import { cn } from "@/lib/utils";
 
@@ -10,19 +13,21 @@ export interface OverviewCardItem {
   title: string;
   description: string;
   icon: LucideIcon;
+  // The entity kind the top-connected pills link to. Omit for a plain tile.
+  entity?: EntityKind;
+  // The already-ranked top 3 most-connected items of this tile's type.
+  topConnected?: TopConnectedItem[];
 }
 
 function OverviewCard({
-  to, title, description, icon: Icon,
+  to, title, description, icon: Icon, entity, topConnected,
 }: OverviewCardItem) {
   return (
-    <Link
-      to={to}
-      className="group"
-    >
-      <ContentBox
+    <ContentBox className="h-full gap-0 overflow-hidden p-0">
+      <Link
+        to={to}
         className="
-          h-full justify-start gap-3 p-5 transition-colors
+          group flex flex-1 flex-col justify-start gap-3 p-5 transition-colors
           hover:bg-accent hover:text-accent-foreground
         "
       >
@@ -41,8 +46,25 @@ function OverviewCard({
         >
           {description}
         </p>
-      </ContentBox>
-    </Link>
+      </Link>
+      {entity && topConnected && topConnected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-5 pb-5">
+          {topConnected.map(item => (
+            <EntityLink
+              key={item.id}
+              entity={entity}
+              id={item.id}
+              className="
+                rounded-sm bg-gray-50 px-2 py-0.5 text-xs
+                hover:bg-gray-900 hover:text-white
+              "
+            >
+              {item.name}
+            </EntityLink>
+          ))}
+        </div>
+      )}
+    </ContentBox>
   );
 }
 

--- a/packages/client/src/routes/actions.tsx
+++ b/packages/client/src/routes/actions.tsx
@@ -1,15 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { CalendarCheckIcon, ListTodoIcon } from "lucide-react";
 
 import { OverviewCardGrid } from "@/components/boxes/OverviewCardGrid";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
+import { fetchRoutines, fetchTasks } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+import {
+  routineConnectionCount,
+  taskConnectionCount,
+  topConnected,
+} from "@/utils/topConnected";
 
 export const Route = createFileRoute("/actions")({
   component: Actions,
 });
 
 function Actions() {
+  const {
+    data: routines,
+  } = useQuery({
+    queryKey: queryKeys.routines.list(),
+    queryFn: () => fetchRoutines(),
+  });
+  const {
+    data: tasks,
+  } = useQuery({
+    queryKey: queryKeys.tasks.list(),
+    queryFn: () => fetchTasks(),
+  });
+
   return (
     <div>
       <PageHeader
@@ -25,12 +46,24 @@ function Actions() {
               title: "Routines",
               description: ENTITY_DESCRIPTIONS.routines,
               icon: CalendarCheckIcon,
+              entity: "routines",
+              topConnected: topConnected(
+                routines,
+                r => r.name,
+                routineConnectionCount,
+              ),
             },
             {
               to: "/tasks",
               title: "Tasks",
               description: ENTITY_DESCRIPTIONS.tasks,
               icon: ListTodoIcon,
+              entity: "tasks",
+              topConnected: topConnected(
+                tasks,
+                t => t.name,
+                taskConnectionCount,
+              ),
             },
           ]}
         />

--- a/packages/client/src/routes/plans.tsx
+++ b/packages/client/src/routes/plans.tsx
@@ -1,15 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { RadarIcon } from "lucide-react";
 
 import { OverviewCardGrid } from "@/components/boxes/OverviewCardGrid";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
+import { fetchDomains } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+import { domainConnectionCount, topConnected } from "@/utils/topConnected";
 
 export const Route = createFileRoute("/plans")({
   component: Plans,
 });
 
 function Plans() {
+  const {
+    data: domains,
+  } = useQuery({
+    queryKey: queryKeys.domains.list(),
+    queryFn: () => fetchDomains(),
+  });
+
   return (
     <div>
       <PageHeader
@@ -29,6 +40,12 @@ function Plans() {
               title: "Domains",
               description: ENTITY_DESCRIPTIONS.domains,
               icon: RadarIcon,
+              entity: "domains",
+              topConnected: topConnected(
+                domains,
+                d => d.title,
+                domainConnectionCount,
+              ),
             },
           ]}
         />

--- a/packages/client/src/routes/records.tsx
+++ b/packages/client/src/routes/records.tsx
@@ -1,15 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { BookOpenIcon, Building2Icon, LightbulbIcon } from "lucide-react";
 
 import { OverviewCardGrid } from "@/components/boxes/OverviewCardGrid";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
+import { fetchProviders, fetchResources, fetchTopics } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+import {
+  providerConnectionCount,
+  resourceConnectionCount,
+  topConnected,
+  topicConnectionCount,
+} from "@/utils/topConnected";
 
 export const Route = createFileRoute("/records")({
   component: Records,
 });
 
 function Records() {
+  const {
+    data: providers,
+  } = useQuery({
+    queryKey: queryKeys.providers.list(),
+    queryFn: () => fetchProviders(),
+  });
+  const {
+    data: resources,
+  } = useQuery({
+    queryKey: queryKeys.resources.list(),
+    queryFn: () => fetchResources(),
+  });
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: queryKeys.topics.list(),
+    queryFn: () => fetchTopics(),
+  });
+
   return (
     <div>
       <PageHeader
@@ -24,18 +52,36 @@ function Records() {
               title: "Providers",
               description: ENTITY_DESCRIPTIONS.providers,
               icon: Building2Icon,
+              entity: "providers",
+              topConnected: topConnected(
+                providers,
+                p => p.name,
+                providerConnectionCount,
+              ),
             },
             {
               to: "/resources",
               title: "Resources",
               description: ENTITY_DESCRIPTIONS.resources,
               icon: BookOpenIcon,
+              entity: "resources",
+              topConnected: topConnected(
+                resources,
+                r => r.name,
+                resourceConnectionCount,
+              ),
             },
             {
               to: "/topics",
               title: "Topics",
               description: ENTITY_DESCRIPTIONS.topics,
               icon: LightbulbIcon,
+              entity: "topics",
+              topConnected: topConnected(
+                topics,
+                t => t.name,
+                topicConnectionCount,
+              ),
             },
           ]}
         />

--- a/packages/client/src/utils/topConnected.test.ts
+++ b/packages/client/src/utils/topConnected.test.ts
@@ -1,0 +1,224 @@
+import type {
+  Domain,
+  ResourceInResources,
+  Tag,
+  TaskResource,
+  TaskResourceLink,
+} from "@emstack/types";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  domainConnectionCount,
+  providerConnectionCount,
+  resourceConnectionCount,
+  routineConnectionCount,
+  taskConnectionCount,
+  topConnected,
+  topicConnectionCount,
+} from "./topConnected.ts";
+
+// Minimal valid resource shell for the resource-count tests (only `topics`
+// matters, but the type requires these fields).
+const baseResource: ResourceInResources = {
+  id: "r",
+  name: "R",
+  url: "",
+  dateExpires: "",
+  cost: {
+    splitBy: 1,
+  } as ResourceInResources["cost"],
+  progressCurrent: 0,
+  progressTotal: 0,
+  status: "active",
+};
+
+describe("connection count formulas", () => {
+  test("topic sums resource, task and daily counts", () => {
+    expect(topicConnectionCount({
+      id: "t",
+      name: "T",
+      resourceCount: 2,
+      taskCount: 3,
+      dailyCount: 1,
+    })).toBe(6);
+  });
+
+  test("missing optional counts are treated as zero", () => {
+    expect(topicConnectionCount({
+      id: "t",
+      name: "T",
+    })).toBe(0);
+    expect(resourceConnectionCount(baseResource)).toBe(0);
+    expect(providerConnectionCount({
+      id: "p",
+      name: "P",
+      url: "",
+    })).toBe(0);
+    expect(domainConnectionCount({
+      id: "d",
+      title: "D",
+    })).toBe(0);
+    expect(routineConnectionCount({
+      id: "r",
+      name: "R",
+    })).toBe(0);
+    expect(taskConnectionCount({
+      id: "k",
+      name: "K",
+    })).toBe(0);
+  });
+
+  test("resource counts only its linked topics", () => {
+    expect(resourceConnectionCount({
+      ...baseResource,
+      topics: [
+        {
+          id: "1",
+          name: "a",
+        },
+        {
+          id: "2",
+          name: "b",
+        },
+      ],
+    })).toBe(2);
+  });
+
+  test("provider uses resourceCount", () => {
+    expect(providerConnectionCount({
+      id: "p",
+      name: "P",
+      url: "",
+      resourceCount: 5,
+    })).toBe(5);
+  });
+
+  test("domain uses topicCount", () => {
+    expect(domainConnectionCount({
+      id: "d",
+      title: "D",
+      topicCount: 4,
+    })).toBe(4);
+  });
+
+  test("routine counts its connections", () => {
+    expect(routineConnectionCount({
+      id: "r",
+      name: "R",
+      connections: [
+        {
+          type: "topic",
+          id: "1",
+        },
+        {
+          type: "task",
+          id: "2",
+        },
+      ],
+    })).toBe(2);
+  });
+
+  test("task sums topic, tags and both kinds of resource link", () => {
+    expect(taskConnectionCount({
+      id: "k",
+      name: "K",
+      topic: {
+        id: "t",
+        name: "T",
+      },
+      tags: [{}, {}] as Tag[],
+      resourceLinks: [{}] as TaskResourceLink[],
+      resources: [{}, {}, {}] as TaskResource[],
+    })).toBe(1 + 2 + 1 + 3);
+  });
+});
+
+describe("topConnected ranker", () => {
+  interface Row {
+    id: string;
+    name: string;
+    count: number;
+  }
+  const make = (id: string, name: string, count: number): Row => ({
+    id,
+    name,
+    count,
+  });
+  const getName = (i: Row) => i.name;
+  const getCount = (i: Row) => i.count;
+
+  test("returns [] for undefined or empty input", () => {
+    expect(topConnected<Row>(undefined, getName, getCount)).toEqual([]);
+    expect(topConnected<Row>([], getName, getCount)).toEqual([]);
+  });
+
+  test("drops items with no connections", () => {
+    const items = [make("a", "A", 0), make("b", "B", 2)];
+    expect(topConnected(items, getName, getCount)).toEqual([
+      {
+        id: "b",
+        name: "B",
+        count: 2,
+      },
+    ]);
+  });
+
+  test("sorts by count desc, breaks ties alphabetically, caps at limit", () => {
+    const items = [
+      make("a", "Beta", 5),
+      make("b", "Alpha", 5),
+      make("c", "Gamma", 9),
+      make("d", "Delta", 1),
+    ];
+    expect(topConnected(items, getName, getCount)).toEqual([
+      {
+        id: "c",
+        name: "Gamma",
+        count: 9,
+      },
+      {
+        id: "b",
+        name: "Alpha",
+        count: 5,
+      },
+      {
+        id: "a",
+        name: "Beta",
+        count: 5,
+      },
+    ]);
+  });
+
+  test("respects a custom limit", () => {
+    const items = [make("a", "A", 3), make("b", "B", 2), make("c", "C", 1)];
+    expect(topConnected(items, getName, getCount, 2)).toHaveLength(2);
+  });
+
+  test("uses the supplied name accessor (domains expose `title`)", () => {
+    const domains: Domain[] = [
+      {
+        id: "d1",
+        title: "Backend",
+        topicCount: 4,
+      },
+      {
+        id: "d2",
+        title: "Frontend",
+        topicCount: 7,
+      },
+    ];
+    expect(topConnected(domains, d => d.title, domainConnectionCount)).toEqual([
+      {
+        id: "d2",
+        name: "Frontend",
+        count: 7,
+      },
+      {
+        id: "d1",
+        name: "Backend",
+        count: 4,
+      },
+    ]);
+  });
+});

--- a/packages/client/src/utils/topConnected.ts
+++ b/packages/client/src/utils/topConnected.ts
@@ -1,0 +1,76 @@
+import type {
+  CourseProvider,
+  Domain,
+  ResourceInResources,
+  Routine,
+  Task,
+  TopicForTopicsPage,
+} from "@emstack/types";
+
+// One ranked entry shown as a pill inside an overview tile. `count` drives the
+// ranking; the tiles render `name` only.
+export interface TopConnectedItem {
+  id: string;
+  name: string;
+  count: number;
+}
+
+// Per-type "total links across all relationship types" counts, computed from
+// the shapes the *list* endpoints return (not the heavier detail payloads).
+// Keeping the definition of "most connected" in one place makes it easy to
+// tweak what counts as a connection later.
+
+export function topicConnectionCount(topic: TopicForTopicsPage): number {
+  return (topic.resourceCount ?? 0)
+    + (topic.taskCount ?? 0)
+    + (topic.dailyCount ?? 0);
+}
+
+// The resources list payload (ResourceInResources) carries linked topics only —
+// no tags — so a resource's connectedness is its linked-topic count.
+export function resourceConnectionCount(resource: ResourceInResources): number {
+  return resource.topics?.length ?? 0;
+}
+
+export function providerConnectionCount(provider: CourseProvider): number {
+  return provider.resourceCount ?? 0;
+}
+
+export function domainConnectionCount(domain: Domain): number {
+  return domain.topicCount ?? 0;
+}
+
+export function routineConnectionCount(routine: Routine): number {
+  return routine.connections?.length ?? 0;
+}
+
+// `resourceLinks` are links to real Resource entities; `resources` are legacy
+// task-local resources. Both are link rows, so both count toward the total.
+export function taskConnectionCount(task: Task): number {
+  return (task.topic ? 1 : 0)
+    + (task.tags?.length ?? 0)
+    + (task.resourceLinks?.length ?? 0)
+    + (task.resources?.length ?? 0);
+}
+
+// Rank a list by connection count and return the top `limit` entries. Items
+// with no connections are dropped so a tile shows nothing rather than empty
+// pills; ties break alphabetically by name for stable display.
+export function topConnected<T extends { id: string }>(
+  items: T[] | undefined,
+  getName: (item: T) => string,
+  getCount: (item: T) => number,
+  limit = 3,
+): TopConnectedItem[] {
+  if (!items?.length) return [];
+
+  return items
+    .map(item => ({
+      id: item.id,
+      name: getName(item),
+      count: getCount(item),
+    }))
+    .filter(item => item.count > 0)
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, limit);
+}

--- a/packages/middleware/src/routes/api/providers/getProviders.ts
+++ b/packages/middleware/src/routes/api/providers/getProviders.ts
@@ -34,7 +34,7 @@ export default async function (server: FastifyInstance) {
         return sendNotFound(reply, "Provider");
       }
 
-      const courseCount = provider.resources?.length ?? 0;
+      const resourceCount = provider.resources?.length ?? 0;
       const resources = provider.resources.map(resource => ({
         name: resource.name,
         id: resource.id,
@@ -51,7 +51,7 @@ export default async function (server: FastifyInstance) {
         recurPeriodUnit: provider.recurPeriodUnit,
         recurPeriod: provider.recurPeriod,
         isCourseFeesShared: provider.isCourseFeesShared,
-        courseCount: courseCount,
+        resourceCount: resourceCount,
         resources: resources,
       };
     },

--- a/packages/middleware/src/routes/api/providers/root.ts
+++ b/packages/middleware/src/routes/api/providers/root.ts
@@ -36,7 +36,7 @@ export default async function (server: FastifyInstance) {
           recurPeriodUnit: provider.recurPeriodUnit,
           recurPeriod: provider.recurPeriod,
           isCourseFeesShared: provider.isCourseFeesShared,
-          courseCount: resources.length,
+          resourceCount: resources.length,
           activeCount: countByStatus("active"),
           inactiveCount: countByStatus("inactive"),
           completeCount: countByStatus("complete"),


### PR DESCRIPTION
## Summary

Add a ranking system to identify and display the most-connected entities (topics, resources, providers, domains, routines, and tasks) on their respective overview tiles. Each tile now shows up to 3 pills linking to the most-connected items of that type, helping users quickly navigate to high-activity areas.

## Key Changes

- **New utility module** (`topConnected.ts`): Defines per-entity connection-count formulas and a generic ranking function
  - `topicConnectionCount`: sums resource, task, and daily counts
  - `resourceConnectionCount`: counts linked topics
  - `providerConnectionCount`: uses resource count
  - `domainConnectionCount`: uses topic count
  - `routineConnectionCount`: counts connections array length
  - `taskConnectionCount`: sums topic (1 if present), tags, resource links, and resources
  - `topConnected()`: filters items with zero connections, sorts by count (desc) then name (asc), caps at limit (default 3)

- **Comprehensive test coverage** (`topConnected.test.ts`): 224 lines of tests covering all connection formulas and ranking edge cases (empty input, zero connections, tie-breaking, custom limits, type-specific accessors)

- **Updated overview pages** to fetch and rank entities:
  - `/records` (providers, resources, topics)
  - `/actions` (routines, tasks)
  - `/plans` (domains)

- **Enhanced `OverviewCardGrid`**: 
  - Added `entity` and `topConnected` optional props to `OverviewCardItem`
  - Renders pills at the bottom of each card linking to top-connected items via `EntityLink`
  - Pills styled as small gray tags with hover effect

- **Backend fix**: Renamed `courseCount` to `resourceCount` in provider API responses for consistency

- **Type expansion**: Added `"routines"` to `EntityKind` union in `EntityLink` component

## Implementation Details

- Connection counts are computed from list-endpoint payloads (lightweight shapes), not detail endpoints, keeping queries efficient
- Items with zero connections are filtered out so tiles show nothing rather than empty pill sections
- Tie-breaking by name ensures stable, predictable display across renders
- Each entity type's "connectedness" definition is isolated in its own function, making it easy to adjust what counts as a connection later

https://claude.ai/code/session_01Q3fi8jKMwvDiar4khe1Hh8