### PR TITLE
refactor(client): extract DashboardIntegrationCard component

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.tsx
@@ -2,14 +2,11 @@ import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { GoogleCalendarEvent } from "@emstack/types";
 
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 
 import {
-  CardSettingsFlyout,
-  DashboardCard,
-  DashboardSectionStatus,
-  isAutoHeight,
+  DashboardIntegrationCard,
   queryKeys,
+  SettingsLink,
 } from "./-cardKit";
 import { formatEventTime, groupEventsByDay } from "./-googleCalendarAgenda";
 
@@ -78,84 +75,52 @@ export function DashboardGoogleCalendar({
   const groups = groupEventsByDay(events, new Date());
 
   return (
-    <DashboardCard
-      autoHeight={isAutoHeight(tile)}
+    <DashboardIntegrationCard
+      tile={tile}
+      onUpdateTile={onUpdateTile}
       title="Calendar"
-      settings={(
-        <CardSettingsFlyout
-          tile={tile}
-          onUpdateTile={onUpdateTile}
+      settingsLink={(
+        <SettingsLink className="text-sm">Manage calendars</SettingsLink>
+      )}
+      configured={configured}
+      isPending={isPending}
+      error={error}
+      connectPrompt={(
+        <p className="text-sm text-muted-foreground">
+          Add a calendar feed in
+          {" "}
+          <SettingsLink>Settings</SettingsLink>
+          {" "}
+          to see your upcoming events.
+        </p>
+      )}
+      isEmpty={configured && events.length === 0}
+      entity="events"
+      emptyMessage="No upcoming events."
+    >
+      {groups.map(group => (
+        <div
+          key={group.dateKey}
+          className="flex flex-col gap-1"
         >
-          <Link
-            to="/settings"
-            search={{
-              tab: "connections",
-            }}
+          <h3
             className="
-              text-sm text-primary underline-offset-2
-              hover:underline
+              text-xs font-semibold tracking-wide text-muted-foreground
+              uppercase
             "
           >
-            Manage calendars
-          </Link>
-        </CardSettingsFlyout>
-      )}
-    >
-      {!isPending && !error && !configured
-        ? (
-          <p className="text-sm text-muted-foreground">
-            Add a calendar feed in
-            {" "}
-            <Link
-              to="/settings"
-              search={{
-                tab: "connections",
-              }}
-              className="
-                text-primary underline-offset-2
-                hover:underline
-              "
-            >
-              Settings
-            </Link>
-            {" "}
-            to see your upcoming events.
-          </p>
-        )
-        : (
-          <>
-            <DashboardSectionStatus
-              isPending={isPending}
-              error={error}
-              isEmpty={configured && events.length === 0}
-              entity="events"
-              emptyMessage="No upcoming events."
-            />
-            {groups.map(group => (
-              <div
-                key={group.dateKey}
-                className="flex flex-col gap-1"
-              >
-                <h3
-                  className="
-                    text-xs font-semibold tracking-wide text-muted-foreground
-                    uppercase
-                  "
-                >
-                  {group.label}
-                </h3>
-                <ul className="flex flex-col divide-y">
-                  {group.events.map(event => (
-                    <EventRow
-                      key={`${event.calendarId}:${event.id}`}
-                      event={event}
-                    />
-                  ))}
-                </ul>
-              </div>
+            {group.label}
+          </h3>
+          <ul className="flex flex-col divide-y">
+            {group.events.map(event => (
+              <EventRow
+                key={`${event.calendarId}:${event.id}`}
+                event={event}
+              />
             ))}
-          </>
-        )}
-    </DashboardCard>
+          </ul>
+        </div>
+      ))}
+    </DashboardIntegrationCard>
   );
 }

--- a/packages/client/src/routes/dashboard.-components/-DashboardIntegrationCard.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardIntegrationCard.tsx
@@ -1,0 +1,121 @@
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
+
+import { Link } from "@tanstack/react-router";
+
+import { CardSettingsFlyout } from "./-DashboardCardSettings";
+
+import {
+  DashboardCard,
+  DashboardSectionStatus,
+} from "@/components/contentBoxComponents/DashboardCard";
+import { isAutoHeight } from "@/lib/dashboardTiles";
+import { cn } from "@/lib/utils";
+
+/**
+ * Link to the connections tab of Settings, shared by the integration tiles for
+ * both the flyout "manage" link and the not-configured prompt. Pass `className`
+ * to extend the base styling (e.g. `text-sm` in the flyout header).
+ */
+export function SettingsLink({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      to="/settings"
+      search={{
+        tab: "connections",
+      }}
+      className={cn(`
+        text-primary underline-offset-2
+        hover:underline
+      `, className)}
+    >
+      {children}
+    </Link>
+  );
+}
+
+interface DashboardIntegrationCardProps extends DashboardTileProps {
+  title: React.ReactNode;
+  /** Optional header button (e.g. "Open Reader"); omitted by Calendar. */
+  action?: React.ReactNode;
+  /** Extra controls rendered in the settings flyout above the link. */
+  settingsExtra?: React.ReactNode;
+  /** Per-card "Manage…/Set … API key" link shown in the settings flyout. */
+  settingsLink: React.ReactNode;
+  configured: boolean;
+  isPending: boolean;
+  error: unknown;
+  /** Shown when loaded, error-free, and not yet configured. */
+  connectPrompt: React.ReactNode;
+  /**
+   * Optional status row rendered before `children` in the configured branch.
+   * Omitted by cards (e.g. Readwise) that render their own per-section status
+   * inside `children`.
+   */
+  isEmpty?: boolean;
+  entity?: string;
+  emptyMessage?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared shell for the dashboard integration tiles (Calendar/Readwise/Todoist):
+ * the `DashboardCard` chrome, settings flyout, and the not-configured prompt vs.
+ * configured-content switch. Each tile supplies only its copy, links, and data
+ * rendering.
+ */
+export function DashboardIntegrationCard({
+  tile,
+  onUpdateTile,
+  title,
+  action,
+  settingsExtra,
+  settingsLink,
+  configured,
+  isPending,
+  error,
+  connectPrompt,
+  isEmpty,
+  entity,
+  emptyMessage,
+  children,
+}: DashboardIntegrationCardProps) {
+  return (
+    <DashboardCard
+      autoHeight={isAutoHeight(tile)}
+      title={title}
+      action={action}
+      settings={(
+        <CardSettingsFlyout
+          tile={tile}
+          onUpdateTile={onUpdateTile}
+        >
+          {settingsExtra}
+          {settingsLink}
+        </CardSettingsFlyout>
+      )}
+    >
+      {!isPending && !error && !configured
+        ? connectPrompt
+        : (
+          <>
+            {entity && (
+              <DashboardSectionStatus
+                isPending={isPending}
+                error={error}
+                isEmpty={isEmpty}
+                entity={entity}
+                emptyMessage={emptyMessage ?? ""}
+              />
+            )}
+            {children}
+          </>
+        )}
+    </DashboardCard>
+  );
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.tsx
@@ -2,17 +2,15 @@ import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ReadwiseDocument } from "@emstack/types";
 
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { ExternalLink } from "lucide-react";
 
 import {
   Button,
-  CardSettingsFlyout,
-  DashboardCard,
+  DashboardIntegrationCard,
   DashboardSectionStatus,
-  isAutoHeight,
   queryKeys,
   RadialProgress,
+  SettingsLink,
   Tabs,
   TabsContent,
   TabsList,
@@ -121,8 +119,9 @@ export function DashboardReadwise({
   const unstarted = data?.unstarted ?? [];
 
   return (
-    <DashboardCard
-      autoHeight={isAutoHeight(tile)}
+    <DashboardIntegrationCard
+      tile={tile}
+      onUpdateTile={onUpdateTile}
       title="Readwise"
       action={(
         <Button
@@ -140,95 +139,68 @@ export function DashboardReadwise({
           </a>
         </Button>
       )}
-      settings={(
-        <CardSettingsFlyout
-          tile={tile}
-          onUpdateTile={onUpdateTile}
-        >
-          <Link
-            to="/settings"
-            search={{
-              tab: "connections",
-            }}
-            className="
-              text-sm text-primary underline-offset-2
-              hover:underline
-            "
-          >
-            Set Readwise API key
-          </Link>
-        </CardSettingsFlyout>
+      settingsLink={(
+        <SettingsLink className="text-sm">Set Readwise API key</SettingsLink>
+      )}
+      configured={configured}
+      isPending={isPending}
+      error={error}
+      connectPrompt={(
+        <p className="text-sm text-muted-foreground">
+          Add your Readwise API key in
+          {" "}
+          <SettingsLink>Settings</SettingsLink>
+          {" "}
+          to see your reading list.
+        </p>
       )}
     >
-      {!isPending && !error && !configured
-        ? (
-          <p className="text-sm text-muted-foreground">
-            Add your Readwise API key in
-            {" "}
-            <Link
-              to="/settings"
-              search={{
-                tab: "connections",
-              }}
-              className="
-                text-primary underline-offset-2
-                hover:underline
-              "
-            >
-              Settings
-            </Link>
-            {" "}
-            to see your reading list.
-          </p>
-        )
-        : (
-          <Tabs defaultValue="started">
-            <TabsList className="h-8">
-              <TabsTrigger
-                value="started"
-                className="text-xs"
-              >
-                In progress
-              </TabsTrigger>
-              <TabsTrigger
-                value="unstarted"
-                className="text-xs"
-              >
-                Unread
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="started">
-              <DashboardSectionStatus
-                isPending={isPending}
-                error={error}
-                isEmpty={configured && started.length === 0}
-                entity="articles"
-                emptyMessage="No articles in progress."
-              />
-              {started.length > 0 && (
-                <ArticleList
-                  docs={started}
-                  showProgress
-                />
-              )}
-            </TabsContent>
-            <TabsContent value="unstarted">
-              <DashboardSectionStatus
-                isPending={isPending}
-                error={error}
-                isEmpty={configured && unstarted.length === 0}
-                entity="articles"
-                emptyMessage="No unread articles."
-              />
-              {unstarted.length > 0 && (
-                <ArticleList
-                  docs={unstarted}
-                  showProgress={false}
-                />
-              )}
-            </TabsContent>
-          </Tabs>
-        )}
-    </DashboardCard>
+      <Tabs defaultValue="started">
+        <TabsList className="h-8">
+          <TabsTrigger
+            value="started"
+            className="text-xs"
+          >
+            In progress
+          </TabsTrigger>
+          <TabsTrigger
+            value="unstarted"
+            className="text-xs"
+          >
+            Unread
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="started">
+          <DashboardSectionStatus
+            isPending={isPending}
+            error={error}
+            isEmpty={configured && started.length === 0}
+            entity="articles"
+            emptyMessage="No articles in progress."
+          />
+          {started.length > 0 && (
+            <ArticleList
+              docs={started}
+              showProgress
+            />
+          )}
+        </TabsContent>
+        <TabsContent value="unstarted">
+          <DashboardSectionStatus
+            isPending={isPending}
+            error={error}
+            isEmpty={configured && unstarted.length === 0}
+            entity="articles"
+            emptyMessage="No unread articles."
+          />
+          {unstarted.length > 0 && (
+            <ArticleList
+              docs={unstarted}
+              showProgress={false}
+            />
+          )}
+        </TabsContent>
+      </Tabs>
+    </DashboardIntegrationCard>
   );
 }

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.tsx
@@ -2,17 +2,14 @@ import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { TodoistTask, TodoistTasks } from "@emstack/types";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { Check, ExternalLink, Repeat } from "lucide-react";
 import { toast } from "sonner";
 
 import {
   Button,
-  CardSettingsFlyout,
-  DashboardCard,
-  DashboardSectionStatus,
-  isAutoHeight,
+  DashboardIntegrationCard,
   queryKeys,
+  SettingsLink,
   SettingToggle,
 } from "./-cardKit";
 
@@ -213,8 +210,9 @@ export function DashboardTodoist({
     : null;
 
   return (
-    <DashboardCard
-      autoHeight={isAutoHeight(tile)}
+    <DashboardIntegrationCard
+      tile={tile}
+      onUpdateTile={onUpdateTile}
       title="Todoist"
       action={(
         <Button
@@ -232,128 +230,96 @@ export function DashboardTodoist({
           </a>
         </Button>
       )}
-      settings={(
-        <CardSettingsFlyout
-          tile={tile}
-          onUpdateTile={onUpdateTile}
-        >
-          <div className="flex flex-col gap-2 border-t pt-3">
-            <SettingToggle
-              label="Show project"
-              checked={display.showProject}
-              onChange={showProject => onUpdateTile({
-                showProject,
-              })}
-            />
-            <SettingToggle
-              label="Show tags"
-              checked={display.showLabels}
-              onChange={showLabels => onUpdateTile({
-                showLabels,
-              })}
-            />
-            <SettingToggle
-              label="Show descriptions"
-              checked={display.showDescription}
-              onChange={showDescription => onUpdateTile({
-                showDescription,
-              })}
-            />
-            <SettingToggle
-              label="Show overdue"
-              checked={showOverdue}
-              onChange={value => onUpdateTile({
-                showOverdue: value,
-              })}
-            />
-          </div>
-          <Link
-            to="/settings"
-            search={{
-              tab: "connections",
-            }}
+      settingsExtra={(
+        <div className="flex flex-col gap-2 border-t pt-3">
+          <SettingToggle
+            label="Show project"
+            checked={display.showProject}
+            onChange={showProject => onUpdateTile({
+              showProject,
+            })}
+          />
+          <SettingToggle
+            label="Show tags"
+            checked={display.showLabels}
+            onChange={showLabels => onUpdateTile({
+              showLabels,
+            })}
+          />
+          <SettingToggle
+            label="Show descriptions"
+            checked={display.showDescription}
+            onChange={showDescription => onUpdateTile({
+              showDescription,
+            })}
+          />
+          <SettingToggle
+            label="Show overdue"
+            checked={showOverdue}
+            onChange={value => onUpdateTile({
+              showOverdue: value,
+            })}
+          />
+        </div>
+      )}
+      settingsLink={(
+        <SettingsLink className="text-sm">Set Todoist API key</SettingsLink>
+      )}
+      configured={configured}
+      isPending={isPending}
+      error={error}
+      connectPrompt={(
+        <p className="text-sm text-muted-foreground">
+          Add your Todoist API key in
+          {" "}
+          <SettingsLink>Settings</SettingsLink>
+          {" "}
+          to see tasks due today and overdue.
+        </p>
+      )}
+      isEmpty={configured && overdue.length === 0 && today.length === 0}
+      entity="tasks"
+      emptyMessage="Nothing due today. 🎉"
+    >
+      {showOverdue && overdue.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h3
             className="
-              text-sm text-primary underline-offset-2
-              hover:underline
+              text-xs font-semibold tracking-wide text-destructive uppercase
             "
           >
-            Set Todoist API key
-          </Link>
-        </CardSettingsFlyout>
+            Overdue (
+            {overdue.length}
+            )
+          </h3>
+          <TaskList
+            tasks={overdue}
+            overdue
+            display={display}
+            onComplete={id => completeMutation.mutate(id)}
+            completingId={completingId}
+          />
+        </div>
       )}
-    >
-      {!isPending && !error && !configured
-        ? (
-          <p className="text-sm text-muted-foreground">
-            Add your Todoist API key in
-            {" "}
-            <Link
-              to="/settings"
-              search={{
-                tab: "connections",
-              }}
-              className="
-                text-primary underline-offset-2
-                hover:underline
-              "
-            >
-              Settings
-            </Link>
-            {" "}
-            to see tasks due today and overdue.
-          </p>
-        )
-        : (
-          <>
-            <DashboardSectionStatus
-              isPending={isPending}
-              error={error}
-              isEmpty={configured && overdue.length === 0 && today.length === 0}
-              entity="tasks"
-              emptyMessage="Nothing due today. 🎉"
-            />
-            {showOverdue && overdue.length > 0 && (
-              <div className="flex flex-col gap-1">
-                <h3
-                  className="
-                    text-xs font-semibold tracking-wide text-destructive
-                    uppercase
-                  "
-                >
-                  Overdue (
-                  {overdue.length}
-                  )
-                </h3>
-                <TaskList
-                  tasks={overdue}
-                  overdue
-                  display={display}
-                  onComplete={id => completeMutation.mutate(id)}
-                  completingId={completingId}
-                />
-              </div>
-            )}
-            {today.length > 0 && (
-              <div className="flex flex-col gap-1">
-                <h3
-                  className="
-                    text-xs font-semibold tracking-wide text-muted-foreground
-                    uppercase
-                  "
-                >
-                  Today
-                </h3>
-                <TaskList
-                  tasks={today}
-                  overdue={false}
-                  display={display}
-                  onComplete={id => completeMutation.mutate(id)}
-                  completingId={completingId}
-                />
-              </div>
-            )}
-          </>
-        )}
-    </DashboardCard>
+      {today.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h3
+            className="
+              text-xs font-semibold tracking-wide text-muted-foreground
+              uppercase
+            "
+          >
+            Today
+          </h3>
+          <TaskList
+            tasks={today}
+            overdue={false}
+            display={display}
+            onComplete={id => completeMutation.mutate(id)}
+            completingId={completingId}
+          />
+        </div>
+      )}
+    </DashboardIntegrationCard>
   );
 }

--- a/packages/client/src/routes/dashboard.-components/-cardKit.ts
+++ b/packages/client/src/routes/dashboard.-components/-cardKit.ts
@@ -7,6 +7,10 @@ export {
   DashboardSectionStatus,
 } from "@/components/contentBoxComponents/DashboardCard";
 export { CardSettingsFlyout, SettingToggle } from "./-DashboardCardSettings";
+export {
+  DashboardIntegrationCard,
+  SettingsLink,
+} from "./-DashboardIntegrationCard";
 export { isAutoHeight } from "@/lib/dashboardTiles";
 export { Button } from "@/components/ui/button";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";


### PR DESCRIPTION
## Summary

Consolidates the shared shell and layout logic for dashboard integration tiles (Calendar, Readwise, Todoist) into a new `DashboardIntegrationCard` component, eliminating duplication and simplifying each tile's implementation.

## Changes

- **New component:** `DashboardIntegrationCard` in `-DashboardIntegrationCard.tsx`
  - Encapsulates the `DashboardCard` chrome, settings flyout, and the not-configured prompt vs. configured-content switch
  - Accepts tile-specific copy, links, and data rendering as props
  - Handles the common pattern: show connect prompt when unconfigured, otherwise render status + children
  - Exports `SettingsLink` helper for consistent Settings navigation across tiles

- **Updated tiles:** Calendar, Readwise, Todoist
  - Replaced `DashboardCard` + `CardSettingsFlyout` + conditional rendering with `DashboardIntegrationCard`
  - Removed manual handling of `configured`/`isPending`/`error` state branching
  - Removed duplicate Settings link markup and navigation logic
  - Simplified prop passing: `tile`, `onUpdateTile`, `settingsLink`, `connectPrompt`, etc.

- **Exports:** Added `DashboardIntegrationCard` and `SettingsLink` to `-cardKit.ts` barrel export

## Implementation Details

- The new component preserves all existing behavior: auto-height detection, settings flyout integration, status rendering, and empty states
- `SettingsLink` centralizes the `/settings?tab=connections` navigation pattern used by all integration tiles
- Each tile now focuses solely on its data fetching, display logic, and UI rendering—no boilerplate
- Readwise and Calendar no longer render `DashboardSectionStatus` directly (handled by the card for Todoist; Readwise/Calendar render per-section status inside their own content)

https://claude.ai/code/session_01FQ3JvzRWD1mCP8rvZPoYJC