### PR TITLE
test: add Storybook stories for form fields and components

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -200,3 +200,28 @@ Tier B (need `RouterStub`): `PageHeader` (renders a section `<Link>` only when
 needs the `DropdownMenu`/`DropdownMenuContent` parent and asserts via
 `document.body`. The rest (`InfoRow`, `InfoArea`, `EditForm`, `PageTabs`,
 `ViewModeToggle`, `EditPageFooter`) are Tier A with `fn()` handlers.
+
+### formFields + forms (#354)
+The 7 TanStack-Form fields (`InputField`, `TextareaField`, `NumberField`,
+`RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) read
+`useFieldContext()`, so they need form context. Added a reusable
+**`test-utils/FormFieldHarness.tsx`**: it mounts a one-field `useAppForm` and
+renders the field via `form.AppField`. Import the field directly (there's **no
+lint ban** — `eslint.config.js` only restricts `@emstack/types/*` subpaths) and
+wrap it with the harness as a meta decorator; seed the field's value per story
+via `parameters.fieldValue` (read in the decorator) so Default/Filled/… states
+need no extra wiring. **Gotcha:** the harness `children` is a **render function**
+(`() => ReactNode`), passed straight through as `AppField`'s render prop — a
+static element hits React's same-element bailout and freezes the field on its
+initial value, so interaction `play`s (typing, selecting) never update. In a
+regular `.tsx` an inline parameterless function child also trips
+`react/no-children-prop` ("pass it as a prop") — pass the identifier
+(`{children}`), not `{() => …}` (story files are exempt via the storybook config,
+but the harness isn't). Option fixtures live in `test-utils/formFieldFixtures.ts`
+(`makeSelectOptions`, `makeGroupedSelectOptions`, `makeCreateConfig`). The two
+presentational `formFields` (`ComboboxCreatePanel`, `ComboboxAddNewRow`) are
+Tier A with `fn()` spies (`const meta: Meta<…>`). In `forms/`, `field.tsx`'s
+primitives are pure Tier A; `CourseFields` takes a whole `form`, so its story uses
+a tiny inline wrapper that builds the form and casts it
+(`as unknown as ReturnType<typeof useAppForm>`, mirroring the onboarding route)
+and types the meta against the wrapper to keep the required `form` out of args.

--- a/packages/client/src/components/formFields/ComboboxAddNewRow.stories.tsx
+++ b/packages/client/src/components/formFields/ComboboxAddNewRow.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ComboboxAddNewRow } from "./ComboboxAddNewRow";
+
+const meta: Meta<typeof ComboboxAddNewRow> = {
+  component: ComboboxAddNewRow,
+  args: {
+    itemLabel: "provider",
+    trimmedInput: "Udemy",
+    onOpenCreate: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("provider", {
+      exact: false,
+    })).toBeInTheDocument();
+    await expect(canvas.getByText("Udemy")).toBeInTheDocument();
+  },
+};
+
+/** The row commits on `mousedown` (so it fires before the combobox blur). */
+export const OpensCreate: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.pointer({
+      keys: "[MouseLeft>]",
+      target: canvas.getByRole("button"),
+    });
+    await expect(args.onOpenCreate).toHaveBeenCalledOnce();
+  },
+};

