### PR TITLE
refactor(client): Fixes #322: promote dashboard tile-meta to @/lib and dedupe layout logic

### DIFF
--- a/.claude/skills/check-components/SKILL.md
+++ b/.claude/skills/check-components/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: check-components
+description: >-
+  Audit React component placement in the client package: find one-off
+  components in shared/inline locations that belong in a route's
+  *.-components/ folder, and route-private *.-components/ components that are
+  used outside their route or duplicate something in shared components/.
+  Reports findings and proposes grouped GitHub refactor tasks. Use when asked
+  to "check components", "audit component placement", or via /check-components.
+  Accepts an optional route/folder to scope the scan.
+---
+
+# Check components (course-tracker)
+
+Audit component **placement** in `packages/client/src` and report drift from the
+project convention — then propose grouped GitHub refactor tasks. This skill
+**reads and reports only**; it never moves files and never creates issues on its
+own (it hands you ready-to-run `gh` commands).
+
+## The convention
+
+Two homes for components (see `packages/client/CLAUDE.md`):
+
+- **Shared library** — `src/components/**`, imported via the `@/components/...`
+  alias and reused across routes. Includes intentionally-shared **primitives**:
+  `components/ui/`, `components/layout/`, `components/formFields/`, and the
+  root-level shadcn files (`button.tsx`, `combobox.tsx`, `popover.tsx`, …).
+  Also feature folders (`dailies/`, `routines/`, `radar/`, `tasks/`,
+  `resources/`, `boxes/`, …).
+- **Route-private** — sibling `*.-components/` folders (the `.-` prefix keeps
+  them out of TanStack routing), imported by relative path like
+  `./dashboard.-components/-DashboardGrid`.
+
+Two things drift over time, and this skill checks both:
+
+1. A component in a **non-`-components`** location (shared folder or inlined in a
+   route) is really used by **one route only** → it should be **colocated** in
+   that route's `*.-components/` folder.
+2. A component in a **`*.-components/`** folder is either **used outside its
+   route** (→ **promote** to shared `components/`) or is **similar to something
+   already in `components/`** (→ **dedupe** / reuse the shared one).
+
+## Scope
+
+Parse `$ARGUMENTS`:
+
+- **Empty** → scan the whole client (`packages/client/src`).
+- **A route name or folder path** (e.g. `/check-components dashboard` or
+  `/check-components packages/client/src/components/radar`) → scope the scan to
+  that route family / directory.
+
+Assume `pnpm install` has been run. All paths below are relative to the repo root.
+
+## Step 1 — Map the territory
+
+Enumerate the route-private folders and their **owning route prefix** (derive it
+from the folder name — strip the `.-components` suffix and any dynamic segments):
+
+```bash
+# All route-private folders (there are ~4 today)
+ls -d packages/client/src/routes/*.-components 2>/dev/null
+```
+
+- `dashboard.-components/` → route family **`dashboard`**
+- `settings.-components/` → **`settings`**
+- `routines.$id.edit.-components/` → **`routines`**
+- `domains.$id.edit.-components/` → **`domains`**
+
+Then enumerate the shared library and mark the **off-limits primitives** — these
+are *never* colocation candidates no matter how few consumers they have:
+
+```bash
+ls packages/client/src/components            # root files + feature subfolders
+ls packages/client/src/components/ui packages/client/src/components/layout \
+   packages/client/src/components/formFields  # intentionally shared — skip for Check 1
+```
+
+For a wide / "whole app" sweep, delegate the enumeration and grepping to an
+**Explore agent** and have it return a `file:line` usage map.
+
+## Step 2 — Build the usage map
+
+For each candidate component, find every importer across the **whole package**
+(consumers live in routes, hooks, and other components). Match both import forms:
+
+```bash
+# absolute alias form, e.g. @/components/radar/BlipLegend
+grep -rn "@/components/<subpath>/<Name>" packages/client/src --include=*.tsx --include=*.ts
+# relative route-private form, e.g. ./dashboard.-components/-DashboardGrid
+grep -rn "\.-components/-<Name>" packages/client/src --include=*.tsx --include=*.ts
+```
+
+Derive each importer's **route family** from its path under `src/routes/` (the
+filename prefix before the first `.`). A component's consumers reduce to a set of
+route families — that set drives all three checks.
+
+Ignore co-located **test/story files** (`*.test.tsx`, `*.stories.tsx`) as
+importers — they follow their component and aren't independent consumers.
+
+## Step 3 — Check 1: Colocation candidates (→ route `*.-components/`)
+
+A component under `src/components/**` (a **feature** folder, not a primitive
+folder) or defined inline in a single route, whose consumer set is **exactly one
+route family**, is a candidate to **move into that route's `*.-components/`
+folder** (relative imports; create the folder named after the route file if the
+route has none).
+
+**Guardrails — do not flag:**
+
+- Anything in `ui/`, `layout/`, `formFields/`, or a root shadcn file.
+- A component with **more than one** route family in its consumer set.
+- A single-consumer component that is **clearly a reusable primitive by design**
+  (generic, presentational, no route coupling — e.g. a generic `ProgressBar`).
+  Note the reasoning when you skip one for this reason.
+
+## Step 4 — Check 2a: Escapees (`*.-components/` → promote to shared)
+
+For each component inside a `*.-components/` folder, check its consumer set
+against the folder's **owning route family**. If any importer belongs to a
+**different** route family, the component has escaped its route and is a
+candidate to **promote** to shared `components/` — pick the matching feature
+subfolder (or root for a generic one) and update all imports to the `@/` alias.
+
+## Step 5 — Check 2b: Duplicates (`*.-components/` ≈ shared `components/`)
+
+Surface structural duplication with the repo's existing tooling, then confirm by
+reading:
+
+```bash
+pnpm exec fallow dupes    # run from repo ROOT; flags duplicated code/shapes
+```
+
+Cross-reference fallow's hits (and obvious name/shape similarity) between
+`*.-components/` files and shared `components/`. A route-private component that
+duplicates or closely resembles a shared one is a candidate to **refactor to
+reuse the shared component**.
+
+- **Guardrail:** structural similarity ≠ semantic equivalence. Read **both**
+  files before flagging — drafts, DTOs, and route-specific variants can look
+  alike but differ on purpose.
+- For the **type** half of any such merge (shared prop shapes / interfaces),
+  hand off to `/condense-types` rather than reinventing it here.
+
+## Step 6 — Report & propose tasks
+
+Produce a findings report grouped **one section per category**, and **within each
+category split by feature or path group**:
+
+- **Colocate** (Check 1) — split by target route family (colocate-`dailies`,
+  colocate-`radar`, …)
+- **Promote** (Check 2a) — split by source `*.-components/` folder
+- **Dedupe** (Check 2b) — split by feature / the shared component involved
+
+Each finding states: the component, its **current path → proposed path**, and the
+**consumer evidence** (which route families import it, with `file:line`).
+
+**Do not create issues automatically.** For each (category × feature/path-group)
+bucket, emit a ready-to-run command using the existing **`refactor`** label
+(repo `emilyeserven/course-tracker`):
+
+Pass the body as a plain multi-line string (not a `$(cat <<EOF …)` heredoc — a
+heredoc-substituted command doesn't start with `gh`, so the `Bash(gh:*)`
+permission pattern won't match):
+
+```bash
+gh issue create --repo emilyeserven/course-tracker --label refactor \
+  --title "refactor(client): colocate <feature> components into *.-components" \
+  --body "Components used by only the <feature> route that should move out of shared components/:
+
+- [ ] components/<feature>/<Name>.tsx → routes/<feature>.-components/-<Name>.tsx (consumers: <route> only)
+- [ ] ...
+
+Found by /check-components."
+```
+
+Use the matching title prefix per category:
+`colocate <feature> components into *.-components` /
+`promote <component> out of <route>.-components to shared components` /
+`dedupe <route>.-components/<Name> against components/<shared>`.
+
+State plainly that filing is left to the user — they can copy/run any command, or
+ask you to file a specific bucket.
+
+## Guardrails recap — never flag
+
+- Shared primitives: `components/ui/`, `components/layout/`, `components/formFields/`,
+  root shadcn files.
+- Generated files: `routeTree.gen.ts`.
+- Test/story files as standalone candidates — they follow their component.

--- a/packages/client/src/hooks/useDashboardLayoutMutations.ts
+++ b/packages/client/src/hooks/useDashboardLayoutMutations.ts
@@ -1,0 +1,122 @@
+import type { DashboardLayout, DashboardLayoutTile } from "@emstack/types";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  createDashboardLayout,
+  deleteSingleDashboardLayout,
+  duplicateDashboardLayout,
+  upsertDashboardLayout,
+} from "@/utils/api";
+import { queryKeys } from "@/utils/queryKeys";
+
+interface UseDashboardLayoutMutationsOptions {
+  /** Runs after a successful rename, before the toast — close the dialog here. */
+  onRenamed?: () => void;
+  /** Runs after a successful save-as-preset, before the toast. */
+  onSavedAsPreset?: () => void;
+  /** Runs after a successful delete, before the toast. */
+  onDeleted?: () => void;
+}
+
+interface RenameInput {
+  layout: DashboardLayout;
+  name: string;
+}
+
+interface SaveAsPresetInput {
+  name: string;
+  tiles: DashboardLayoutTile[];
+}
+
+/**
+ * The dashboard-layout CRUD mutations shared by the /dashboard route and the
+ * settings layouts section: rename, save-as-preset, duplicate, delete. Each
+ * invalidates the layouts list and shows the same toast on both surfaces; the
+ * only per-call-site difference (closing a dialog) is injected via callbacks.
+ *
+ * Create and tile-toggle are deliberately NOT here — they diverge between the
+ * two surfaces (create's side effects/inputs differ; the dashboard toggles
+ * optimistically while settings invalidates), so each keeps its own.
+ */
+export function useDashboardLayoutMutations(
+  options: UseDashboardLayoutMutationsOptions = {},
+) {
+  const queryClient = useQueryClient();
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.dashboardLayouts.list(),
+    });
+
+  const renameMutation = useMutation({
+    mutationFn: ({
+      layout, name,
+    }: RenameInput) =>
+      upsertDashboardLayout(layout.id, {
+        name,
+        position: layout.position ?? null,
+        tiles: layout.tiles,
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      options.onRenamed?.();
+      toast.success("Layout renamed");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const saveAsPresetMutation = useMutation({
+    mutationFn: ({
+      name, tiles,
+    }: SaveAsPresetInput) =>
+      createDashboardLayout({
+        name,
+        position: null,
+        tiles,
+        isTemplate: true,
+      }),
+    onSuccess: () => {
+      void invalidate();
+      options.onSavedAsPreset?.();
+      toast.success("Saved as a layout you can reuse");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const duplicateMutation = useMutation({
+    mutationFn: (id: string) => duplicateDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      toast.success("Layout duplicated");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
+    onSuccess: () => {
+      void invalidate();
+      options.onDeleted?.();
+      toast.success("Layout deleted");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  return {
+    renameMutation,
+    saveAsPresetMutation,
+    duplicateMutation,
+    deleteMutation,
+  };
+}

--- a/packages/client/src/lib/dashboardTiles.test.ts
+++ b/packages/client/src/lib/dashboardTiles.test.ts
@@ -1,4 +1,4 @@
-import type { DashboardLayoutTile } from "@emstack/types";
+import type { DashboardLayout, DashboardLayoutTile } from "@emstack/types";
 
 import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import { describe, expect, test } from "vitest";
@@ -12,24 +12,23 @@ import {
   sortTilesForMobile,
   tilesEqual,
   tilesToLayoutItems,
+  tileVisibilityItems,
   TILE_META,
   toggleTile,
-} from "./-dashboardTileMeta";
+} from "./dashboardTiles";
 
 function overlaps(a: DashboardLayoutTile, b: DashboardLayoutTile): boolean {
   return (
-    a.x < b.x + b.w
-    && b.x < a.x + a.w
-    && a.y < b.y + b.h
-    && b.y < a.y + a.h
+    a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
   );
 }
 
 describe("buildDefaultTiles", () => {
   test("contains every tile exactly once", () => {
     const tiles = buildDefaultTiles();
-    expect(tiles.map(t => t.tileId).sort())
-      .toEqual([...DASHBOARD_TILE_IDS].sort());
+    expect(tiles.map(t => t.tileId).sort()).toEqual(
+      [...DASHBOARD_TILE_IDS].sort(),
+    );
   });
 
   test("puts Do Now full-width at the top", () => {
@@ -307,14 +306,52 @@ describe("needsNormalization", () => {
 describe("resizeHandlesForTile", () => {
   test("auto-height tiles get only the width (east) handle", () => {
     expect(resizeHandlesForTile({})).toEqual(["e"]);
-    expect(resizeHandlesForTile({
-      heightMode: "auto",
-    })).toEqual(["e"]);
+    expect(
+      resizeHandlesForTile({
+        heightMode: "auto",
+      }),
+    ).toEqual(["e"]);
   });
 
   test("fixed-height tiles also get the SE corner for height", () => {
-    expect(resizeHandlesForTile({
-      heightMode: "fixed",
-    })).toEqual(["e", "se"]);
+    expect(
+      resizeHandlesForTile({
+        heightMode: "fixed",
+      }),
+    ).toEqual(["e", "se"]);
+  });
+});
+
+describe("tileVisibilityItems", () => {
+  const layout = {
+    id: "l1",
+    name: "Layout",
+    position: 0,
+    isTemplate: false,
+    tiles: [
+      {
+        tileId: "doNow",
+        x: 0,
+        y: 0,
+        w: 4,
+        h: 6,
+      },
+    ],
+  } as DashboardLayout;
+
+  test("returns one item per known tile id", () => {
+    expect(tileVisibilityItems(layout)).toHaveLength(DASHBOARD_TILE_IDS.length);
+  });
+
+  test("marks present tiles checked and uses TILE_META titles", () => {
+    const items = tileVisibilityItems(layout);
+    const doNow = items.find(i => i.tileId === "doNow");
+    const changelog = items.find(i => i.tileId === "changelog");
+    expect(doNow).toEqual({
+      tileId: "doNow",
+      title: TILE_META.doNow.title,
+      checked: true,
+    });
+    expect(changelog?.checked).toBe(false);
   });
 });

--- a/packages/client/src/lib/dashboardTiles.ts
+++ b/packages/client/src/lib/dashboardTiles.ts
@@ -1,4 +1,8 @@
-import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
+import type {
+  DashboardLayout,
+  DashboardLayoutTile,
+  DashboardTileId,
+} from "@emstack/types";
 
 import { DASHBOARD_TILE_IDS } from "@emstack/types";
 
@@ -90,14 +94,24 @@ function isDashboardTileId(id: string): id is DashboardTileId {
 }
 
 /** Whether a tile's height is content-driven (auto) rather than handle-driven. */
-export function isAutoHeight(tile: Pick<DashboardLayoutTile, "heightMode">): boolean {
+export function isAutoHeight(
+  tile: Pick<DashboardLayoutTile, "heightMode">,
+): boolean {
   return (tile.heightMode ?? "auto") === "auto";
 }
 
 /** Mirrors @dnd-grid's ResizeHandleAxis; its published d.ts re-exports the core
  * types through a broken relative path, so the imported type resolves to `any`
  * (the same reason GridLayoutItem below is hand-rolled). */
-export type ResizeHandleAxis = "s" | "w" | "e" | "n" | "sw" | "nw" | "se" | "ne";
+export type ResizeHandleAxis
+  = | "s"
+    | "w"
+    | "e"
+    | "n"
+    | "sw"
+    | "nw"
+    | "se"
+    | "ne";
 
 /**
  * Resize handles a tile exposes. Every tile gets the east (right-edge) handle so
@@ -265,6 +279,25 @@ export function toggleTile(
   ];
 }
 
+export interface TileVisibilityItem {
+  tileId: DashboardTileId;
+  title: string;
+  checked: boolean;
+}
+
+/** Every tile id paired with its title and whether `layout` currently shows it.
+ * Backs the tile-visibility checklists (dashboard dialog + settings dropdown),
+ * which share this logic but render different controls. */
+export function tileVisibilityItems(
+  layout: DashboardLayout,
+): TileVisibilityItem[] {
+  return DASHBOARD_TILE_IDS.map(tileId => ({
+    tileId,
+    title: TILE_META[tileId].title,
+    checked: layout.tiles.some(t => t.tileId === tileId),
+  }));
+}
+
 /**
  * Order-insensitive comparison of two tile sets. Compares id + position + width
  * for every tile, and height only for fixed-height tiles — an auto-height
@@ -277,8 +310,12 @@ export function tilesEqual(
   if (a.length !== b.length) return false;
   return a.every((tile) => {
     const other = b.find(t => t.tileId === tile.tileId);
-    if (!other || other.x !== tile.x || other.y !== tile.y
-      || other.w !== tile.w) {
+    if (
+      !other
+      || other.x !== tile.x
+      || other.y !== tile.y
+      || other.w !== tile.w
+    ) {
       return false;
     }
     return isAutoHeight(tile) ? true : other.h === tile.h;

--- a/packages/client/src/routes/dashboard.-components/-DashboardCardSettings.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCardSettings.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { TileHeightMode } from "@emstack/types";
 import type * as React from "react";
 
@@ -6,8 +6,6 @@ import { useEffect, useRef, useState } from "react";
 
 import { SettingsIcon } from "lucide-react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
-
-import { MAX_TILE_ROWS, TILE_META } from "./-dashboardTileMeta";
 
 import { Input } from "@/components/input";
 import {
@@ -17,6 +15,7 @@ import {
 } from "@/components/popover";
 import { RadioGroupItem } from "@/components/radio-group";
 import { Button } from "@/components/ui/button";
+import { MAX_TILE_ROWS, TILE_META } from "@/lib/dashboardTiles";
 import { cn } from "@/lib/utils";
 
 /** Auto / Fixed height chooser shared by every card's settings flyout. When

--- a/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardChangelog.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ReactNode } from "react";
 
 // Bundled at build time from the repo-root CHANGELOG.md (the `@root` Vite

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -1,5 +1,5 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
 import type { SortDirection } from "@/components/ui/manualSort";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ResourceInResources, CourseProvider } from "@emstack/types";
 import type { ColumnDef } from "@tanstack/react-table";
 

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 
 import { useState } from "react";
 

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 
 import { Link } from "@tanstack/react-router";
 

--- a/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardExplore.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ExploreItem } from "@emstack/types";
 
 import { useState } from "react";

--- a/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { GoogleCalendarEvent } from "@emstack/types";
 
 import { useQuery } from "@tanstack/react-query";

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.tsx
@@ -1,10 +1,13 @@
-import type { GridLayoutItem } from "./-dashboardTileMeta";
+import type { GridLayoutItem } from "@/lib/dashboardTiles";
 import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { DndGrid } from "@dnd-grid/react";
 
+import { TILE_COMPONENTS } from "./-tileComponents";
+
+import { useIsMobile } from "@/hooks/useIsMobile";
 import {
   GRID_EM_PER_ROW,
   GRID_GAP,
@@ -14,10 +17,7 @@ import {
   sortTilesForMobile,
   TILE_META,
   tilesToLayoutItems,
-} from "./-dashboardTileMeta";
-import { TILE_COMPONENTS } from "./-tileComponents";
-
-import { useIsMobile } from "@/hooks/useIsMobile";
+} from "@/lib/dashboardTiles";
 import { cn } from "@/lib/utils";
 
 interface DashboardGridProps {

--- a/packages/client/src/routes/dashboard.-components/-DashboardRadars.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardRadars.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";

--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ReadwiseDocument } from "@emstack/types";
 
 import { useQuery } from "@tanstack/react-query";

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { TodoistTask, TodoistTasks } from "@emstack/types";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { CourseProvider } from "@emstack/types";
 import type { ColumnDef } from "@tanstack/react-table";
 

--- a/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.tsx
+++ b/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.tsx
@@ -1,10 +1,6 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
-import { DASHBOARD_TILE_IDS } from "@emstack/types";
-
-import { TILE_META } from "./-dashboardTileMeta";
-
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
@@ -14,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { tileVisibilityItems } from "@/lib/dashboardTiles";
 
 interface VisibleTilesDialogProps extends ControlledDialogProps {
   /** The layout whose tiles are being toggled, or null when closed. */
@@ -47,24 +44,23 @@ export function VisibleTilesDialog({
         </DialogHeader>
         {layout && (
           <div className="flex flex-col gap-1">
-            {DASHBOARD_TILE_IDS.map((tileId) => {
-              const checked = layout.tiles.some(t => t.tileId === tileId);
-              return (
-                <Label
-                  key={tileId}
-                  className={`
-                    cursor-pointer rounded-md p-2 font-normal
-                    hover:bg-accent
-                  `}
-                >
-                  <Checkbox
-                    checked={checked}
-                    onCheckedChange={() => onToggleTile(layout, tileId)}
-                  />
-                  {TILE_META[tileId].title}
-                </Label>
-              );
-            })}
+            {tileVisibilityItems(layout).map(({
+              tileId, title, checked,
+            }) => (
+              <Label
+                key={tileId}
+                className={`
+                  cursor-pointer rounded-md p-2 font-normal
+                  hover:bg-accent
+                `}
+              >
+                <Checkbox
+                  checked={checked}
+                  onCheckedChange={() => onToggleTile(layout, tileId)}
+                />
+                {title}
+              </Label>
+            ))}
           </div>
         )}
       </DialogContent>

--- a/packages/client/src/routes/dashboard.-components/-cardKit.ts
+++ b/packages/client/src/routes/dashboard.-components/-cardKit.ts
@@ -7,7 +7,7 @@ export {
   DashboardSectionStatus,
 } from "@/components/contentBoxComponents/DashboardCard";
 export { CardSettingsFlyout, SettingToggle } from "./-DashboardCardSettings";
-export { isAutoHeight } from "./-dashboardTileMeta";
+export { isAutoHeight } from "@/lib/dashboardTiles";
 export { Button } from "@/components/ui/button";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 export { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";

--- a/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
@@ -2,7 +2,7 @@ import type { DashboardLayoutTile } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import { TILE_META } from "./-dashboardTileMeta";
+import { TILE_META } from "@/lib/dashboardTiles";
 import { LAYOUT_PRESETS } from "./-layoutPresets";
 
 function overlaps(a: DashboardLayoutTile, b: DashboardLayoutTile): boolean {

--- a/packages/client/src/routes/dashboard.-components/-layoutPresets.ts
+++ b/packages/client/src/routes/dashboard.-components/-layoutPresets.ts
@@ -1,6 +1,6 @@
 import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
 
-import { buildDefaultTiles, TILE_META } from "./-dashboardTileMeta";
+import { buildDefaultTiles, TILE_META } from "@/lib/dashboardTiles";
 
 // Curated, code-defined starting layouts offered when adding a tab. Built-ins
 // are never persisted as rows — picking one just creates a new layout from the

--- a/packages/client/src/routes/dashboard.-components/-tileComponents.tsx
+++ b/packages/client/src/routes/dashboard.-components/-tileComponents.tsx
@@ -1,4 +1,4 @@
-import type { DashboardTileProps } from "./-dashboardTileMeta";
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { DashboardTileId } from "@emstack/types";
 
 import { DashboardChangelog } from "./-DashboardChangelog";

--- a/packages/client/src/routes/dashboard.-components/index.ts
+++ b/packages/client/src/routes/dashboard.-components/index.ts
@@ -12,7 +12,7 @@ export {
   normalizeTiles,
   tilesEqual,
   toggleTile,
-} from "./-dashboardTileMeta";
+} from "@/lib/dashboardTiles";
 export { ConfirmDialog } from "@/components/ConfirmDialog";
 export { LayoutNameDialog } from "@/components/LayoutNameDialog";
 export { PageHeader } from "@/components/layout/PageHeader";

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -1,4 +1,8 @@
-import type { DashboardLayout, DashboardLayoutTile, DashboardTileId } from "@emstack/types";
+import type {
+  DashboardLayout,
+  DashboardLayoutTile,
+  DashboardTileId,
+} from "@emstack/types";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -26,10 +30,9 @@ import {
 } from "./dashboard.-components";
 
 import { useActiveDashboardLayoutId } from "@/hooks/useActiveDashboardLayoutId";
+import { useDashboardLayoutMutations } from "@/hooks/useDashboardLayoutMutations";
 import {
   createDashboardLayout,
-  deleteSingleDashboardLayout,
-  duplicateDashboardLayout,
   fetchDashboardLayouts,
   upsertDashboardLayout,
 } from "@/utils/api";
@@ -93,9 +96,12 @@ function Dashboard() {
 
   const createTabMutation = useMutation({
     mutationFn: ({
-      name, tiles,
-    }: { name: string;
-      tiles: DashboardLayoutTile[]; }) =>
+      name,
+      tiles,
+    }: {
+      name: string;
+      tiles: DashboardLayoutTile[];
+    }) =>
       createDashboardLayout({
         name,
         position: tabs.length,
@@ -129,78 +135,27 @@ function Dashboard() {
     }
   }, [layouts, autoCreate]);
 
-  const saveAsPresetMutation = useMutation({
-    mutationFn: ({
-      name, tiles,
-    }: { name: string;
-      tiles: DashboardLayoutTile[]; }) =>
-      createDashboardLayout({
-        name,
-        position: null,
-        tiles,
-        isTemplate: true,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setSaveAsTargetId(null);
-      toast.success("Saved as a layout you can reuse");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const renameMutation = useMutation({
-    mutationFn: ({
-      layout, name,
-    }: { layout: DashboardLayout;
-      name: string; }) =>
-      upsertDashboardLayout(layout.id, {
-        name,
-        position: layout.position ?? null,
-        tiles: layout.tiles,
-        isTemplate: layout.isTemplate ?? false,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setRenameTargetId(null);
-      toast.success("Layout renamed");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const duplicateMutation = useMutation({
-    mutationFn: (id: string) => duplicateDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      toast.success("Layout duplicated");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      setDeleteTargetId(null);
-      toast.success("Layout deleted");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
+  const {
+    renameMutation,
+    saveAsPresetMutation,
+    duplicateMutation,
+    deleteMutation,
+  } = useDashboardLayoutMutations({
+    onRenamed: () => setRenameTargetId(null),
+    onSavedAsPreset: () => setSaveAsTargetId(null),
+    onDeleted: () => setDeleteTargetId(null),
   });
 
   // Tile moves/resizes save through an optimistic cache write with no
   // invalidate on success — a refetch mid-drag would snap tiles back.
   const saveTilesMutation = useMutation({
     mutationFn: ({
-      layout, tiles,
-    }: { layout: DashboardLayout;
-      tiles: DashboardLayoutTile[]; }) =>
+      layout,
+      tiles,
+    }: {
+      layout: DashboardLayout;
+      tiles: DashboardLayoutTile[];
+    }) =>
       upsertDashboardLayout(layout.id, {
         name: layout.name,
         position: layout.position ?? null,
@@ -212,13 +167,14 @@ function Dashboard() {
     }) => {
       queryClient.setQueryData<DashboardLayout[]>(
         queryKeys.dashboardLayouts.list(),
-        prev => prev?.map(l =>
-          l.id === layout.id
-            ? {
-              ...l,
-              tiles,
-            }
-            : l),
+        prev =>
+          prev?.map(l =>
+            l.id === layout.id
+              ? {
+                ...l,
+                tiles,
+              }
+              : l),
       );
     },
     onError: (err: Error) => {
@@ -227,7 +183,9 @@ function Dashboard() {
     },
   });
 
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
   useEffect(() => () => clearTimeout(saveTimerRef.current), []);
 
   // Self-heal: persist the normalized tiles once when a layout still holds a

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -1,6 +1,5 @@
 import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
-import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import {
   BookmarkIcon,
   CopyIcon,
@@ -24,7 +23,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { TILE_META } from "@/routes/dashboard.-components/-dashboardTileMeta";
+import { tileVisibilityItems } from "@/lib/dashboardTiles";
 
 interface LayoutRowProps {
   layout: DashboardLayout;
@@ -45,15 +44,11 @@ function LayoutRow({
   onDelete,
 }: LayoutRowProps) {
   return (
-    <li
-      className="flex flex-wrap items-center justify-between gap-2 p-3"
-    >
+    <li className="flex flex-wrap items-center justify-between gap-2 p-3">
       <div className="flex flex-col gap-1">
         <span className="font-medium">{layout.name}</span>
         <span className="text-xs text-muted-foreground">
-          {layout.tiles.length}
-          {" "}
-          tile(s) shown
+          {layout.tiles.length} tile(s) shown
         </span>
       </div>
       <DropdownMenu>
@@ -69,14 +64,16 @@ function LayoutRow({
         <DropdownMenuContent align="end">
           <DropdownMenuLabel>Visible tiles</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {DASHBOARD_TILE_IDS.map(tileId => (
+          {tileVisibilityItems(layout).map(({
+            tileId, title, checked,
+          }) => (
             <DropdownMenuCheckboxItem
               key={tileId}
-              checked={layout.tiles.some(t => t.tileId === tileId)}
+              checked={checked}
               onCheckedChange={() => onToggleTile(layout, tileId)}
               onSelect={e => e.preventDefault()}
             >
-              {TILE_META[tileId].title}
+              {title}
             </DropdownMenuCheckboxItem>
           ))}
           <DropdownMenuSeparator />
@@ -159,7 +156,9 @@ export function DashboardLayoutsSection() {
         </p>
 
         {isPending
-          ? <p className="text-sm text-muted-foreground">Loading...</p>
+          ? (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          )
           : (
             <>
               <div className="flex flex-col gap-2">
@@ -169,8 +168,8 @@ export function DashboardLayoutsSection() {
                 {tabs.length === 0
                   ? (
                     <p className="text-sm text-muted-foreground">
-                      No layouts yet. Visit the dashboard to create the default
-                      one, or add one here.
+                      No layouts yet. Visit the dashboard to create the default one,
+                      or add one here.
                     </p>
                   )
                   : (

--- a/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
+++ b/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
@@ -5,11 +5,10 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { toggleTile } from "@/routes/dashboard.-components/-dashboardTileMeta";
+import { useDashboardLayoutMutations } from "@/hooks/useDashboardLayoutMutations";
+import { toggleTile } from "@/lib/dashboardTiles";
 import {
   createDashboardLayout,
-  deleteSingleDashboardLayout,
-  duplicateDashboardLayout,
   fetchDashboardLayouts,
   upsertDashboardLayout,
 } from "@/utils/api";
@@ -71,76 +70,25 @@ export function useDashboardLayouts() {
     },
   });
 
-  const renameMutation = useMutation({
-    mutationFn: ({
-      layout, name,
-    }: { layout: DashboardLayout;
-      name: string; }) =>
-      upsertDashboardLayout(layout.id, {
-        name,
-        position: layout.position ?? null,
-        tiles: layout.tiles,
-        isTemplate: layout.isTemplate ?? false,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setRenameTargetId(null);
-      toast.success("Layout renamed");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const saveAsPresetMutation = useMutation({
-    mutationFn: ({
-      name, layout,
-    }: { name: string;
-      layout: DashboardLayout; }) =>
-      createDashboardLayout({
-        name,
-        position: null,
-        tiles: layout.tiles,
-        isTemplate: true,
-      }),
-    onSuccess: () => {
-      void invalidate();
-      setSaveAsTargetId(null);
-      toast.success("Saved as a layout you can reuse");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const duplicateMutation = useMutation({
-    mutationFn: (id: string) => duplicateDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      toast.success("Layout duplicated");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleDashboardLayout(id),
-    onSuccess: () => {
-      void invalidate();
-      setDeleteTargetId(null);
-      toast.success("Layout deleted");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
+  const {
+    renameMutation,
+    saveAsPresetMutation,
+    duplicateMutation,
+    deleteMutation,
+  } = useDashboardLayoutMutations({
+    onRenamed: () => setRenameTargetId(null),
+    onSavedAsPreset: () => setSaveAsTargetId(null),
+    onDeleted: () => setDeleteTargetId(null),
   });
 
   const toggleTileMutation = useMutation({
     mutationFn: ({
-      layout, tileId,
-    }: { layout: DashboardLayout;
-      tileId: DashboardTileId; }) =>
+      layout,
+      tileId,
+    }: {
+      layout: DashboardLayout;
+      tileId: DashboardTileId;
+    }) =>
       upsertDashboardLayout(layout.id, {
         name: layout.name,
         position: layout.position ?? null,
@@ -162,7 +110,8 @@ export function useDashboardLayouts() {
         tileId,
       }),
     onRename: (layout: DashboardLayout) => setRenameTargetId(layout.id),
-    onDuplicate: (layout: DashboardLayout) => duplicateMutation.mutate(layout.id),
+    onDuplicate: (layout: DashboardLayout) =>
+      duplicateMutation.mutate(layout.id),
     onSaveAs: (layout: DashboardLayout) => setSaveAsTargetId(layout.id),
     onDelete: (layout: DashboardLayout) => setDeleteTargetId(layout.id),
   };
@@ -204,7 +153,7 @@ export function useDashboardLayouts() {
       if (saveAsTarget) {
         saveAsPresetMutation.mutate({
           name,
-          layout: saveAsTarget,
+          tiles: saveAsTarget.tiles,
         });
       }
     },


### PR DESCRIPTION
## ELI5
The dashboard's "which tiles to show" settings code lived in a private folder but was being borrowed by the settings page, and a big chunk of the "create/rename/delete a layout" logic was copy-pasted in two places. This moves the shared helper to a neutral spot and folds the duplicated logic into one reusable piece, so there's a single source of truth and less code to keep in sync.

## Summary
- Move the pure tile-meta module (+ its test) from `routes/dashboard.-components/-dashboardTileMeta.ts` to `@/lib/dashboardTiles.ts`, resolving the cross-route private import from the settings layouts section.
- Extract the shared layout CRUD mutations (rename / save-as-preset / duplicate / delete) into a new `useDashboardLayoutMutations` hook consumed by both `dashboard.tsx` and `settings/-useDashboardLayouts.ts`; `create` and tile-`toggle` stay local because they genuinely diverge (dashboard is optimistic, settings invalidates).
- Add a `tileVisibilityItems` helper so the dashboard dialog and settings dropdown share the checked-tile logic while keeping their own UI controls.
- fallow clone family for the layout mutations dropped from 4 groups / ~171 lines to 2 groups / 77 lines (residual is the intentionally-divergent create/toggle).
- Vendors the `check-components` skill that surfaced these placement issues.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors (pre-existing `no-console` warnings only)
- [x] `pnpm --filter=@emstack/client test` — 403 passing, incl. new `tileVisibilityItems` test
- [x] `pnpm exec fallow dupes` confirms the dashboard↔settings clone family is sharply reduced
- [ ] Manual smoke: on `/dashboard` add/rename/duplicate/delete a layout, toggle tiles (no snap-back on drag), save-as-preset; on `/settings` Dashboard Layouts section rename/duplicate/delete/save-as-preset and toggle tiles via the row dropdown — toasts read identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)