### PR TITLE
refactor: rename ResourceLinkOption to ResourceSelectOption

### DIFF
--- a/packages/client/src/components/tasks/ResourceLinksPicker.tsx
+++ b/packages/client/src/components/tasks/ResourceLinksPicker.tsx
@@ -1,4 +1,4 @@
-import type { ResourceLinkOption } from "./resourceMeta";
+import type { ResourceSelectOption } from "./resourceMeta";
 import type { Module, ModuleGroup } from "@emstack/types";
 
 import { useMemo } from "react";
@@ -19,7 +19,7 @@ interface ResourceLinkInput {
 interface ResourceLinksPickerProps {
   value: ResourceLinkInput[];
   onChange: (next: ResourceLinkInput[]) => void;
-  courses: ResourceLinkOption[];
+  courses: ResourceSelectOption[];
   moduleGroups: ModuleGroup[];
   modules: Module[];
 }

--- a/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
+++ b/packages/client/src/components/tasks/TaskResourceEditingRow.tsx
@@ -1,4 +1,4 @@
-import type { ResourceLinkOption } from "./resourceMeta";
+import type { ResourceSelectOption } from "./resourceMeta";
 import type {
   Module,
   ModuleGroup,
@@ -24,7 +24,7 @@ export function EditingRow({
   onDelete,
 }: {
   resource: TaskResource;
-  resourceOptions: ResourceLinkOption[];
+  resourceOptions: ResourceSelectOption[];
   allModuleGroups: ModuleGroup[];
   allModules: Module[];
   isNew?: boolean;

--- a/packages/client/src/components/tasks/resourceMeta.ts
+++ b/packages/client/src/components/tasks/resourceMeta.ts
@@ -48,9 +48,9 @@ export function getResourceLevelClass(
 export type ResourceLevelKey
   = "easeOfStarting" | "timeNeeded" | "interactivity";
 
-// A Resource reduced to its identity ({ id, name }) for a resource-link
+// A Resource reduced to its identity ({ id, name }) for a resource
 // <select> option.
-export interface ResourceLinkOption {
+export interface ResourceSelectOption {
   id: string;
   name: string;
 }


### PR DESCRIPTION
## Summary
Rename the `ResourceLinkOption` type to `ResourceSelectOption` to better reflect its actual usage as a generic resource selection option, not specifically tied to resource links.

## Changes
- Renamed `ResourceLinkOption` interface to `ResourceSelectOption` in `resourceMeta.ts`
- Updated type imports and usages in `ResourceLinksPicker.tsx` and `TaskResourceEditingRow.tsx`
- Updated JSDoc comment to reflect the more general purpose of the type

## Details
The type represents a resource reduced to its identity (`{ id, name }`) for use in `<select>` options. The previous name was misleading as it suggested a specific link-related context, while the type is actually used generically across resource selection scenarios. This rename improves code clarity and maintainability.

https://claude.ai/code/session_01SoCZ2faLfcTDCkC8VHFX3m