### PR TITLE
refactor: extract dashboard layout manager hook

### DIFF
--- a/packages/client/src/hooks/useDashboardLayoutManager.ts
+++ b/packages/client/src/hooks/useDashboardLayoutManager.ts
@@ -1,0 +1,109 @@
+import { useMemo, useState } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useDashboardLayoutMutations } from "@/hooks/useDashboardLayoutMutations";
+import { fetchDashboardLayouts } from "@/utils/api";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Shared dashboard-layout data + dialog orchestration for the /dashboard route
+ * and the settings layouts section. Owns the layouts query, the tabs/presets
+ * split, and the rename/save-as/delete dialog targets wired to
+ * `useDashboardLayoutMutations` so each `onSuccess` closes its own dialog.
+ *
+ * Create and tile-toggle deliberately stay with each caller — they diverge (see
+ * `useDashboardLayoutMutations`): the dashboard creates a tab with tiles + selects
+ * it and toggles optimistically, while settings creates a tab-or-preset and
+ * toggles via invalidate.
+ */
+export function useDashboardLayoutManager() {
+  const queryClient = useQueryClient();
+
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
+  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+
+  const layoutsQuery = useQuery({
+    queryKey: queryKeys.dashboardLayouts.list(),
+    queryFn: () => fetchDashboardLayouts(),
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.dashboardLayouts.list(),
+    });
+
+  const layouts = layoutsQuery.data ?? [];
+
+  // Tabs are the non-template layouts; presets are offered as starting points
+  // when adding a tab and never appear in the strip. Memoized on the raw query
+  // data so the references stay stable across renders (a `?? []` fallback would
+  // be a fresh array every loading render and defeat the memo).
+  const tabs = useMemo(
+    () => layoutsQuery.data?.filter(l => !l.isTemplate) ?? [],
+    [layoutsQuery.data],
+  );
+  const presets = useMemo(
+    () => layoutsQuery.data?.filter(l => l.isTemplate) ?? [],
+    [layoutsQuery.data],
+  );
+
+  const renameTarget = layouts.find(l => l.id === renameTargetId) ?? null;
+  const saveAsTarget = layouts.find(l => l.id === saveAsTargetId) ?? null;
+  const deleteTarget = layouts.find(l => l.id === deleteTargetId) ?? null;
+
+  const {
+    renameMutation,
+    saveAsPresetMutation,
+    duplicateMutation,
+    deleteMutation,
+  } = useDashboardLayoutMutations({
+    onRenamed: () => setRenameTargetId(null),
+    onSavedAsPreset: () => setSaveAsTargetId(null),
+    onDeleted: () => setDeleteTargetId(null),
+  });
+
+  return {
+    layouts,
+    tabs,
+    presets,
+    isPending: layoutsQuery.isPending,
+    error: layoutsQuery.error,
+    invalidate,
+    duplicateMutation,
+
+    renameTarget,
+    openRename: (id: string) => setRenameTargetId(id),
+    closeRename: () => setRenameTargetId(null),
+    submitRename: (name: string) => {
+      if (renameTarget) {
+        renameMutation.mutate({
+          layout: renameTarget,
+          name,
+        });
+      }
+    },
+    isRenaming: renameMutation.isPending,
+
+    saveAsTarget,
+    openSaveAs: (id: string) => setSaveAsTargetId(id),
+    closeSaveAs: () => setSaveAsTargetId(null),
+    submitSaveAs: (name: string) => {
+      if (saveAsTarget) {
+        saveAsPresetMutation.mutate({
+          name,
+          tiles: saveAsTarget.tiles,
+        });
+      }
+    },
+    isSavingPreset: saveAsPresetMutation.isPending,
+
+    deleteTarget,
+    openDelete: (id: string) => setDeleteTargetId(id),
+    closeDelete: () => setDeleteTargetId(null),
+    confirmDelete: () => {
+      if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+    },
+  };
+}

