### PR TITLE
refactor: rename LinkOptionResource to ResourceLinkOption

### DIFF
--- a/packages/client/src/components/tasks/ResourceLinksPicker.tsx
+++ b/packages/client/src/components/tasks/ResourceLinksPicker.tsx
@@ -1,4 +1,4 @@
-import type { LinkOptionResource } from "./resourceMeta";
+import type { ResourceLinkOption } from "./resourceMeta";
 import type { Module, ModuleGroup } from "@emstack/types";
 
 import { useMemo } from "react";
@@ -19,7 +19,7 @@ interface ResourceLinkInput {
 interface ResourceLinksPickerProps {
   value: ResourceLinkInput[];
   onChange: (next: ResourceLinkInput[]) => void;
-  courses: LinkOptionResource[];
+  courses: ResourceLinkOption[];
   moduleGroups: ModuleGroup[];
   modules: Module[];
 }

--- a/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
+++ b/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
@@ -1,4 +1,4 @@
-import type { LinkOptionResource } from "./resourceMeta";
+import type { ResourceLinkOption } from "./resourceMeta";
 import type {
   Module,
   ModuleGroup,
@@ -24,7 +24,7 @@ export function EditingRow({
   onDelete,
 }: {
   resource: TaskResource;
-  resourceOptions: LinkOptionResource[];
+  resourceOptions: ResourceLinkOption[];
   allModuleGroups: ModuleGroup[];
   allModules: Module[];
   isNew?: boolean;

--- a/packages/client/src/components/tasks/resourceMeta.ts
+++ b/packages/client/src/components/tasks/resourceMeta.ts
@@ -48,8 +48,9 @@ export function getResourceLevelClass(
 export type ResourceLevelKey
   = "easeOfStarting" | "timeNeeded" | "interactivity";
 
-// A Resource reduced to its identity for a resource-link <select>.
-export interface LinkOptionResource {
+// A Resource reduced to its identity ({ id, name }) for a resource-link
+// <select> option.
+export interface ResourceLinkOption {
   id: string;
   name: string;
 }


### PR DESCRIPTION
## Summary
Rename the `LinkOptionResource` interface to `ResourceLinkOption` for improved clarity and consistency with naming conventions.

## Changes
- Renamed `LinkOptionResource` interface to `ResourceLinkOption` in `resourceMeta.ts`
- Updated the JSDoc comment to clarify that the interface represents a resource reduced to its identity (`{ id, name }`) for use in resource-link `<select>` options
- Updated all imports and type references in `ResourceLinksPicker.tsx` and `TaskResourceEditingRow.tsx` to use the new name

## Details
The new name `ResourceLinkOption` better reflects the interface's purpose as an option type for resource-link selection components, improving code readability and maintainability.

https://claude.ai/code/session_01RiBF6n1fSJu6M25qQAJkRg