### PR TITLE
test(resources): fixes #355: add Storybook stories for module/interaction components

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -240,3 +240,22 @@ primitives are pure Tier A; `CourseFields` takes a whole `form`, so its story us
 a tiny inline wrapper that builds the form and casts it
 (`as unknown as ReturnType<typeof useAppForm>`, mirroring the onboarding route)
 and types the meta against the wrapper to keep the required `form` out of args.
+
+### resources (#355)
+All 10 covered. New fixture file `test-utils/resourceModulesFixtures.ts`
+(`makeTag`/`makeTagGroup`/`makeTagGroups`/`makeModule`/`makeModuleGroup`/
+`makeInteraction`, defaults keyed to `resourceId: "resource-1"`). Reuse the
+draft factories from `resources/moduleDrafts` (`emptyGroupDraft`, `groupToDraft`,
+`emptyModuleDraft`, `moduleToDraft`) for the edit-card drafts — don't hand-roll.
+Tier A (no decorator): `OptionalSelectField`, `LevelTriad`, `ModuleDisplayRow`
+(host in a `<ul>`), `LevelAndTagsFields`, `GroupEditCard`, `ModuleEditCard` — the
+last three pull in `TagPicker` (Base UI `Combobox`), which is self-contained, so
+just don't open the combobox in `play`. Tier B: `InteractionQuickLog` +
+`ModuleSuggestDialog` need only a bare `QueryStub` (mutations, no reads — don't
+fire the submit so the real network mutation never runs); `ModuleSuggestDialog`
+is a Radix `Dialog` so set `open: true` and assert via `within(document.body)`.
+`ResourceInteractionsLog` and `ResourceModulesAdmin` read through hooks
+(`useInteractionsLog` / `useResourceModules`), so seed a `QueryClient`
+(`staleTime: Infinity`) for their keys — interactions/moduleGroups/modules, plus
+`tagGroups.list()` and `resources.detail()` for the admin — and pass it as the
+`QueryStub client`. Neither renders a `<Link>` (plain `<a>`), so no `RouterStub`.