--- a/packages/client/src/components/formFields/ComboboxCreatePanel.stories.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ComboboxCreatePanel } from "./ComboboxCreatePanel";
+
+import { makeCreateConfig } from "@/test-utils/formFieldFixtures";
+
+const meta: Meta<typeof ComboboxCreatePanel> = {
+  component: ComboboxCreatePanel,
+  args: {
+    config: makeCreateConfig(),
+    initialPrimaryValue: "Udemy",
+    onCancel: fn(),
+    onSubmit: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/New/)).toBeInTheDocument();
+    await expect(canvas.getByLabelText(/Name/)).toHaveValue("Udemy");
+    await expect(
+      canvas.getByRole("button", {
+        name: "Create",
+      }),
+    ).toBeEnabled();
+  },
+};
+
+/** Clicking Create with the required field filled fires `onSubmit`. */
+export const Submitting: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Create",
+    }));
+    await expect(args.onSubmit).toHaveBeenCalledOnce();
+  },
+};
+
+/** An empty required field disables Create. */
+export const RequiredEmpty: Story = {
+  args: {
+    initialPrimaryValue: "",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Create",
+      }),
+    ).toBeDisabled();
+  },
+};
+
+export const InFlight: Story = {
+  args: {
+    submitting: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Create",
+      }),
+    ).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", {
+        name: "Cancel",
+      }),
+    ).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/formFields/ComboboxField.stories.tsx
+++ b/packages/client/src/components/formFields/ComboboxField.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { ComboboxField } from "./ComboboxField";
+
+import {
+  makeCreateConfig,
+  makeSelectOptions,
+} from "@/test-utils/formFieldFixtures";
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: ComboboxField,
+  args: {
+    label: "Topic",
+    options: makeSelectOptions(),
+    placeholder: "Search topics...",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness defaultValue={(parameters.fieldValue as string) ?? ""}>
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof ComboboxField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Topic")).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText("Search topics..."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Selected: Story = {
+  parameters: {
+    fieldValue: "course",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByDisplayValue("Course")).toBeInTheDocument();
+  },
+};
+
+/** With a `create` config the field offers an inline "add new option" flow. */
+export const WithCreate: Story = {
+  args: {
+    create: makeCreateConfig(),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByPlaceholderText("Search topics..."),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/formFields/DatePickerField.stories.tsx
+++ b/packages/client/src/components/formFields/DatePickerField.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { DatePickerField } from "./DatePickerField";
+
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: DatePickerField,
+  args: {
+    label: "Expiry date",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness
+        defaultValue={(parameters.fieldValue as Date | null) ?? null}
+      >
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof DatePickerField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** No value → the trigger shows the placeholder and there's no clear button. */
+export const Empty: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Expiry date")).toBeInTheDocument();
+    await expect(canvas.getByText("No expiry date")).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole("button", {
+        name: "Clear date",
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const WithDate: Story = {
+  parameters: {
+    fieldValue: new Date(2026, 11, 25),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(new Date(2026, 11, 25).toLocaleDateString()),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: "Clear date",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/formFields/InputField.stories.tsx
+++ b/packages/client/src/components/formFields/InputField.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { InputField } from "./InputField";
+
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: InputField,
+  args: {
+    label: "Resource name",
+    placeholder: "React 19 essentials",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness defaultValue={(parameters.fieldValue as string) ?? ""}>
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof InputField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Resource name")).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText("React 19 essentials"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Filled: Story = {
+  parameters: {
+    fieldValue: "React 19 essentials",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("textbox")).toHaveValue("React 19 essentials");
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("textbox")).toBeDisabled();
+  },
+};
+
+/** Typing updates the field value through the form's `handleChange`. */
+export const Typing: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+    await userEvent.type(input, "Clean Architecture");
+    await expect(input).toHaveValue("Clean Architecture");
+  },
+};

--- a/packages/client/src/components/formFields/MultiComboboxField.stories.tsx
+++ b/packages/client/src/components/formFields/MultiComboboxField.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { MultiComboboxField } from "./MultiComboboxField";
+
+import {
+  makeGroupedSelectOptions,
+  makeSelectOptions,
+} from "@/test-utils/formFieldFixtures";
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: MultiComboboxField,
+  args: {
+    label: "Tags",
+    options: makeSelectOptions(),
+    placeholder: "Pick tags...",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness
+        defaultValue={(parameters.fieldValue as string[]) ?? []}
+      >
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof MultiComboboxField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Tags")).toBeInTheDocument();
+    await expect(canvas.getByPlaceholderText("Pick tags...")).toBeInTheDocument();
+  },
+};
+
+/** Seeded values render as chips. */
+export const WithSelection: Story = {
+  parameters: {
+    fieldValue: ["book", "course"],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Book")).toBeInTheDocument();
+    await expect(canvas.getByText("Course")).toBeInTheDocument();
+  },
+};
+
+/** `groupByPrefix` buckets options under headers derived from their value prefix. */
+export const Grouped: Story = {
+  args: {
+    options: makeGroupedSelectOptions(),
+    groupByPrefix: true,
+  },
+};

--- a/packages/client/src/components/formFields/NumberField.stories.tsx
+++ b/packages/client/src/components/formFields/NumberField.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { NumberField } from "./NumberField";
+
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: NumberField,
+  args: {
+    label: "Progress (%)",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness
+        defaultValue={(parameters.fieldValue as number | null) ?? null}
+      >
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof NumberField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Progress (%)")).toBeInTheDocument();
+    await expect(canvas.getByRole("spinbutton")).toHaveValue(null);
+  },
+};
+
+export const WithValue: Story = {
+  parameters: {
+    fieldValue: 42,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("spinbutton")).toHaveValue(42);
+  },
+};
+
+export const Constrained: Story = {
+  args: {
+    min: 0,
+    step: "5",
+  },
+};

