### PR TITLE
refactor(client): reduce code duplication in stories, settings, tracker & quick-add

### DIFF
--- a/packages/client/src/components/contentBoxComponents/CourseBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/CourseBox.stories.tsx
@@ -4,24 +4,16 @@ import { expect, within } from "storybook/test";
 
 import { CourseBox } from "./CourseBox";
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { makeResource } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof CourseBox> = {
   component: CourseBox,
   args: makeResource(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <TooltipProvider>
-          <div className="max-w-sm">
-            <Story />
-          </div>
-        </TooltipProvider>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    tooltip: true,
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/contentBoxComponents/DomainBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/DomainBox.stories.tsx
@@ -5,20 +5,14 @@ import { expect, within } from "storybook/test";
 import { DomainBox } from "./DomainBox";
 
 import { makeDomain } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof DomainBox> = {
   component: DomainBox,
   args: makeDomain(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <div className="max-w-sm">
-          <Story />
-        </div>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/contentBoxComponents/ProviderBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/ProviderBox.stories.tsx
@@ -5,20 +5,14 @@ import { expect, within } from "storybook/test";
 import { ProviderBox } from "./ProviderBox";
 
 import { makeProvider } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof ProviderBox> = {
   component: ProviderBox,
   args: makeProvider(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <div className="max-w-sm">
-          <Story />
-        </div>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/contentBoxComponents/RoutineBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.stories.tsx
@@ -4,24 +4,16 @@ import { expect, within } from "storybook/test";
 
 import { RoutineBox } from "./RoutineBox";
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { makeRoutine } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof RoutineBox> = {
   component: RoutineBox,
   args: makeRoutine(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <TooltipProvider>
-          <div className="max-w-sm">
-            <Story />
-          </div>
-        </TooltipProvider>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    tooltip: true,
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/contentBoxComponents/TaskBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/TaskBox.stories.tsx
@@ -5,20 +5,14 @@ import { expect, within } from "storybook/test";
 import { TaskBox } from "./TaskBox";
 
 import { makeTask } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof TaskBox> = {
   component: TaskBox,
   args: makeTask(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <div className="max-w-sm">
-          <Story />
-        </div>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/contentBoxComponents/TopicBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/TopicBox.stories.tsx
@@ -5,20 +5,14 @@ import { expect, within } from "storybook/test";
 import { TopicBox } from "./TopicBox";
 
 import { makeTopicRow } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof TopicBox> = {
   component: TopicBox,
   args: makeTopicRow(),
-  decorators: [
-    Story => (
-      <RouterStub>
-        <div className="max-w-sm">
-          <Story />
-        </div>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    constrained: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+
+import { Loader2 } from "lucide-react";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface QuickAddNameDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Dialog heading, e.g. "Add Resource". */
+  title: string;
+  /** Slug for the input's id, e.g. "resource" → `quick-add-resource-name`. */
+  entity: string;
+  /** Placeholder shown in the name input. */
+  placeholder: string;
+  /** Seeds the name input each time the dialog opens. */
+  initialName?: string;
+  /** Whether the create mutation is in flight (disables submit, shows a spinner). */
+  isPending: boolean;
+  /** Called with the trimmed, non-empty name when the form is submitted. */
+  onSubmit: (name: string) => void;
+}
+
+/**
+ * Presentational shell for the single-name quick-add dialogs (Resource, Task):
+ * a name field plus Cancel/Create footer. It owns the input state and open-reset
+ * effect; callers own the create mutation and pass `isPending` + `onSubmit`.
+ */
+export function QuickAddNameDialog({
+  open,
+  onOpenChange,
+  title,
+  entity,
+  placeholder,
+  initialName,
+  isPending,
+  onSubmit,
+}: QuickAddNameDialogProps) {
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (open) setName(initialName ?? "");
+  }, [open, initialName]);
+
+  const trimmed = name.trim();
+  const inputId = `quick-add-${entity}-name`;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) onSubmit(trimmed);
+          }}
+        >
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor={inputId}
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id={inputId}
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder={placeholder}
+              maxLength={255}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!trimmed || isPending}
+            >
+              {isPending && <Loader2 className="animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
@@ -1,23 +1,13 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 
-import { useEffect, useState } from "react";
-
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
-import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { upsertResource, uuidv4 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
+
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
 
 interface QuickAddResourceDialogProps extends ControlledDialogProps {
   /**
@@ -38,11 +28,6 @@ export function QuickAddResourceDialog({
 }: QuickAddResourceDialogProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [name, setName] = useState("");
-
-  useEffect(() => {
-    if (open) setName(initialName ?? "");
-  }, [open, initialName]);
 
   const mutation = useMutation({
     // Resources have no POST create endpoint — a PUT with a fresh id upserts,
@@ -82,58 +67,16 @@ export function QuickAddResourceDialog({
     },
   });
 
-  const trimmed = name.trim();
-
   return (
-    <Dialog
+    <QuickAddNameDialog
       open={open}
       onOpenChange={onOpenChange}
-    >
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Add Resource</DialogTitle>
-        </DialogHeader>
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (trimmed) mutation.mutate(trimmed);
-          }}
-        >
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor="quick-add-resource-name"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Name
-            </label>
-            <Input
-              id="quick-add-resource-name"
-              autoFocus
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="Resource name"
-              maxLength={255}
-            />
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!trimmed || mutation.isPending}
-            >
-              {mutation.isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+      title="Add Resource"
+      entity="resource"
+      placeholder="Resource name"
+      initialName={initialName}
+      isPending={mutation.isPending}
+      onSubmit={name => mutation.mutate(name)}
+    />
   );
 }

--- a/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddResourceDialog.tsx
@@ -4,10 +4,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
+
 import { upsertResource, uuidv4 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
-
-import { QuickAddNameDialog } from "./QuickAddNameDialog";
 
 interface QuickAddResourceDialogProps extends ControlledDialogProps {
   /**

--- a/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
@@ -4,10 +4,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
+
 import { createTask } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
-
-import { QuickAddNameDialog } from "./QuickAddNameDialog";
 
 export function QuickAddTaskDialog({
   open,

--- a/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTaskDialog.tsx
@@ -1,23 +1,13 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 
-import { useEffect, useState } from "react";
-
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
-import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { createTask } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
+
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
 
 export function QuickAddTaskDialog({
   open,
@@ -25,11 +15,6 @@ export function QuickAddTaskDialog({
 }: ControlledDialogProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [name, setName] = useState("");
-
-  useEffect(() => {
-    if (open) setName("");
-  }, [open]);
 
   const mutation = useMutation({
     mutationFn: (taskName: string) =>
@@ -59,58 +44,15 @@ export function QuickAddTaskDialog({
     },
   });
 
-  const trimmed = name.trim();
-
   return (
-    <Dialog
+    <QuickAddNameDialog
       open={open}
       onOpenChange={onOpenChange}
-    >
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Add Task</DialogTitle>
-        </DialogHeader>
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (trimmed) mutation.mutate(trimmed);
-          }}
-        >
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor="quick-add-task-name"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Name
-            </label>
-            <Input
-              id="quick-add-task-name"
-              autoFocus
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="Task name"
-              maxLength={255}
-            />
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!trimmed || mutation.isPending}
-            >
-              {mutation.isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+      title="Add Task"
+      entity="task"
+      placeholder="Task name"
+      isPending={mutation.isPending}
+      onSubmit={name => mutation.mutate(name)}
+    />
   );
 }

--- a/packages/client/src/components/tables/CoursesTable.stories.tsx
+++ b/packages/client/src/components/tables/CoursesTable.stories.tsx
@@ -4,24 +4,17 @@ import { expect, within } from "storybook/test";
 
 import { CoursesTable } from "./CoursesTable";
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { makeResources } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof CoursesTable> = {
   component: CoursesTable,
   args: {
     courses: makeResources(3),
   },
-  decorators: [
-    Story => (
-      <RouterStub>
-        <TooltipProvider>
-          <Story />
-        </TooltipProvider>
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator({
+    tooltip: true,
+  })],
 };
 
 export default meta;

--- a/packages/client/src/components/tables/TopicsTable.stories.tsx
+++ b/packages/client/src/components/tables/TopicsTable.stories.tsx
@@ -5,20 +5,14 @@ import { expect, fn, within } from "storybook/test";
 import { TopicsTable } from "./TopicsTable";
 
 import { makeTopicRows } from "@/test-utils/boxFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { cardStoryDecorator } from "@/test-utils/storyDecorators";
 
 const meta: Meta<typeof TopicsTable> = {
   component: TopicsTable,
   args: {
     topics: makeTopicRows(3),
   },
-  decorators: [
-    Story => (
-      <RouterStub>
-        <Story />
-      </RouterStub>
-    ),
-  ],
+  decorators: [cardStoryDecorator()],
 };
 
 export default meta;

--- a/packages/client/src/routes/routines.tracker.-components/-TrackerTables.tsx
+++ b/packages/client/src/routes/routines.tracker.-components/-TrackerTables.tsx
@@ -58,57 +58,48 @@ function lastEntryCell(daily: Daily) {
   );
 }
 
+// Columns shared between the Paused and Completed tracker tables.
+const nameColumn: ColumnDef<Daily> = {
+  id: "name",
+  header: "Name",
+  cell: ({
+    row,
+  }) => <DailyNameCell daily={row.original} />,
+};
+
+const lastEntryColumn: ColumnDef<Daily> = {
+  id: "lastEntry",
+  header: "Last Entry",
+  meta: {
+    headClassName: "whitespace-nowrap",
+    cellClassName: "whitespace-nowrap",
+  },
+  cell: ({
+    row,
+  }) => lastEntryCell(row.original),
+};
+
+const daysCompletedColumn: ColumnDef<Daily> = {
+  id: "daysCompleted",
+  header: "Days Completed",
+  meta: {
+    headClassName: "whitespace-nowrap",
+    cellClassName: "whitespace-nowrap",
+  },
+  cell: ({
+    row,
+  }) => getTotalCompletedDays(row.original),
+};
+
 const pausedColumns: ColumnDef<Daily>[] = [
-  {
-    id: "name",
-    header: "Name",
-    cell: ({
-      row,
-    }) => <DailyNameCell daily={row.original} />,
-  },
-  {
-    id: "lastEntry",
-    header: "Last Entry",
-    meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
-    cell: ({
-      row,
-    }) => lastEntryCell(row.original),
-  },
-  {
-    id: "daysCompleted",
-    header: "Days Completed",
-    meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
-    cell: ({
-      row,
-    }) => getTotalCompletedDays(row.original),
-  },
+  nameColumn,
+  lastEntryColumn,
+  daysCompletedColumn,
 ];
 
 const completedColumns: ColumnDef<Daily>[] = [
-  {
-    id: "name",
-    header: "Name",
-    cell: ({
-      row,
-    }) => <DailyNameCell daily={row.original} />,
-  },
-  {
-    id: "lastEntry",
-    header: "Last Entry",
-    meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
-    cell: ({
-      row,
-    }) => lastEntryCell(row.original),
-  },
+  nameColumn,
+  lastEntryColumn,
   {
     id: "longestStreak",
     header: "Longest Streak",
@@ -120,17 +111,7 @@ const completedColumns: ColumnDef<Daily>[] = [
       row,
     }) => getLongestStreak(row.original),
   },
-  {
-    id: "daysCompleted",
-    header: "Days Completed",
-    meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
-    cell: ({
-      row,
-    }) => getTotalCompletedDays(row.original),
-  },
+  daysCompletedColumn,
   {
     id: "span",
     header: "Span (days)",

--- a/packages/client/src/routes/settings.-components/-IntegrationKeySection.tsx
+++ b/packages/client/src/routes/settings.-components/-IntegrationKeySection.tsx
@@ -1,0 +1,128 @@
+import type { AppSettingsSummary, AppSettingsUpdate } from "@emstack/types";
+import type { ReactNode } from "react";
+
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import { fetchSettings, updateSettings } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface IntegrationKeySectionProps {
+  /** Display name (e.g. "Readwise"); drives the heading, button labels, toasts. */
+  title: string;
+  /** Prose + token link explaining where to find the API key. */
+  description: ReactNode;
+  /** Placeholder shown in the empty key input. */
+  placeholder: string;
+  /** Builds the settings patch that stores (or clears) this integration's key. */
+  buildUpdate: (key: string | null) => AppSettingsUpdate;
+  /** Reads the configured flag + masked hint out of the settings response. */
+  selectStatus: (data: AppSettingsSummary | undefined) => {
+    configured: boolean;
+    hint: string | null;
+  };
+  /** The integration's dashboard data key, invalidated so it refetches on save. */
+  dataQueryKey: readonly unknown[];
+}
+
+/**
+ * Shared "paste an API key" settings section for the dashboard integrations
+ * that authenticate with a single token (Readwise, Todoist). The query,
+ * save/remove mutation, and markup are identical across integrations; callers
+ * supply only the per-integration copy and the settings field/query key.
+ */
+export function IntegrationKeySection({
+  title,
+  description,
+  placeholder,
+  buildUpdate,
+  selectStatus,
+  dataQueryKey,
+}: IntegrationKeySectionProps) {
+  const queryClient = useQueryClient();
+  const [apiKey, setApiKey] = useState("");
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (key: string | null) => updateSettings(buildUpdate(key)),
+    onSuccess: (_data, key) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.settings.detail(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: dataQueryKey,
+      });
+      setApiKey("");
+      toast.success(key ? `${title} API key saved` : `${title} API key removed`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const {
+    configured, hint,
+  } = selectStatus(settingsQuery.data);
+
+  function handleSave() {
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    saveMutation.mutate(trimmed);
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+      {configured && (
+        <p className="text-sm text-muted-foreground">
+          A key is currently saved
+          {hint ? ` (ending ${hint})` : ""}
+          .
+        </p>
+      )}
+      <div
+        className="
+          flex flex-col gap-2
+          sm:flex-row sm:items-center
+        "
+      >
+        <Input
+          type="password"
+          autoComplete="off"
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+          placeholder={configured
+            ? "Enter a new key to replace the saved one"
+            : placeholder}
+          className="sm:max-w-md"
+        />
+        <div className="flex gap-2">
+          <Button
+            onClick={handleSave}
+            disabled={!apiKey.trim() || saveMutation.isPending}
+          >
+            {configured ? "Update key" : "Save key"}
+          </Button>
+          {configured && (
+            <Button
+              variant="outline"
+              onClick={() => saveMutation.mutate(null)}
+              disabled={saveMutation.isPending}
+            >
+              Remove
+            </Button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/routes/settings.-components/-ReadwiseSection.tsx
+++ b/packages/client/src/routes/settings.-components/-ReadwiseSection.tsx
@@ -1,6 +1,6 @@
-import { queryKeys } from "@/utils/queryKeys";
-
 import { IntegrationKeySection } from "./-IntegrationKeySection";
+
+import { queryKeys } from "@/utils/queryKeys";
 
 export function ReadwiseSection() {
   return (

--- a/packages/client/src/routes/settings.-components/-ReadwiseSection.tsx
+++ b/packages/client/src/routes/settings.-components/-ReadwiseSection.tsx
@@ -1,112 +1,39 @@
-import { useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-
-import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
-import { fetchSettings, updateSettings } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
+import { IntegrationKeySection } from "./-IntegrationKeySection";
+
 export function ReadwiseSection() {
-  const queryClient = useQueryClient();
-  const [apiKey, setApiKey] = useState("");
-
-  const settingsQuery = useQuery({
-    queryKey: queryKeys.settings.detail(),
-    queryFn: () => fetchSettings(),
-  });
-
-  const saveMutation = useMutation({
-    mutationFn: (key: string | null) =>
-      updateSettings({
-        readwiseApiKey: key,
-      }),
-    onSuccess: (_data, key) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.settings.detail(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.readwise.readingList(),
-      });
-      setApiKey("");
-      toast.success(key ? "Readwise API key saved" : "Readwise API key removed");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const configured = settingsQuery.data?.readwiseConfigured ?? false;
-  const hint = settingsQuery.data?.readwiseKeyHint ?? null;
-
-  function handleSave() {
-    const trimmed = apiKey.trim();
-    if (!trimmed) return;
-    saveMutation.mutate(trimmed);
-  }
-
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-xl font-semibold">Readwise</h2>
-      <p className="text-sm text-muted-foreground">
-        Connect your Readwise Reader account to show your reading list on the
-        dashboard. Paste a token from
-        {" "}
-        <a
-          href="https://readwise.io/access_token"
-          target="_blank"
-          rel="noreferrer"
-          className="
-            text-primary underline-offset-2
-            hover:underline
-          "
-        >
-          readwise.io/access_token
-        </a>
-        .
-      </p>
-      {configured && (
-        <p className="text-sm text-muted-foreground">
-          A key is currently saved
-          {hint ? ` (ending ${hint})` : ""}
-          .
-        </p>
-      )}
-      <div
-        className="
-          flex flex-col gap-2
-          sm:flex-row sm:items-center
-        "
-      >
-        <Input
-          type="password"
-          autoComplete="off"
-          value={apiKey}
-          onChange={e => setApiKey(e.target.value)}
-          placeholder={configured
-            ? "Enter a new key to replace the saved one"
-            : "Paste your Readwise token"}
-          className="sm:max-w-md"
-        />
-        <div className="flex gap-2">
-          <Button
-            onClick={handleSave}
-            disabled={!apiKey.trim() || saveMutation.isPending}
+    <IntegrationKeySection
+      title="Readwise"
+      placeholder="Paste your Readwise token"
+      buildUpdate={key => ({
+        readwiseApiKey: key,
+      })}
+      selectStatus={data => ({
+        configured: data?.readwiseConfigured ?? false,
+        hint: data?.readwiseKeyHint ?? null,
+      })}
+      dataQueryKey={queryKeys.readwise.readingList()}
+      description={
+        <>
+          Connect your Readwise Reader account to show your reading list on the
+          dashboard. Paste a token from
+          {" "}
+          <a
+            href="https://readwise.io/access_token"
+            target="_blank"
+            rel="noreferrer"
+            className="
+              text-primary underline-offset-2
+              hover:underline
+            "
           >
-            {configured ? "Update key" : "Save key"}
-          </Button>
-          {configured && (
-            <Button
-              variant="outline"
-              onClick={() => saveMutation.mutate(null)}
-              disabled={saveMutation.isPending}
-            >
-              Remove
-            </Button>
-          )}
-        </div>
-      </div>
-    </section>
+            readwise.io/access_token
+          </a>
+          .
+        </>
+      }
+    />
   );
 }

--- a/packages/client/src/routes/settings.-components/-TodoistSection.tsx
+++ b/packages/client/src/routes/settings.-components/-TodoistSection.tsx
@@ -1,112 +1,39 @@
-import { useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-
-import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
-import { fetchSettings, updateSettings } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
+import { IntegrationKeySection } from "./-IntegrationKeySection";
+
 export function TodoistSection() {
-  const queryClient = useQueryClient();
-  const [apiKey, setApiKey] = useState("");
-
-  const settingsQuery = useQuery({
-    queryKey: queryKeys.settings.detail(),
-    queryFn: () => fetchSettings(),
-  });
-
-  const saveMutation = useMutation({
-    mutationFn: (key: string | null) =>
-      updateSettings({
-        todoistApiKey: key,
-      }),
-    onSuccess: (_data, key) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.settings.detail(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.todoist.tasks(),
-      });
-      setApiKey("");
-      toast.success(key ? "Todoist API key saved" : "Todoist API key removed");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const configured = settingsQuery.data?.todoistConfigured ?? false;
-  const hint = settingsQuery.data?.todoistKeyHint ?? null;
-
-  function handleSave() {
-    const trimmed = apiKey.trim();
-    if (!trimmed) return;
-    saveMutation.mutate(trimmed);
-  }
-
   return (
-    <section className="flex flex-col gap-3">
-      <h2 className="text-xl font-semibold">Todoist</h2>
-      <p className="text-sm text-muted-foreground">
-        Connect your Todoist account to show tasks due today and overdue on the
-        dashboard. Copy your API token from
-        {" "}
-        <a
-          href="https://app.todoist.com/app/settings/integrations/developer"
-          target="_blank"
-          rel="noreferrer"
-          className="
-            text-primary underline-offset-2
-            hover:underline
-          "
-        >
-          Settings → Integrations → Developer
-        </a>
-        .
-      </p>
-      {configured && (
-        <p className="text-sm text-muted-foreground">
-          A key is currently saved
-          {hint ? ` (ending ${hint})` : ""}
-          .
-        </p>
-      )}
-      <div
-        className="
-          flex flex-col gap-2
-          sm:flex-row sm:items-center
-        "
-      >
-        <Input
-          type="password"
-          autoComplete="off"
-          value={apiKey}
-          onChange={e => setApiKey(e.target.value)}
-          placeholder={configured
-            ? "Enter a new key to replace the saved one"
-            : "Paste your Todoist API token"}
-          className="sm:max-w-md"
-        />
-        <div className="flex gap-2">
-          <Button
-            onClick={handleSave}
-            disabled={!apiKey.trim() || saveMutation.isPending}
+    <IntegrationKeySection
+      title="Todoist"
+      placeholder="Paste your Todoist API token"
+      buildUpdate={key => ({
+        todoistApiKey: key,
+      })}
+      selectStatus={data => ({
+        configured: data?.todoistConfigured ?? false,
+        hint: data?.todoistKeyHint ?? null,
+      })}
+      dataQueryKey={queryKeys.todoist.tasks()}
+      description={
+        <>
+          Connect your Todoist account to show tasks due today and overdue on
+          the dashboard. Copy your API token from
+          {" "}
+          <a
+            href="https://app.todoist.com/app/settings/integrations/developer"
+            target="_blank"
+            rel="noreferrer"
+            className="
+              text-primary underline-offset-2
+              hover:underline
+            "
           >
-            {configured ? "Update key" : "Save key"}
-          </Button>
-          {configured && (
-            <Button
-              variant="outline"
-              onClick={() => saveMutation.mutate(null)}
-              disabled={saveMutation.isPending}
-            >
-              Remove
-            </Button>
-          )}
-        </div>
-      </div>
-    </section>
+            Settings → Integrations → Developer
+          </a>
+          .
+        </>
+      }
+    />
   );
 }

--- a/packages/client/src/routes/settings.-components/-TodoistSection.tsx
+++ b/packages/client/src/routes/settings.-components/-TodoistSection.tsx
@@ -1,6 +1,6 @@
-import { queryKeys } from "@/utils/queryKeys";
-
 import { IntegrationKeySection } from "./-IntegrationKeySection";
+
+import { queryKeys } from "@/utils/queryKeys";
 
 export function TodoistSection() {
   return (

--- a/packages/client/src/test-utils/storyDecorators.tsx
+++ b/packages/client/src/test-utils/storyDecorators.tsx
@@ -1,0 +1,29 @@
+import type { Decorator } from "@storybook/react-vite";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+/**
+ * Shared Storybook decorator for the card / table library stories, which all
+ * render inside a stub router so their `<Link>`s resolve. Set `tooltip` for
+ * cards that use tooltips and `constrained` to preview a card at the ~sidebar
+ * width its list renders it at.
+ */
+export function cardStoryDecorator(
+  options: { tooltip?: boolean;
+    constrained?: boolean; } = {},
+): Decorator {
+  const {
+    tooltip = false, constrained = false,
+  } = options;
+  return function CardStoryWrapper(Story) {
+    let content = <Story />;
+    if (constrained) {
+      content = <div className="max-w-sm">{content}</div>;
+    }
+    if (tooltip) {
+      content = <TooltipProvider>{content}</TooltipProvider>;
+    }
+    return <RouterStub>{content}</RouterStub>;
+  };
+}


### PR DESCRIPTION
## ELI5
Several parts of the app had near-identical chunks of code copy-pasted in two or more places. This groups each set of twins into one shared piece, so there's a single place to change them and less code overall. Nothing about how the app behaves changes.

## Summary
Reduces fallow's duplication from **69 → 58 clone groups (6.0% → 5.1%)** across four focused, behavior-preserving refactors:
- **Storybook decorators** — extracted `test-utils/storyDecorators.tsx` (`cardStoryDecorator`) and applied it to the 8 box/table library stories, removing the repeated `RouterStub`/`TooltipProvider`/`max-w-sm` decorator JSX.
- **Settings integrations** — `ReadwiseSection` and `TodoistSection` were near-identical 112-line files; extracted a shared `IntegrationKeySection` parameterized by copy, the settings field, and the invalidated query key. Each section is now a thin config wrapper.
- **Routine tracker** — hoisted the shared `name`/`lastEntry`/`daysCompleted` column defs in `-TrackerTables.tsx` into consts and composed both column arrays from them.
- **Quick-add dialogs** — extracted a `QuickAddNameDialog` presentational shell (dialog/form/name-input/footer + input state); `QuickAddResourceDialog` and `QuickAddTaskDialog` keep their own mutations and pass `isPending` + `onSubmit`.

Follow-up clone groups (dashboard integration cards, `QuickAddReadwise↔Todoist`, `dashboard.tsx↔useDashboardLayouts`, `BlipLlmAssist↔useBlipLlmAssist`) are tracked as separate issues — they're larger/stateful and warrant dedicated review.

## Test plan
- [x] `pnpm --filter=@emstack/client run typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter=@emstack/client exec vitest run` — 409 tests pass
- [x] `pnpm --filter=@emstack/client run build` — builds clean
- [x] `pnpm exec fallow --fail-on-issues` — no issues; duplication down to 5.1%

🤖 Generated with [Claude Code](https://claude.com/claude-code)