### PR TITLE
refactor(client): Fixes #309: reduce imports in dailies components

### DIFF
--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: reduce-imports
+description: >-
+  Bring a file (or folder) under the `import/max-dependencies` ESLint warning
+  (threshold 10) by grouping cohesive sibling modules into sub-barrels and
+  extracting logic-heavy hooks — without changing behavior. Use when asked to
+  "reduce imports", "fix max-dependencies", "too many imports/dependencies in
+  this file", or to resolve an issue under the import/max-dependencies cleanup
+  tracker (#312).
+---
+
+# Reduce imports (course-tracker)
+
+`pnpm lint` warns on `import/max-dependencies` for many files in
+`packages/client`. The cleanup is tracked in **#312**, split into per-area
+issues (dailies, resources, routines, routes, …). This skill is the repeatable
+procedure for one such area. Quality only — behavior must not change. For
+behavior cleanups use `/simplify`; for bugs use `/code-review`.
+
+## How the rule actually counts (read this first)
+
+Config: `@emilyeserven/eslint-config/configs/import.js` →
+`"import/max-dependencies": ["warn", { max: 10, ignoreTypeImports: true }]`.
+
+- It counts **distinct source modules** (import *paths*), **not** named imports.
+  `import { a, b, c } from "x"` is **one** dependency.
+- **Type-only imports don't count** (`ignoreTypeImports: true`). `import type {…}`
+  is free.
+- Two statements from the same module count **once**
+  (`import x` + `import type {X}` from `"./x"` = 1). `import/no-duplicates`
+  will tell you to merge them anyway.
+
+So before restructuring, do the cheap wins:
+- Convert imports used **only as types** to `import type` (or inline
+  `import { type Foo }`) — they drop off the count entirely.
+- Then count only the remaining **value** imports. You need that number ≤ 10.
+
+```bash
+# Which files are flagged (this is also the acceptance check):
+pnpm lint 2>&1 | grep -B40 "Maximum number of dependencies" | grep -E "^/|max-dependencies"
+```
+
+## Strategy, in order of preference
+
+### 1. Group cohesive sibling sub-components into a dedicated sub-barrel
+A component that imports 8–10 siblings from the same feature folder collapses to
+**one** import. Create a small, **purpose-named** barrel (e.g.
+`dailyCells.ts`, `completionControls.ts`) that `export { … } from "./X"` the
+leaf modules. Consumers import from the sub-barrel; **the leaf sub-components
+keep their own direct `./X` imports**.
+
+**Circular-dependency rule (the trap the issues call out):** do **not** import
+the folder's own `index.ts` from inside the same folder, and never have a
+barrel re-export a module that imports that barrel. A sub-barrel that only
+re-exports *leaf* components (ones that don't import the barrel) is safe.
+`pnpm exec fallow dead-code` reports circular dependencies — run it after.
+
+Keep barrels **cohesive**, not grab-bags: split by role (e.g. row-display cells
+vs. entry-editing controls) rather than dumping every sub-component into one
+file. Prefer 1–2 small barrels per consumer over a single junk-drawer.
+
+### 2. Extract a logic-heavy hook
+When a component is large and pulls in `@tanstack/react-query`,
+`sonner`/`toast`, data helpers from `@/utils`, and other hooks just to compute
+state, move that logic into a `use…` hook under `src/hooks/`. The hook absorbs
+those imports; the component is left rendering JSX from a
+presentational-ready return value.
+
+Mirror the existing bundled-hook pattern:
+- `hooks/useResourceModules.ts` — rich `{ data…, mutations…, handlers… }` return.
+- `hooks/useDailyTracker.tsx`, `hooks/useDailyCompletions.ts` — feature hooks
+  returning pre-derived rows + action callbacks. Return *computed* values
+  (formatted labels, `canGoNext`, per-row flags) so the component imports no
+  helpers itself.
+
+### 3. Last resort — scoped disable for genuine barrels
+Some files legitimately re-export everything (`utils/index.ts`,
+`utils/api/index.ts`). Those carry a top-of-file
+`/* eslint-disable import/max-dependencies -- <reason> */`. Only use this for a
+real barrel/aggregator, never to dodge restructuring a component.
+
+## Guardrails (don't break behavior to win the count)
+
+- **Don't swap inline markup for a similar existing component** unless it's
+  truly equivalent. The dailies row files inline a recent-days strip; the
+  `DailyRecentDaysStrip` component looks similar but renders different
+  table/list markup — reusing it would change behavior. Group the imports; keep
+  the markup.
+- **Keep public props identical** so `*.stories.tsx` and tests keep passing.
+- **Merge same-module imports** into one statement (`import/no-duplicates`).
+- **Don't hand-fuss import ordering** — lint-staged + the on-save formatter
+  reorder them (in this project, sibling `./` imports sort *after* `@/`
+  imports). Just run the formatter / `--fix`.
+- Move stale suppression comments with their code; delete ones made obsolete by
+  the refactor (e.g. a `fallow-ignore code-duplication` note on an import block
+  that's now a single barrel import).
+- **Skip generated files**: `routeTree.gen.ts`, anything under `dist/`.
+
+## Verify
+
+```bash
+# Acceptance: the target files no longer appear
+pnpm lint 2>&1 | grep -B40 "Maximum number of dependencies" \
+  | grep -E "^/|max-dependencies" | grep -E "<your file names>" \
+  || echo "PASS"
+
+pnpm typecheck
+pnpm --filter=@emstack/client exec vitest run            # or scope to changed dirs
+pnpm exec fallow dead-code                                # reports new cycles
+```
+
+When spot-linting individual files, run `eslint` from the **repo root** (or via
+`pnpm lint`). Invoking `pnpm --filter=@emstack/client exec eslint <file>`
+directly makes `better-tailwindcss/no-unknown-classes` falsely error with
+"No tailwind css entry point found" — that's a cwd artifact, not a real
+problem. If you must scope it, add `--rule '{"better-tailwindcss/no-unknown-classes":"off"}'`.
+
+Commit with a `refactor(<scope>):` Conventional Commit (e.g.
+`refactor(client): reduce imports in dailies components`). Splitting the
+sub-barrel extraction and the hook extraction into separate commits reads
+better.

--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -5,15 +5,17 @@ import { Fragment } from "react";
 import { Link } from "@tanstack/react-router";
 import { FlameIcon, LaughIcon } from "lucide-react";
 
-import { DailyCommentPopover } from "./DailyCommentPopover";
-import { DailyLocationCell } from "./DailyLocationCell";
-import { DailyProgressCell } from "./DailyProgressCell";
-import { DailyResourceIndicator } from "./DailyResourceIndicator";
-import { DailyStatusCircle } from "./DailyStatusCircle";
-import { DailyStatusConnector } from "./DailyStatusConnector";
-import { DailyTaskIndicator } from "./DailyTaskIndicator";
-import { DailyTitle } from "./DailyTitle";
-import { TodayStatusCell } from "./TodayStatusCell";
+import {
+  DailyCommentPopover,
+  DailyLocationCell,
+  DailyProgressCell,
+  DailyResourceIndicator,
+  DailyStatusCircle,
+  DailyStatusConnector,
+  DailyTaskIndicator,
+  DailyTitle,
+  TodayStatusCell,
+} from "./dailyCells";
 
 import { cn } from "@/lib/utils";
 import {
@@ -60,7 +62,9 @@ export function DailiesActiveListView({
           recentDaysCount + 1,
           referenceKey,
           "mmdd",
-        ).slice(0, -1).reverse();
+        )
+          .slice(0, -1)
+          .reverse();
         const mostRecentPast = recentDays[0] ?? null;
         return (
           <li
@@ -102,9 +106,7 @@ export function DailiesActiveListView({
                           ? "text-orange-600"
                           : "text-muted-foreground",
                     )}
-                    title={chain > 0
-                      ? `${chain}-day chain`
-                      : "No active chain"}
+                    title={chain > 0 ? `${chain}-day chain` : "No active chain"}
                   >
                     <FlameIcon className="size-4" />
                     {chain}
@@ -112,9 +114,7 @@ export function DailiesActiveListView({
                   <span
                     className={cn(
                       "inline-flex items-center gap-1.5",
-                      total > 0
-                        ? "text-emerald-600"
-                        : "text-muted-foreground",
+                      total > 0 ? "text-emerald-600" : "text-muted-foreground",
                     )}
                     title={`${total} total day${total === 1 ? "" : "s"} completed`}
                   >
@@ -185,9 +185,7 @@ export function DailiesActiveListView({
                         className="mt-[11px] w-2.5 shrink-0"
                       />
                     )}
-                    <div
-                      className="flex shrink-0 flex-col items-center gap-0.5"
-                    >
+                    <div className="flex shrink-0 flex-col items-center gap-0.5">
                       <DailyStatusCircle
                         status={day.status}
                         size="sm"

--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -1,13 +1,5 @@
-import type { ViewMonth } from "./MonthYearPicker";
-import type {
-  Daily,
-  DailyCompletionStatus,
-  RoutineWeekday,
-} from "@emstack/types";
+import type { Daily } from "@emstack/types";
 
-import { useMemo, useState } from "react";
-
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   CalendarIcon,
   ChevronDownIcon,
@@ -15,209 +7,51 @@ import {
   ChevronRightIcon,
   Trash2Icon,
 } from "lucide-react";
-import { toast } from "sonner";
 
-import { DailyStatusButtons } from "./DailyStatusButtons";
-import { DailyStatusCircle } from "./DailyStatusCircle";
-import { DailyStatusConnector } from "./DailyStatusConnector";
-import { MonthYearPicker } from "./MonthYearPicker";
-import { NoteEditButton } from "./NoteEditButton";
+import {
+  DailyStatusButtons,
+  MonthYearPicker,
+  NoteEditButton,
+} from "./completionControls";
+import { DailyStatusCircle, DailyStatusConnector } from "./dailyCells";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
 import { RoutineEntryLabel } from "@/components/routines/RoutineEntryLabel";
 import { Button } from "@/components/ui/button";
-import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
+import { useDailyCompletions } from "@/hooks/useDailyCompletions";
 import { cn } from "@/lib/utils";
-import {
-  getReferenceDateKey,
-  getTodayKey,
-  shiftDateKey,
-  upsertDaily,
-  withCompletion,
-  withCompletionNote,
-} from "@/utils";
 
 interface DailyCompletionsManagerProps {
   daily: Daily;
   readOnly?: boolean;
 }
 
-const RECENT_DAYS_COUNT = 30;
-const EARLIEST_PICKER_YEAR = 2020;
-
-function formatDateLabel(dateKey: string): string {
-  const d = new Date(`${dateKey}T00:00:00Z`);
-  return d.toLocaleDateString(undefined, {
-    weekday: "short",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
-
-// Day-of-week key for a UTC date key, matching RoutineWeekday ("0" = Sunday …
-// "6" = Saturday) so it can index a routine's `weekly` grid.
-function weekdayKey(dateKey: string): RoutineWeekday {
-  return String(
-    new Date(`${dateKey}T00:00:00Z`).getUTCDay(),
-  ) as RoutineWeekday;
-}
-
-function formatMonthLabel(year: number, month: number): string {
-  return new Date(Date.UTC(year, month, 1)).toLocaleDateString(undefined, {
-    month: "long",
-    year: "numeric",
-    timeZone: "UTC",
-  });
-}
-
-function pad2(n: number): string {
-  return String(n).padStart(2, "0");
-}
-
-function dateKeyFromYM(year: number, month: number, day: number): string {
-  return `${year}-${pad2(month + 1)}-${pad2(day)}`;
-}
-
-function daysInMonth(year: number, month: number): number {
-  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-}
-
-function getMonthFromKey(dateKey: string): ViewMonth {
-  const d = new Date(`${dateKey}T00:00:00Z`);
-  return {
-    year: d.getUTCFullYear(),
-    month: d.getUTCMonth(),
-  };
-}
-
-function isSameMonth(a: ViewMonth, b: ViewMonth): boolean {
-  return a.year === b.year && a.month === b.month;
-}
-
-function isAfterMonth(a: ViewMonth, b: ViewMonth): boolean {
-  return a.year > b.year || (a.year === b.year && a.month > b.month);
-}
-
-function shiftMonth(m: ViewMonth, delta: number): ViewMonth {
-  const d = new Date(Date.UTC(m.year, m.month + delta, 1));
-  return {
-    year: d.getUTCFullYear(),
-    month: d.getUTCMonth(),
-  };
-}
-
-function buildVisibleDateKeys(
-  viewMonth: ViewMonth,
-  currentMonth: ViewMonth,
-  todayKey: string,
-): string[] {
-  if (isSameMonth(viewMonth, currentMonth)) {
-    const keys: string[] = [];
-    for (let i = 0; i < RECENT_DAYS_COUNT; i++) {
-      keys.push(shiftDateKey(todayKey, -i));
-    }
-    return keys;
-  }
-  const total = daysInMonth(viewMonth.year, viewMonth.month);
-  const keys: string[] = [];
-  for (let day = total; day >= 1; day--) {
-    keys.push(dateKeyFromYM(viewMonth.year, viewMonth.month, day));
-  }
-  return keys;
-}
-
 export function DailyCompletionsManager({
   daily,
   readOnly = false,
 }: DailyCompletionsManagerProps) {
-  const queryClient = useQueryClient();
-  const isComplete = daily.status === "complete";
-  const effectiveReadOnly = readOnly || isComplete;
-  const todayKey = getReferenceDateKey(daily);
-  const realToday = getTodayKey();
-  const currentMonth = getMonthFromKey(todayKey);
-
-  const [viewMonth, setViewMonth] = useState<ViewMonth>(currentMonth);
-  const [monthPickerOpen, setMonthPickerOpen] = useState(false);
-  const [expandedDateKey, setExpandedDateKey] = useState<string | null>(null);
-
-  // Weekly routines schedule a different item per weekday; surface that item on
-  // each date row. The grid carries unresolved ids, so resolve task/resource
-  // names from the (already cached) task/resource lists.
-  const isWeekly = daily.mode === "weekly";
-  const weekly = daily.weekly ?? {};
-
   const {
+    earliestYear,
+    viewMonth,
+    currentMonth,
+    monthLabel,
+    monthPickerOpen,
+    setMonthPickerOpen,
+    selectMonth,
+    goToPrevMonth,
+    goToNextMonth,
+    canGoPrev,
+    canGoNext,
+    toggleExpanded,
     taskNames,
     resourceNames,
-  } = useTaskResourceNames(isWeekly);
-
-  const completionsByDate = useMemo(() => {
-    const map = new Map<
-      string,
-      { status: DailyCompletionStatus | null;
-        note: string | null; }
-    >();
-    for (const c of daily.completions) {
-      map.set(c.date, {
-        status: c.status ?? null,
-        note: c.note ?? null,
-      });
-    }
-    return map;
-  }, [daily.completions]);
-
-  const visibleDateKeys = useMemo(
-    () => buildVisibleDateKeys(viewMonth, currentMonth, todayKey),
-    [viewMonth, currentMonth, todayKey],
-  );
-
-  const mutation = useMutation({
-    mutationFn: (
-      args:
-        | {
-          kind: "status";
-          dateKey: string;
-          status: DailyCompletionStatus | null;
-        }
-        | {
-          kind: "note";
-          dateKey: string;
-          note: string | null;
-        },
-    ) => {
-      const completions = args.kind === "status"
-        ? withCompletion(daily, args.dateKey, args.status)
-        : withCompletionNote(daily, args.dateKey, args.note);
-      return upsertDaily(daily.id, {
-        name: daily.name,
-        location: daily.location ?? null,
-        description: daily.description ?? null,
-        completions,
-        courseProviderId: daily.provider?.id ?? null,
-      });
-    },
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ["daily", daily.id],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ["routine", daily.id],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ["dailies"],
-        }),
-      ]);
-    },
-    onError: () => {
-      toast.error("Failed to update completion.");
-    },
-  });
-
-  const isCurrentMonth = isSameMonth(viewMonth, currentMonth);
+    rows,
+    hasRows,
+    mutationPending,
+    setStatus,
+    setNote,
+    deleteEntry,
+  } = useDailyCompletions(daily, readOnly);
 
   return (
     <div className="flex flex-col gap-3">
@@ -230,8 +64,8 @@ export function DailyCompletionsManager({
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => setViewMonth(m => shiftMonth(m, -1))}
-            disabled={shiftMonth(viewMonth, -1).year < EARLIEST_PICKER_YEAR}
+            onClick={goToPrevMonth}
+            disabled={!canGoPrev}
             aria-label="Previous month"
           >
             <ChevronLeftIcon className="size-4" />
@@ -248,9 +82,7 @@ export function DailyCompletionsManager({
                 className="min-w-40 justify-center font-normal"
               >
                 <CalendarIcon className="mr-2 size-4" />
-                {isCurrentMonth
-                  ? (isComplete ? "Last 30 days (final)" : "Last 30 days")
-                  : formatMonthLabel(viewMonth.year, viewMonth.month)}
+                {monthLabel}
               </Button>
             </PopoverTrigger>
             <PopoverContent
@@ -260,11 +92,8 @@ export function DailyCompletionsManager({
               <MonthYearPicker
                 viewMonth={viewMonth}
                 currentMonth={currentMonth}
-                earliestYear={EARLIEST_PICKER_YEAR}
-                onChange={(m) => {
-                  setViewMonth(m);
-                  setMonthPickerOpen(false);
-                }}
+                earliestYear={earliestYear}
+                onChange={selectMonth}
               />
             </PopoverContent>
           </Popover>
@@ -272,46 +101,38 @@ export function DailyCompletionsManager({
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => setViewMonth(m => shiftMonth(m, 1))}
-            disabled={
-              isCurrentMonth
-              || isAfterMonth(shiftMonth(viewMonth, 1), currentMonth)
-            }
+            onClick={goToNextMonth}
+            disabled={!canGoNext}
             aria-label="Next month"
           >
             <ChevronRightIcon className="size-4" />
           </Button>
         </div>
       </div>
-      {visibleDateKeys.length === 0 && (
+      {!hasRows && (
         <p className="text-sm text-muted-foreground">
           <i>No days to show.</i>
         </p>
       )}
-      {visibleDateKeys.length > 0 && (
+      {hasRows && (
         <ul className="flex flex-col divide-y rounded-md border">
           {/* Pre-existing complexity hotspot (untested render callback);
               suppressed so unrelated edits don't trip the audit gate. */}
           {/* fallow-ignore-next-line complexity */}
-          {visibleDateKeys.map((dateKey, i) => {
-            const entry = completionsByDate.get(dateKey);
-            const status = entry?.status ?? null;
-            const note = entry?.note ?? null;
-            const hasStatusEntry = status !== null;
-            const isFuture = dateKey > realToday;
-            const isToday = dateKey === realToday;
-            const isEditable = isToday || !effectiveReadOnly;
-            const hasActions = isEditable && !isFuture;
-            const isExpanded = expandedDateKey === dateKey;
-            const nextDateKey = visibleDateKeys[i + 1];
-            const nextStatus = nextDateKey
-              ? completionsByDate.get(nextDateKey)?.status ?? null
-              : null;
-            const showVerticalConnector
-              = status !== null && nextStatus !== null;
-            const scheduledEntry = isWeekly
-              ? (weekly[weekdayKey(dateKey)] ?? null)
-              : null;
+          {rows.map((row) => {
+            const {
+              dateKey,
+              status,
+              note,
+              dateLabel,
+              hasStatusEntry,
+              isFuture,
+              hasActions,
+              isExpanded,
+              showVerticalConnector,
+              nextStatus,
+              scheduledEntry,
+            } = row;
             return (
               <li
                 key={dateKey}
@@ -342,9 +163,7 @@ export function DailyCompletionsManager({
                     )}
                   </div>
                   <div className="flex min-w-0 shrink-0 flex-col">
-                    <span className="text-sm font-medium">
-                      {formatDateLabel(dateKey)}
-                    </span>
+                    <span className="text-sm font-medium">{dateLabel}</span>
                     {scheduledEntry && (
                       <span className="text-xs text-muted-foreground">
                         <RoutineEntryLabel
@@ -375,9 +194,7 @@ export function DailyCompletionsManager({
                         className="w-80 max-w-[90vw]"
                         align="start"
                       >
-                        <p
-                          className="text-sm/relaxed whitespace-pre-wrap"
-                        >
+                        <p className="text-sm/relaxed whitespace-pre-wrap">
                           {note}
                         </p>
                       </PopoverContent>
@@ -389,16 +206,13 @@ export function DailyCompletionsManager({
                     type="button"
                     variant="ghost"
                     size="icon-sm"
-                    onClick={() => setExpandedDateKey(prev =>
-                      prev === dateKey ? null : dateKey)}
+                    onClick={() => toggleExpanded(dateKey)}
                     className="
                       shrink-0
                       md:hidden
                     "
                     aria-expanded={isExpanded}
-                    aria-label={isExpanded
-                      ? "Hide actions"
-                      : "Show actions"}
+                    aria-label={isExpanded ? "Hide actions" : "Show actions"}
                   >
                     <ChevronDownIcon
                       className={cn(
@@ -426,22 +240,14 @@ export function DailyCompletionsManager({
                   >
                     <DailyStatusButtons
                       currentStatus={status}
-                      disabled={mutation.isPending}
-                      onChange={newStatus => mutation.mutate({
-                        kind: "status",
-                        dateKey,
-                        status: newStatus,
-                      })}
+                      disabled={mutationPending}
+                      onChange={newStatus => setStatus(dateKey, newStatus)}
                       iconOnly
                     />
                     <NoteEditButton
                       initialNote={note}
-                      disabled={mutation.isPending}
-                      onSave={newNote => mutation.mutate({
-                        kind: "note",
-                        dateKey,
-                        note: newNote,
-                      })}
+                      disabled={mutationPending}
+                      onSave={newNote => setNote(dateKey, newNote)}
                     />
                     {hasStatusEntry
                       ? (
@@ -449,12 +255,8 @@ export function DailyCompletionsManager({
                           type="button"
                           variant="ghost"
                           size="icon-sm"
-                          disabled={mutation.isPending}
-                          onClick={() => mutation.mutate({
-                            kind: "status",
-                            dateKey,
-                            status: null,
-                          })}
+                          disabled={mutationPending}
+                          onClick={() => deleteEntry(dateKey)}
                           className="text-destructive"
                           title="Delete entry"
                           aria-label="Delete entry"

--- a/packages/client/src/components/dailies/DailyTrackerRow.tsx
+++ b/packages/client/src/components/dailies/DailyTrackerRow.tsx
@@ -2,19 +2,18 @@ import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
 import { FlameIcon, LaughIcon } from "lucide-react";
 
-import { DailyCadenceBadge } from "./DailyCadenceBadge";
-// Shares the same daily-cell building blocks as DailiesActiveListView; the
-// overlapping import block is incidental.
-// fallow-ignore-next-line code-duplication
-import { DailyCommentPopover } from "./DailyCommentPopover";
-import { DailyLocationCell } from "./DailyLocationCell";
-import { DailyProgressCell } from "./DailyProgressCell";
-import { DailyResourceIndicator } from "./DailyResourceIndicator";
-import { DailyStatusCircle } from "./DailyStatusCircle";
-import { DailyStatusConnector } from "./DailyStatusConnector";
-import { DailyTaskIndicator } from "./DailyTaskIndicator";
-import { DailyTitle } from "./DailyTitle";
-import { TodayStatusCell } from "./TodayStatusCell";
+import {
+  DailyCadenceBadge,
+  DailyCommentPopover,
+  DailyLocationCell,
+  DailyProgressCell,
+  DailyResourceIndicator,
+  DailyStatusCircle,
+  DailyStatusConnector,
+  DailyTaskIndicator,
+  DailyTitle,
+  TodayStatusCell,
+} from "./dailyCells";
 
 import { EntityLink } from "@/components/boxElements/EntityLink";
 import { cn } from "@/lib/utils";

--- a/packages/client/src/components/dailies/completionControls.ts
+++ b/packages/client/src/components/dailies/completionControls.ts
@@ -1,0 +1,6 @@
+// Entry-editing controls used by the completions manager's date list: the
+// per-entry status buttons, the month/year picker, and the inline note editor.
+// Grouped here so DailyCompletionsManager imports them as one dependency.
+export { DailyStatusButtons } from "./DailyStatusButtons";
+export { MonthYearPicker } from "./MonthYearPicker";
+export { NoteEditButton } from "./NoteEditButton";

--- a/packages/client/src/components/dailies/dailyCells.ts
+++ b/packages/client/src/components/dailies/dailyCells.ts
@@ -1,0 +1,16 @@
+// Shared per-daily row building blocks. The list view, the tracker rows, and
+// the completions manager all render the same handful of daily cells/status
+// primitives; grouping the re-exports here lets each consumer import them as a
+// single dependency. This barrel only re-exports leaf sub-components — it does
+// not import the folder `index.ts`, and the sub-components keep their own
+// direct imports, so there is no circular dependency.
+export { DailyCadenceBadge } from "./DailyCadenceBadge";
+export { DailyCommentPopover } from "./DailyCommentPopover";
+export { DailyLocationCell } from "./DailyLocationCell";
+export { DailyProgressCell } from "./DailyProgressCell";
+export { DailyResourceIndicator } from "./DailyResourceIndicator";
+export { DailyStatusCircle } from "./DailyStatusCircle";
+export { DailyStatusConnector } from "./DailyStatusConnector";
+export { DailyTaskIndicator } from "./DailyTaskIndicator";
+export { DailyTitle } from "./DailyTitle";
+export { TodayStatusCell } from "./TodayStatusCell";

--- a/packages/client/src/hooks/useDailyCompletions.ts
+++ b/packages/client/src/hooks/useDailyCompletions.ts
@@ -1,0 +1,314 @@
+import type { ViewMonth } from "@/components/dailies/MonthYearPicker";
+import type {
+  Daily,
+  DailyCompletionStatus,
+  RoutineReferenceItem,
+  RoutineWeekday,
+} from "@emstack/types";
+
+import { useMemo, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
+import {
+  getReferenceDateKey,
+  getTodayKey,
+  shiftDateKey,
+  upsertDaily,
+  withCompletion,
+  withCompletionNote,
+} from "@/utils";
+
+const RECENT_DAYS_COUNT = 30;
+const EARLIEST_PICKER_YEAR = 2020;
+
+function formatDateLabel(dateKey: string): string {
+  const d = new Date(`${dateKey}T00:00:00Z`);
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+// Day-of-week key for a UTC date key, matching RoutineWeekday ("0" = Sunday …
+// "6" = Saturday) so it can index a routine's `weekly` grid.
+function weekdayKey(dateKey: string): RoutineWeekday {
+  return String(new Date(`${dateKey}T00:00:00Z`).getUTCDay()) as RoutineWeekday;
+}
+
+function formatMonthLabel(year: number, month: number): string {
+  return new Date(Date.UTC(year, month, 1)).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function dateKeyFromYM(year: number, month: number, day: number): string {
+  return `${year}-${pad2(month + 1)}-${pad2(day)}`;
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function getMonthFromKey(dateKey: string): ViewMonth {
+  const d = new Date(`${dateKey}T00:00:00Z`);
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth(),
+  };
+}
+
+function isSameMonth(a: ViewMonth, b: ViewMonth): boolean {
+  return a.year === b.year && a.month === b.month;
+}
+
+function isAfterMonth(a: ViewMonth, b: ViewMonth): boolean {
+  return a.year > b.year || (a.year === b.year && a.month > b.month);
+}
+
+function shiftMonth(m: ViewMonth, delta: number): ViewMonth {
+  const d = new Date(Date.UTC(m.year, m.month + delta, 1));
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth(),
+  };
+}
+
+function buildVisibleDateKeys(
+  viewMonth: ViewMonth,
+  currentMonth: ViewMonth,
+  todayKey: string,
+): string[] {
+  if (isSameMonth(viewMonth, currentMonth)) {
+    const keys: string[] = [];
+    for (let i = 0; i < RECENT_DAYS_COUNT; i++) {
+      keys.push(shiftDateKey(todayKey, -i));
+    }
+    return keys;
+  }
+  const total = daysInMonth(viewMonth.year, viewMonth.month);
+  const keys: string[] = [];
+  for (let day = total; day >= 1; day--) {
+    keys.push(dateKeyFromYM(viewMonth.year, viewMonth.month, day));
+  }
+  return keys;
+}
+
+/** A single date row of the completions list, pre-derived for rendering. */
+export interface DailyCompletionRow {
+  dateKey: string;
+  status: DailyCompletionStatus | null;
+  note: string | null;
+  dateLabel: string;
+  hasStatusEntry: boolean;
+  isFuture: boolean;
+  isToday: boolean;
+  hasActions: boolean;
+  isExpanded: boolean;
+  showVerticalConnector: boolean;
+  nextStatus: DailyCompletionStatus | null;
+  scheduledEntry: RoutineReferenceItem | null;
+}
+
+/**
+ * Calendar / log / mutation logic for {@link DailyCompletionsManager}, mirroring
+ * the bundled-hook pattern of `useResourceModules`. Owns month navigation, the
+ * visible-date window, weekly-schedule name resolution, and the upsert mutation,
+ * returning a presentational-ready shape so the component renders only JSX.
+ */
+export function useDailyCompletions(daily: Daily, readOnly = false) {
+  const queryClient = useQueryClient();
+  const isComplete = daily.status === "complete";
+  const effectiveReadOnly = readOnly || isComplete;
+  const todayKey = getReferenceDateKey(daily);
+  const realToday = getTodayKey();
+  const currentMonth = getMonthFromKey(todayKey);
+
+  const [viewMonth, setViewMonth] = useState<ViewMonth>(currentMonth);
+  const [monthPickerOpen, setMonthPickerOpen] = useState(false);
+  const [expandedDateKey, setExpandedDateKey] = useState<string | null>(null);
+
+  // Weekly routines schedule a different item per weekday; surface that item on
+  // each date row. The grid carries unresolved ids, so resolve task/resource
+  // names from the (already cached) task/resource lists.
+  const isWeekly = daily.mode === "weekly";
+  const weekly = daily.weekly ?? {};
+
+  const {
+    taskNames, resourceNames,
+  } = useTaskResourceNames(isWeekly);
+
+  const completionsByDate = useMemo(() => {
+    const map = new Map<
+      string,
+      { status: DailyCompletionStatus | null;
+        note: string | null; }
+    >();
+    for (const c of daily.completions) {
+      map.set(c.date, {
+        status: c.status ?? null,
+        note: c.note ?? null,
+      });
+    }
+    return map;
+  }, [daily.completions]);
+
+  const visibleDateKeys = useMemo(
+    () => buildVisibleDateKeys(viewMonth, currentMonth, todayKey),
+    [viewMonth, currentMonth, todayKey],
+  );
+
+  const rows = useMemo<DailyCompletionRow[]>(
+    () =>
+      visibleDateKeys.map((dateKey, i) => {
+        const entry = completionsByDate.get(dateKey);
+        const status = entry?.status ?? null;
+        const isToday = dateKey === realToday;
+        const isFuture = dateKey > realToday;
+        const isEditable = isToday || !effectiveReadOnly;
+        const nextDateKey = visibleDateKeys[i + 1];
+        const nextStatus = nextDateKey
+          ? (completionsByDate.get(nextDateKey)?.status ?? null)
+          : null;
+        return {
+          dateKey,
+          status,
+          note: entry?.note ?? null,
+          dateLabel: formatDateLabel(dateKey),
+          hasStatusEntry: status !== null,
+          isFuture,
+          isToday,
+          hasActions: isEditable && !isFuture,
+          isExpanded: expandedDateKey === dateKey,
+          showVerticalConnector: status !== null && nextStatus !== null,
+          nextStatus,
+          scheduledEntry: isWeekly
+            ? (weekly[weekdayKey(dateKey)] ?? null)
+            : null,
+        };
+      }),
+    [
+      visibleDateKeys,
+      completionsByDate,
+      realToday,
+      effectiveReadOnly,
+      expandedDateKey,
+      isWeekly,
+      weekly,
+    ],
+  );
+
+  const mutation = useMutation({
+    mutationFn: (
+      args:
+        | {
+          kind: "status";
+          dateKey: string;
+          status: DailyCompletionStatus | null;
+        }
+        | {
+          kind: "note";
+          dateKey: string;
+          note: string | null;
+        },
+    ) => {
+      const completions
+        = args.kind === "status"
+          ? withCompletion(daily, args.dateKey, args.status)
+          : withCompletionNote(daily, args.dateKey, args.note);
+      return upsertDaily(daily.id, {
+        name: daily.name,
+        location: daily.location ?? null,
+        description: daily.description ?? null,
+        completions,
+        courseProviderId: daily.provider?.id ?? null,
+      });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["daily", daily.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["routine", daily.id],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["dailies"],
+        }),
+      ]);
+    },
+    onError: () => {
+      toast.error("Failed to update completion.");
+    },
+  });
+
+  const isCurrentMonth = isSameMonth(viewMonth, currentMonth);
+  const monthLabel = isCurrentMonth
+    ? isComplete
+      ? "Last 30 days (final)"
+      : "Last 30 days"
+    : formatMonthLabel(viewMonth.year, viewMonth.month);
+
+  return {
+    effectiveReadOnly,
+    isComplete,
+    earliestYear: EARLIEST_PICKER_YEAR,
+
+    viewMonth,
+    currentMonth,
+    isCurrentMonth,
+    monthLabel,
+    monthPickerOpen,
+    setMonthPickerOpen,
+    selectMonth: (m: ViewMonth) => {
+      setViewMonth(m);
+      setMonthPickerOpen(false);
+    },
+    goToPrevMonth: () => setViewMonth(m => shiftMonth(m, -1)),
+    goToNextMonth: () => setViewMonth(m => shiftMonth(m, 1)),
+    canGoPrev: shiftMonth(viewMonth, -1).year >= EARLIEST_PICKER_YEAR,
+    canGoNext:
+      !isCurrentMonth && !isAfterMonth(shiftMonth(viewMonth, 1), currentMonth),
+
+    toggleExpanded: (dateKey: string) =>
+      setExpandedDateKey(prev => (prev === dateKey ? null : dateKey)),
+
+    isWeekly,
+    taskNames,
+    resourceNames,
+
+    rows,
+    hasRows: visibleDateKeys.length > 0,
+
+    mutationPending: mutation.isPending,
+    setStatus: (dateKey: string, status: DailyCompletionStatus | null) =>
+      mutation.mutate({
+        kind: "status",
+        dateKey,
+        status,
+      }),
+    setNote: (dateKey: string, note: string | null) =>
+      mutation.mutate({
+        kind: "note",
+        dateKey,
+        note,
+      }),
+    deleteEntry: (dateKey: string) =>
+      mutation.mutate({
+        kind: "status",
+        dateKey,
+        status: null,
+      }),
+  };
+}


### PR DESCRIPTION
## ELI5
Three of the daily-tracker screens were importing so many little pieces that a code-quality check kept complaining. This tidies them up by bundling the related pieces together and moving a big chunk of behind-the-scenes logic into its own reusable helper — the screens look and work exactly the same, they're just easier to read now.

## Summary
- Added two cohesive sub-barrels in `components/dailies/` — `dailyCells.ts` (shared per-daily row building blocks) and `completionControls.ts` (completions-manager entry controls) — so each consumer imports them as a single dependency. Barrels re-export only leaf modules, so no circular deps.
- Extracted the 480-line `DailyCompletionsManager`'s calendar/log/mutation logic into a new `useDailyCompletions` hook (mirrors `useResourceModules`), leaving the component to render JSX from a presentational-ready return value.
- All three files (`DailiesActiveListView`, `DailyTrackerRow`, `DailyCompletionsManager`) now clear the `import/max-dependencies` warning (threshold 10); public props unchanged so stories/tests are unaffected.
- Added a `reduce-imports` skill documenting the procedure for the remaining areas under the import/max-dependencies cleanup (tracker #312).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter=@emstack/client exec vitest run` — 401/401 pass
- [x] `pnpm lint` — none of the three files appear in `Maximum number of dependencies` output
- [x] `pnpm exec fallow dead-code` — no new circular dependencies
- [ ] Storybook spot-check: `DailyCompletionsManager` month-nav / status / note / delete actions and the two row views render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)