### PR TITLE
fix(client): include routine name in criteria upsert request

### DIFF
--- a/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
@@ -73,9 +73,11 @@ export function CriteriaTab({
           criteria.freeze = value.criteriaFreeze;
         }
 
-        // Partial save: only `criteria` is sent, so the routine's schedule,
-        // connections and completions are preserved by the backend merge.
+        // Partial save: `name` is included to satisfy the upsert body schema;
+        // the backend merge preserves the routine's schedule, connections and
+        // completions since they're omitted here.
         await upsertRoutine(routine.id, {
+          name: routine.name,
           criteria,
         });
         onChangeStateChange?.(false);


### PR DESCRIPTION
## Summary
Fixed a bug in the criteria tab where the routine name was not being sent in the upsert request, causing the backend schema validation to fail.

## Changes
- Added `name: routine.name` to the upsert payload in the criteria save handler
- Updated the comment to clarify that `name` is required to satisfy the upsert body schema, while other fields (schedule, connections, completions) are intentionally omitted to leverage the backend's merge logic for preservation

## Implementation Details
The backend's upsert endpoint requires a `name` field in the request body schema. Previously, only `criteria` was being sent, which would fail validation. By including the routine's existing name in the payload, the request now satisfies the schema while still allowing the backend to preserve unmodified fields through its merge strategy.

https://claude.ai/code/session_01HD9wxcvXAuD6LbLfagqkmk