--- a/packages/client/src/hooks/useDashboardLayoutMutations.ts
+++ b/packages/client/src/hooks/useDashboardLayoutMutations.ts
@@ -32,9 +32,10 @@ interface SaveAsPresetInput {
 
 /**
  * The dashboard-layout CRUD mutations shared by the /dashboard route and the
- * settings layouts section: rename, save-as-preset, duplicate, delete. Each
- * invalidates the layouts list and shows the same toast on both surfaces; the
- * only per-call-site difference (closing a dialog) is injected via callbacks.
+ * settings layouts section (both via `useDashboardLayoutManager`): rename,
+ * save-as-preset, duplicate, delete. Each invalidates the layouts list and shows
+ * the same toast on both surfaces; the only per-call-site difference (closing a
+ * dialog) is injected via callbacks.
  *
  * Create and tile-toggle are deliberately NOT here — they diverge between the
  * two surfaces (create's side effects/inputs differ; the dashboard toggles

--- a/packages/client/src/routes/dashboard.tsx
+++ b/packages/client/src/routes/dashboard.tsx
@@ -6,7 +6,7 @@ import type {
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -30,12 +30,8 @@ import {
 } from "./dashboard.-components";
 
 import { useActiveDashboardLayoutId } from "@/hooks/useActiveDashboardLayoutId";
-import { useDashboardLayoutMutations } from "@/hooks/useDashboardLayoutMutations";
-import {
-  createDashboardLayout,
-  fetchDashboardLayouts,
-  upsertDashboardLayout,
-} from "@/utils/api";
+import { useDashboardLayoutManager } from "@/hooks/useDashboardLayoutManager";
+import { createDashboardLayout, upsertDashboardLayout } from "@/utils/api";
 import { queryKeys } from "@/utils/queryKeys";
 
 export const Route = createFileRoute("/dashboard")({
@@ -48,29 +44,30 @@ function Dashboard() {
   const queryClient = useQueryClient();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [tilesTargetId, setTilesTargetId] = useState<string | null>(null);
-  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
-  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
   const {
-    data: layouts,
+    layouts,
+    tabs,
+    presets,
     isPending,
     error,
-  } = useQuery({
-    queryKey: queryKeys.dashboardLayouts.list(),
-    queryFn: () => fetchDashboardLayouts(),
-  });
-
-  // Tabs are the non-template layouts; presets are offered as starting points
-  // when adding a tab and never appear in the strip.
-  const tabs = useMemo(
-    () => layouts?.filter(l => !l.isTemplate) ?? [],
-    [layouts],
-  );
-  const presets = useMemo(
-    () => layouts?.filter(l => l.isTemplate) ?? [],
-    [layouts],
-  );
+    invalidate,
+    duplicateMutation,
+    renameTarget,
+    openRename,
+    closeRename,
+    submitRename,
+    isRenaming,
+    saveAsTarget,
+    openSaveAs,
+    closeSaveAs,
+    submitSaveAs,
+    isSavingPreset,
+    deleteTarget,
+    openDelete,
+    closeDelete,
+    confirmDelete,
+  } = useDashboardLayoutManager();
 
   const {
     activeId, setActiveId,
@@ -84,15 +81,7 @@ function Dashboard() {
     [activeLayout],
   );
 
-  const tilesTarget = layouts?.find(l => l.id === tilesTargetId) ?? null;
-  const renameTarget = layouts?.find(l => l.id === renameTargetId) ?? null;
-  const saveAsTarget = layouts?.find(l => l.id === saveAsTargetId) ?? null;
-  const deleteTarget = layouts?.find(l => l.id === deleteTargetId) ?? null;
-
-  const invalidate = () =>
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.dashboardLayouts.list(),
-    });
+  const tilesTarget = layouts.find(l => l.id === tilesTargetId) ?? null;
 
   const createTabMutation = useMutation({
     mutationFn: ({
@@ -119,32 +108,23 @@ function Dashboard() {
   });
 
   // First visit on an empty database: create the "Default" layout that
-  // replicates the pre-grid dashboard. Ref-guarded so StrictMode's double
-  // effect run can't create two rows.
+  // replicates the pre-grid dashboard. Wait for a settled, successful load so a
+  // still-loading (or errored) query can't trigger a spurious create, and
+  // ref-guard so StrictMode's double effect run can't create two rows.
   const autoCreatedRef = useRef(false);
   const {
     mutate: autoCreate,
   } = createTabMutation;
   useEffect(() => {
-    if (layouts && layouts.length === 0 && !autoCreatedRef.current) {
+    if (isPending || error != null) return;
+    if (layouts.length === 0 && !autoCreatedRef.current) {
       autoCreatedRef.current = true;
       autoCreate({
         name: "Default",
         tiles: buildDefaultTiles(),
       });
     }
-  }, [layouts, autoCreate]);
-
-  const {
-    renameMutation,
-    saveAsPresetMutation,
-    duplicateMutation,
-    deleteMutation,
-  } = useDashboardLayoutMutations({
-    onRenamed: () => setRenameTargetId(null),
-    onSavedAsPreset: () => setSaveAsTargetId(null),
-    onDeleted: () => setDeleteTargetId(null),
-  });
+  }, [isPending, error, layouts, autoCreate]);
 
   // Tile moves/resizes save through an optimistic cache write with no
   // invalidate on success — a refetch mid-drag would snap tiles back.
@@ -258,7 +238,7 @@ function Dashboard() {
             Failed to load dashboard layouts.
           </p>
         )}
-        {!isPending && error == null && layouts != null && (
+        {!isPending && error == null && (
           <>
             <div className="flex flex-wrap items-center gap-2">
               <Tabs
@@ -271,10 +251,10 @@ function Dashboard() {
                       key={layout.id}
                       layout={layout}
                       onEditTiles={l => setTilesTargetId(l.id)}
-                      onRename={l => setRenameTargetId(l.id)}
+                      onRename={l => openRename(l.id)}
                       onDuplicate={l => duplicateMutation.mutate(l.id)}
-                      onSaveAs={l => setSaveAsTargetId(l.id)}
-                      onDelete={l => setDeleteTargetId(l.id)}
+                      onSaveAs={l => openSaveAs(l.id)}
+                      onDelete={l => openDelete(l.id)}
                     />
                   ))}
                 </TabsList>
@@ -330,18 +310,11 @@ function Dashboard() {
         open={renameTarget !== null}
         title="Rename layout"
         initialName={renameTarget?.name ?? ""}
-        isSaving={renameMutation.isPending}
+        isSaving={isRenaming}
         onOpenChange={(open) => {
-          if (!open) setRenameTargetId(null);
+          if (!open) closeRename();
         }}
-        onSubmit={(name) => {
-          if (renameTarget) {
-            renameMutation.mutate({
-              layout: renameTarget,
-              name,
-            });
-          }
-        }}
+        onSubmit={submitRename}
       />
 
       <LayoutNameDialog
@@ -349,18 +322,11 @@ function Dashboard() {
         title="Save as layout"
         submitLabel="Save"
         initialName={saveAsTarget?.name ?? ""}
-        isSaving={saveAsPresetMutation.isPending}
+        isSaving={isSavingPreset}
         onOpenChange={(open) => {
-          if (!open) setSaveAsTargetId(null);
+          if (!open) closeSaveAs();
         }}
-        onSubmit={(name) => {
-          if (saveAsTarget) {
-            saveAsPresetMutation.mutate({
-              name,
-              tiles: saveAsTarget.tiles,
-            });
-          }
-        }}
+        onSubmit={submitSaveAs}
       />
 
       <ConfirmDialog
@@ -373,10 +339,8 @@ function Dashboard() {
         }
         confirmLabel="Delete"
         cancelLabel="Cancel"
-        onConfirm={() => {
-          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
-        }}
-        onCancel={() => setDeleteTargetId(null)}
+        onConfirm={confirmDelete}
+        onCancel={closeDelete}
       />
     </div>
   );

--- a/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
+++ b/packages/client/src/routes/settings.-components/-useDashboardLayouts.ts
@@ -2,50 +2,45 @@ import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
 import { useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { useDashboardLayoutMutations } from "@/hooks/useDashboardLayoutMutations";
+import { useDashboardLayoutManager } from "@/hooks/useDashboardLayoutManager";
 import { toggleTile } from "@/lib/dashboardTiles";
-import {
-  createDashboardLayout,
-  fetchDashboardLayouts,
-  upsertDashboardLayout,
-} from "@/utils/api";
-import { queryKeys } from "@/utils/queryKeys";
+import { createDashboardLayout, upsertDashboardLayout } from "@/utils/api";
 
 export type CreateKind = "tab" | "preset";
 
 /**
- * Data + mutations for the dashboard-layouts settings section. Owns the dialog
- * target state alongside the mutations so each `onSuccess` can close its own
- * dialog; the section is left rendering from a presentational-ready return.
+ * Data + mutations for the dashboard-layouts settings section. Wraps the shared
+ * `useDashboardLayoutManager` (query + rename/save-as/delete dialogs) and layers
+ * on the settings-only create (tab or preset) and per-row tile toggle, returning
+ * a presentational-ready shape for the section to render.
  */
 export function useDashboardLayouts() {
-  const queryClient = useQueryClient();
+  const {
+    isPending,
+    tabs,
+    presets,
+    invalidate,
+    duplicateMutation,
+    renameTarget,
+    openRename,
+    closeRename,
+    submitRename,
+    isRenaming,
+    saveAsTarget,
+    openSaveAs,
+    closeSaveAs,
+    submitSaveAs,
+    isSavingPreset,
+    deleteTarget,
+    openDelete,
+    closeDelete,
+    confirmDelete,
+  } = useDashboardLayoutManager();
 
-  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
-  const [saveAsTargetId, setSaveAsTargetId] = useState<string | null>(null);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [creatingKind, setCreatingKind] = useState<CreateKind | null>(null);
-
-  const layoutsQuery = useQuery({
-    queryKey: queryKeys.dashboardLayouts.list(),
-    queryFn: () => fetchDashboardLayouts(),
-  });
-
-  const invalidate = () =>
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.dashboardLayouts.list(),
-    });
-
-  const layouts = layoutsQuery.data ?? [];
-  const tabs = layouts.filter(l => !l.isTemplate);
-  const presets = layouts.filter(l => l.isTemplate);
-
-  const renameTarget = layouts.find(l => l.id === renameTargetId) ?? null;
-  const saveAsTarget = layouts.find(l => l.id === saveAsTargetId) ?? null;
-  const deleteTarget = layouts.find(l => l.id === deleteTargetId) ?? null;
 
   const createMutation = useMutation({
     mutationFn: ({
@@ -68,17 +63,6 @@ export function useDashboardLayouts() {
     onError: (err: Error) => {
       toast.error(err.message);
     },
-  });
-
-  const {
-    renameMutation,
-    saveAsPresetMutation,
-    duplicateMutation,
-    deleteMutation,
-  } = useDashboardLayoutMutations({
-    onRenamed: () => setRenameTargetId(null),
-    onSavedAsPreset: () => setSaveAsTargetId(null),
-    onDeleted: () => setDeleteTargetId(null),
   });
 
   const toggleTileMutation = useMutation({
@@ -109,15 +93,15 @@ export function useDashboardLayouts() {
         layout,
         tileId,
       }),
-    onRename: (layout: DashboardLayout) => setRenameTargetId(layout.id),
+    onRename: (layout: DashboardLayout) => openRename(layout.id),
     onDuplicate: (layout: DashboardLayout) =>
       duplicateMutation.mutate(layout.id),
-    onSaveAs: (layout: DashboardLayout) => setSaveAsTargetId(layout.id),
-    onDelete: (layout: DashboardLayout) => setDeleteTargetId(layout.id),
+    onSaveAs: (layout: DashboardLayout) => openSaveAs(layout.id),
+    onDelete: (layout: DashboardLayout) => openDelete(layout.id),
   };
 
   return {
-    isPending: layoutsQuery.isPending,
+    isPending,
     tabs,
     presets,
     rowProps,
@@ -136,33 +120,17 @@ export function useDashboardLayouts() {
     isCreating: createMutation.isPending,
 
     renameTarget,
-    closeRename: () => setRenameTargetId(null),
-    submitRename: (name: string) => {
-      if (renameTarget) {
-        renameMutation.mutate({
-          layout: renameTarget,
-          name,
-        });
-      }
-    },
-    isRenaming: renameMutation.isPending,
+    closeRename,
+    submitRename,
+    isRenaming,
 
     saveAsTarget,
-    closeSaveAs: () => setSaveAsTargetId(null),
-    submitSaveAs: (name: string) => {
-      if (saveAsTarget) {
-        saveAsPresetMutation.mutate({
-          name,
-          tiles: saveAsTarget.tiles,
-        });
-      }
-    },
-    isSavingPreset: saveAsPresetMutation.isPending,
+    closeSaveAs,
+    submitSaveAs,
+    isSavingPreset,
 
     deleteTarget,
-    closeDelete: () => setDeleteTargetId(null),
-    confirmDelete: () => {
-      if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
-    },
+    closeDelete,
+    confirmDelete,
   };
 }


### PR DESCRIPTION
## Summary

Consolidate shared dashboard-layout state management and dialog orchestration into a new `useDashboardLayoutManager` hook, eliminating duplication between the `/dashboard` route and the settings layouts section.

## Key Changes

- **New hook:** `useDashboardLayoutManager` owns the layouts query, tabs/presets split, and rename/save-as/delete dialog state wired to `useDashboardLayoutMutations`
- **Dashboard route:** Simplified by delegating query + dialog management to the new hook; removed local state for `renameTargetId`, `saveAsTargetId`, `deleteTargetId`
- **Settings layouts section:** Refactored `useDashboardLayouts` to wrap `useDashboardLayoutManager` and layer on settings-specific create and tile-toggle logic
- **Improved auto-create logic:** Dashboard now checks `isPending` and `error` before attempting auto-create, preventing spurious creates during loading or failed queries
- **Removed unused import:** Dropped `useQuery` from dashboard route (now handled by the manager hook)

## Implementation Details

- The manager hook memoizes `tabs` and `presets` on the raw query data to maintain stable references across renders
- Dialog open/close/submit functions are provided by the manager, simplifying component code
- Create and tile-toggle remain with each caller since they diverge: dashboard creates a tab with tiles and toggles optimistically, while settings creates a tab-or-preset and toggles via invalidate
- All mutation callbacks (`onRenamed`, `onSavedAsPreset`, `onDeleted`) are wired in the manager to close their respective dialogs on success

https://claude.ai/code/session_01VqrgSNFtvtyRbc1t4WNzd8