### PR TITLE
test(client): storybook stories for layout + add-stories skill

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: add-stories
+description: >-
+  Add Storybook stories for React components that lack them in
+  packages/client, following this repo's CSF3 conventions (Meta/StoryObj,
+  storybook/test play smoke tests, test-utils fixture factories,
+  RouterStub/QueryStub decorators). Use when asked to "add/write storybook
+  stories", "cover this component in storybook", "story coverage", "missing
+  stories", or to resolve an area under the story-coverage tracker (#351).
+  Pairs with `condense-components` — that skill stories the components it
+  extracts; this one fills coverage gaps wholesale.
+---
+
+# Add stories (course-tracker)
+
+Write co-located `*.stories.tsx` for components that don't have one yet, so they
+render in Storybook and run as browser interaction tests under the `storybook`
+vitest project (the CI gate). **Story-only — no behavior changes** to the
+components themselves. The one exception is route shells (Tier C below), where
+the prescribed move is a behavior-preserving *extract* before storying.
+
+Coverage is tracked in **#351**, split into per-area sub-issues (formFields,
+layout, resources, routes, …) — same model as the import cleanup tracker #312.
+This skill is the repeatable procedure for one such area.
+
+Stories already exist for ~40-50% of components; whole areas are done
+(`contentBoxComponents/`, `boxElements/`, `dailies/`, `radar/`, `tables/`). Don't
+re-story those. The shared infra is already in place — reuse it, don't reinvent.
+
+## 1. Inventory the target area — what's actually uncovered
+
+Story files are **co-located** next to the component and a story's filename
+**need not match** its component file (e.g. `radarLegendItem.tsx` →
+`BlipLegendItem.stories.tsx`). So don't audit by filename match alone — grep each
+component's export for a referencing story. A quick first pass for a folder:
+
+```bash
+cd packages/client/src/components/<area>
+for f in *.tsx; do case "$f" in *.stories.tsx) ;; *) \
+  [ -f "${f%.tsx}.stories.tsx" ] || echo "missing: $f";; esac; done
+```
+
+Then confirm the "missing" ones really lack coverage (a sibling story may render
+them) before writing:
+
+```bash
+grep -rln "import .*{ *<ComponentName> *}" packages/client/src --include='*.stories.tsx'
+```
+
+For a wide sweep across the app, delegate to an **Explore agent** to map
+component → story coverage by feature folder.
+
+## 2. Classify each component into a tier (read its imports)
+
+Open the file and look at what it imports/calls — that dictates the decorators.
+
+- **Tier A — pure / presentational.** Props in, render out. No router, no query,
+  no context hooks. Just JSX + `ui/` primitives. (e.g. `InfoRow`, `InfoArea`,
+  `EditForm`, `PageTabs`, `ViewModeToggle`, `EditPageFooter`.) → no decorator, or
+  a sizing/host wrapper only.
+- **Tier B — context-coupled.** Renders a TanStack `<Link>` (often
+  transitively — a legend/table/chart that renders a link counts), or calls
+  `useQuery`/`useMutation`/`useQueryClient`, reads settings, uses a Radix
+  primitive that needs its provider/parent (Tooltip, DropdownMenuItem), or a
+  TanStack Form field. → wrap in the matching decorator(s) (§3).
+- **Tier C — route shell.** A `routes/*.tsx` file. Its component is defined
+  **inline and not exported** (only `Route` is), and it calls `useQuery` with a
+  real network `queryFn` plus `Route.useSearch()`/`useLoaderData()`. → see §4;
+  don't try to render the shell directly.
+
+## 3. Author the story (the canonical pattern)
+
+Mirror `components/ui/Badge.stories.tsx` (Tier A) and
+`routes/resources.-components/-ResourcesList.stories.tsx` (Tier B). Rules:
+
+- **CSF3:** `import type { Meta, StoryObj } from "@storybook/react-vite";`
+- **Test helpers from `storybook/test`** — the bare package, **NOT**
+  `@storybook/test`. Storybook 10 dropped the scoped package; importing it can
+  pass a local run with stale `node_modules` but **CI fails** with
+  `Cannot find module '@storybook/test'`. Available: `within`, `screen`,
+  `expect`, `fn`, `userEvent`, `waitFor`.
+- **Default `args` on `meta`**; variants as named exports (`Default`, `Empty`,
+  `WithProgress`, …). Cover meaningful states, not every prop permutation.
+- **`play` smoke test.** Give at least `Default` a `play` that asserts on
+  rendered output. A render-only story (no `play`) still smoke-tests that it
+  mounts — fine for heavy containers, but prefer one assertion.
+- **`meta` typing:** use `const meta: Meta<typeof X> = {…}` (explicit
+  annotation) whenever any arg is a `fn()` spy — the inferred type embeds the
+  `@vitest/spy` Mock type and isn't portable (TS2742). Use
+  `} satisfies Meta<typeof X>;` only when there are no spies. If `meta`
+  references a prop whose interface isn't exported, export it (TS4023).
+- **Async handler args:** `fn(() => Promise.resolve())`, not `fn(async () => {})`
+  (trips `no-empty-function`).
+- **Mock data from fixtures.** Use the `make*` factories in
+  `src/test-utils/*Fixtures.ts` (`boxFixtures`, `dailiesFixtures`,
+  `radarFixtures`) — `makeResource`, `makeDaily`, `makeBlip`, `makeTopics`, … —
+  with partial overrides. Extend a factory rather than hand-rolling literals. If
+  an area has no factory yet and you're writing several stories, add a
+  `test-utils/<area>Fixtures.ts` instead of duplicating args per story.
+
+## 4. Decorators by need (all per-component in `meta.decorators` — no globals)
+
+There are **no global decorators** in `.storybook/preview.ts`, and don't add any
+(an async router mount would break existing sync `play`s). Wrap per story.
+
+- **Router `<Link>`** → `RouterStub` from `@/test-utils/RouterStub` (memory
+  router, context-only; navigation is a no-op — assert on output, not URLs). It
+  mounts children **after** the router's initial load, so assert with async
+  `findBy*`, not `getBy*`.
+- **Query hooks** → `QueryStub` from `@/test-utils/QueryStub`. For a component
+  that *reads* via `useQuery`, build a `QueryClient`, seed it with
+  `setQueryData(queryKeys.…, data)` (keys from `@/utils/queryKeys`), and pass it
+  as the `client` prop so the component sees data without a network call.
+- **Settings** → `SettingsProvider` from `@/context/SettingsProvider`.
+- **Tooltips** → `TooltipProvider` from `@/components/ui/tooltip`.
+- **Radix menu items** (`DropdownMenuItem` and friends) need their menu context:
+  wrap in `<DropdownMenu open><DropdownMenuContent forceMount>…</…>`. The content
+  **portals to `document.body`**, so assert with `within(document.body)` /
+  `screen`, not `canvasElement`.
+- **Host-element fragments** → supply the parent: SVG `<g>`/`<circle>` in
+  `<svg>`, `TableRow` in `<Table><TableBody>`. Give width-dependent components a
+  sizing wrapper (`<div className="max-w-sm">`).
+- **Persisted UI state** (localStorage view-mode etc.) → reset in
+  `beforeEach: () => window.localStorage.clear()`
+  (see `-ResourcesList.stories.tsx`).
+
+Compose decorators by nesting (outermost first), e.g.
+`RouterStub > TooltipProvider > sizing div > Story`.
+
+## 5. Route shells (Tier C) — story the leaf, don't render the shell
+
+Route shells are thin glue (fetch + `useSearch` → render a presentational child).
+The established convention covers them by **storying their extracted leaf**, which
+already takes plain props (`-ResourcesList` gets `resources`/`providers`/`topics`;
+`-DashboardGrid` exports `GridTile`). So:
+
+1. **Route already delegates to a props-driven `routes/<x>.-components/-X.tsx`
+   leaf** → story that leaf (Tier A/B). Done.
+2. **Route holds inline render logic worth covering** → first *extract* it into a
+   `routes/<x>.-components/-X.tsx` presentational component (props in,
+   behavior-preserving — mirrors the existing route structure), wire the route to
+   render it, regenerate the route tree
+   (`pnpm --filter=@emstack/client run routeTree`, expect no routing diff — the
+   `.-` folder is excluded), then story the new leaf.
+3. **Rendering the `Route` shell itself** is **out of band** for this skill. It
+   would need new infra — MSW (not currently a dep) or `@/utils` fetch stubs, a
+   router that registers the *real* route so `useSearch`/`useLoaderData`/
+   `useParams` resolve, and exporting the inner component. Don't bolt per-route
+   fetch mocks on ad hoc. If a sub-issue truly requires shell-level stories,
+   raise the infra decision (add MSW + a richer router stub) rather than
+   improvising, and `log`/note that the shell is uncovered so it doesn't read as
+   done.
+
+## 6. Verify
+
+```bash
+# The CI gate — stories run in headless Chromium. Run with --no-file-parallelism:
+# the storybook project is flaky under parallelism (bare TypeErrors across
+# unrelated files), so serialize it for a trustworthy signal.
+pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism
+
+# Typecheck (catches @storybook/test slips, TS2742 satisfies/fn issues, TS4023):
+pnpm typecheck      # whole repo; or: pnpm --filter=@emstack/client run typecheck
+
+# Lint — run from the repo ROOT (the better-tailwindcss plugin needs the root cwd;
+# scoping to the package falsely errors "No tailwind css entry point found").
+pnpm lint
+```
+
+Typecheck must be clean apart from pre-existing unrelated errors (confirm with
+`git stash` if unsure one predates your change).
+
+Commit with a `test(<scope>):` Conventional Commit (stories are tests here), e.g.
+`test(client): add storybook stories for layout components`. One area per commit
+reads best. Check off the area's sub-issue under #351 and add an Area-notes entry
+below for anything learned (new fixture file, a tricky decorator).
+
+## Gotchas (learned the hard way)
+
+- **`@storybook/test` is gone** — always `storybook/test`. CI is the only place
+  the stale-package import reliably fails.
+- **RouterStub mounts async** → `findBy*`, never `getBy*`, for anything inside it.
+- **Radix portals escape `canvasElement`** → query `document.body`/`screen` for
+  dropdown/dialog/popover content (see `DailyStatusModal.stories.tsx`).
+- **`satisfies Meta` + `fn()` = TS2742.** Switch to `const meta: Meta<typeof X>`.
+- **TanStack Form fields** (`components/formFields/*`) must **not** be imported
+  directly (per `packages/client/CLAUDE.md`) — they read `useFieldContext()`.
+  Storying them needs a small form harness that provides field context; create a
+  reusable `test-utils` helper on first use rather than per-story boilerplate.
+- **Don't add global decorators** in `preview.ts`.
+- **Skip generated files:** `routeTree.gen.ts`, anything under `dist/`.
+
+## Area notes
+
+### layout (#352)
+First batch. All 12 covered components are Tier A/B — no fixtures needed.
+Tier B (need `RouterStub`): `PageHeader` (renders a section `<Link>` only when
+`pageSection` is set), `EntityHeaderButton`, `OnboardingEmptyState`,
+`ResourceLinksSection`, `NavDropdown`, `DropdownNavItem`. `DropdownNavItem` also
+needs the `DropdownMenu`/`DropdownMenuContent` parent and asserts via
+`document.body`. The rest (`InfoRow`, `InfoArea`, `EditForm`, `PageTabs`,
+`ViewModeToggle`, `EditPageFooter`) are Tier A with `fn()` handlers.

