### PR TITLE
build: use path.resolve for tailwindcss entryPoint in eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,6 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import path from "node:path";
+
 import emstackConfig from "@emilyeserven/eslint-config";
 import globals from "globals";
 import tseslint from "typescript-eslint";
@@ -12,7 +14,7 @@ export default tseslint.config([
     ignores: ["pnpm-lock.yaml"],
     settings: {
       "better-tailwindcss": {
-        entryPoint: "./packages/client/src/index.css",
+        entryPoint: path.resolve(import.meta.dirname, "packages/client/src/index.css"),
       },
     },
   },


### PR DESCRIPTION
## Summary
Updates the ESLint configuration to use `path.resolve()` with `import.meta.dirname` for the Tailwind CSS entry point, replacing a relative path string with an absolute path resolution.

## Changes
- Added `import node:path` import to `eslint.config.js`
- Changed `better-tailwindcss.entryPoint` from a relative path string (`"./packages/client/src/index.css"`) to an absolute path resolved via `path.resolve(import.meta.dirname, "packages/client/src/index.css")`

## Details
This change ensures the Tailwind CSS entry point is resolved relative to the ESLint config file's location rather than the current working directory, making the configuration more robust across different execution contexts (e.g., when ESLint is run from different directories or in CI environments).

https://claude.ai/code/session_01GJU7iZqiJ7RkKGZp8ziiXT