### PR TITLE
refactor: extract hover popover logic into useHoverPopover hook

### DIFF
--- a/packages/client/src/components/dailies/DailyCommentPopover.tsx
+++ b/packages/client/src/components/dailies/DailyCommentPopover.tsx
@@ -1,6 +1,6 @@
 import type { Daily } from "@emstack/types";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CheckIcon, MessageSquareIcon, PencilIcon } from "lucide-react";
@@ -13,6 +13,7 @@ import {
 } from "@/components/popover";
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
+import { useHoverPopover } from "@/hooks/useHoverPopover";
 import { cn } from "@/lib/utils";
 import {
   getTodayKey,
@@ -35,10 +36,12 @@ export function DailyCommentPopover({
     = daily.completions.find(c => c.date === todayKey)?.note?.trim() || "";
   const hasNote = note.length > 0;
 
-  const [open, setOpen] = useState(false);
+  const {
+    open, setOpen, cancelClose, handleOpen, handleClose,
+  }
+    = useHoverPopover();
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(note);
-  const hoverCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!open) {
@@ -48,37 +51,18 @@ export function DailyCommentPopover({
     setDraft(note);
   }, [open, hasNote, note]);
 
-  useEffect(() => {
-    return () => {
-      if (hoverCloseTimer.current) {
-        clearTimeout(hoverCloseTimer.current);
-      }
-    };
-  }, []);
-
-  const cancelHoverClose = () => {
-    if (hoverCloseTimer.current) {
-      clearTimeout(hoverCloseTimer.current);
-      hoverCloseTimer.current = null;
-    }
-  };
-
   const handleHoverOpen = () => {
     if (!hasNote || isEditing) {
       return;
     }
-    cancelHoverClose();
-    setOpen(true);
+    handleOpen();
   };
 
   const handleHoverClose = () => {
     if (isEditing) {
       return;
     }
-    cancelHoverClose();
-    hoverCloseTimer.current = setTimeout(() => {
-      setOpen(false);
-    }, 120);
+    handleClose();
   };
 
   const mutation = useMutation({
@@ -139,7 +123,7 @@ export function DailyCommentPopover({
           aria-expanded={open}
           title={hasNote ? "View comment" : "Add comment"}
           onClick={() => {
-            cancelHoverClose();
+            cancelClose();
             if (!hasNote) {
               setIsEditing(true);
             }
@@ -162,7 +146,7 @@ export function DailyCommentPopover({
       <PopoverContent
         className="w-80 p-3"
         align="end"
-        onMouseEnter={cancelHoverClose}
+        onMouseEnter={cancelClose}
         onMouseLeave={handleHoverClose}
         onOpenAutoFocus={(e) => {
           if (!isEditing) {

--- a/packages/client/src/components/dailies/DailyProgressCell.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.tsx
@@ -1,7 +1,5 @@
 import type { Daily } from "@emstack/types";
 
-import { useEffect, useRef, useState } from "react";
-
 import { InfinityIcon } from "lucide-react";
 
 import {
@@ -15,6 +13,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHoverPopover } from "@/hooks/useHoverPopover";
 
 interface DailyProgressCellProps {
   daily: Daily;
@@ -33,33 +32,10 @@ function HoverProgressPopover({
   total,
   children,
 }: HoverProgressPopoverProps) {
-  const [open, setOpen] = useState(false);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (closeTimer.current) {
-        clearTimeout(closeTimer.current);
-      }
-    };
-  }, []);
-
-  const cancelClose = () => {
-    if (closeTimer.current) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  };
-
-  const handleOpen = () => {
-    cancelClose();
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    cancelClose();
-    closeTimer.current = setTimeout(() => setOpen(false), 120);
-  };
+  const {
+    open, setOpen, cancelClose, handleOpen, handleClose,
+  }
+    = useHoverPopover();
 
   return (
     <Popover

--- a/packages/client/src/hooks/useHoverPopover.test.ts
+++ b/packages/client/src/hooks/useHoverPopover.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useHoverPopover } from "./useHoverPopover";
+
+describe("useHoverPopover", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  test("starts closed", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover());
+    expect(result.current.open).toBe(false);
+  });
+
+  test("handleOpen opens immediately", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover());
+    act(() => {
+      result.current.handleOpen();
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  test("handleClose keeps it open until the close delay elapses", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover());
+    act(() => {
+      result.current.handleOpen();
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+
+    // still open just before the 120ms grace period ends
+    act(() => {
+      vi.advanceTimersByTime(119);
+    });
+    expect(result.current.open).toBe(true);
+
+    // closed once the grace period completes
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  test("cancelClose aborts a pending close", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover());
+    act(() => {
+      result.current.handleOpen();
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+    act(() => {
+      result.current.cancelClose();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  test("honours a custom closeDelay", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover({
+      closeDelay: 300,
+    }));
+    act(() => {
+      result.current.handleOpen();
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(result.current.open).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(180);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  test("setOpen toggles directly (click-toggle escape hatch)", () => {
+    const {
+      result,
+    } = renderHook(() => useHoverPopover());
+    act(() => {
+      result.current.setOpen(prev => !prev);
+    });
+    expect(result.current.open).toBe(true);
+    act(() => {
+      result.current.setOpen(prev => !prev);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  test("clears a pending close timer on unmount", () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const {
+      result, unmount,
+    } = renderHook(() => useHoverPopover());
+    act(() => {
+      result.current.handleOpen();
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+
+    unmount();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/hooks/useHoverPopover.ts
+++ b/packages/client/src/hooks/useHoverPopover.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseHoverPopoverOptions {
+  /** ms to wait after hover-out before closing (grace period for re-entering). */
+  closeDelay?: number;
+}
+
+/**
+ * Hover-driven open/close state for a popover: opens immediately on
+ * handleOpen, closes after a short grace delay on handleClose (so the
+ * pointer can travel into the popover content), with cancelClose to abort a
+ * pending close and a setOpen escape hatch for click-toggle / onOpenChange.
+ * Stays dumb about app-specific guards — wrap handleOpen/handleClose at the
+ * call site where needed.
+ */
+export function useHoverPopover({
+  closeDelay = 120,
+}: UseHoverPopoverOptions = {}) {
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const handleOpen = () => {
+    cancelClose();
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setOpen(false), closeDelay);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    };
+  }, []);
+
+  return {
+    open,
+    setOpen,
+    cancelClose,
+    handleOpen,
+    handleClose,
+  };
+}


### PR DESCRIPTION
## Summary

Extracted repeated hover-driven popover state management logic into a reusable `useHoverPopover` hook. This eliminates duplication across `DailyCommentPopover` and `DailyProgressCell` components and provides a consistent, tested interface for managing popover open/close state with a configurable grace period.

## Key Changes

- **New hook:** `useHoverPopover` in `packages/client/src/hooks/useHoverPopover.ts`
  - Manages open/close state with a configurable `closeDelay` (default 120ms)
  - Provides `handleOpen()` (immediate), `handleClose()` (delayed), and `cancelClose()` (abort pending close)
  - Includes `setOpen()` escape hatch for click-toggle / `onOpenChange` scenarios
  - Cleans up pending timers on unmount

- **Comprehensive test suite:** `useHoverPopover.test.ts`
  - Tests initial state, immediate open, delayed close with grace period
  - Verifies `cancelClose()` aborts pending closes
  - Validates custom `closeDelay` option
  - Confirms `setOpen()` works as an escape hatch
  - Ensures cleanup on unmount

- **Refactored components:**
  - `DailyCommentPopover`: Replaced inline timer logic with `useHoverPopover()`
  - `DailyProgressCell` (`HoverProgressPopover`): Replaced inline timer logic with `useHoverPopover()`

## Implementation Details

The hook keeps the popover dumb about app-specific guards (e.g., "don't open if editing" or "don't open if no note exists") — those checks remain at the call site where `handleOpen`/`handleClose` are wrapped. This separation of concerns makes the hook reusable and testable without coupling it to component-specific logic.

https://claude.ai/code/session_01QFVZM6nh9jtRDGPzEebts5