### PR TITLE
test(client): restore NavDropdown interaction tests with stable queries

### DIFF
--- a/packages/client/src/components/layout/NavDropdown.stories.tsx
+++ b/packages/client/src/components/layout/NavDropdown.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { expect, fireEvent, within } from "storybook/test";
+
 import { DropdownNavItem } from "./DropdownNavItem";
 import { NavDropdown } from "./NavDropdown";
 
@@ -30,11 +32,59 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Render-only smoke stories. The `play` interaction assertions (trigger render,
-// and click → portal menu items) were flaky in the browser-mode CI job —
-// `findByRole` could not resolve the trigger/menu accessible names under loaded
-// headless Chromium even with a widened timeout. Removed for now; tracked in
-// #377 to restore with a CI-stable query strategy.
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    // Label renders as a real text node inside the <Link>; the chevron's
+    // "Open Routines menu" is an aria-label (attribute, not text), so this is
+    // unambiguous and avoids resolving the trigger's composite role/name (#377).
+    await expect(
+      await within(canvasElement).findByText("Routines"),
+    ).toBeInTheDocument();
 
-export const Open: Story = {};
+    // The trigger wrapper renders. Query by data-slot rather than role/name —
+    // the div wraps a link + a role=button span, whose composite name resolves
+    // inconsistently under loaded headless Chromium.
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      "[data-slot=\"dropdown-menu-trigger\"]",
+    );
+    if (!trigger) throw new Error("dropdown-menu-trigger did not render");
+    await expect(trigger).toBeInTheDocument();
+  },
+};
+
+export const Open: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      "[data-slot=\"dropdown-menu-trigger\"]",
+    );
+    if (!trigger) throw new Error("dropdown-menu-trigger did not render");
+
+    // Open via hover, through the component's own state. The trigger fires
+    // setOpen(true) on mouseenter; dispatch that with fireEvent.mouseOver
+    // (React synthesizes onMouseEnter from mouseover) rather than
+    // userEvent.hover/click — those assert hit-testable pointer events, and
+    // Radix's open modal layer leaves document.body at `pointer-events: none`,
+    // which the trigger inherits. fireEvent dispatches the event directly, so
+    // it's immune to that and to Radix's pointerdown-toggle timing. Hover fires
+    // no mouseleave, so the 400ms close timer never arms.
+    fireEvent.mouseOver(trigger);
+
+    // Content portals to document.body; DropdownNavItem uses asChild so each
+    // item resolves as role=menuitem (proven-stable per DropdownNavItem.stories).
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("menuitem", {
+        name: "All routines",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      await body.findByRole("menuitem", {
+        name: "Tracker",
+      }),
+    ).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary

Restores interaction tests for the `NavDropdown` component that were previously removed due to flaky `findByRole` queries in headless Chromium CI. Implements stable query strategies using text content and `data-slot` attributes instead of composite role/name resolution.

## Changes

- **Default story:** Added `play` function that verifies the trigger renders by querying for the "Routines" text node (unambiguous, avoids composite role resolution) and confirms the trigger wrapper exists via `data-slot="dropdown-menu-trigger"` selector
- **Open story:** Added `play` function that:
  - Opens the dropdown via `fireEvent.mouseOver()` on the trigger (immune to Radix's `pointer-events: none` modal layer, unlike `userEvent.hover()`)
  - Verifies menu items render to the document body portal using stable `findByRole("menuitem")` queries (proven stable per `DropdownNavItem.stories`)
  - Confirms both "All routines" and "Tracker" menu items are present

## Implementation Details

- Uses `fireEvent.mouseOver()` instead of `userEvent.hover()` to work around Radix's pointer-events restrictions on the trigger element
- Queries by `data-slot` attribute for the trigger wrapper to avoid flaky composite role/name resolution under loaded headless Chromium
- Leverages `DropdownNavItem`'s `asChild` prop which ensures menu items resolve as stable `role=menuitem` elements
- Imports test utilities from `storybook/test` (Storybook's built-in testing library)

Addresses #377 by providing a CI-stable query strategy for NavDropdown interactions.

https://claude.ai/code/session_0189hYNsLuLhJfp9WQZG82Jc