--- a/packages/client/src/components/layout/DropdownNavItem.stories.tsx
+++ b/packages/client/src/components/layout/DropdownNavItem.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { DropdownNavItem } from "./DropdownNavItem";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof DropdownNavItem> = {
+  component: DropdownNavItem,
+  args: {
+    to: "/routines",
+    children: "All routines",
+  },
+  // A DropdownMenuItem needs its menu context, and the content must anchor to a
+  // trigger — render inside an open menu with one. Content portals to
+  // document.body, so assertions query there.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <DropdownMenu defaultOpen>
+          <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <Story />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async () => {
+    // `asChild` makes the rendered <a> a menuitem (Radix sets role), so query
+    // by the menuitem role rather than link.
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("menuitem", {
+        name: "All routines",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/EditForm.stories.tsx
+++ b/packages/client/src/components/layout/EditForm.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { EditForm } from "./EditForm";
+
+import { Button } from "@/components/ui/button";
+
+const meta: Meta<typeof EditForm> = {
+  component: EditForm,
+  args: {
+    onSubmit: fn(),
+    className: "flex flex-col gap-3",
+    children: (
+      <>
+        <input
+          name="name"
+          placeholder="Name"
+          className="rounded-md border px-2 py-1"
+        />
+        <Button type="submit">Save</Button>
+      </>
+    ),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByPlaceholderText("Name")).toBeInTheDocument();
+  },
+};
+
+// Submitting calls onSubmit after preventDefault (no page reload).
+export const SubmitCallsHandler: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Save",
+    }));
+    await expect(args.onSubmit).toHaveBeenCalledTimes(1);
+  },
+};

