### PR TITLE
refactor(client): Fixes #311: reduce imports in app shell & quick-add dialogs

### DIFF
--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -119,3 +119,56 @@ Commit with a `refactor(<scope>):` Conventional Commit (e.g.
 `refactor(client): reduce imports in dailies components`). Splitting the
 sub-barrel extraction and the hook extraction into separate commits reads
 better.
+
+## Area notes: app shell & quick-add dialogs (#311)
+
+Worked counts (non-type value imports): `routes/__root.tsx` = **12** (shed 2);
+`components/quickAdd/QuickAddRoutineDialog.tsx` = **11** (shed 1);
+`QuickAddTodoistDialog.tsx` = **11** (shed 1). Both dialogs cleared the line via
+Strategy 2 (a per-dialog bundled hook); `__root` used Strategy 1 (a folder
+barrel) **plus** Strategy 2 (a query hook).
+
+### `queryKeys` is NOT in the `@/utils` barrel
+`@/utils/queryKeys` is imported as its own line everywhere — it is deliberately
+**not** re-exported from `utils/index.ts`. So `@/utils` + `@/utils/queryKeys` are
+always two distinct sources you can't merge. The only way to drop the
+`queryKeys` line from a component is to move the query/mutation logic that uses
+it into a hook (Strategy 2). Don't try to "fix" this by adding it to the barrel —
+that bloats the barrel's own dep count and fights the convention.
+
+### Preserve query keys verbatim when extracting a query hook
+Keys in this repo are inconsistent by accretion — some use the factory
+(`queryKeys.resources.list()`), some are inline arrays (`["topics"]`,
+`["providers"]`, `["domains"]`). When you lift `useQuery` calls into a hook
+(e.g. `useShowOnboard` pulling the four onboarding fetches out of `__root`),
+**copy each key exactly as-is**. "Tidying" an inline array into a factory call
+while extracting silently breaks invalidation elsewhere that still uses the old
+key. Behavior-preserving means key-preserving.
+
+### Per-dialog bundled hook — the big collapse
+A quick-add dialog drags in `react` (`useState`/`useEffect`) +
+`@tanstack/react-query` (`useMutation`/`useQuery`/`useQueryClient`) +
+`@tanstack/react-router` (`useNavigate`) + `sonner` + `@/utils` (the create fn) +
+`@/utils/queryKeys` — **six** sources — purely to run one form+mutation. Fold all
+of it into one `use…` hook returning a presentational-ready object
+(`{ name, setName, mode, setMode, handleSubmit, isPending, canSubmit }`, with
+`handleSubmit` owning `preventDefault` + trim-guard + `mutate`). The component is
+left importing only render deps (a `lucide` icon, the form primitives,
+`ui/button`, `ui/dialog`, the hook — and a `<Link>` if the JSX still navigates).
+
+- **Placement:** the established home is `src/hooks/` (matches `useResourceModules`,
+  `useDailyTracker`). A hook used by exactly one dialog may co-locate next to it
+  (`components/quickAdd/useQuickAddRoutine.ts`) and stay **out** of the feature
+  barrel — it's internal, not public surface. Either is fine; default to
+  `src/hooks/` unless the hook is single-consumer and feature-private.
+- `react`/`useState` only leaves the component if **all** its uses leave. In
+  `__root` the `activeQuickAdd` state stays, so `react` stays — don't count it as
+  shed.
+
+### Folder barrel where none exists yet (Strategy 1, app-shell flavor)
+`__root` imported two nav primitives by full path
+(`@/components/layout/DropdownNavItem`, `…/NavDropdown`). There was no
+`components/layout/index.ts`, so creating a cohesive one (export just the nav
+set, not all ~13 layout files) merged them to a single `@/components/layout`
+import. A barrel only pays off at ≥2 sources sharing a folder; re-exporting one
+component buys nothing.

--- a/packages/client/src/components/layout/index.ts
+++ b/packages/client/src/components/layout/index.ts
@@ -1,0 +1,2 @@
+export { DropdownNavItem } from "./DropdownNavItem";
+export { NavDropdown } from "./NavDropdown";

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
@@ -1,12 +1,9 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 import type { RoutineMode } from "@emstack/types";
 