--- a/packages/client/src/components/resources/GroupEditCard.stories.tsx
+++ b/packages/client/src/components/resources/GroupEditCard.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { GroupEditCard } from "./GroupEditCard";
+import { emptyGroupDraft, groupToDraft } from "./moduleDrafts";
+
+import {
+  makeModuleGroup,
+  makeTagGroups,
+} from "@/test-utils/resourceModulesFixtures";
+
+const meta: Meta<typeof GroupEditCard> = {
+  component: GroupEditCard,
+  args: {
+    draft: emptyGroupDraft(),
+    hasEnumeratedModules: false,
+    tagGroups: makeTagGroups(),
+    isNew: true,
+    isSaving: false,
+    onSave: fn(),
+    onCancel: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const New: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Group Name")).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText("e.g. Section 1: Fundamentals"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Editing: Story = {
+  args: {
+    draft: groupToDraft(
+      makeModuleGroup({
+        name: "Section 2: Advanced",
+        totalCount: 8,
+        completedCount: 3,
+      }),
+    ),
+    isNew: false,
+    onDelete: fn(),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("Section 2: Advanced"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: "Remove Group",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/resources/InteractionQuickLog.stories.tsx
+++ b/packages/client/src/components/resources/InteractionQuickLog.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { InteractionQuickLog } from "./InteractionQuickLog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+
+const meta: Meta<typeof InteractionQuickLog> = {
+  component: InteractionQuickLog,
+  args: {
+    resourceId: "resource-1",
+    scopeLabel: "module: Getting Started",
+    onCancel: fn(),
+    onSaved: fn(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub>
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  // Clicking Cancel (not submit) avoids firing the real network mutation.
+  play: async ({
+    args,
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("module: Getting Started"),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+export const NoScope: Story = {
+  args: {
+    scopeLabel: undefined,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Log",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/resources/LevelAndTagsFields.stories.tsx
+++ b/packages/client/src/components/resources/LevelAndTagsFields.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { LevelAndTagsFields } from "./LevelAndTagsFields";
+
+import { makeTagGroups } from "@/test-utils/resourceModulesFixtures";
+
+const meta: Meta<typeof LevelAndTagsFields> = {
+  component: LevelAndTagsFields,
+  args: {
+    draft: {
+      easeOfStarting: "",
+      timeNeeded: "",
+      interactivity: "",
+      tagIds: [],
+    },
+    tagGroups: makeTagGroups(),
+    onChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Tags")).toBeInTheDocument();
+    await expect(canvas.getByText("Ease of Starting")).toBeInTheDocument();
+  },
+};
+
+export const Prefilled: Story = {
+  args: {
+    draft: {
+      easeOfStarting: "low",
+      timeNeeded: "medium",
+      interactivity: "high",
+      tagIds: ["tag-1-a"],
+    },
+  },
+};

--- a/packages/client/src/components/resources/LevelTriad.stories.tsx
+++ b/packages/client/src/components/resources/LevelTriad.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { LevelTriad } from "./LevelTriad";
+
+const meta: Meta<typeof LevelTriad> = {
+  component: LevelTriad,
+  args: {
+    easeOfStarting: "",
+    timeNeeded: "",
+    interactivity: "",
+    onChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Ease of Starting")).toBeInTheDocument();
+    await expect(canvas.getByText("Time Needed")).toBeInTheDocument();
+    await expect(canvas.getByText("Interactivity")).toBeInTheDocument();
+  },
+};
+
+export const AllSet: Story = {
+  args: {
+    easeOfStarting: "low",
+    timeNeeded: "medium",
+    interactivity: "high",
+  },
+};

--- a/packages/client/src/components/resources/ModuleDisplayRow.stories.tsx
+++ b/packages/client/src/components/resources/ModuleDisplayRow.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { ModuleDisplayRow } from "./ModuleDisplayRow";
+
+import { makeModule } from "@/test-utils/resourceModulesFixtures";
+
+const meta: Meta<typeof ModuleDisplayRow> = {
+  component: ModuleDisplayRow,
+  args: {
+    module: makeModule(),
+    isAnyEditing: false,
+    isReordering: false,
+    canMoveUp: true,
+    canMoveDown: true,
+    onMoveUp: fn(),
+    onMoveDown: fn(),
+    onToggleComplete: fn(),
+    onEdit: fn(),
+    onLogInteraction: fn(),
+    isToggling: false,
+  },
+  // The component renders an <li>, so host it in a <ul>.
+  decorators: [
+    Story => (
+      <ul className="max-w-md rounded-md border">
+        <Story />
+      </ul>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Getting Started")).toBeInTheDocument();
+    await expect(canvas.getByRole("checkbox")).not.toBeChecked();
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    module: makeModule({
+      isComplete: true,
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("checkbox")).toBeChecked();
+  },
+};
+
+export const RangeLength: Story = {
+  args: {
+    module: makeModule({
+      length: "long",
+    }),
+  },
+};

--- a/packages/client/src/components/resources/ModuleEditCard.stories.tsx
+++ b/packages/client/src/components/resources/ModuleEditCard.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { emptyModuleDraft, moduleToDraft } from "./moduleDrafts";
+import { ModuleEditCard } from "./ModuleEditCard";
+
+import {
+  makeModule,
+  makeTagGroups,
+} from "@/test-utils/resourceModulesFixtures";
+
+const meta: Meta<typeof ModuleEditCard> = {
+  component: ModuleEditCard,
+  args: {
+    draft: emptyModuleDraft(),
+    tagGroups: makeTagGroups(),
+    isNew: true,
+    isComplete: false,
+    isSaving: false,
+    onSave: fn(),
+    onCancel: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const New: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Module Name")).toBeInTheDocument();
+  },
+};
+
+export const Editing: Story = {
+  args: {
+    draft: moduleToDraft(
+      makeModule({
+        name: "Variables and Types",
+        length: "45",
+      }),
+    ),
+    isNew: false,
+    onDelete: fn(),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("Variables and Types"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const RangeLength: Story = {
+  args: {
+    draft: moduleToDraft(
+      makeModule({
+        name: "Deep Dive",
+        length: "long",
+      }),
+    ),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Range",
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+  },
+};

--- a/packages/client/src/components/resources/ModuleSuggestDialog.stories.tsx
+++ b/packages/client/src/components/resources/ModuleSuggestDialog.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ModuleSuggestDialog } from "./ModuleSuggestDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+
+const meta: Meta<typeof ModuleSuggestDialog> = {
+  component: ModuleSuggestDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    resourceId: "resource-1",
+    resourceName: "Intro to TypeScript",
+    resourceDescription: "A practical introduction.",
+    resourceUrl: "https://example.com/course",
+    providerName: "Acme Learning",
+    topicNames: ["TypeScript", "Tooling"],
+    existingGroupNames: [],
+    existingUngroupedModuleNames: [],
+    onApplied: fn(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  // The Radix DialogContent portals to document.body, so assert against it
+  // rather than the canvas element.
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByText("LLM Assist — Modules for \"Intro to TypeScript\""),
+    ).toBeInTheDocument();
+    await expect(
+      body.getByRole("button", {
+        name: "Parse and Review",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const ReviewState: Story = {
+  // Paste a valid suggestion JSON and parse it to reach the review step.
+  play: async () => {
+    const body = within(document.body);
+    const textarea = await body.findByPlaceholderText(
+      "{\"moduleGroups\": [...], \"ungroupedModules\": [...], \"notes\": null}",
+    );
+    await userEvent.click(textarea);
+    await userEvent.paste(
+      JSON.stringify({
+        moduleGroups: [
+          {
+            name: "Basics",
+            description: "Start here.",
+            location: null,
+            modules: [
+              {
+                name: "Hello World",
+                description: null,
+                location: null,
+                length: "short",
+              },
+            ],
+          },
+        ],
+        ungroupedModules: [],
+        notes: null,
+      }),
+    );
+    await userEvent.click(
+      body.getByRole("button", {
+        name: "Parse and Review",
+      }),
+    );
+    await expect(await body.findByText("Basics")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/resources/OptionalSelectField.stories.tsx
+++ b/packages/client/src/components/resources/OptionalSelectField.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { OptionalSelectField } from "./OptionalSelectField";
+
+const meta: Meta<typeof OptionalSelectField> = {
+  component: OptionalSelectField,
+  args: {
+    label: "Difficulty (optional)",
+    value: "",
+    options: ["easy", "medium", "hard"],
+    onValueChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xs">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("Difficulty (optional)"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("option", {
+        name: "medium",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: "hard",
+  },
+};

--- a/packages/client/src/components/resources/ResourceInteractionsLog.stories.tsx
+++ b/packages/client/src/components/resources/ResourceInteractionsLog.stories.tsx
@@ -1,0 +1,105 @@
+import type { Interaction } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { ResourceInteractionsLog } from "./ResourceInteractionsLog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeInteraction } from "@/test-utils/resourceModulesFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+const RESOURCE_ID = "resource-1";
+
+// Build a QueryClient seeded with the data `useInteractionsLog` reads via
+// useQuery, so the log renders its loaded state without a network call.
+// staleTime Infinity stops a background (networkless) refetch from clobbering
+// the seeded entries in the story environment.
+function seededClient(interactions: Interaction[]): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(
+    queryKeys.resources.interactions(RESOURCE_ID),
+    interactions,
+  );
+  client.setQueryData(queryKeys.resources.moduleGroups(RESOURCE_ID), []);
+  client.setQueryData(queryKeys.resources.modules(RESOURCE_ID), []);
+  return client;
+}
+
+const meta = {
+  component: ResourceInteractionsLog,
+  args: {
+    resourceId: RESOURCE_ID,
+  },
+} satisfies Meta<typeof ResourceInteractionsLog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient([])}>
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("No interactions logged yet."),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: "Log Interaction",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const WithInteractions: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededClient([
+          makeInteraction({
+            id: "i1",
+            date: "2026-06-12",
+            progress: "started",
+            note: "Read chapter 1.",
+          }),
+          makeInteraction({
+            id: "i2",
+            date: "2026-06-10",
+            progress: "complete",
+            note: "Finished the intro.",
+          }),
+        ])}
+      >
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Read chapter 1.")).toBeInTheDocument();
+    await expect(canvas.getByText("Finished the intro.")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/resources/ResourceModulesAdmin.stories.tsx
+++ b/packages/client/src/components/resources/ResourceModulesAdmin.stories.tsx
@@ -1,0 +1,144 @@
+import type { Module, ModuleGroup, Resource } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { ResourceModulesAdmin } from "./ResourceModulesAdmin";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import {
+  makeModule,
+  makeModuleGroup,
+  makeTagGroups,
+} from "@/test-utils/resourceModulesFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+const RESOURCE_ID = "resource-1";
+
+// The detail query only feeds the (closed) LLM-assist dialog's props, which read
+// it via optional chaining — a minimal resource is plenty.
+const resourceDetail: Resource = {
+  id: RESOURCE_ID,
+  name: "Intro to TypeScript",
+  description: "A practical introduction.",
+  url: "https://example.com/course",
+  cost: {
+    cost: "0",
+    isCostFromPlatform: false,
+    splitBy: 1,
+  },
+  progressCurrent: 0,
+  progressTotal: 0,
+  status: "active",
+  topics: [],
+};
+
+// Seed everything `useResourceModules` reads via useQuery so the admin renders
+// without any network call. staleTime Infinity keeps the seeded entries fresh.
+function seededClient(seed: {
+  groups: ModuleGroup[];
+  modules: Module[];
+}): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.resources.moduleGroups(RESOURCE_ID), seed.groups);
+  client.setQueryData(queryKeys.resources.modules(RESOURCE_ID), seed.modules);
+  client.setQueryData(queryKeys.tagGroups.list(), makeTagGroups());
+  client.setQueryData(queryKeys.resources.detail(RESOURCE_ID), resourceDetail);
+  return client;
+}
+
+const meta = {
+  component: ResourceModulesAdmin,
+  args: {
+    resourceId: RESOURCE_ID,
+  },
+} satisfies Meta<typeof ResourceModulesAdmin>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededClient({
+          groups: [],
+          modules: [],
+        })}
+      >
+        <div className="max-w-2xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No modules yet\./)).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: "LLM Assist",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Populated: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededClient({
+          groups: [
+            makeModuleGroup({
+              id: "g1",
+              name: "Section 1: Fundamentals",
+            }),
+          ],
+          modules: [
+            makeModule({
+              id: "m1",
+              moduleGroupId: "g1",
+              name: "Variables",
+              isComplete: true,
+            }),
+            makeModule({
+              id: "m2",
+              moduleGroupId: "g1",
+              name: "Functions",
+            }),
+            makeModule({
+              id: "m3",
+              moduleGroupId: null,
+              name: "Standalone intro",
+            }),
+          ],
+        })}
+      >
+        <div className="max-w-2xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("Section 1: Fundamentals"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Variables")).toBeInTheDocument();
+    await expect(canvas.getByText("Standalone intro")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/test-utils/resourceModulesFixtures.ts
+++ b/packages/client/src/test-utils/resourceModulesFixtures.ts
@@ -1,0 +1,128 @@
+import type {
+  Interaction,
+  Module,
+  ModuleGroup,
+  Tag,
+  TagGroup,
+} from "@emstack/types";
+
+/**
+ * Mock-data builders for the resource-detail module / interaction admin stories
+ * (`components/resources/*`). Each `make*` takes a partial override and fills in
+ * sensible defaults so a story only specifies the fields it cares about. Mirrors
+ * the pattern in `boxFixtures.ts`. Defaults share `resourceId: "resource-1"` so
+ * they line up with the `resourceId` the stories seed their query cache against.
+ */
+
+export function makeTag(overrides: Partial<Tag> = {}): Tag {
+  return {
+    id: "tag-1",
+    groupId: "tag-group-1",
+    name: "fundamentals",
+    color: null,
+    position: 0,
+    ...overrides,
+  };
+}
+
+export function makeTagGroup(overrides: Partial<TagGroup> = {}): TagGroup {
+  return {
+    id: "tag-group-1",
+    name: "Topics",
+    description: null,
+    color: null,
+    position: 0,
+    tags: [
+      makeTag({
+        id: "tag-1-a",
+        name: "fundamentals",
+      }),
+      makeTag({
+        id: "tag-1-b",
+        name: "advanced",
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+export function makeTagGroups(count = 2): TagGroup[] {
+  return Array.from(
+    {
+      length: count,
+    },
+    (_, i) =>
+      makeTagGroup({
+        id: `tag-group-${i + 1}`,
+        name: `Tag Group ${i + 1}`,
+        tags: [
+          makeTag({
+            id: `tag-${i + 1}-a`,
+            groupId: `tag-group-${i + 1}`,
+            name: `tag-${i + 1}a`,
+          }),
+          makeTag({
+            id: `tag-${i + 1}-b`,
+            groupId: `tag-group-${i + 1}`,
+            name: `tag-${i + 1}b`,
+          }),
+        ],
+      }),
+  );
+}
+
+export function makeModule(overrides: Partial<Module> = {}): Module {
+  return {
+    id: "module-1",
+    resourceId: "resource-1",
+    moduleGroupId: null,
+    name: "Getting Started",
+    description: "An overview of the basics.",
+    url: "https://example.com/module",
+    length: "30",
+    isComplete: false,
+    position: 0,
+    easeOfStarting: "low",
+    timeNeeded: "medium",
+    interactivity: "high",
+    tags: [],
+    ...overrides,
+  };
+}
+
+export function makeModuleGroup(
+  overrides: Partial<ModuleGroup> = {},
+): ModuleGroup {
+  return {
+    id: "module-group-1",
+    resourceId: "resource-1",
+    name: "Section 1: Fundamentals",
+    description: "The core concepts.",
+    url: null,
+    position: 0,
+    totalCount: null,
+    completedCount: null,
+    easeOfStarting: "low",
+    timeNeeded: "medium",
+    interactivity: "high",
+    tags: [],
+    ...overrides,
+  };
+}
+
+export function makeInteraction(
+  overrides: Partial<Interaction> = {},
+): Interaction {
+  return {
+    id: "interaction-1",
+    resourceId: "resource-1",
+    moduleGroupId: null,
+    moduleId: null,
+    date: "2026-06-12",
+    progress: "started",
+    note: "Worked through the intro.",
+    difficulty: "medium",
+    understanding: "comfortable",
+    ...overrides,
+  };
+}

--- a/packages/client/src/test-utils/resourceModulesFixtures.ts
+++ b/packages/client/src/test-utils/resourceModulesFixtures.ts
@@ -14,7 +14,7 @@ import type {
  * they line up with the `resourceId` the stories seed their query cache against.
  */
 
-export function makeTag(overrides: Partial<Tag> = {}): Tag {
+function makeTag(overrides: Partial<Tag> = {}): Tag {
   return {
     id: "tag-1",
     groupId: "tag-group-1",
@@ -25,7 +25,7 @@ export function makeTag(overrides: Partial<Tag> = {}): Tag {
   };
 }
 
-export function makeTagGroup(overrides: Partial<TagGroup> = {}): TagGroup {
+function makeTagGroup(overrides: Partial<TagGroup> = {}): TagGroup {
   return {
     id: "tag-group-1",
     name: "Topics",


### PR DESCRIPTION
Add comprehensive Storybook coverage for the resource modules and interactions admin UI, including a new shared fixture library for consistent mock data across stories.

## Summary
This PR adds 10 new Storybook stories covering the resource management components (`ResourceModulesAdmin`, `ResourceInteractionsLog`, `ModuleSuggestDialog`, `ModuleEditCard`, `GroupEditCard`, `ModuleDisplayRow`, `InteractionQuickLog`, `LevelAndTagsFields`, `OptionalSelectField`, `LevelTriad`) and introduces a reusable fixture library (`resourceModulesFixtures.ts`) for generating mock `Module`, `ModuleGroup`, `Interaction`, `Tag`, and `TagGroup` objects with sensible defaults.

## Key Changes
- **New fixture file:** `packages/client/src/test-utils/resourceModulesFixtures.ts`
  - Provides `makeModule()`, `makeModuleGroup()`, `makeInteraction()`, `makeTag()`, `makeTagGroup()`, and `makeTagGroups()` builders
  - All fixtures default to `resourceId: "resource-1"` for consistency with story query cache seeding
  - Mirrors the pattern established in `boxFixtures.ts`

- **New story files (10 total):**
  - `ResourceModulesAdmin.stories.tsx` — Empty and Populated states with module groups and standalone modules
  - `ResourceInteractionsLog.stories.tsx` — Empty and WithInteractions states
  - `ModuleSuggestDialog.stories.tsx` — Default and ReviewState (JSON parsing flow)
  - `ModuleEditCard.stories.tsx` — New, Editing, and RangeLength variants
  - `GroupEditCard.stories.tsx` — New and Editing states with delete action
  - `ModuleDisplayRow.stories.tsx` — Default, Complete, and RangeLength states
  - `InteractionQuickLog.stories.tsx` — Default and NoScope variants
  - `LevelAndTagsFields.stories.tsx` — Default and Prefilled states
  - `OptionalSelectField.stories.tsx` — Default and WithValue states
  - `LevelTriad.stories.tsx` — Empty and AllSet states

- **Story patterns:**
  - Tier A components (no special decorators): `OptionalSelectField`, `LevelTriad`, `ModuleDisplayRow`, `LevelAndTagsFields`, `GroupEditCard`, `ModuleEditCard`
  - Tier B components (with `QueryStub` decorator): `ResourceModulesAdmin`, `ResourceInteractionsLog`, `InteractionQuickLog`, `ModuleSuggestDialog`
  - Query cache seeding with `staleTime: Infinity` to prevent background refetches in the story environment
  - Play functions with `expect()` assertions to verify rendered content

## Implementation Details
- Reuses draft factories from `resources/moduleDrafts` (`emptyGroupDraft`, `groupToDraft`, `emptyModuleDraft`, `moduleToDraft`) rather than hand-rolling test data
- Stories that require query data use a `seededClient()` helper to pre-populate the QueryClient with mock data
- Radix `DialogContent` portals are asserted against `document.body` rather than the canvas element
- Module length can be either a numeric string (e.g., `"30"`) or a range label (e.g., `"long"`)
- Updated `.claude/skills/add-stories/SKILL.md` with resources component coverage notes

https://claude.ai/code/session_019GNUeuJKQ3Aaqdwn4AqAbX