### PR TITLE
test(ui): add Storybook stories for 13 UI primitive components

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -201,6 +201,21 @@ needs the `DropdownMenu`/`DropdownMenuContent` parent and asserts via
 `document.body`. The rest (`InfoRow`, `InfoArea`, `EditForm`, `PageTabs`,
 `ViewModeToggle`, `EditPageFooter`) are Tier A with `fn()` handlers.
 
+### ui primitives (#353)
+13 new stories; no fixtures needed (inline literals only). Radix composites
+(`select`, `dialog`, `alert-dialog`, `dropdown-menu`, `tooltip`, `tabs`) use a
+small non-generic `*Demo` harness as `meta.component` (same trick as
+`data-table.stories.tsx`'s `DataTableDemo`) — it sidesteps the multi-export Root
+typing and lets spies ride in as harness props. Dialog/AlertDialog **don't export
+their `Trigger`**, so drive them with a controlled `open` prop and assert content
+via `within(document.body)`. Tooltip self-wraps its provider — assert
+`findByRole("tooltip")` in the body. `data-table-column-header` mocks just the
+`Column` methods it calls (`getCanSort`/`getIsSorted`/`getToggleSortingHandler`)
+cast `as unknown as Column<unknown, unknown>`. **`toHaveStyle({ width: "30%" })`
+fails** in the browser project — computed style resolves `%` to px; assert the
+inline `el.style.width` string instead. `table.tsx` was left unstoried: it's
+already exercised transitively by `data-table.stories.tsx`.
+
 ### formFields + forms (#354)
 The 7 TanStack-Form fields (`InputField`, `TextareaField`, `NumberField`,
 `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) read

--- a/packages/client/src/components/ui/DeleteButton.stories.tsx
+++ b/packages/client/src/components/ui/DeleteButton.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { DeleteButton } from "./DeleteButton";
+
+const meta: Meta<typeof DeleteButton> = {
+  component: DeleteButton,
+  args: {
+    children: "Delete topic",
+    onClick: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Clicking the button swaps it for a confirmation prompt.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: /delete topic/i,
+    }));
+    await expect(await canvas.findByText("Are you sure?")).toBeInTheDocument();
+  },
+};
+
+// Confirming triggers onClick (the first of the two icon buttons).
+export const Confirms: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: /delete topic/i,
+    }));
+    await canvas.findByText("Are you sure?");
+    const [confirm] = canvas.getAllByRole("button");
+    await userEvent.click(confirm);
+    await expect(args.onClick).toHaveBeenCalled();
+  },
+};
+
+// Cancelling restores the original button without calling onClick.
+export const Cancels: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: /delete topic/i,
+    }));
+    await canvas.findByText("Are you sure?");
+    const buttons = canvas.getAllByRole("button");
+    await userEvent.click(buttons[1]);
+    await expect(canvas.queryByText("Are you sure?")).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /delete topic/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(args.onClick).not.toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/components/ui/ProgressBar.stories.tsx
+++ b/packages/client/src/components/ui/ProgressBar.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect } from "storybook/test";
+
+import { ProgressBar } from "./ProgressBar";
+
+const meta = {
+  component: ProgressBar,
+  args: {
+    progressCurrent: 3,
+    progressTotal: 10,
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const fill = canvasElement.querySelector<HTMLElement>("div[style*='width']");
+    // Assert the inline style — computed style resolves the % to pixels.
+    await expect(fill?.style.width).toBe("30%");
+  },
+};
+
+export const Inactive: Story = {
+  args: {
+    progressCurrent: 2,
+    progressTotal: 4,
+    status: "inactive",
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    progressCurrent: 5,
+    progressTotal: 5,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const fill = canvasElement.querySelector<HTMLElement>("div[style*='width']");
+    await expect(fill?.style.width).toBe("100%");
+  },
+};
+
+// With no current progress the component renders nothing.
+export const Empty: Story = {
+  args: {
+    progressCurrent: 0,
+    progressTotal: 10,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    await expect(canvasElement.querySelector("div[style*='width']")).toBeNull();
+  },
+};

--- a/packages/client/src/components/ui/RadialProgress.stories.tsx
+++ b/packages/client/src/components/ui/RadialProgress.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { RadialProgress } from "./RadialProgress";
+
+const meta = {
+  component: RadialProgress,
+  args: {
+    current: 3,
+    total: 4,
+    size: 48,
+  },
+} satisfies Meta<typeof RadialProgress>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("img", {
+        name: "75% complete",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// total of 0 must not divide by zero — it renders 0%.
+export const Empty: Story = {
+  args: {
+    current: 0,
+    total: 0,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("img", {
+        name: "0% complete",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Full: Story = {
+  args: {
+    current: 5,
+    total: 5,
+  },
+};
+
+// A custom `title` overrides the tooltip, but the aria-label stays percentage.
+export const CustomTitle: Story = {
+  args: {
+    current: 1,
+    total: 2,
+    title: "Halfway there",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("img", {
+        name: "50% complete",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/client/src/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./alert-dialog";
+
+function AlertDialogDemo({
+  open,
+  onConfirm,
+  onCancel,
+}: {
+  open?: boolean;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+const meta: Meta<typeof AlertDialogDemo> = {
+  component: AlertDialogDemo,
+  args: {
+    open: true,
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Content portals to document.body.
+export const Open: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByText("Are you absolutely sure?"),
+    ).toBeInTheDocument();
+  },
+};
+
+// The action button runs the confirm handler.
+export const Confirms: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(
+      await body.findByRole("button", {
+        name: "Continue",
+      }),
+    );
+    await expect(args.onConfirm).toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/components/ui/button.stories.tsx
+++ b/packages/client/src/components/ui/button.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { Button } from "./button";
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  args: {
+    children: "Button",
+    onClick: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Button",
+    }));
+    await expect(args.onClick).toHaveBeenCalled();
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+    children: "Secondary",
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    variant: "destructive",
+    children: "Delete",
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: "outline",
+    children: "Outline",
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: "ghost",
+    children: "Ghost",
+  },
+};
+
+export const Link: Story = {
+  args: {
+    variant: "link",
+    children: "Link",
+  },
+};
+
+// `asChild` renders the child element (here an anchor) with the button styling
+// instead of a <button>, so the rendered node is a link.
+export const AsChild: Story = {
+  args: {
+    asChild: true,
+    children: <a href="/somewhere">Link button</a>,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("link", {
+        name: "Link button",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/ui/checkbox.stories.tsx
+++ b/packages/client/src/components/ui/checkbox.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { Checkbox } from "./checkbox";
+
+const meta: Meta<typeof Checkbox> = {
+  component: Checkbox,
+  args: {
+    "aria-label": "Accept terms",
+    "onCheckedChange": fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Unchecked: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole("checkbox", {
+      name: "Accept terms",
+    });
+    await expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("checkbox")).toBeChecked();
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("checkbox")).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/ui/data-table-column-header.stories.tsx
+++ b/packages/client/src/components/ui/data-table-column-header.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Column } from "@tanstack/react-table";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { DataTableColumnHeader } from "./data-table-column-header";
+
+/**
+ * Non-generic harness that fakes the slice of the TanStack `Column` API the
+ * header actually calls, so it can be storied without wiring up a full table.
+ */
+function ColumnHeaderDemo({
+  label,
+  align,
+  hideLabel,
+  canSort = true,
+  sorted = false,
+  onToggle,
+}: {
+  label: string;
+  align?: "left" | "right";
+  hideLabel?: boolean;
+  canSort?: boolean;
+  sorted?: false | "asc" | "desc";
+  onToggle?: () => void;
+}) {
+  const column = {
+    getCanSort: () => canSort,
+    getIsSorted: () => sorted,
+    getToggleSortingHandler: () => onToggle,
+  } as unknown as Column<unknown, unknown>;
+
+  return (
+    <DataTableColumnHeader
+      column={column}
+      label={label}
+      align={align}
+      hideLabel={hideLabel}
+    />
+  );
+}
+
+const meta: Meta<typeof ColumnHeaderDemo> = {
+  component: ColumnHeaderDemo,
+  args: {
+    label: "Name",
+    onToggle: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A sortable column renders a button that toggles the column's sort.
+export const Sortable: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: /name/i,
+    }));
+    await expect(args.onToggle).toHaveBeenCalled();
+  },
+};
+
+export const SortedAscending: Story = {
+  args: {
+    sorted: "asc",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: /name/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const SortedDescending: Story = {
+  args: {
+    sorted: "desc",
+  },
+};
+
+// A non-sortable column renders a plain label, not a button.
+export const NotSortable: Story = {
+  args: {
+    canSort: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole("button")).not.toBeInTheDocument();
+    await expect(canvas.getByText("Name")).toBeInTheDocument();
+  },
+};
+
+// The label is kept for screen readers even when visually hidden.
+export const HideLabel: Story = {
+  args: {
+    hideLabel: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Name")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/ui/dialog.stories.tsx
+++ b/packages/client/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+
+function DialogDemo({
+  open,
+  onOpenChange,
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Make changes to your profile here.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose>Cancel</DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const meta: Meta<typeof DialogDemo> = {
+  component: DialogDemo,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Open: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Edit profile")).toBeInTheDocument();
+    await expect(
+      body.getByText("Make changes to your profile here."),
+    ).toBeInTheDocument();
+  },
+};
+
+// The close control requests a close via onOpenChange.
+export const ClosesOnCancel: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByText("Cancel"));
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};

--- a/packages/client/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/client/src/components/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+
+function DropdownMenuDemo({
+  onSelect,
+}: { onSelect?: () => void }) {
+  return (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>My account</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={onSelect}>Profile</DropdownMenuItem>
+        <DropdownMenuCheckboxItem checked>
+          Notifications
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const meta: Meta<typeof DropdownMenuDemo> = {
+  component: DropdownMenuDemo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Content portals to document.body and mounts async — assert with findBy* there.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("menuitem", {
+        name: "Profile",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      await body.findByRole("menuitemcheckbox", {
+        name: "Notifications",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Activating an item fires its onSelect and closes the menu.
+export const SelectsItem: Story = {
+  args: {
+    onSelect: fn(),
+  },
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Profile",
+      }),
+    );
+    await expect(args.onSelect).toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/components/ui/label.stories.tsx
+++ b/packages/client/src/components/ui/label.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { Label } from "./label";
+
+const meta = {
+  component: Label,
+  args: {
+    children: "Email address",
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Email address")).toBeInTheDocument();
+  },
+};
+
+// `htmlFor` associates the label with a control so clicking it focuses the input.
+export const WithControl: Story = {
+  args: {
+    htmlFor: "email",
+  },
+  render: args => (
+    <div className="grid gap-1.5">
+      <Label {...args} />
+      <input
+        id="email"
+        type="email"
+        className="border"
+      />
+    </div>
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText("Email address")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/ui/select.stories.tsx
+++ b/packages/client/src/components/ui/select.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+function SelectDemo({
+  open,
+  onValueChange,
+}: {
+  open?: boolean;
+  onValueChange?: (value: string) => void;
+}) {
+  return (
+    <Select
+      open={open}
+      onValueChange={onValueChange}
+    >
+      <SelectTrigger className="w-48">
+        <SelectValue placeholder="Pick a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="cherry">Cherry</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+const meta: Meta<typeof SelectDemo> = {
+  component: SelectDemo,
+  args: {
+    onValueChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Closed: only the trigger placeholder is shown.
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Pick a fruit")).toBeInTheDocument();
+  },
+};
+
+// Open: the listbox content portals to document.body; picking fires onValueChange.
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("option", {
+        name: "Apple",
+      }),
+    ).toBeInTheDocument();
+    await userEvent.click(await body.findByRole("option", {
+      name: "Banana",
+    }));
+    await expect(args.onValueChange).toHaveBeenCalledWith("banana");
+  },
+};

--- a/packages/client/src/components/ui/tabs.stories.tsx
+++ b/packages/client/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+function TabsDemo() {
+  return (
+    <Tabs
+      defaultValue="account"
+      className="w-80"
+    >
+      <TabsList>
+        <TabsTrigger value="account">Account</TabsTrigger>
+        <TabsTrigger value="password">Password</TabsTrigger>
+      </TabsList>
+      <TabsContent value="account">Account settings</TabsContent>
+      <TabsContent value="password">Password settings</TabsContent>
+    </Tabs>
+  );
+}
+
+const meta = {
+  component: TabsDemo,
+} satisfies Meta<typeof TabsDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Account settings")).toBeInTheDocument();
+  },
+};
+
+// Inactive tab content is unmounted until its trigger is selected.
+export const SwitchTab: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("tab", {
+      name: "Password",
+    }));
+    await expect(
+      await canvas.findByText("Password settings"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/ui/tooltip.stories.tsx
+++ b/packages/client/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+// `Tooltip` self-wraps a `TooltipProvider`, so no extra decorator is needed; the
+// `open` prop drives visibility (more reliable in CI than hover timing).
+function TooltipDemo({
+  open,
+}: { open?: boolean }) {
+  return (
+    <Tooltip open={open}>
+      <TooltipTrigger>Hover me</TooltipTrigger>
+      <TooltipContent>Helpful hint</TooltipContent>
+    </Tooltip>
+  );
+}
+
+const meta = {
+  component: TooltipDemo,
+} satisfies Meta<typeof TooltipDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Hover me")).toBeInTheDocument();
+    await expect(within(document.body).queryByRole("tooltip")).toBeNull();
+  },
+};
+
+// Content portals to document.body, so assert there rather than canvasElement.
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByRole("tooltip")).toHaveTextContent(
+      "Helpful hint",
+    );
+  },
+};


### PR DESCRIPTION
Add comprehensive Storybook stories for 13 UI primitive components from the shadcn/ui library and custom components, enabling visual regression testing and interactive documentation.

## Summary
This PR adds 13 new Storybook story files covering core UI primitives used throughout the application. Stories include interactive play tests that verify component behavior (click handlers, state changes, accessibility attributes) and visual states.

## Key Changes
- **Radix composite components** (`select`, `dialog`, `alert-dialog`, `dropdown-menu`, `tooltip`, `tabs`): Each uses a small non-generic `*Demo` harness as the story component to sidestep multi-export Root typing and allow spy handlers to be passed as props. Content that portals to `document.body` is asserted via `within(document.body)` rather than `canvasElement`.
- **Button variants** (`button.stories.tsx`): Tests default, secondary, destructive, outline, ghost, and link variants, plus the `asChild` prop for rendering as a link.
- **Data table column header** (`data-table-column-header.stories.tsx`): Mocks the TanStack `Column` API slice to test sortable/non-sortable states and label visibility.
- **Custom components** (`DeleteButton`, `ProgressBar`, `RadialProgress`): Test state transitions (e.g., delete confirmation flow), progress calculations, and edge cases (empty/full states, zero division).
- **Form primitives** (`checkbox`, `label`): Test checked/unchecked/disabled states and label-control association.

## Implementation Details
- All stories use Storybook's `play` function for interactive assertions via Testing Library (`expect`, `userEvent`, `within`).
- Radix components that render portals use `defaultOpen` or controlled `open` props to avoid timing issues in CI.
- Edge cases are explicitly tested (e.g., `RadialProgress` with `total: 0` to verify no division by zero).
- Accessibility is verified throughout (ARIA labels, roles, checked states).

https://claude.ai/code/session_01MZYh297bSDRQkRAE1Ub6yM