### PR TITLE
refactor(client): Fixes #308: reduce imports in settings page & sections

### DIFF
--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -172,3 +172,41 @@ left importing only render deps (a `lucide` icon, the form primitives,
 set, not all ~13 layout files) merged them to a single `@/components/layout`
 import. A barrel only pays off at ≥2 sources sharing a folder; re-exporting one
 component buys nothing.
+
+## Learnings: route layout + sections (settings, #308)
+
+- **A route layout that renders N route-private sections → barrel the folder.**
+  `foo.tsx` importing 10 `<XSection/>` from `foo.-components/-XSection.tsx`
+  collapses to one import via a `foo.-components/index.ts` that
+  `export { XSection } from "./-XSection"` for each. The un-prefixed `index.ts`
+  is **router-safe** — the `.-` on the *folder* already excludes the whole
+  directory from routing, so the barrel never becomes a route. Confirm with
+  `pnpm --filter=@emstack/client run routeTree` (expect no diff). Generalizes
+  #337's `dashboard.-components/index.ts`. Keep it cohesive: re-export just the
+  route's own sections (stops at exactly the section count — no disable needed)
+  rather than also folding in `@/components/*` chrome, which would push the
+  barrel over 10 and force a scoped disable on it.
+
+- **Colocate a route-private hook as `-use*.ts` inside the `.-components/`
+  folder**, not `src/hooks/`, when only that route uses it (precedent:
+  `dashboard.-components/-useDashboardDailies.ts`). Reserve `src/hooks/` for
+  genuinely cross-route hooks (`useResourceModules`, `useEditFormPage`).
+
+- **When extracting a hook, move the UI state its mutations reset.** Mutation
+  `onSuccess` commonly calls component `setState` (close a dialog, clear a
+  `*TargetId`/`creatingKind`). Move that state **into the hook** alongside the
+  mutations and return `open*/close*/submit*` handlers plus `is*Pending` flags —
+  otherwise the hook can't reset it and you'd have to thread setters back in.
+  (`-useDashboardLayouts` owns its dialog-target + `creatingKind` state for
+  exactly this reason.)
+
+- **One hook can serve a parent + child split.** A section that's a thin
+  fetch-wrapper around a form child: call the data/mutation hook once in the
+  parent and pass the mutation **down as a prop**, rather than re-calling the
+  hook (and re-importing react-query/utils) inside the child. (`FocusedDomains`:
+  `useFocusedDomains()` in the section, `saveMutation` passed to the form.)
+
+- **`lucide-react` is already one dependency** — multiple icons from it are one
+  import line, so "consolidate the icons" advice is a no-op for the count. Look
+  for whole *modules* to shed (react-query, sonner, `@/utils/api`,
+  `@/utils/queryKeys`), which a hook absorbs in one move.

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -1,9 +1,6 @@
 import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
-import { useState } from "react";
-
 import { DASHBOARD_TILE_IDS } from "@emstack/types";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   BookmarkIcon,
   CopyIcon,
@@ -12,7 +9,8 @@ import {
   PlusIcon,
   Trash2Icon,
 } from "lucide-react";
