### PR TITLE
chore: configure Prettier to be a no-op in this repo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# This repo formats with ESLint @stylistic, not Prettier.
+# Prettier is only present transitively; ignore everything so any
+# editor/agent "format on save" Prettier run is a no-op here.
+**


### PR DESCRIPTION
## Summary

Added a `.prettierignore` file to prevent Prettier from formatting code in this repository, since the project uses ESLint @stylistic for code formatting instead.

## Changes

- Created `.prettierignore` with a comment explaining that this repo uses ESLint @stylistic, not Prettier
- Configured to ignore all files (`**`) so that any editor or agent "format on save" Prettier runs become no-ops

## Details

Prettier is present in the dependency tree transitively but is not the active formatter for this project. This file ensures that if an editor or tooling agent attempts to run Prettier automatically (e.g., on save), it will have no effect, preventing conflicts with the ESLint @stylistic configuration that is the actual source of truth for code formatting.

https://claude.ai/code/session_014Ld7vxft68qyYoRdxuxzLB