-import { useEffect, useState } from "react";
-
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
+
+import { useQuickAddRoutine } from "./useQuickAddRoutine";
 
 import { Input } from "@/components/input";
 import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
@@ -18,57 +15,23 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { createRoutine } from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
 
 export function QuickAddRoutineDialog({
   open,
   onOpenChange,
 }: ControlledDialogProps) {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const [name, setName] = useState("");
-  const [mode, setMode] = useState<RoutineMode>("weekly");
-
-  useEffect(() => {
-    if (open) {
-      setName("");
-      setMode("weekly");
-    }
-  }, [open]);
-
-  const mutation = useMutation({
-    mutationFn: (input: { name: string;
-      mode: RoutineMode; }) =>
-      createRoutine({
-        name: input.name,
-        mode: input.mode,
-        status: "active",
-      }),
-    onSuccess: (result) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.routines.list(),
-      });
-      onOpenChange(false);
-      toast.success("Routine created", {
-        action: {
-          label: "Edit",
-          onClick: () =>
-            navigate({
-              to: "/routines/$id/edit",
-              params: {
-                id: result.id,
-              },
-            }),
-        },
-      });
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
+  const {
+    name,
+    setName,
+    mode,
+    setMode,
+    handleSubmit,
+    isPending,
+    canSubmit,
+  } = useQuickAddRoutine({
+    open,
+    onOpenChange,
   });
-
-  const trimmed = name.trim();
 
   return (
     <Dialog
@@ -81,15 +44,7 @@ export function QuickAddRoutineDialog({
         </DialogHeader>
         <form
           className="flex flex-col gap-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (trimmed) {
-              mutation.mutate({
-                name: trimmed,
-                mode,
-              });
-            }
-          }}
+          onSubmit={handleSubmit}
         >
           <div className="flex flex-col gap-1">
             <label
@@ -147,9 +102,9 @@ export function QuickAddRoutineDialog({
             </Button>
             <Button
               type="submit"
-              disabled={!trimmed || mutation.isPending}
+              disabled={!canSubmit || isPending}
             >
-              {mutation.isPending && <Loader2 className="animate-spin" />}
+              {isPending && <Loader2 className="animate-spin" />}
               Create
             </Button>
           </DialogFooter>

--- a/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
@@ -1,11 +1,9 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 
-import { useEffect, useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
+
+import { useQuickAddTodoist } from "./useQuickAddTodoist";
 
 import { Input } from "@/components/input";
 import { Textarea } from "@/components/textarea";
@@ -18,48 +16,24 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { createTodoistTask, fetchSettings } from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
 
 export function QuickAddTodoistDialog({
   open,
   onOpenChange,
 }: ControlledDialogProps) {
-  const queryClient = useQueryClient();
-  const [content, setContent] = useState("");
-  const [description, setDescription] = useState("");
-
-  useEffect(() => {
-    if (open) {
-      setContent("");
-      setDescription("");
-    }
-  }, [open]);
-
-  const settingsQuery = useQuery({
-    queryKey: queryKeys.settings.detail(),
-    queryFn: () => fetchSettings(),
+  const {
+    content,
+    setContent,
+    description,
+    setDescription,
+    configured,
+    handleSubmit,
+    isPending,
+    canSubmit,
+  } = useQuickAddTodoist({
+    open,
+    onOpenChange,
   });
-  const configured = settingsQuery.data?.todoistConfigured ?? false;
-
-  const mutation = useMutation({
-    mutationFn: (input: { content: string;
-      description?: string; }) =>
-      createTodoistTask(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.todoist.tasks(),
-      });
-      onOpenChange(false);
-      toast.success("Added to Todoist");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const trimmedContent = content.trim();
-  const trimmedDescription = description.trim();
 
   return (
     <Dialog
@@ -80,15 +54,7 @@ export function QuickAddTodoistDialog({
           ? (
             <form
               className="flex flex-col gap-4"
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (trimmedContent) {
-                  mutation.mutate({
-                    content: trimmedContent,
-                    description: trimmedDescription || undefined,
-                  });
-                }
-              }}
+              onSubmit={handleSubmit}
             >
               <div className="flex flex-col gap-1">
                 <label
@@ -129,9 +95,9 @@ export function QuickAddTodoistDialog({
                 </Button>
                 <Button
                   type="submit"
-                  disabled={!trimmedContent || mutation.isPending}
+                  disabled={!canSubmit || isPending}
                 >
-                  {mutation.isPending && <Loader2 className="animate-spin" />}
+                  {isPending && <Loader2 className="animate-spin" />}
                   Add
                 </Button>
               </DialogFooter>

--- a/packages/client/src/components/quickAdd/useQuickAddRoutine.ts
+++ b/packages/client/src/components/quickAdd/useQuickAddRoutine.ts
@@ -1,0 +1,85 @@
+import type { ControlledDialogProps } from "@/components/dialogProps";
+import type { RoutineMode } from "@emstack/types";
+
+import { useEffect, useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { createRoutine } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Bundles the form state, reset-on-open, and create mutation for
+ * {@link QuickAddRoutineDialog} so the component stays presentational.
+ */
+export function useQuickAddRoutine({
+  open,
+  onOpenChange,
+}: ControlledDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [mode, setMode] = useState<RoutineMode>("weekly");
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setMode("weekly");
+    }
+  }, [open]);
+
+  const mutation = useMutation({
+    mutationFn: (input: { name: string;
+      mode: RoutineMode; }) =>
+      createRoutine({
+        name: input.name,
+        mode: input.mode,
+        status: "active",
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.routines.list(),
+      });
+      onOpenChange(false);
+      toast.success("Routine created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/routines/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmed = name.trim();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (trimmed) {
+      mutation.mutate({
+        name: trimmed,
+        mode,
+      });
+    }
+  };
+
+  return {
+    name,
+    setName,
+    mode,
+    setMode,
+    handleSubmit,
+    isPending: mutation.isPending,
+    canSubmit: Boolean(trimmed),
+  };
+}

--- a/packages/client/src/components/quickAdd/useQuickAddTodoist.ts
+++ b/packages/client/src/components/quickAdd/useQuickAddTodoist.ts
@@ -1,0 +1,75 @@
+import type { ControlledDialogProps } from "@/components/dialogProps";
+
+import { useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { createTodoistTask, fetchSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Bundles the form state, settings lookup, and create mutation for
+ * {@link QuickAddTodoistDialog} so the component stays presentational.
+ */
+export function useQuickAddTodoist({
+  open,
+  onOpenChange,
+}: ControlledDialogProps) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setContent("");
+      setDescription("");
+    }
+  }, [open]);
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const configured = settingsQuery.data?.todoistConfigured ?? false;
+
+  const mutation = useMutation({
+    mutationFn: (input: { content: string;
+      description?: string; }) =>
+      createTodoistTask(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.todoist.tasks(),
+      });
+      onOpenChange(false);
+      toast.success("Added to Todoist");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmedContent = content.trim();
+  const trimmedDescription = description.trim();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (trimmedContent) {
+      mutation.mutate({
+        content: trimmedContent,
+        description: trimmedDescription || undefined,
+      });
+    }
+  };
+
+  return {
+    content,
+    setContent,
+    description,
+    setDescription,
+    configured,
+    handleSubmit,
+    isPending: mutation.isPending,
+    canSubmit: Boolean(trimmedContent),
+  };
+}

--- a/packages/client/src/hooks/useShowOnboard.ts
+++ b/packages/client/src/hooks/useShowOnboard.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  fetchResources,
+  fetchDomains,
+  fetchProviders,
+  fetchTopics,
+} from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Whether the app shell should surface the Onboard nav link — true until the
+ * core record types have loaded and at least one record exists.
+ */
+export function useShowOnboard(): boolean {
+  const {
+    data: resourcesData,
+  } = useQuery({
+    queryKey: queryKeys.resources.list(),
+    queryFn: () => fetchResources(),
+  });
+
+  const {
+    data: topicsData,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: providersData,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
+
+  const {
+    data: domainsData,
+  } = useQuery({
+    queryKey: ["domains"],
+    queryFn: () => fetchDomains(),
+  });
+
+  const allLoaded
+    = resourcesData !== undefined
+      && topicsData !== undefined
+      && providersData !== undefined
+      && domainsData !== undefined;
+
+  return (
+    !allLoaded
+    || (!resourcesData?.length
+      && !topicsData?.length
+      && !providersData?.length
+      && !domainsData?.length)
+  );
+}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -2,7 +2,6 @@ import type { QuickAddKey } from "@/components/quickAdd";
 
 import React, { useState } from "react";
 
-import { useQuery } from "@tanstack/react-query";
 import {
   createRootRoute,
   Link,
@@ -10,8 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { HomeIcon, MenuIcon } from "lucide-react";
 
-import { DropdownNavItem } from "@/components/layout/DropdownNavItem";
-import { NavDropdown } from "@/components/layout/NavDropdown";
+import { DropdownNavItem, NavDropdown } from "@/components/layout";
 import {
   QuickAddDialogs,
   QuickAddMenu,
@@ -29,56 +27,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  fetchResources,
-  fetchDomains,
-  fetchProviders,
-  fetchTopics,
-} from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
+import { useShowOnboard } from "@/hooks/useShowOnboard";
 
 const RootComponent: React.FunctionComponent = () => {
   const [activeQuickAdd, setActiveQuickAdd] = useState<QuickAddKey | null>(null);
 
-  const {
-    data: resourcesData,
-  } = useQuery({
-    queryKey: queryKeys.resources.list(),
-    queryFn: () => fetchResources(),
-  });
-
-  const {
-    data: topicsData,
-  } = useQuery({
-    queryKey: ["topics"],
-    queryFn: () => fetchTopics(),
-  });
-
-  const {
-    data: providersData,
-  } = useQuery({
-    queryKey: ["providers"],
-    queryFn: () => fetchProviders(),
-  });
-
-  const {
-    data: domainsData,
-  } = useQuery({
-    queryKey: ["domains"],
-    queryFn: () => fetchDomains(),
-  });
-
-  const allLoaded
-    = resourcesData !== undefined
-      && topicsData !== undefined
-      && providersData !== undefined
-      && domainsData !== undefined;
-  const showOnboard
-    = !allLoaded
-      || (!resourcesData?.length
-        && !topicsData?.length
-        && !providersData?.length
-        && !domainsData?.length);
+  const showOnboard = useShowOnboard();
 
   const navLinkClass = `
     underline-offset-2


### PR DESCRIPTION
## ELI5
Some of the app's files were importing from too many places, which the project's linter flags as a sign a file is getting unwieldy. This tidies three of them — the top navigation bar and the two "quick add" pop-ups — by grouping related imports and moving their behind-the-scenes logic into small helper functions. Nothing about how the app looks or works changes; it's purely a cleanup.

## Summary
- `__root.tsx`: import the two nav primitives through a new `@/components/layout` barrel, and move the four onboarding data-queries into a `useShowOnboard()` hook (drops the direct react-query/utils/queryKeys imports). 12 → 9 dependencies.
- `QuickAddRoutineDialog` / `QuickAddTodoistDialog`: fold each dialog's form state, reset-on-open, and create mutation into a co-located bundled hook (`useQuickAddRoutine` / `useQuickAddTodoist`), leaving the components presentational. 11 → 6 and 11 → 7.
- Query keys preserved verbatim (factory vs. inline arrays untouched) so invalidation is unchanged; dialog public props are unchanged.
- Appended the resulting learnings to the `reduce-imports` skill.

## Test plan
- [x] `pnpm lint` — none of the three files appear under `import/max-dependencies` (remaining warnings are other #312 sibling-issue files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter=@emstack/client exec vitest run` — 401 passed
- [x] `pnpm exec fallow dead-code` — no new circular dependency from the layout barrel
- [ ] Smoke: desktop nav dropdowns + mobile menu render; Onboard link shows only when no records exist; Quick-Add → Routine creates a routine (with Edit toast action); Quick-Add → Todoist shows the configure-key state when unconfigured and resets on reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)