### PR TITLE
refactor(client): reduce imports in radar & resource-management components

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -1,6 +1,3 @@
-import type { PromptMode } from "./blipLlmPrompts";
-import type { ResolvedLlmEntry } from "./blipLlmReview";
-import type { BulkBlipEntry } from "@/utils";
 import type {
   DomainExcludedTopic,
   DomainTopic,
@@ -10,27 +7,14 @@ import type {
   TopicForTopicsPage,
 } from "@emstack/types";
 
-import { useMemo, useState } from "react";
-
 import { CopyIcon, Loader2 } from "lucide-react";
-import { toast } from "sonner";
 
 import { BulkEditBar } from "./BlipLlmBulkEditBar";
-import { buildCleanupPrompt, buildLlmPrompt } from "./blipLlmPrompts";
-import { descriptionChanged, parseLlmEntries } from "./blipLlmReview";
 import { ReviewTable } from "./BlipLlmReviewTable";
 
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
-import { useBlipLlmReview } from "@/hooks/useBlipLlmReview";
-import {
-  bulkCreateRadarBlips,
-  copyTextToClipboard,
-  deleteRadarBlip,
-  deleteSingleTopic,
-  upsertRadarBlip,
-  upsertTopic,
-} from "@/utils";
+import { useBlipLlmAssist } from "@/hooks/useBlipLlmAssist";
 
 interface BlipLlmAssistProps {
   domainId: string;
@@ -49,162 +33,27 @@ interface BlipLlmAssistProps {
   onComplete: () => void;
 }
 
-export function BlipLlmAssist({
-  domainId,
-  domainTitle,
-  domainDescription = null,
-  domainTopics = [],
-  excludedTopics = [],
-  withinScopeDescription = null,
-  outOfScopeDescription = null,
-  withinScopeTopicNames = [],
-  outOfScopeTopicNames = [],
-  quadrants,
-  rings,
-  topics,
-  existingBlips,
-  onComplete,
-}: BlipLlmAssistProps) {
-  const [mode, setMode] = useState<PromptMode>("setup");
-
-  const prompt = useMemo(
-    () => {
-      const topicById = new Map(topics.map(t => [t.id, t]));
-      const quadrantById = new Map(quadrants.map(q => [q.id, q]));
-      const ringById = new Map(rings.map(r => [r.id, r]));
-      if (mode === "cleanup") {
-        const unassignedBlips = existingBlips
-          .filter(b => !b.quadrantId || !b.ringId)
-          .map(b => ({
-            topicName: b.topicName,
-            quadrantName: b.quadrantId
-              ? quadrantById.get(b.quadrantId)?.name ?? null
-              : null,
-            ringName: b.ringId ? ringById.get(b.ringId)?.name ?? null : null,
-            radarNote: b.description,
-            topicDescription: topicById.get(b.topicId)?.description ?? null,
-          }));
-        return buildCleanupPrompt({
-          domainTitle,
-          domainDescription,
-          withinScopeDescription,
-          outOfScopeDescription,
-          quadrants,
-          rings,
-          unassignedBlips,
-        });
-      }
-      return buildLlmPrompt({
-        domainTitle,
-        domainDescription,
-        domainTopics,
-        excludedTopics,
-        withinScopeDescription,
-        outOfScopeDescription,
-        withinScopeTopicNames,
-        outOfScopeTopicNames,
-        quadrants,
-        rings,
-        existingBlips: existingBlips.map((b) => {
-          const ring = b.ringId ? ringById.get(b.ringId) : null;
-          const quadrant = b.quadrantId ? quadrantById.get(b.quadrantId) : null;
-          return {
-            topicName: b.topicName,
-            radarNote: b.description,
-            topicDescription: topicById.get(b.topicId)?.description ?? null,
-            currentSliceName: quadrant?.name ?? null,
-            currentRingName: ring?.name ?? null,
-          };
-        }),
-      });
-    },
-    [
-      mode,
-      domainTitle,
-      domainDescription,
-      domainTopics,
-      excludedTopics,
-      withinScopeDescription,
-      outOfScopeDescription,
-      withinScopeTopicNames,
-      outOfScopeTopicNames,
-      quadrants,
-      rings,
-      existingBlips,
-      topics,
-    ],
-  );
-
-  const unassignedCount = useMemo(
-    () => existingBlips.filter(b => !b.quadrantId || !b.ringId).length,
-    [existingBlips],
-  );
-
-  const [jsonText, setJsonText] = useState("");
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const topicByLowerName = useMemo(() => {
-    const map = new Map<string, TopicForTopicsPage>();
-    topics.forEach((t) => {
-      map.set(t.name.toLowerCase(), t);
-    });
-    return map;
-  }, [topics]);
-
-  const quadrantByLowerName = useMemo(() => {
-    const map = new Map<string, RadarQuadrant>();
-    quadrants.forEach((q) => {
-      map.set(q.name.toLowerCase(), q);
-    });
-    return map;
-  }, [quadrants]);
-
-  const ringByLowerName = useMemo(() => {
-    const map = new Map<string, RadarRing>();
-    rings.forEach((r) => {
-      map.set(r.name.toLowerCase(), r);
-    });
-    return map;
-  }, [rings]);
-
-  const existingBlipByTopicId = useMemo(() => {
-    const map = new Map<string, RadarBlip>();
-    existingBlips.forEach((b) => {
-      map.set(b.topicId, b);
-    });
-    return map;
-  }, [existingBlips]);
-
-  const quadrantById = useMemo(() => {
-    const map = new Map<string, RadarQuadrant>();
-    quadrants.forEach(q => map.set(q.id, q));
-    return map;
-  }, [quadrants]);
-
-  const ringById = useMemo(() => {
-    const map = new Map<string, RadarRing>();
-    rings.forEach(r => map.set(r.id, r));
-    return map;
-  }, [rings]);
-
-  const topicById = useMemo(() => {
-    const map = new Map<string, TopicForTopicsPage>();
-    topics.forEach(t => map.set(t.id, t));
-    return map;
-  }, [topics]);
-
-  const excludedNamesLower = useMemo(() => {
-    const set = new Set<string>();
-    excludedTopics.forEach((t) => {
-      if (t.name) {
-        set.add(t.name.toLowerCase());
-      }
-    });
-    return set;
-  }, [excludedTopics]);
-
+export function BlipLlmAssist(props: BlipLlmAssistProps) {
   const {
+    quadrants, rings,
+  } = props;
+  const {
+    mode,
+    setMode,
+    prompt,
+    unassignedCount,
+    jsonText,
+    setJsonText,
+    parseError,
+    isSubmitting,
+    quadrantById,
+    ringById,
+    topicById,
+    counts,
+    actionableCount,
+    copyPrompt,
+    parseAndResolve,
+    handleConfirm,
     resolved,
     setResolved,
     updateEntry,
@@ -219,155 +68,7 @@ export function BlipLlmAssist({
     bulkSetResolution,
     bulkClearDescriptions,
     bulkClearRadarNotes,
-    counts,
-  } = useBlipLlmReview({
-    quadrants,
-    rings,
-    excludedNamesLower,
-  });
-
-  async function copyPrompt() {
-    const ok = await copyTextToClipboard(prompt);
-    if (ok) {
-      toast.success("Prompt copied to clipboard.");
-    }
-    else {
-      toast.error("Couldn't copy — please select and copy manually.");
-    }
-  }
-
-  function parseAndResolve() {
-    setParseError(null);
-    const result = parseLlmEntries(jsonText, {
-      topicByLowerName,
-      quadrantByLowerName,
-      ringByLowerName,
-      existingBlipByTopicId,
-      excludedNamesLower,
-    });
-    if (result.error !== null) {
-      setParseError(result.error);
-      setResolved(null);
-      return;
-    }
-    setResolved(result.entries);
-  }
-
-  function isActionable(r: ResolvedLlmEntry): boolean {
-    if (r.resolution === "skip") {
-      return false;
-    }
-    return r.problems.length === 0;
-  }
-
-  async function handleConfirm() {
-    if (!resolved) {
-      return;
-    }
-    const actionable = resolved.filter(isActionable);
-    if (actionable.length === 0) {
-      toast.error("No actionable entries.");
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      const toCreate = actionable.filter(r => r.resolution === "create");
-      const toOverwriteAll = actionable.filter(
-        r => r.resolution === "overwriteAll" && r.existingBlipId,
-      );
-      const toUpdateBlip = actionable.filter(
-        r => r.resolution === "updateBlip" && r.existingBlipId,
-      );
-      const toRemove = actionable.filter(
-        r => r.resolution === "removeBlip" && r.existingBlipId,
-      );
-
-      let createCount = 0;
-      if (toCreate.length > 0) {
-        const blips: BulkBlipEntry[] = toCreate.map(r => ({
-          topicId: r.matchedTopicId,
-          newTopicName: r.matchedTopicId ? null : r.topicName,
-          newTopicDescription: r.matchedTopicId ? null : r.description,
-          quadrantId: r.quadrantId as string,
-          ringId: r.ringId as string,
-          description: r.radarNote,
-        }));
-        const result = await bulkCreateRadarBlips(domainId, {
-          blips,
-        });
-        createCount = result.count;
-      }
-
-      let overwriteCount = 0;
-      for (const r of toOverwriteAll) {
-        await upsertRadarBlip(domainId, r.existingBlipId as string, {
-          topicId: r.matchedTopicId as string,
-          quadrantId: r.quadrantId as string,
-          ringId: r.ringId as string,
-          description: r.radarNote,
-        });
-        if (r.matchedTopicId && descriptionChanged(r)) {
-          await upsertTopic(r.matchedTopicId, {
-            name: r.topicName,
-            description: r.description,
-          });
-        }
-        overwriteCount += 1;
-      }
-
-      let updateCount = 0;
-      for (const r of toUpdateBlip) {
-        await upsertRadarBlip(domainId, r.existingBlipId as string, {
-          topicId: r.matchedTopicId as string,
-          quadrantId: (r.quadrantId ?? r.existingQuadrantId) as string,
-          ringId: (r.ringId ?? r.existingRingId) as string,
-          description: r.radarNote,
-        });
-        updateCount += 1;
-      }
-
-      let removeBlipCount = 0;
-      let removeTopicCount = 0;
-      for (const r of toRemove) {
-        await deleteRadarBlip(domainId, r.existingBlipId as string);
-        removeBlipCount += 1;
-        if (r.deleteTopicOnRemove && r.matchedTopicId) {
-          await deleteSingleTopic(r.matchedTopicId);
-          removeTopicCount += 1;
-        }
-      }
-
-      const parts: string[] = [];
-      if (createCount > 0) {
-        parts.push(`added ${createCount}`);
-      }
-      if (overwriteCount > 0) {
-        parts.push(`overwrote ${overwriteCount}`);
-      }
-      if (updateCount > 0) {
-        parts.push(`updated ${updateCount}`);
-      }
-      if (removeBlipCount > 0) {
-        parts.push(`removed ${removeBlipCount}`);
-      }
-      if (removeTopicCount > 0) {
-        parts.push(`deleted ${removeTopicCount} topic${removeTopicCount === 1 ? "" : "s"}`);
-      }
-      toast.success(`Done — ${parts.join(", ")}.`);
-      setJsonText("");
-      setResolved(null);
-      onComplete();
-    }
-    catch {
-      toast.error("Failed to apply changes.");
-    }
-    finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  const actionableCount
-    = counts.create + counts.overwriteAll + counts.updateBlip + counts.removeBlip;
+  } = useBlipLlmAssist(props);
 
   return (
     <div className="flex flex-col gap-4 rounded-sm border p-4">

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -19,27 +19,21 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { toast } from "sonner";
 
-import { Input } from "@/components/input";
-import { BlipBulkBar } from "@/components/radar/BlipBulkBar";
-import { BlipDisplayRow } from "@/components/radar/BlipDisplayRow";
-import { BlipEditRow } from "@/components/radar/BlipEditRow";
 import {
   ALL,
   countByField,
   filterAndSortBlips,
   NO_CHANGE,
-  UNASSIGNED,
 } from "@/components/radar/blipTableFilters";
+import {
+  BlipBulkBar,
+  BlipDisplayRow,
+  BlipEditRow,
+} from "@/components/radar/blipTableRows";
+import { BlipTableToolbar } from "@/components/radar/BlipTableToolbar";
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
 import { makeManualSortHandler, toSortingState } from "@/components/ui/manualSort";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { SelectAllCheckbox } from "@/components/ui/SelectAllCheckbox";
 import {
   TableCell,
@@ -376,74 +370,21 @@ export function BlipTable({
 
   return (
     <div className="flex flex-col gap-3">
-      <div
-        className={`
-          grid grid-cols-1 gap-2
-          sm:grid-cols-[1fr_auto_auto_auto]
-        `}
-      >
-        <Input
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          placeholder="Search topic or note"
-        />
-        <Select
-          value={filterQuadrant}
-          onValueChange={setFilterQuadrant}
-        >
-          <SelectTrigger className="min-w-40">
-            <SelectValue placeholder="Slice" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>All Slices ({blips.length})</SelectItem>
-            <SelectItem value={UNASSIGNED}>
-              Unassigned ({sliceCounts.unassigned})
-            </SelectItem>
-            {quadrants.map(q => (
-              <SelectItem
-                key={q.id}
-                value={q.id}
-              >
-                {q.name}
-                {" ("}
-                {sliceCounts.counts.get(q.id) ?? 0})
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select
-          value={filterRing}
-          onValueChange={setFilterRing}
-        >
-          <SelectTrigger className="min-w-32">
-            <SelectValue placeholder="Ring" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>All Rings ({blips.length})</SelectItem>
-            <SelectItem value={UNASSIGNED}>
-              Unassigned ({ringCounts.unassigned})
-            </SelectItem>
-            {rings.map(r => (
-              <SelectItem
-                key={r.id}
-                value={r.id}
-              >
-                {r.name}
-                {" ("}
-                {ringCounts.counts.get(r.id) ?? 0})
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <label className="flex flex-row items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={showItemsColumn}
-            onChange={e => setShowItemsColumn(e.target.checked)}
-          />
-          Topic Items
-        </label>
-      </div>
+      <BlipTableToolbar
+        search={search}
+        onSearchChange={setSearch}
+        filterQuadrant={filterQuadrant}
+        onFilterQuadrantChange={setFilterQuadrant}
+        filterRing={filterRing}
+        onFilterRingChange={setFilterRing}
+        showItemsColumn={showItemsColumn}
+        onShowItemsColumnChange={setShowItemsColumn}
+        quadrants={quadrants}
+        rings={rings}
+        blipCount={blips.length}
+        sliceCounts={sliceCounts}
+        ringCounts={ringCounts}
+      />
 
       {selectedIds.size > 0 && (
         <BlipBulkBar

--- a/packages/client/src/components/radar/BlipTableToolbar.tsx
+++ b/packages/client/src/components/radar/BlipTableToolbar.tsx
@@ -1,0 +1,122 @@
+import type { RadarQuadrant, RadarRing } from "@emstack/types";
+
+import { Input } from "@/components/input";
+import {
+  ALL,
+  UNASSIGNED,
+} from "@/components/radar/blipTableFilters";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface FieldCounts {
+  unassigned: number;
+  counts: Map<string, number>;
+}
+
+interface BlipTableToolbarProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  filterQuadrant: string;
+  onFilterQuadrantChange: (value: string) => void;
+  filterRing: string;
+  onFilterRingChange: (value: string) => void;
+  showItemsColumn: boolean;
+  onShowItemsColumnChange: (value: boolean) => void;
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  blipCount: number;
+  sliceCounts: FieldCounts;
+  ringCounts: FieldCounts;
+}
+
+export function BlipTableToolbar({
+  search,
+  onSearchChange,
+  filterQuadrant,
+  onFilterQuadrantChange,
+  filterRing,
+  onFilterRingChange,
+  showItemsColumn,
+  onShowItemsColumnChange,
+  quadrants,
+  rings,
+  blipCount,
+  sliceCounts,
+  ringCounts,
+}: BlipTableToolbarProps) {
+  return (
+    <div
+      className={`
+        grid grid-cols-1 gap-2
+        sm:grid-cols-[1fr_auto_auto_auto]
+      `}
+    >
+      <Input
+        value={search}
+        onChange={e => onSearchChange(e.target.value)}
+        placeholder="Search topic or note"
+      />
+      <Select
+        value={filterQuadrant}
+        onValueChange={onFilterQuadrantChange}
+      >
+        <SelectTrigger className="min-w-40">
+          <SelectValue placeholder="Slice" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All Slices ({blipCount})</SelectItem>
+          <SelectItem value={UNASSIGNED}>
+            Unassigned ({sliceCounts.unassigned})
+          </SelectItem>
+          {quadrants.map(q => (
+            <SelectItem
+              key={q.id}
+              value={q.id}
+            >
+              {q.name}
+              {" ("}
+              {sliceCounts.counts.get(q.id) ?? 0})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        value={filterRing}
+        onValueChange={onFilterRingChange}
+      >
+        <SelectTrigger className="min-w-32">
+          <SelectValue placeholder="Ring" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>All Rings ({blipCount})</SelectItem>
+          <SelectItem value={UNASSIGNED}>
+            Unassigned ({ringCounts.unassigned})
+          </SelectItem>
+          {rings.map(r => (
+            <SelectItem
+              key={r.id}
+              value={r.id}
+            >
+              {r.name}
+              {" ("}
+              {ringCounts.counts.get(r.id) ?? 0})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <label className="flex flex-row items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={showItemsColumn}
+          onChange={e => onShowItemsColumnChange(e.target.checked)}
+        />
+        Topic Items
+      </label>
+    </div>
+  );
+}

--- a/packages/client/src/components/radar/blipTableRows.ts
+++ b/packages/client/src/components/radar/blipTableRows.ts
@@ -1,0 +1,9 @@
+// Row/bulk sub-components rendered by BlipTable: the bulk-edit bar, the
+// read-only display row, and the inline edit row. Grouping the re-exports here
+// lets BlipTable import them as a single dependency. This barrel only
+// re-exports leaf sub-components — it does not import the folder, and the
+// sub-components keep their own direct imports, so there is no circular
+// dependency.
+export { BlipBulkBar } from "./BlipBulkBar";
+export { BlipDisplayRow } from "./BlipDisplayRow";
+export { BlipEditRow } from "./BlipEditRow";

--- a/packages/client/src/components/resources/ResourceInteractionsLog.tsx
+++ b/packages/client/src/components/resources/ResourceInteractionsLog.tsx
@@ -1,3 +1,4 @@
+import type { InteractionDraft } from "@/hooks/useInteractionsLog";
 import type {
   Interaction,
   InteractionDifficulty,
@@ -7,13 +8,9 @@ import type {
   ModuleGroup,
 } from "@emstack/types";
 
-// Incidental overlap of a standard import block.
-// fallow-ignore-next-line code-duplication
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PencilIcon, PlusIcon } from "lucide-react";
-import { toast } from "sonner";
 
 import { EditFormActions } from "@/components/EditFormActions";
 import { Input } from "@/components/input";
@@ -21,30 +18,13 @@ import { OptionalSelectField } from "@/components/resources/OptionalSelectField"
 import { Textarea } from "@/components/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  createInteraction,
-  deleteSingleInteraction,
-  fetchInteractions,
-  fetchModuleGroups,
-  fetchModules,
-  upsertInteraction,
-} from "@/utils/fetchFunctions";
-import { queryKeys } from "@/utils/queryKeys";
+import { useInteractionsLog } from "@/hooks/useInteractionsLog";
 
 interface Props {
   resourceId: string;
 }
 
-interface Draft {
-  id: string;
-  date: string;
-  progress: InteractionProgress;
-  note: string;
-  difficulty: InteractionDifficulty | "";
-  understanding: InteractionUnderstanding | "";
-  moduleGroupId: string;
-  moduleId: string;
-}
+type Draft = InteractionDraft;
 
 const NEW_ID = "__new__";
 
@@ -115,94 +95,17 @@ const PROGRESS_COLOR: Record<InteractionProgress, string> = {
 export function ResourceInteractionsLog({
   resourceId,
 }: Props) {
-  const queryClient = useQueryClient();
-
-  const interactionsQuery = useQuery({
-    queryKey: queryKeys.resources.interactions(resourceId),
-    queryFn: () => fetchInteractions(),
-  });
-
-  const moduleGroupsQuery = useQuery({
-    queryKey: queryKeys.resources.moduleGroups(resourceId),
-    queryFn: () => fetchModuleGroups(),
-  });
-
-  const modulesQuery = useQuery({
-    queryKey: queryKeys.resources.modules(resourceId),
-    queryFn: () => fetchModules(),
-  });
-
-  const allInteractions = interactionsQuery.data ?? [];
-  const interactions = allInteractions.filter(i => i.resourceId === resourceId);
-
-  const moduleGroups = useMemo(
-    () =>
-      (moduleGroupsQuery.data ?? []).filter(g => g.resourceId === resourceId),
-    [moduleGroupsQuery.data, resourceId],
-  );
-  const modules = useMemo(
-    () => (modulesQuery.data ?? []).filter(m => m.resourceId === resourceId),
-    [modulesQuery.data, resourceId],
-  );
+  const {
+    interactions,
+    moduleGroups,
+    modules,
+    createMutation,
+    upsertMutation,
+    deleteMutation,
+  } = useInteractionsLog(resourceId);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
-
-  function invalidate() {
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.resources.interactions(resourceId),
-    });
-  }
-
-  const upsertMutation = useMutation({
-    mutationFn: (d: Draft) =>
-      upsertInteraction(d.id, {
-        resourceId,
-        moduleGroupId: d.moduleGroupId || null,
-        moduleId: d.moduleId || null,
-        date: d.date,
-        progress: d.progress,
-        note: d.note || null,
-        difficulty: d.difficulty || null,
-        understanding: d.understanding || null,
-      }),
-    onSuccess: () => {
-      invalidate();
-      setEditingId(null);
-      toast.success("Interaction saved");
-    },
-    onError: (e: Error) => toast.error(e.message),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (d: Draft) =>
-      createInteraction({
-        resourceId,
-        moduleGroupId: d.moduleGroupId || null,
-        moduleId: d.moduleId || null,
-        date: d.date,
-        progress: d.progress,
-        note: d.note || null,
-        difficulty: d.difficulty || null,
-        understanding: d.understanding || null,
-      }),
-    onSuccess: () => {
-      invalidate();
-      setCreating(false);
-      toast.success("Interaction logged");
-    },
-    onError: (e: Error) => toast.error(e.message),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleInteraction(id),
-    onSuccess: () => {
-      invalidate();
-      setEditingId(null);
-      toast.success("Interaction deleted");
-    },
-    onError: (e: Error) => toast.error(e.message),
-  });
 
   const isAnyEditing = creating || editingId !== null;
 
@@ -238,7 +141,10 @@ export function ResourceInteractionsLog({
           modules={modules}
           isNew
           isSaving={createMutation.isPending}
-          onSave={d => createMutation.mutate(d)}
+          onSave={d =>
+            createMutation.mutate(d, {
+              onSuccess: () => setCreating(false),
+            })}
           onCancel={() => setCreating(false)}
         />
       )}
@@ -256,9 +162,15 @@ export function ResourceInteractionsLog({
                   isSaving={
                     upsertMutation.isPending || deleteMutation.isPending
                   }
-                  onSave={d => upsertMutation.mutate(d)}
+                  onSave={d =>
+                    upsertMutation.mutate(d, {
+                      onSuccess: () => setEditingId(null),
+                    })}
                   onCancel={() => setEditingId(null)}
-                  onDelete={() => deleteMutation.mutate(i.id)}
+                  onDelete={() =>
+                    deleteMutation.mutate(i.id, {
+                      onSuccess: () => setEditingId(null),
+                    })}
                 />
               );
             }

--- a/packages/client/src/components/resources/ResourceModulesAdmin.tsx
+++ b/packages/client/src/components/resources/ResourceModulesAdmin.tsx
@@ -10,17 +10,20 @@ import {
   SparklesIcon,
 } from "lucide-react";
 
-import { GroupEditCard, GroupMetaChips } from "./GroupEditCard";
-import { InteractionQuickLog } from "./InteractionQuickLog";
-import { ModuleDisplayRow } from "./ModuleDisplayRow";
+import {
+  GroupEditCard,
+  GroupMetaChips,
+  InteractionQuickLog,
+  ModuleDisplayRow,
+  ModuleEditCard,
+  ModuleSuggestDialog,
+} from "./moduleAdminComponents";
 import {
   emptyGroupDraft,
   emptyModuleDraft,
   groupToDraft,
   moduleToDraft,
 } from "./moduleDrafts";
-import { ModuleEditCard } from "./ModuleEditCard";
-import { ModuleSuggestDialog } from "./ModuleSuggestDialog";
 
 import { Button } from "@/components/ui/button";
 import { useResourceModules } from "@/hooks/useResourceModules";

--- a/packages/client/src/components/resources/moduleAdminComponents.ts
+++ b/packages/client/src/components/resources/moduleAdminComponents.ts
@@ -1,0 +1,11 @@
+// Module-admin sub-components rendered by ResourceModulesAdmin: the group/module
+// edit cards, the display row, the suggest dialog, and the quick-log form.
+// Grouping the re-exports here lets ResourceModulesAdmin import them as a single
+// dependency. This barrel only re-exports leaf sub-components — it does not
+// import the folder, and the sub-components keep their own direct imports, so
+// there is no circular dependency.
+export { GroupEditCard, GroupMetaChips } from "./GroupEditCard";
+export { InteractionQuickLog } from "./InteractionQuickLog";
+export { ModuleDisplayRow } from "./ModuleDisplayRow";
+export { ModuleEditCard } from "./ModuleEditCard";
+export { ModuleSuggestDialog } from "./ModuleSuggestDialog";

--- a/packages/client/src/hooks/useBlipLlmAssist.ts
+++ b/packages/client/src/hooks/useBlipLlmAssist.ts
@@ -1,0 +1,371 @@
+import type { PromptMode } from "@/components/radar/blipLlmPrompts";
+import type { ResolvedLlmEntry } from "@/components/radar/blipLlmReview";
+import type { BulkBlipEntry } from "@/utils";
+import type {
+  DomainExcludedTopic,
+  DomainTopic,
+  RadarBlip,
+  RadarQuadrant,
+  RadarRing,
+  TopicForTopicsPage,
+} from "@emstack/types";
+
+import { useMemo, useState } from "react";
+
+import { toast } from "sonner";
+
+import { buildCleanupPrompt, buildLlmPrompt } from "@/components/radar/blipLlmPrompts";
+import { descriptionChanged, parseLlmEntries } from "@/components/radar/blipLlmReview";
+import { useBlipLlmReview } from "@/hooks/useBlipLlmReview";
+import {
+  bulkCreateRadarBlips,
+  copyTextToClipboard,
+  deleteRadarBlip,
+  deleteSingleTopic,
+  upsertRadarBlip,
+  upsertTopic,
+} from "@/utils";
+
+export interface UseBlipLlmAssistArgs {
+  domainId: string;
+  domainTitle: string;
+  domainDescription?: string | null;
+  domainTopics?: DomainTopic[];
+  excludedTopics?: DomainExcludedTopic[];
+  withinScopeDescription?: string | null;
+  outOfScopeDescription?: string | null;
+  withinScopeTopicNames?: string[];
+  outOfScopeTopicNames?: string[];
+  quadrants: RadarQuadrant[];
+  rings: RadarRing[];
+  topics: TopicForTopicsPage[];
+  existingBlips: RadarBlip[];
+  onComplete: () => void;
+}
+
+export function useBlipLlmAssist({
+  domainId,
+  domainTitle,
+  domainDescription = null,
+  domainTopics = [],
+  excludedTopics = [],
+  withinScopeDescription = null,
+  outOfScopeDescription = null,
+  withinScopeTopicNames = [],
+  outOfScopeTopicNames = [],
+  quadrants,
+  rings,
+  topics,
+  existingBlips,
+  onComplete,
+}: UseBlipLlmAssistArgs) {
+  const [mode, setMode] = useState<PromptMode>("setup");
+
+  const prompt = useMemo(
+    () => {
+      const topicById = new Map(topics.map(t => [t.id, t]));
+      const quadrantById = new Map(quadrants.map(q => [q.id, q]));
+      const ringById = new Map(rings.map(r => [r.id, r]));
+      if (mode === "cleanup") {
+        const unassignedBlips = existingBlips
+          .filter(b => !b.quadrantId || !b.ringId)
+          .map(b => ({
+            topicName: b.topicName,
+            quadrantName: b.quadrantId
+              ? quadrantById.get(b.quadrantId)?.name ?? null
+              : null,
+            ringName: b.ringId ? ringById.get(b.ringId)?.name ?? null : null,
+            radarNote: b.description,
+            topicDescription: topicById.get(b.topicId)?.description ?? null,
+          }));
+        return buildCleanupPrompt({
+          domainTitle,
+          domainDescription,
+          withinScopeDescription,
+          outOfScopeDescription,
+          quadrants,
+          rings,
+          unassignedBlips,
+        });
+      }
+      return buildLlmPrompt({
+        domainTitle,
+        domainDescription,
+        domainTopics,
+        excludedTopics,
+        withinScopeDescription,
+        outOfScopeDescription,
+        withinScopeTopicNames,
+        outOfScopeTopicNames,
+        quadrants,
+        rings,
+        existingBlips: existingBlips.map((b) => {
+          const ring = b.ringId ? ringById.get(b.ringId) : null;
+          const quadrant = b.quadrantId ? quadrantById.get(b.quadrantId) : null;
+          return {
+            topicName: b.topicName,
+            radarNote: b.description,
+            topicDescription: topicById.get(b.topicId)?.description ?? null,
+            currentSliceName: quadrant?.name ?? null,
+            currentRingName: ring?.name ?? null,
+          };
+        }),
+      });
+    },
+    [
+      mode,
+      domainTitle,
+      domainDescription,
+      domainTopics,
+      excludedTopics,
+      withinScopeDescription,
+      outOfScopeDescription,
+      withinScopeTopicNames,
+      outOfScopeTopicNames,
+      quadrants,
+      rings,
+      existingBlips,
+      topics,
+    ],
+  );
+
+  const unassignedCount = useMemo(
+    () => existingBlips.filter(b => !b.quadrantId || !b.ringId).length,
+    [existingBlips],
+  );
+
+  const [jsonText, setJsonText] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const topicByLowerName = useMemo(() => {
+    const map = new Map<string, TopicForTopicsPage>();
+    topics.forEach((t) => {
+      map.set(t.name.toLowerCase(), t);
+    });
+    return map;
+  }, [topics]);
+
+  const quadrantByLowerName = useMemo(() => {
+    const map = new Map<string, RadarQuadrant>();
+    quadrants.forEach((q) => {
+      map.set(q.name.toLowerCase(), q);
+    });
+    return map;
+  }, [quadrants]);
+
+  const ringByLowerName = useMemo(() => {
+    const map = new Map<string, RadarRing>();
+    rings.forEach((r) => {
+      map.set(r.name.toLowerCase(), r);
+    });
+    return map;
+  }, [rings]);
+
+  const existingBlipByTopicId = useMemo(() => {
+    const map = new Map<string, RadarBlip>();
+    existingBlips.forEach((b) => {
+      map.set(b.topicId, b);
+    });
+    return map;
+  }, [existingBlips]);
+
+  const quadrantById = useMemo(() => {
+    const map = new Map<string, RadarQuadrant>();
+    quadrants.forEach(q => map.set(q.id, q));
+    return map;
+  }, [quadrants]);
+
+  const ringById = useMemo(() => {
+    const map = new Map<string, RadarRing>();
+    rings.forEach(r => map.set(r.id, r));
+    return map;
+  }, [rings]);
+
+  const topicById = useMemo(() => {
+    const map = new Map<string, TopicForTopicsPage>();
+    topics.forEach(t => map.set(t.id, t));
+    return map;
+  }, [topics]);
+
+  const excludedNamesLower = useMemo(() => {
+    const set = new Set<string>();
+    excludedTopics.forEach((t) => {
+      if (t.name) {
+        set.add(t.name.toLowerCase());
+      }
+    });
+    return set;
+  }, [excludedTopics]);
+
+  const review = useBlipLlmReview({
+    quadrants,
+    rings,
+    excludedNamesLower,
+  });
+  const {
+    resolved, setResolved, counts,
+  } = review;
+
+  async function copyPrompt() {
+    const ok = await copyTextToClipboard(prompt);
+    if (ok) {
+      toast.success("Prompt copied to clipboard.");
+    }
+    else {
+      toast.error("Couldn't copy — please select and copy manually.");
+    }
+  }
+
+  function parseAndResolve() {
+    setParseError(null);
+    const result = parseLlmEntries(jsonText, {
+      topicByLowerName,
+      quadrantByLowerName,
+      ringByLowerName,
+      existingBlipByTopicId,
+      excludedNamesLower,
+    });
+    if (result.error !== null) {
+      setParseError(result.error);
+      setResolved(null);
+      return;
+    }
+    setResolved(result.entries);
+  }
+
+  function isActionable(r: ResolvedLlmEntry): boolean {
+    if (r.resolution === "skip") {
+      return false;
+    }
+    return r.problems.length === 0;
+  }
+
+  async function handleConfirm() {
+    if (!resolved) {
+      return;
+    }
+    const actionable = resolved.filter(isActionable);
+    if (actionable.length === 0) {
+      toast.error("No actionable entries.");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const toCreate = actionable.filter(r => r.resolution === "create");
+      const toOverwriteAll = actionable.filter(
+        r => r.resolution === "overwriteAll" && r.existingBlipId,
+      );
+      const toUpdateBlip = actionable.filter(
+        r => r.resolution === "updateBlip" && r.existingBlipId,
+      );
+      const toRemove = actionable.filter(
+        r => r.resolution === "removeBlip" && r.existingBlipId,
+      );
+
+      let createCount = 0;
+      if (toCreate.length > 0) {
+        const blips: BulkBlipEntry[] = toCreate.map(r => ({
+          topicId: r.matchedTopicId,
+          newTopicName: r.matchedTopicId ? null : r.topicName,
+          newTopicDescription: r.matchedTopicId ? null : r.description,
+          quadrantId: r.quadrantId as string,
+          ringId: r.ringId as string,
+          description: r.radarNote,
+        }));
+        const result = await bulkCreateRadarBlips(domainId, {
+          blips,
+        });
+        createCount = result.count;
+      }
+
+      let overwriteCount = 0;
+      for (const r of toOverwriteAll) {
+        await upsertRadarBlip(domainId, r.existingBlipId as string, {
+          topicId: r.matchedTopicId as string,
+          quadrantId: r.quadrantId as string,
+          ringId: r.ringId as string,
+          description: r.radarNote,
+        });
+        if (r.matchedTopicId && descriptionChanged(r)) {
+          await upsertTopic(r.matchedTopicId, {
+            name: r.topicName,
+            description: r.description,
+          });
+        }
+        overwriteCount += 1;
+      }
+
+      let updateCount = 0;
+      for (const r of toUpdateBlip) {
+        await upsertRadarBlip(domainId, r.existingBlipId as string, {
+          topicId: r.matchedTopicId as string,
+          quadrantId: (r.quadrantId ?? r.existingQuadrantId) as string,
+          ringId: (r.ringId ?? r.existingRingId) as string,
+          description: r.radarNote,
+        });
+        updateCount += 1;
+      }
+
+      let removeBlipCount = 0;
+      let removeTopicCount = 0;
+      for (const r of toRemove) {
+        await deleteRadarBlip(domainId, r.existingBlipId as string);
+        removeBlipCount += 1;
+        if (r.deleteTopicOnRemove && r.matchedTopicId) {
+          await deleteSingleTopic(r.matchedTopicId);
+          removeTopicCount += 1;
+        }
+      }
+
+      const parts: string[] = [];
+      if (createCount > 0) {
+        parts.push(`added ${createCount}`);
+      }
+      if (overwriteCount > 0) {
+        parts.push(`overwrote ${overwriteCount}`);
+      }
+      if (updateCount > 0) {
+        parts.push(`updated ${updateCount}`);
+      }
+      if (removeBlipCount > 0) {
+        parts.push(`removed ${removeBlipCount}`);
+      }
+      if (removeTopicCount > 0) {
+        parts.push(`deleted ${removeTopicCount} topic${removeTopicCount === 1 ? "" : "s"}`);
+      }
+      toast.success(`Done — ${parts.join(", ")}.`);
+      setJsonText("");
+      setResolved(null);
+      onComplete();
+    }
+    catch {
+      toast.error("Failed to apply changes.");
+    }
+    finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const actionableCount
+    = counts.create + counts.overwriteAll + counts.updateBlip + counts.removeBlip;
+
+  return {
+    ...review,
+    mode,
+    setMode,
+    prompt,
+    unassignedCount,
+    jsonText,
+    setJsonText,
+    parseError,
+    isSubmitting,
+    quadrantById,
+    ringById,
+    topicById,
+    actionableCount,
+    copyPrompt,
+    parseAndResolve,
+    handleConfirm,
+  };
+}

--- a/packages/client/src/hooks/useInteractionsLog.ts
+++ b/packages/client/src/hooks/useInteractionsLog.ts
@@ -1,0 +1,125 @@
+import type {
+  InteractionDifficulty,
+  InteractionProgress,
+  InteractionUnderstanding,
+} from "@emstack/types";
+
+import { useMemo } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  createInteraction,
+  deleteSingleInteraction,
+  fetchInteractions,
+  fetchModuleGroups,
+  fetchModules,
+  upsertInteraction,
+} from "@/utils/fetchFunctions";
+import { queryKeys } from "@/utils/queryKeys";
+
+export interface InteractionDraft {
+  id: string;
+  date: string;
+  progress: InteractionProgress;
+  note: string;
+  difficulty: InteractionDifficulty | "";
+  understanding: InteractionUnderstanding | "";
+  moduleGroupId: string;
+  moduleId: string;
+}
+
+export function useInteractionsLog(resourceId: string) {
+  const queryClient = useQueryClient();
+
+  const interactionsQuery = useQuery({
+    queryKey: queryKeys.resources.interactions(resourceId),
+    queryFn: () => fetchInteractions(),
+  });
+
+  const moduleGroupsQuery = useQuery({
+    queryKey: queryKeys.resources.moduleGroups(resourceId),
+    queryFn: () => fetchModuleGroups(),
+  });
+
+  const modulesQuery = useQuery({
+    queryKey: queryKeys.resources.modules(resourceId),
+    queryFn: () => fetchModules(),
+  });
+
+  const allInteractions = interactionsQuery.data ?? [];
+  const interactions = allInteractions.filter(i => i.resourceId === resourceId);
+
+  const moduleGroups = useMemo(
+    () =>
+      (moduleGroupsQuery.data ?? []).filter(g => g.resourceId === resourceId),
+    [moduleGroupsQuery.data, resourceId],
+  );
+  const modules = useMemo(
+    () => (modulesQuery.data ?? []).filter(m => m.resourceId === resourceId),
+    [modulesQuery.data, resourceId],
+  );
+
+  function invalidate() {
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.resources.interactions(resourceId),
+    });
+  }
+
+  const upsertMutation = useMutation({
+    mutationFn: (d: InteractionDraft) =>
+      upsertInteraction(d.id, {
+        resourceId,
+        moduleGroupId: d.moduleGroupId || null,
+        moduleId: d.moduleId || null,
+        date: d.date,
+        progress: d.progress,
+        note: d.note || null,
+        difficulty: d.difficulty || null,
+        understanding: d.understanding || null,
+      }),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Interaction saved");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (d: InteractionDraft) =>
+      createInteraction({
+        resourceId,
+        moduleGroupId: d.moduleGroupId || null,
+        moduleId: d.moduleId || null,
+        date: d.date,
+        progress: d.progress,
+        note: d.note || null,
+        difficulty: d.difficulty || null,
+        understanding: d.understanding || null,
+      }),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Interaction logged");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleInteraction(id),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Interaction deleted");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  return {
+    interactions,
+    moduleGroups,
+    modules,
+    createMutation,
+    upsertMutation,
+    deleteMutation,
+  };
+}


### PR DESCRIPTION
## What

Brings the four largest `import/max-dependencies` offenders in the radar/resource-management areas under the threshold of 10 — quality only, **no behavior or public-prop changes**. Mirrors the merged dailies refactor (#309).

| File | Before | After | Technique |
|---|---|---|---|
| `radar/BlipLlmAssist.tsx` | 11 | 6 | extract `useBlipLlmAssist` hook |
| `radar/BlipTable.tsx` | 13 | 9 | `blipTableRows` barrel + `BlipTableToolbar` |
| `resources/ResourceInteractionsLog.tsx` | 12 | 9 | extract `useInteractionsLog` hook |
| `resources/ResourceModulesAdmin.tsx` | 11 | 7 | `moduleAdminComponents` barrel |

New files:
- `hooks/useBlipLlmAssist.ts`, `hooks/useInteractionsLog.ts` — bundled hooks modelled on `useResourceModules`
- `radar/blipTableRows.ts`, `resources/moduleAdminComponents.ts` — leaf-only sub-barrels (no folder index import → no cycles)
- `radar/BlipTableToolbar.tsx` — extracted filter row (markup copied verbatim)

The two extracted hooks own the queries/mutations/derivation; UI-close side effects (`setEditingId`/`setCreating`) move to per-`mutate` `onSuccess` options, matching the `useResourceModules`/`ResourceModulesAdmin` pattern.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` — all four target files cleared, 0 errors, new files clean ✓
- `pnpm --filter=@emstack/client exec vitest run` — 131 tests pass ✓
- `pnpm exec fallow dead-code` — no new circular dependencies, no issues ✓

Fixes #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)