--- a/packages/client/src/components/layout/EditPageFooter.stories.tsx
+++ b/packages/client/src/components/layout/EditPageFooter.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { EditPageFooter } from "./EditPageFooter";
+
+import { Button } from "@/components/ui/button";
+
+const meta: Meta<typeof EditPageFooter> = {
+  component: EditPageFooter,
+  args: {
+    isNew: false,
+    onDelete: fn(() => Promise.resolve()),
+    onDuplicate: fn(() => Promise.resolve()),
+    children: <Button type="submit">Save</Button>,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Editing an existing entity: primary action plus the destructive controls.
+export const Existing: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Save",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /Duplicate/,
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /Delete/,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// New entity: destructive actions are hidden (nothing to delete/duplicate yet).
+export const New: Story = {
+  args: {
+    isNew: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Save",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", {
+        name: /Delete/,
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// DeleteButton requires a confirmation click before firing onDelete.
+export const DeleteRequiresConfirm: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: /Delete/,
+    }));
+    await expect(canvas.getByText("Are you sure?")).toBeInTheDocument();
+    await expect(args.onDelete).not.toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/components/layout/EntityHeaderButton.stories.tsx
+++ b/packages/client/src/components/layout/EntityHeaderButton.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { EyeIcon } from "lucide-react";
+import { expect, within } from "storybook/test";
+
+import { EntityHeaderButton } from "./EntityHeaderButton";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof EntityHeaderButton> = {
+  component: EntityHeaderButton,
+  args: {
+    to: "/providers/$id",
+    params: {
+      id: "p1",
+    },
+    label: "View Provider",
+    icon: <EyeIcon className="size-4" />,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: /View Provider/,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/InfoArea.stories.tsx
+++ b/packages/client/src/components/layout/InfoArea.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { InfoArea } from "./InfoArea";
+
+const meta = {
+  component: InfoArea,
+  args: {
+    header: "Resources",
+    children: <p>Linked resource list goes here.</p>,
+  },
+} satisfies Meta<typeof InfoArea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Resources")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Linked resource list goes here."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const WithoutHeader: Story = {
+  args: {
+    header: undefined,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText("Resources")).not.toBeInTheDocument();
+    await expect(
+      canvas.getByText("Linked resource list goes here."),
+    ).toBeInTheDocument();
+  },
+};
+
+// `condition={false}` short-circuits to null.
+export const Hidden: Story = {
+  args: {
+    condition: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText("Resources")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/InfoRow.stories.tsx
+++ b/packages/client/src/components/layout/InfoRow.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { InfoRow } from "./InfoRow";
+
+const meta = {
+  component: InfoRow,
+  args: {
+    header: "Details",
+    children: (
+      <>
+        <span>First column</span>
+        <span>Second column</span>
+      </>
+    ),
+  },
+} satisfies Meta<typeof InfoRow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Details")).toBeInTheDocument();
+    await expect(canvas.getByText("First column")).toBeInTheDocument();
+  },
+};
+
+export const WithoutHeader: Story = {
+  args: {
+    header: undefined,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("First column")).toBeInTheDocument();
+    await expect(canvas.queryByText("Details")).not.toBeInTheDocument();
+  },
+};
+
+// `condition={false}` short-circuits to null — nothing renders.
+export const Hidden: Story = {
+  args: {
+    condition: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText("First column")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/NavDropdown.stories.tsx
+++ b/packages/client/src/components/layout/NavDropdown.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { DropdownNavItem } from "./DropdownNavItem";
+import { NavDropdown } from "./NavDropdown";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof NavDropdown> = {
+  component: NavDropdown,
+  args: {
+    label: "Routines",
+    to: "/routines",
+    children: (
+      <>
+        <DropdownNavItem to="/routines">All routines</DropdownNavItem>
+        <DropdownNavItem to="/routines/tracker">Tracker</DropdownNavItem>
+      </>
+    ),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "Routines",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Opening the trigger reveals the menu items, which portal to document.body.
+export const Open: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", {
+        name: "Open Routines menu",
+      }),
+    );
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("menuitem", {
+        name: "All routines",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/OnboardingEmptyState.stories.tsx
+++ b/packages/client/src/components/layout/OnboardingEmptyState.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { OnboardingEmptyState } from "./OnboardingEmptyState";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof OnboardingEmptyState> = {
+  component: OnboardingEmptyState,
+  args: {
+    message: "No resources yet!",
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("No resources yet!"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", {
+        name: /Go to onboarding/,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/PageHeader.stories.tsx
+++ b/packages/client/src/components/layout/PageHeader.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PlusIcon } from "lucide-react";
+import { expect, within } from "storybook/test";
+
+import { PageHeader } from "./PageHeader";
+
+import { Button } from "@/components/ui/button";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof PageHeader> = {
+  component: PageHeader,
+  args: {
+    pageTitle: "Your Resources",
+    description: "Everything you're learning from, in one place.",
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: "Your Resources",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// With a `pageSection` set, a breadcrumb-style section <Link> renders.
+export const WithSectionLink: Story = {
+  args: {
+    pageSection: "resources",
+    pageTitle: "React Fundamentals",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "Resources",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Header actions render in the children slot.
+export const WithAction: Story = {
+  args: {
+    children: (
+      <Button>
+        <PlusIcon className="size-4" />
+        New Course
+      </Button>
+    ),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", {
+        name: /New Course/,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// A non-zero progress value renders the ProgressBar beneath the header.
+export const WithProgress: Story = {
+  args: {
+    progressCurrent: 3,
+    progressTotal: 10,
+    status: "active",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: "Your Resources",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/PageTabs.stories.tsx
+++ b/packages/client/src/components/layout/PageTabs.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ComponentProps } from "react";
+
+import { useState } from "react";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { PageTabs } from "./PageTabs";
+
+const tabs = [
+  {
+    value: "overview",
+    label: "Overview",
+    content: <p>Overview panel</p>,
+  },
+  {
+    value: "details",
+    label: "Details",
+    content: <p>Details panel</p>,
+  },
+];
+
+// PageTabs is controlled; drive `value` from local state so clicks switch tabs.
+function ControlledPageTabs(args: ComponentProps<typeof PageTabs>) {
+  const [value, setValue] = useState(args.value);
+  return (
+    <PageTabs
+      {...args}
+      value={value}
+      onValueChange={setValue}
+    />
+  );
+}
+
+const meta: Meta<typeof PageTabs> = {
+  component: PageTabs,
+  args: {
+    tabs,
+    value: "overview",
+  },
+  render: args => <ControlledPageTabs {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("tab", {
+        name: "Overview",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Overview panel")).toBeInTheDocument();
+  },
+};
+
+export const SwitchTab: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("tab", {
+      name: "Details",
+    }));
+    await expect(canvas.getByText("Details panel")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/ResourceLinksSection.stories.tsx
+++ b/packages/client/src/components/layout/ResourceLinksSection.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { ResourceLinksSection } from "./ResourceLinksSection";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof ResourceLinksSection> = {
+  component: ResourceLinksSection,
+  args: {
+    resources: [
+      {
+        id: "r1",
+        name: "React Fundamentals",
+      },
+      {
+        id: "r2",
+        name: "Advanced TypeScript",
+      },
+    ],
+    resourceCount: 2,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "React Fundamentals",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", {
+        name: "Advanced TypeScript",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// With no resources the InfoArea's condition is false — the section is empty.
+export const Empty: Story = {
+  args: {
+    resources: [],
+    resourceCount: 0,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText("Resources")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/layout/ViewModeToggle.stories.tsx
+++ b/packages/client/src/components/layout/ViewModeToggle.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ViewModeToggle } from "./ViewModeToggle";
+
+const meta: Meta<typeof ViewModeToggle> = {
+  component: ViewModeToggle,
+  args: {
+    viewMode: "grid",
+    onChange: fn(),
+    gridLabel: "Grid view",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const GridSelected: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Grid view",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+  },
+};
+
+export const TableSelected: Story = {
+  args: {
+    viewMode: "table",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Table view",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+  },
+};
+
+export const ClickSwitchesMode: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Table view",
+    }));
+    await expect(args.onChange).toHaveBeenCalledWith("table");
+  },
+};


### PR DESCRIPTION
## What

Kicks off Storybook story coverage for every component (tracker **#351**) with two pieces:

1. **`add-stories` skill** (`.claude/skills/add-stories/SKILL.md`) — codifies this repo's CSF3 story conventions (Meta/StoryObj, `storybook/test` `play` smoke tests, `test-utils/*Fixtures.ts` factories, `RouterStub`/`QueryStub`/`SettingsProvider`/`TooltipProvider` decorators), a tier classification (A pure / B context-coupled / C route shell), the route-shell "extract-the-leaf" strategy, verify commands, and the hard-won gotchas.
2. **layout stories** — co-located `*.stories.tsx` for the 12 uncovered `components/layout/*` components (was 1/13, now 13/13), each with a `play` smoke test.

## Why

Coverage already existed for ~40–50% of components with a strong, consistent pattern — but it wasn't a discoverable skill and the remaining work was untracked. This makes the pattern first-class and sets up a parent/sub-issue backlog (#351 → #352–#364) to fill the rest incrementally, mirroring the import-cleanup tracker #312.

Note: the original request referenced "#319" for Storybook, but that issue number is an unrelated settings refactor on this repo — so a fresh tracker (#351) was created instead.

## Tier B specifics

`PageHeader`, `EntityHeaderButton`, `OnboardingEmptyState`, `ResourceLinksSection`, `NavDropdown`, `DropdownNavItem` render TanStack `<Link>`s → wrapped in `RouterStub` (async `findBy*`). The dropdown items render in a Radix menu that portals to `document.body`, so their assertions query there (and `DropdownMenuItem asChild` makes the anchor a `menuitem`, not a `link`).

## Verification

- `pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism src/components/layout` → **28 passed (13 files)**
- `pnpm typecheck` → clean
- `pnpm lint` → clean

Closes #352. Part of #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)