### PR TITLE
feat(client): add inline resource creation in routine comboboxes

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
@@ -19,17 +19,30 @@ import {
 import { upsertResource, uuidv4 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
+interface QuickAddResourceDialogProps extends ControlledDialogProps {
+  /**
+   * Called with the new resource's id after a successful create. When provided,
+   * the success toast skips the "Edit"/navigate action so callers (e.g. an
+   * inline combobox) can keep the user in place and auto-select the resource.
+   */
+  onCreated?: (id: string) => void;
+  /** Seeds the name input when the dialog opens (e.g. the combobox's typed text). */
+  initialName?: string;
+}
+
 export function QuickAddResourceDialog({
   open,
   onOpenChange,
-}: ControlledDialogProps) {
+  onCreated,
+  initialName,
+}: QuickAddResourceDialogProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
 
   useEffect(() => {
-    if (open) setName("");
-  }, [open]);
+    if (open) setName(initialName ?? "");
+  }, [open, initialName]);
 
   const mutation = useMutation({
     // Resources have no POST create endpoint — a PUT with a fresh id upserts,
@@ -46,6 +59,11 @@ export function QuickAddResourceDialog({
         queryKey: queryKeys.resources.list(),
       });
       onOpenChange(false);
+      if (onCreated) {
+        onCreated(id);
+        toast.success("Resource created");
+        return;
+      }
       toast.success("Resource created", {
         action: {
           label: "Edit",

--- a/packages/client/src/components/routines/TaskResourceComboboxContent.tsx
+++ b/packages/client/src/components/routines/TaskResourceComboboxContent.tsx
@@ -1,3 +1,5 @@
+import { PlusIcon } from "lucide-react";
+
 import {
   ComboboxContent,
   ComboboxEmpty,
@@ -9,14 +11,37 @@ import {
  * Dropdown body (empty state + value list) for the task/resource combobox used
  * by the weekly routine editors. Shared by WeeklyEntryEditor and
  * WeeklyScheduleField, which only differ in how `optionsMap` is sourced.
+ *
+ * When `onAddNew` is provided, a pinned "Add resource" row is shown above the
+ * results so the user can create a resource inline. It's a plain button (not a
+ * ComboboxItem) so base-ui's text filtering never hides it.
  */
 export function TaskResourceComboboxContent({
   optionsMap,
+  onAddNew,
 }: {
   optionsMap: Map<string, string>;
+  onAddNew?: () => void;
 }) {
   return (
     <ComboboxContent>
+      {onAddNew && (
+        <button
+          type="button"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onAddNew();
+          }}
+          className="
+            flex w-full items-center gap-2 border-b border-border p-2 text-left
+            text-sm
+            hover:bg-accent hover:text-accent-foreground
+          "
+        >
+          <PlusIcon className="size-4" />
+          <span>Add resource</span>
+        </button>
+      )}
       <ComboboxEmpty>No items found.</ComboboxEmpty>
       <ComboboxList>
         {(val: string) => (

--- a/packages/client/src/components/routines/WeeklyEntryEditor.tsx
+++ b/packages/client/src/components/routines/WeeklyEntryEditor.tsx
@@ -1,11 +1,12 @@
 import type { WeeklyEntry, WeeklyRowType } from "@/components/routines/weekly";
 import type { SelectOption } from "@/utils";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
 import { Combobox, ComboboxInput } from "@/components/combobox";
+import { QuickAddResourceDialog } from "@/components/quickAdd/QuickAddResourceDialog";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 
 interface WeeklyEntryEditorProps extends WeeklyEntry {
@@ -35,6 +36,10 @@ export function WeeklyEntryEditor({
     () => new Map(itemOptions.map(o => [o.value, o.label])),
     [itemOptions],
   );
+
+  // Inline "Add resource" modal (only offered for the resource type).
+  const [addOpen, setAddOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
 
   function emit(patch: Partial<WeeklyEntry>) {
     onChange({
@@ -111,6 +116,7 @@ export function WeeklyEntryEditor({
                 emit({
                   id: val ?? "",
                 })}
+              onInputValueChange={val => setInputValue(val)}
               itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
             >
               <ComboboxInput
@@ -124,7 +130,12 @@ export function WeeklyEntryEditor({
                 showClear
                 disabled={!type}
               />
-              <TaskResourceComboboxContent optionsMap={optionsMap} />
+              <TaskResourceComboboxContent
+                optionsMap={optionsMap}
+                onAddNew={
+                  type === "resource" ? () => setAddOpen(true) : undefined
+                }
+              />
             </Combobox>
           )}
       </div>
@@ -195,6 +206,16 @@ export function WeeklyEntryEditor({
           )}
         </>
       )}
+
+      <QuickAddResourceDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        initialName={inputValue}
+        onCreated={newId =>
+          emit({
+            id: newId,
+          })}
+      />
     </div>
   );
 }

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -2,11 +2,12 @@ import type { WeeklyRow, WeeklyRowType } from "@/components/routines/weekly";
 import type { SelectOption } from "@/utils";
 import type { RoutineWeekday } from "@emstack/types";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
 import { Combobox, ComboboxInput } from "@/components/combobox";
+import { QuickAddResourceDialog } from "@/components/quickAdd/QuickAddResourceDialog";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { DAY_LABELS, DAY_ORDER } from "@/components/routines/weekly";
 
@@ -27,6 +28,12 @@ export function WeeklyScheduleField({
     () => new Map(value.map(r => [r.day, r])),
     [value],
   );
+
+  // Inline "Add resource" modal — shared across days; only one combobox dropdown
+  // is open at a time, so a single typed-text value and target day are enough.
+  const [addOpen, setAddOpen] = useState(false);
+  const [addForDay, setAddForDay] = useState<RoutineWeekday | null>(null);
+  const [inputValue, setInputValue] = useState("");
 
   function update(day: RoutineWeekday, patch: Partial<WeeklyRow>) {
     onChange(
@@ -132,6 +139,7 @@ export function WeeklyScheduleField({
                         update(day, {
                           id: val ?? "",
                         })}
+                      onInputValueChange={val => setInputValue(val)}
                       itemToStringLabel={(val: string) =>
                         optionsMap.get(val) ?? ""}
                     >
@@ -146,7 +154,17 @@ export function WeeklyScheduleField({
                         showClear
                         disabled={!row.type}
                       />
-                      <TaskResourceComboboxContent optionsMap={optionsMap} />
+                      <TaskResourceComboboxContent
+                        optionsMap={optionsMap}
+                        onAddNew={
+                          row.type === "resource"
+                            ? () => {
+                              setAddForDay(day);
+                              setAddOpen(true);
+                            }
+                            : undefined
+                        }
+                      />
                     </Combobox>
                   )}
               </div>
@@ -225,6 +243,19 @@ export function WeeklyScheduleField({
           );
         })}
       </ul>
+
+      <QuickAddResourceDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        initialName={inputValue}
+        onCreated={(newId) => {
+          if (addForDay != null) {
+            update(addForDay, {
+              id: newId,
+            });
+          }
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds the ability to create new resources directly from the task/resource combobox dropdowns in the weekly routine editors, eliminating the need to navigate away to create a resource before selecting it.

## Changes

- **QuickAddResourceDialog:** Extended to accept `onCreated` callback and `initialName` prop, allowing callers to handle resource creation inline (e.g., auto-select the new resource) without navigation
- **TaskResourceComboboxContent:** Added a pinned "Add resource" button at the top of the dropdown (via `onAddNew` prop) that appears only when the callback is provided; implemented as a plain button to avoid being filtered by base-ui's text search
- **WeeklyScheduleField & WeeklyEntryEditor:** Integrated inline resource creation by:
  - Tracking the combobox's typed input value and target day (for WeeklyScheduleField)
  - Passing `onAddNew` to TaskResourceComboboxContent when row/entry type is "resource"
  - Opening QuickAddResourceDialog with the typed text as `initialName`
  - Auto-selecting the newly created resource on success

## Implementation Details

- Single shared QuickAddResourceDialog instance per editor (WeeklyScheduleField has one for all days; WeeklyEntryEditor has one for the single entry) since only one combobox dropdown can be open at a time
- Input value is captured via `onInputValueChange` on the Combobox to seed the dialog's name field
- Success path skips the "Edit" toast action when `onCreated` is provided, keeping the user in the current context
- The "Add resource" button uses `onMouseDown` with `preventDefault()` to avoid closing the combobox before the dialog opens

https://claude.ai/code/session_013DjNwi4ZL41F2F43T93XTL