### PR TITLE
refactor(client): adopt EmptyDash/EmptyHint primitives outside boxes/

### DIFF
--- a/packages/client/src/components/radar/BlipDisplayRow.tsx
+++ b/packages/client/src/components/radar/BlipDisplayRow.tsx
@@ -34,6 +34,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { EmptyDash } from "@/components/ui/EmptyDash";
+import { EmptyHint } from "@/components/ui/EmptyHint";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
@@ -94,9 +96,7 @@ export function BlipDisplayRow({
             : undefined;
           if (!q) {
             return (
-              <span className="text-xs text-muted-foreground italic">
-                unassigned
-              </span>
+              <EmptyHint>unassigned</EmptyHint>
             );
           }
           return (
@@ -114,14 +114,12 @@ export function BlipDisplayRow({
       <TableCell>
         {(() => {
           if (blip.isIgnored) {
-            return <span className="text-xs text-muted-foreground">—</span>;
+            return <EmptyDash className="text-xs" />;
           }
           const r = blip.ringId ? ringById.get(blip.ringId) : undefined;
           if (!r) {
             return (
-              <span className="text-xs text-muted-foreground italic">
-                unassigned
-              </span>
+              <EmptyHint>unassigned</EmptyHint>
             );
           }
           return (

--- a/packages/client/src/components/radar/BlipLlmReviewTable.tsx
+++ b/packages/client/src/components/radar/BlipLlmReviewTable.tsx
@@ -24,6 +24,7 @@ import { Textarea } from "@/components/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
+import { EmptyDash } from "@/components/ui/EmptyDash";
 import {
   Select,
   SelectContent,
@@ -396,7 +397,7 @@ function PlacementTableCell({
   if (isRemove) {
     return (
       <TableCell className="align-top">
-        <span className="text-xs text-muted-foreground">—</span>
+        <EmptyDash className="text-xs" />
       </TableCell>
     );
   }

--- a/packages/client/src/components/radar/radarLegendItem.tsx
+++ b/packages/client/src/components/radar/radarLegendItem.tsx
@@ -6,6 +6,7 @@ import { ArrowRightIcon } from "lucide-react";
 
 import { BlipDescriptionPopover } from "@/components/radar/BlipDescriptionPopover";
 import { Button } from "@/components/ui/button";
+import { EmptyHint } from "@/components/ui/EmptyHint";
 import { cn } from "@/lib/utils";
 
 /** Callbacks threaded from a legend section down to each blip row. */
@@ -71,7 +72,9 @@ export function BlipLegendSection({
         {title}
       </h4>
       {items.length === 0 && emptyMessage !== undefined && (
-        <p className="text-xs text-muted-foreground italic">{emptyMessage}</p>
+        <EmptyHint asChild>
+          <p>{emptyMessage}</p>
+        </EmptyHint>
       )}
       <ul className="flex flex-col gap-0.5">
         {items.map(({
@@ -162,9 +165,12 @@ export function BlipLegendItem({
         </div>
       </div>
       {description && (
-        <p className="mt-0.5 ml-4 text-xs text-muted-foreground italic">
-          {description}
-        </p>
+        <EmptyHint
+          asChild
+          className="mt-0.5 ml-4"
+        >
+          <p>{description}</p>
+        </EmptyHint>
       )}
     </li>
   );

--- a/packages/client/src/components/resources/ModuleSuggestDialog.tsx
+++ b/packages/client/src/components/resources/ModuleSuggestDialog.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { EmptyHint } from "@/components/ui/EmptyHint";
 import { copyTextToClipboard, stripCodeFence } from "@/utils";
 import { createModule, createModuleGroup } from "@/utils/fetchFunctions";
 
@@ -850,10 +851,10 @@ function SuggestionGroupCard({
             </span>
           )}
           {!groupSelected && (
-            <span className="text-xs text-muted-foreground italic">
+            <EmptyHint>
               Group skipped — selected modules below will be created without
               this group.
-            </span>
+            </EmptyHint>
           )}
         </span>
       </label>

--- a/packages/client/src/components/ui/EmptyHint.stories.tsx
+++ b/packages/client/src/components/ui/EmptyHint.stories.tsx
@@ -23,3 +23,18 @@ export const Default: Story = {
     await expect(canvas.getByText("No connections")).toBeInTheDocument();
   },
 };
+
+export const AsChild: Story = {
+  args: {
+    asChild: true,
+    className: "mt-0.5 ml-4",
+    children: <p>Rendered as a block paragraph</p>,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const hint = canvas.getByText("Rendered as a block paragraph");
+    await expect(hint.tagName).toBe("P");
+  },
+};

--- a/packages/client/src/components/ui/EmptyHint.test.tsx
+++ b/packages/client/src/components/ui/EmptyHint.test.tsx
@@ -16,4 +16,20 @@ describe("EmptyHint", () => {
     expect(hint).toHaveClass("italic");
     expect(hint).toHaveClass("ml-4");
   });
+
+  test("asChild renders the styling onto the provided element", () => {
+    render(
+      <EmptyHint
+        asChild
+        className="mt-0.5"
+      >
+        <p>No connections</p>
+      </EmptyHint>,
+    );
+    const hint = screen.getByText("No connections");
+    expect(hint.tagName).toBe("P");
+    expect(hint).toHaveClass("text-muted-foreground");
+    expect(hint).toHaveClass("italic");
+    expect(hint).toHaveClass("mt-0.5");
+  });
 });

--- a/packages/client/src/components/ui/EmptyHint.tsx
+++ b/packages/client/src/components/ui/EmptyHint.tsx
@@ -1,15 +1,21 @@
+import { Slot } from "radix-ui";
+
 import { cn } from "@/lib/utils";
 
 /**
  * Small italic muted text for an empty/placeholder hint, e.g. "No topic" or
  * "No connections". Pass children for the message and `className` to extend.
+ * Pass `asChild` to render the styling onto a custom element (e.g. a block
+ * `<p>`) instead of the default inline `<span>`.
  */
 export function EmptyHint({
   className,
+  asChild = false,
   ...props
-}: React.ComponentProps<"span">) {
+}: React.ComponentProps<"span"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
   return (
-    <span
+    <Comp
       className={cn("text-xs text-muted-foreground italic", className)}
       {...props}
     />

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -24,6 +24,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
+import { EmptyDash } from "@/components/ui/EmptyDash";
 import { makeManualSortHandler, toSortingState } from "@/components/ui/manualSort";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
@@ -296,7 +297,7 @@ const courseColumns: ColumnDef<CourseRow>[] = [
           </Button>
         )
         : (
-          <span className="text-muted-foreground">—</span>
+          <EmptyDash />
         ),
   },
 ];


### PR DESCRIPTION
## Summary

Follow-up to #316 (`refactor/boxes-components`). That PR extracted the `EmptyDash` and `EmptyHint` placeholder primitives but only converted the `components/boxes/` call sites to stay scoped. This adopts them at the remaining identical hand-rolled spans elsewhere.

> **Stacked on #316.** This PR targets `refactor/boxes-components` (where the primitives live) and should merge after / into it. The diff here is only the #315 change.

## Changes

- **`EmptyDash` (`—`)** — `radar/BlipLlmReviewTable.tsx`, `radar/BlipDisplayRow.tsx` (both the `text-xs` variant), and `dashboard.-components/-DashboardCoursesByAmortization.tsx`.
- **`EmptyHint` (italic muted hint)** — the two `unassigned` cells in `radar/BlipDisplayRow.tsx` and the "Group skipped…" note in `resources/ModuleSuggestDialog.tsx`.
- **Widened `EmptyHint` with an `asChild` override** (Radix `Slot.Root`, matching the `button.tsx` pattern) so the two `radar/radarLegendItem.tsx` `<p>` blocks adopt the styling while keeping their block element and `mt-0.5 ml-4` spacing. This resolves the issue's open "decide during the refactor" question in favor of the element override.
- Added co-located `asChild` coverage to `EmptyHint.test.tsx` and `EmptyHint.stories.tsx`.

## Test plan

- [x] `pnpm --filter=@emstack/client run typecheck` — clean
- [x] `pnpm --filter=@emstack/client exec vitest run --project=unit-tests src/components/ui/EmptyHint.test.tsx` — 3/3
- [x] `pnpm --filter=@emstack/client exec vitest run --project=storybook` for the EmptyHint + affected radar stories — 10/10
- [x] `pnpm exec eslint` on changed files — 0 errors

Resolves #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)