-import { toast } from "sonner";
+
+import { useDashboardLayouts } from "./-useDashboardLayouts";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { LayoutNameDialog } from "@/components/LayoutNameDialog";
@@ -26,20 +24,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  TILE_META,
-  toggleTile,
-} from "@/routes/dashboard.-components/-dashboardTileMeta";
-import {
-  createDashboardLayout,
-  deleteSingleDashboardLayout,
-  duplicateDashboardLayout,
-  fetchDashboardLayouts,
-  upsertDashboardLayout,
-} from "@/utils/api";
-import { queryKeys } from "@/utils/queryKeys";
-
-type CreateKind = "tab" | "preset";
+import { TILE_META } from "@/routes/dashboard.-components/-dashboardTileMeta";
 
 interface LayoutRowProps {
   layout: DashboardLayout;
@@ -124,149 +109,28 @@ function LayoutRow({
 }
 
 export function DashboardLayoutsSection() {
-  const queryClient = useQueryClient();
-
-  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
-  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-  const [creatingKind, setCreatingKind] = useState<CreateKind | null>(null);
-
-  const layoutsQuery = useQuery({
-    queryKey: queryKeys.dashboardLayouts.list(),
-    queryFn: () => fetchDashboardLayouts(),
-  });
-
-  const invalidate = () =>
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.dashboardLayouts.list(),
-    });
-
-  const layouts = layoutsQuery.data ?? [];
-  const tabs = layouts.filter(l => !l.isTemplate);
-  const presets = layouts.filter(l => l.isTemplate);
-
-  const renameTarget = layouts.find(l => l.id === renameTargetId) ?? null;
-  const saveAsTarget = layouts.find(l => l.id === saveAsTargetId) ?? null;
-  const deleteTarget = layouts.find(l => l.id === deleteTargetId) ?? null;
-
-  const createMutation = useMutation({
-    mutationFn: ({
-      name, kind,
-    }: { name: string;
-      kind: CreateKind; }) =>
-      createDashboardLayout({
-        name,
-        position: kind === "tab" ? tabs.length : null,
-        tiles: [],
-        isTemplate: kind === "preset",
-      }),
-    onSuccess: (_res, {
-      kind,
-    }) => {
-      void invalidate();
-      setCreatingKind(null);
-      toast.success(kind === "preset" ? "Preset created" : "Layout created");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const renameMutation = useMutation({
-    mutationFn: ({
-      layout, name,
-    }: { layout: DashboardLayout;
-      name: string; }) =>
-      upsertDashboardLayout(layout.id, {
-        name,
-        position: layout.position ?? null,
-        tiles: layout.tiles,
-        isTemplate: layout.isTemplate ?? false,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setRenameTargetId(null);
-      toast.success("Layout renamed");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const saveAsPresetMutation = useMutation({
-    mutationFn: ({
-      name, layout,
-    }: { name: string;
-      layout: DashboardLayout; }) =>
-      createDashboardLayout({
-        name,
-        position: null,
-        tiles: layout.tiles,
-        isTemplate: true,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setSaveAsTargetId(null);
-      toast.success("Saved as a layout you can reuse");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const duplicateMutation = useMutation({
-    mutationFn: (id: string) => duplicateDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      toast.success("Layout duplicated");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      setDeleteTargetId(null);
-      toast.success("Layout deleted");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const toggleTileMutation = useMutation({
-    mutationFn: ({
-      layout, tileId,
-    }: { layout: DashboardLayout;
-      tileId: DashboardTileId; }) =>
-      upsertDashboardLayout(layout.id, {
-        name: layout.name,
-        position: layout.position ?? null,
-        tiles: toggleTile(layout.tiles, tileId),
-        isTemplate: layout.isTemplate ?? false,
-      }),
-    onSuccess: () => {
-      void invalidate();
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const rowProps = {
-    onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) =>
-      toggleTileMutation.mutate({
-        layout,
-        tileId,
-      }),
-    onRename: (layout: DashboardLayout) => setRenameTargetId(layout.id),
-    onDuplicate: (layout: DashboardLayout) => duplicateMutation.mutate(layout.id),
-    onSaveAs: (layout: DashboardLayout) => setSaveAsTargetId(layout.id),
-    onDelete: (layout: DashboardLayout) => setDeleteTargetId(layout.id),
-  };
+  const {
+    isPending,
+    tabs,
+    presets,
+    rowProps,
+    creatingKind,
+    startCreate,
+    closeCreate,
+    submitCreate,
+    isCreating,
+    renameTarget,
+    closeRename,
+    submitRename,
+    isRenaming,
+    saveAsTarget,
+    closeSaveAs,
+    submitSaveAs,
+    isSavingPreset,
+    deleteTarget,
+    closeDelete,
+    confirmDelete,
+  } = useDashboardLayouts();
 
   return (
     <>
@@ -275,14 +139,14 @@ export function DashboardLayoutsSection() {
           <div className="flex gap-2">
             <Button
               variant="outline"
-              onClick={() => setCreatingKind("preset")}
+              onClick={() => startCreate("preset")}
             >
               <BookmarkIcon />
               New Preset
             </Button>
             <Button
               variant="outline"
-              onClick={() => setCreatingKind("tab")}
+              onClick={() => startCreate("tab")}
             >
               <PlusIcon />
               New Layout
@@ -294,7 +158,7 @@ export function DashboardLayoutsSection() {
           tab from.
         </p>
 
-        {layoutsQuery.isPending
+        {isPending
           ? <p className="text-sm text-muted-foreground">Loading...</p>
           : (
             <>
@@ -353,18 +217,11 @@ export function DashboardLayoutsSection() {
         open={renameTarget !== null}
         title="Rename layout"
         initialName={renameTarget?.name ?? ""}
-        isSaving={renameMutation.isPending}
+        isSaving={isRenaming}
         onOpenChange={(open) => {
-          if (!open) setRenameTargetId(null);
+          if (!open) closeRename();
         }}
-        onSubmit={(name) => {
-          if (renameTarget) {
-            renameMutation.mutate({
-              layout: renameTarget,
-              name,
-            });
-          }
-        }}
+        onSubmit={submitRename}
       />
 
       <LayoutNameDialog
@@ -372,36 +229,22 @@ export function DashboardLayoutsSection() {
         title="Save as preset"
         submitLabel="Save"
         initialName={saveAsTarget?.name ?? ""}
-        isSaving={saveAsPresetMutation.isPending}
+        isSaving={isSavingPreset}
         onOpenChange={(open) => {
-          if (!open) setSaveAsTargetId(null);
+          if (!open) closeSaveAs();
         }}
-        onSubmit={(name) => {
-          if (saveAsTarget) {
-            saveAsPresetMutation.mutate({
-              name,
-              layout: saveAsTarget,
-            });
-          }
-        }}
+        onSubmit={submitSaveAs}
       />
 
       <LayoutNameDialog
         open={creatingKind !== null}
         title={creatingKind === "preset" ? "New preset" : "New layout"}
         submitLabel="Create"
-        isSaving={createMutation.isPending}
+        isSaving={isCreating}
         onOpenChange={(open) => {
-          if (!open) setCreatingKind(null);
+          if (!open) closeCreate();
         }}
-        onSubmit={(name) => {
-          if (creatingKind) {
-            createMutation.mutate({
-              name,
-              kind: creatingKind,
-            });
-          }
-        }}
+        onSubmit={submitCreate}
       />
 
       <ConfirmDialog
@@ -414,10 +257,8 @@ export function DashboardLayoutsSection() {
         }
         confirmLabel="Delete"
         cancelLabel="Cancel"
-        onConfirm={() => {
-          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
-        }}
-        onCancel={() => setDeleteTargetId(null)}
+        onConfirm={confirmDelete}
+        onCancel={closeDelete}
       />
     </>
   );

--- a/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-FocusedDomainsSection.tsx
@@ -2,16 +2,14 @@ import type { AppSettingsSummary, Domain } from "@emstack/types";
 
 import { MAX_FOCUSED_DOMAINS } from "@emstack/types";
 import { useStore } from "@tanstack/react-form";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import * as z from "zod";
+
+import { useFocusedDomains } from "./-useFocusedDomains";
 
 import { useAppForm } from "@/components/formFields";
 import { EditForm } from "@/components/layout/EditForm";
 import { Button } from "@/components/ui/button";
-import { fetchDomains, fetchSettings, updateSettings } from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
 
 const formSchema = z.object({
   focusedDomainIds: z
@@ -19,15 +17,14 @@ const formSchema = z.object({
     .max(MAX_FOCUSED_DOMAINS, `Pick at most ${MAX_FOCUSED_DOMAINS} domains.`),
 });
 
+type SaveMutation = ReturnType<typeof useFocusedDomains>["saveMutation"];
+
 export function FocusedDomainsSection() {
-  const settingsQuery = useQuery({
-    queryKey: queryKeys.settings.detail(),
-    queryFn: () => fetchSettings(),
-  });
-  const domainsQuery = useQuery({
-    queryKey: queryKeys.domains.list(),
-    queryFn: () => fetchDomains(),
-  });
+  const {
+    settingsQuery,
+    domainsQuery,
+    saveMutation,
+  } = useFocusedDomains();
 
   return (
     <section className="flex flex-col gap-3">
@@ -45,6 +42,7 @@ export function FocusedDomainsSection() {
           <FocusedDomainsForm
             settings={settingsQuery.data}
             domains={domainsQuery.data}
+            saveMutation={saveMutation}
           />
         )
         : (
@@ -57,12 +55,12 @@ export function FocusedDomainsSection() {
 function FocusedDomainsForm({
   settings,
   domains,
+  saveMutation,
 }: {
   settings: AppSettingsSummary;
   domains: Domain[];
+  saveMutation: SaveMutation;
 }) {
-  const queryClient = useQueryClient();
-
   const domainOptions = domains
     .filter((d): d is Domain & { id: string } => Boolean(d.id))
     .map(d => ({
@@ -75,22 +73,6 @@ function FocusedDomainsForm({
   const existingIds = new Set(domainOptions.map(o => o.value));
   const initialFocused = settings.focusedDomainIds.filter(id =>
     existingIds.has(id));
-
-  const saveMutation = useMutation({
-    mutationFn: (focusedDomainIds: string[]) =>
-      updateSettings({
-        focusedDomainIds,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.settings.detail(),
-      });
-      toast.success("Focused domains saved");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
 
   const form = useAppForm({
     defaultValues: {

--- a/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
+++ b/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
@@ -1,0 +1,219 @@
+import type { DashboardLayout, DashboardTileId } from "@emstack/types";
+
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { toggleTile } from "@/routes/dashboard.-components/-dashboardTileMeta";
+import {
+  createDashboardLayout,
+  deleteSingleDashboardLayout,
+  duplicateDashboardLayout,
+  fetchDashboardLayouts,
+  upsertDashboardLayout,
+} from "@/utils/api";
+import { queryKeys } from "@/utils/queryKeys";
+
+export type CreateKind = "tab" | "preset";
+
+/**
+ * Data + mutations for the dashboard-layouts settings section. Owns the dialog
+ * target state alongside the mutations so each `onSuccess` can close its own
+ * dialog; the section is left rendering from a presentational-ready return.
+ */
+export function useDashboardLayouts() {
+  const queryClient = useQueryClient();
+
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
+  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [creatingKind, setCreatingKind] = useState<CreateKind | null>(null);
+
+  const layoutsQuery = useQuery({
+    queryKey: queryKeys.dashboardLayouts.list(),
+    queryFn: () => fetchDashboardLayouts(),
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.dashboardLayouts.list(),
+    });
+
+  const layouts = layoutsQuery.data ?? [];
+  const tabs = layouts.filter(l => !l.isTemplate);
+  const presets = layouts.filter(l => l.isTemplate);
+
+  const renameTarget = layouts.find(l => l.id === renameTargetId) ?? null;
+  const saveAsTarget = layouts.find(l => l.id === saveAsTargetId) ?? null;
+  const deleteTarget = layouts.find(l => l.id === deleteTargetId) ?? null;
+
+  const createMutation = useMutation({
+    mutationFn: ({
+      name, kind,
+    }: { name: string;
+      kind: CreateKind; }) =>
+      createDashboardLayout({
+        name,
+        position: kind === "tab" ? tabs.length : null,
+        tiles: [],
+        isTemplate: kind === "preset",
+      }),
+    onSuccess: (_res, {
+      kind,
+    }) => {
+      void invalidate();
+      setCreatingKind(null);
+      toast.success(kind === "preset" ? "Preset created" : "Layout created");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const renameMutation = useMutation({
+    mutationFn: ({
+      layout, name,
+    }: { layout: DashboardLayout;
+      name: string; }) =>
+      upsertDashboardLayout(layout.id, {
+        name,
+        position: layout.position ?? null,
+        tiles: layout.tiles,
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      setRenameTargetId(null);
+      toast.success("Layout renamed");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const saveAsPresetMutation = useMutation({
+    mutationFn: ({
+      name, layout,
+    }: { name: string;
+      layout: DashboardLayout; }) =>
+      createDashboardLayout({
+        name,
+        position: null,
+        tiles: layout.tiles,
+        isTemplate: true,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      setSaveAsTargetId(null);
+      toast.success("Saved as a layout you can reuse");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (id: string) => duplicateDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      toast.success("Layout duplicated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      setDeleteTargetId(null);
+      toast.success("Layout deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const toggleTileMutation = useMutation({
+    mutationFn: ({
+      layout, tileId,
+    }: { layout: DashboardLayout;
+      tileId: DashboardTileId; }) =>
+      upsertDashboardLayout(layout.id, {
+        name: layout.name,
+        position: layout.position ?? null,
+        tiles: toggleTile(layout.tiles, tileId),
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onSuccess: () => {
+      void invalidate();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const rowProps = {
+    onToggleTile: (layout: DashboardLayout, tileId: DashboardTileId) =>
+      toggleTileMutation.mutate({
+        layout,
+        tileId,
+      }),
+    onRename: (layout: DashboardLayout) => setRenameTargetId(layout.id),
+    onDuplicate: (layout: DashboardLayout) => duplicateMutation.mutate(layout.id),
+    onSaveAs: (layout: DashboardLayout) => setSaveAsTargetId(layout.id),
+    onDelete: (layout: DashboardLayout) => setDeleteTargetId(layout.id),
+  };
+
+  return {
+    isPending: layoutsQuery.isPending,
+    tabs,
+    presets,
+    rowProps,
+
+    creatingKind,
+    startCreate: (kind: CreateKind) => setCreatingKind(kind),
+    closeCreate: () => setCreatingKind(null),
+    submitCreate: (name: string) => {
+      if (creatingKind) {
+        createMutation.mutate({
+          name,
+          kind: creatingKind,
+        });
+      }
+    },
+    isCreating: createMutation.isPending,
+
+    renameTarget,
+    closeRename: () => setRenameTargetId(null),
+    submitRename: (name: string) => {
+      if (renameTarget) {
+        renameMutation.mutate({
+          layout: renameTarget,
+          name,
+        });
+      }
+    },
+    isRenaming: renameMutation.isPending,
+
+    saveAsTarget,
+    closeSaveAs: () => setSaveAsTargetId(null),
+    submitSaveAs: (name: string) => {
+      if (saveAsTarget) {
+        saveAsPresetMutation.mutate({
+          name,
+          layout: saveAsTarget,
+        });
+      }
+    },
+    isSavingPreset: saveAsPresetMutation.isPending,
+
+    deleteTarget,
+    closeDelete: () => setDeleteTargetId(null),
+    confirmDelete: () => {
+      if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+    },
+  };
+}

--- a/packages/client/src/routes/settings.-components/-useFocusedDomains.ts
+++ b/packages/client/src/routes/settings.-components/-useFocusedDomains.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { fetchDomains, fetchSettings, updateSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Settings + domains queries plus the save mutation for the focused-domains
+ * section. The section calls this once and hands `saveMutation` down to the
+ * form, so neither component imports react-query/toast/data helpers directly.
+ */
+export function useFocusedDomains() {
+  const queryClient = useQueryClient();
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const domainsQuery = useQuery({
+    queryKey: queryKeys.domains.list(),
+    queryFn: () => fetchDomains(),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (focusedDomainIds: string[]) =>
+      updateSettings({
+        focusedDomainIds,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.settings.detail(),
+      });
+      toast.success("Focused domains saved");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  return {
+    settingsQuery,
+    domainsQuery,
+    saveMutation,
+  };
+}

--- a/packages/client/src/routes/settings.-components/index.ts
+++ b/packages/client/src/routes/settings.-components/index.ts
@@ -1,0 +1,13 @@
+// One import surface for the section components the /settings route composes.
+// Each section imports its own dependencies directly (never this index), so
+// this re-export barrel introduces no cycle.
+export { CriteriaTemplatesSection } from "./-CriteriaTemplatesSection";
+export { DashboardLayoutsSection } from "./-DashboardLayoutsSection";
+export { DataToolsSection } from "./-DataToolsSection";
+export { FocusedDomainsSection } from "./-FocusedDomainsSection";
+export { GoogleCalendarSection } from "./-GoogleCalendarSection";
+export { ReadwiseSection } from "./-ReadwiseSection";
+export { RoutineTemplatesSection } from "./-RoutineTemplatesSection";
+export { TaskTypesSection } from "./-TaskTypesSection";
+export { ThemeSection } from "./-ThemeSection";
+export { TodoistSection } from "./-TodoistSection";

--- a/packages/client/src/routes/settings.tsx
+++ b/packages/client/src/routes/settings.tsx
@@ -1,15 +1,17 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
-import { CriteriaTemplatesSection } from "./settings.-components/-CriteriaTemplatesSection";
-import { DashboardLayoutsSection } from "./settings.-components/-DashboardLayoutsSection";
-import { DataToolsSection } from "./settings.-components/-DataToolsSection";
-import { FocusedDomainsSection } from "./settings.-components/-FocusedDomainsSection";
-import { GoogleCalendarSection } from "./settings.-components/-GoogleCalendarSection";
-import { ReadwiseSection } from "./settings.-components/-ReadwiseSection";
-import { RoutineTemplatesSection } from "./settings.-components/-RoutineTemplatesSection";
-import { TaskTypesSection } from "./settings.-components/-TaskTypesSection";
-import { ThemeSection } from "./settings.-components/-ThemeSection";
-import { TodoistSection } from "./settings.-components/-TodoistSection";
+import {
+  CriteriaTemplatesSection,
+  DashboardLayoutsSection,
+  DataToolsSection,
+  FocusedDomainsSection,
+  GoogleCalendarSection,
+  ReadwiseSection,
+  RoutineTemplatesSection,
+  TaskTypesSection,
+  ThemeSection,
+  TodoistSection,
+} from "./settings.-components";
 
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageTabs } from "@/components/layout/PageTabs";


### PR DESCRIPTION
## ELI5
The Settings screen's code was importing from too many different places, which our linter flags as a sign a file has grown unwieldy. This PR tidies that up — it groups the settings sub-screens behind a single front door and moves the data-loading/saving logic into dedicated helpers — so the screen behaves exactly the same but is easier to read and stays under the limit.

## Summary
- Added `settings.-components/index.ts` barrel so `settings.tsx` imports its 10 sections in one line (router-safe under the `.-` folder prefix).
- Extracted `-useDashboardLayouts` (queries + 6 mutations + dialog state) and `-useFocusedDomains` (queries + save mutation) hooks, leaving both sections presentational.
- Recorded the route-layout/section playbook learnings in the `reduce-imports` skill.

## Test plan
- [x] `pnpm lint` — none of the three settings files appear under "Maximum number of dependencies"
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter=@emstack/client exec vitest run` — 401 passed
- [x] `pnpm --filter=@emstack/client run routeTree` — no drift (new files excluded from routing)
- [x] `pnpm exec fallow dead-code` — no cycles introduced
- [ ] Manual: Settings → Dashboard tab (create/rename/duplicate/save-as-preset/toggle-tiles/delete each toast + close their dialog); Domains tab (change selection + Save persists across reload, max-domains validation still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)