--- a/packages/client/src/components/formFields/RadioGroupField.stories.tsx
+++ b/packages/client/src/components/formFields/RadioGroupField.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { RadioGroupField } from "./RadioGroupField";
+
+import { makeSelectOptions } from "@/test-utils/formFieldFixtures";
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: RadioGroupField,
+  args: {
+    label: "Resource type",
+    options: makeSelectOptions(),
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness defaultValue={(parameters.fieldValue as string) ?? ""}>
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof RadioGroupField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Resource type")).toBeInTheDocument();
+    await expect(canvas.getAllByRole("radio")).toHaveLength(3);
+  },
+};
+
+export const Preselected: Story = {
+  parameters: {
+    fieldValue: "course",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("radio", {
+      name: "Course",
+    })).toBeChecked();
+  },
+};
+
+/** Selecting an option updates the field value. */
+export const Selecting: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const book = canvas.getByRole("radio", {
+      name: "Book",
+    });
+    await userEvent.click(book);
+    await expect(book).toBeChecked();
+  },
+};

--- a/packages/client/src/components/formFields/TextareaField.stories.tsx
+++ b/packages/client/src/components/formFields/TextareaField.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FileTextIcon } from "lucide-react";
+import { expect, within } from "storybook/test";
+
+import { TextareaField } from "./TextareaField";
+
+import { FormFieldHarness } from "@/test-utils/FormFieldHarness";
+
+const meta = {
+  component: TextareaField,
+  args: {
+    label: "Description",
+    placeholder: "What is this resource about?",
+  },
+  decorators: [
+    (Story, {
+      parameters,
+    }) => (
+      <FormFieldHarness defaultValue={(parameters.fieldValue as string) ?? ""}>
+        {() => (
+          <div className="max-w-sm">
+            <Story />
+          </div>
+        )}
+      </FormFieldHarness>
+    ),
+  ],
+} satisfies Meta<typeof TextareaField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Description")).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText("What is this resource about?"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Filled: Story = {
+  parameters: {
+    fieldValue: "A deep dive into the React 19 compiler and Actions API.",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("textbox")).toHaveValue(
+      "A deep dive into the React 19 compiler and Actions API.",
+    );
+  },
+};
+
+export const WithLabelIcon: Story = {
+  args: {
+    labelIcon: <FileTextIcon className="size-4" />,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Description")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/forms/CourseFields.stories.tsx
+++ b/packages/client/src/components/forms/CourseFields.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { CourseFields } from "./CourseFields";
+
+import { useAppForm } from "@/hooks/useAppForm";
+
+/**
+ * `CourseFields` takes a whole `form`, so it can't use the single-field
+ * `FormFieldHarness`. This wrapper builds a real form (matching the `course0Name`
+ * / `course0Url` fields it renders) and bridges TanStack Form's invariant
+ * generics the same way the onboarding route does.
+ */
+function CourseFieldsHarness({
+  condition,
+  name,
+  label,
+}: {
+  condition: boolean;
+  name: string;
+  label: string;
+}) {
+  const form = useAppForm({
+    defaultValues: {
+      course0Name: "",
+      course0Url: "",
+    },
+  });
+  return (
+    <CourseFields
+      form={form as unknown as ReturnType<typeof useAppForm>}
+      condition={condition}
+      name={name}
+      label={label}
+    />
+  );
+}
+
+// Typed against the harness (which renders the real `CourseFields` below) so the
+// required `form` prop stays out of the story args — it's supplied internally.
+const meta = {
+  component: CourseFieldsHarness,
+  args: {
+    condition: true,
+    name: "course0",
+    label: "React",
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CourseFieldsHarness>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("React")).toBeInTheDocument();
+    await expect(canvas.getByText("Resource Name")).toBeInTheDocument();
+    await expect(canvas.getByText("Resource URL")).toBeInTheDocument();
+  },
+};
+
+/** When `condition` is false the section renders nothing. */
+export const Hidden: Story = {
+  args: {
+    condition: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText("Resource Name")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/forms/field.stories.tsx
+++ b/packages/client/src/components/forms/field.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "./field";
+
+import { Input } from "@/components/input";
+
+const meta = {
+  component: Field,
+  decorators: [
+    Story => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Field>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A labelled field with a description — the building block every form field wraps. */
+export const Default: Story = {
+  render: () => (
+    <Field>
+      <FieldLabel htmlFor="resource-name">Resource name</FieldLabel>
+      <Input
+        id="resource-name"
+        placeholder="React 19 essentials"
+      />
+      <FieldDescription>The title shown across the app.</FieldDescription>
+    </Field>
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Resource name")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("The title shown across the app."),
+    ).toBeInTheDocument();
+  },
+};
+
+/** Invalid state: `data-invalid` tints the field and `FieldError` renders messages. */
+export const Invalid: Story = {
+  render: () => (
+    <Field data-invalid={true}>
+      <FieldLabel htmlFor="resource-name-invalid">Resource name</FieldLabel>
+      <Input
+        id="resource-name-invalid"
+        aria-invalid={true}
+      />
+      <FieldError
+        errors={[{
+          message: "Name is required",
+        }]}
+      />
+    </Field>
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("alert")).toHaveTextContent(
+      "Name is required",
+    );
+  },
+};
+
+/** Multiple related fields grouped under a legend. */
+export const Grouped: Story = {
+  render: () => (
+    <FieldSet>
+      <FieldLegend>Resource details</FieldLegend>
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="name">Name</FieldLabel>
+          <Input id="name" />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="url">URL</FieldLabel>
+          <Input id="url" />
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Resource details")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Name")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("URL")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/test-utils/FormFieldHarness.tsx
+++ b/packages/client/src/test-utils/FormFieldHarness.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+import { useAppForm } from "@/hooks/useAppForm";
+import { FieldChangeHighlightContext } from "@/utils/fieldChangeHighlight";
+
+/**
+ * Provides TanStack-Form field context for a single field so the
+ * `components/formFields/*` components — which read `useFieldContext()` and crash
+ * without a form around them — can be rendered in isolation (stories and tests).
+ *
+ * It mounts a one-field form (`useAppForm`) and renders `children` inside
+ * `form.AppField`, which supplies the field context. A directly-imported field
+ * (e.g. `<InputField label="…" />`) returned from `children` therefore gets a
+ * real field API, so value seeding and typing interactions work.
+ *
+ * `children` is a **render function** (not an element): `form.AppField`
+ * re-invokes it on every field-state change, so a controlled field re-renders
+ * with the new value when the user interacts. Passing a static element instead
+ * would hit React's same-element bailout and freeze the field on its initial value.
+ *
+ * `defaultValue` seeds the field's value/type (string, number, Date, string[], …)
+ * — pass it per story to render Default/Filled/… states. Set `highlightChanges`
+ * to exercise the changed-field tint (`FieldChangeHighlightContext`).
+ */
+export function FormFieldHarness<TValue>({
+  defaultValue,
+  highlightChanges = false,
+  children,
+}: {
+  defaultValue: TValue;
+  highlightChanges?: boolean;
+  children: () => ReactNode;
+}) {
+  const form = useAppForm({
+    defaultValues: {
+      field: defaultValue,
+    },
+  });
+
+  // `children` is passed straight through as `AppField`'s render prop (an
+  // identifier, not an inline function) so it is re-invoked on each field-state
+  // change. It ignores the `field` arg — the field components read context themselves.
+  const content = <form.AppField name="field">{children}</form.AppField>;
+
+  return highlightChanges
+    ? (
+      <FieldChangeHighlightContext.Provider value={true}>
+        {content}
+      </FieldChangeHighlightContext.Provider>
+    )
+    : (
+      content
+    );
+}

--- a/packages/client/src/test-utils/formFieldFixtures.ts
+++ b/packages/client/src/test-utils/formFieldFixtures.ts
@@ -1,0 +1,71 @@
+import type { CreateConfig } from "@/components/formFields/ComboboxCreatePanel";
+import type { SelectOption } from "@/utils";
+
+const DEFAULT_OPTIONS: SelectOption[] = [
+  {
+    value: "book",
+    label: "Book",
+  },
+  {
+    value: "course",
+    label: "Course",
+  },
+  {
+    value: "article",
+    label: "Article",
+  },
+  {
+    value: "video",
+    label: "Video",
+  },
+];
+
+/** Mock `SelectOption[]` for radio/combobox stories (defaults to 3). */
+export function makeSelectOptions(count = 3): SelectOption[] {
+  return DEFAULT_OPTIONS.slice(0, count);
+}
+
+/**
+ * Mock `SelectOption[]` whose values carry a `prefix:` so a grouped combobox
+ * (`groupByPrefix`) buckets them under group headers.
+ */
+export function makeGroupedSelectOptions(): SelectOption[] {
+  return [
+    {
+      value: "lang:typescript",
+      label: "lang:TypeScript",
+    },
+    {
+      value: "lang:rust",
+      label: "lang:Rust",
+    },
+    {
+      value: "tool:vite",
+      label: "tool:Vite",
+    },
+  ];
+}
+
+/** Mock inline-create config for the combobox "create new option" flow. */
+export function makeCreateConfig(
+  overrides: Partial<CreateConfig> = {},
+): CreateConfig {
+  return {
+    itemLabel: "provider",
+    fields: [
+      {
+        name: "name",
+        label: "Name",
+        required: true,
+        isPrimary: true,
+      },
+      {
+        name: "url",
+        label: "URL",
+        type: "url",
+      },
+    ],
+    onCreate: () => Promise.resolve("new-id"),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
Added comprehensive Storybook stories for form field components and related UI elements, along with test utilities to support isolated component rendering in stories.

## Key Changes

- **Form field stories** (`packages/client/src/components/formFields/*.stories.tsx`):
  - `InputField.stories.tsx` — Default, Filled, Disabled, and Typing interaction states
  - `TextareaField.stories.tsx` — Default, Filled, and WithLabelIcon variants
  - `NumberField.stories.tsx` — Empty, WithValue, and Constrained states
  - `DatePickerField.stories.tsx` — Empty and WithDate states
  - `RadioGroupField.stories.tsx` — Default, Preselected, and Selecting interaction
  - `ComboboxField.stories.tsx` — Default, Selected, and WithCreate variants
  - `MultiComboboxField.stories.tsx` — Empty, WithSelection, and Grouped states
  - `ComboboxAddNewRow.stories.tsx` — Default and OpensCreate interaction
  - `ComboboxCreatePanel.stories.tsx` — Default, Submitting, RequiredEmpty, and InFlight states

- **Form layout stories** (`packages/client/src/components/forms/*.stories.tsx`):
  - `field.stories.tsx` — Field, FieldLabel, FieldDescription, FieldError, FieldGroup, FieldLegend, FieldSet components with Default, Invalid, and Grouped examples
  - `CourseFields.stories.tsx` — Multi-field form section with Default and Hidden states

- **Test utilities** (`packages/client/src/test-utils/`):
  - `FormFieldHarness.tsx` — Reusable wrapper that mounts a one-field `useAppForm` and renders fields via `form.AppField`, enabling isolated field testing/stories without a full form. Supports value seeding via `parameters.fieldValue` and optional field-change highlighting.
  - `formFieldFixtures.ts` — Mock data generators: `makeSelectOptions()`, `makeGroupedSelectOptions()`, and `makeCreateConfig()` for consistent test data across stories

## Implementation Details

- **FormFieldHarness design:** The harness accepts `children` as a **render function** (not an element) so it's re-invoked on each field-state change, allowing controlled interactions (typing, selection) to update the rendered field. This avoids React's same-element bailout that would freeze the field on its initial value.

- **Story patterns:** Form field stories use the harness as a meta decorator and seed field values via `parameters.fieldValue` (read in the decorator), keeping story definitions clean and enabling Default/Filled/… states without extra wiring.

- **Interaction testing:** Stories include `play` functions with Storybook's test utilities (`expect`, `userEvent`, `within`) to verify rendering, user interactions (typing, clicking, selecting), and state changes.

- **No lint restrictions:** Form field components are imported directly in stories (no `@emstack/types/*` subpath restriction applies to them).

https://claude.ai/code/session_015P35LNaoepKHn65XMAaQ1k