### PR TITLE
feat(client): add success toast on entity deletion

### DIFF
--- a/packages/client/src/hooks/useEditFormPage.ts
+++ b/packages/client/src/hooks/useEditFormPage.ts
@@ -97,6 +97,9 @@ export function useEditFormPage<TData>({
           await invalidateRelated();
           skipBlock();
           await navigateToList();
+          toast.success(
+            `${entityLabel.charAt(0).toUpperCase()}${entityLabel.slice(1)} deleted.`,
+          );
         }
         catch {
           toast.error(`Failed to delete ${entityLabel}. Please try again.`);


### PR DESCRIPTION
## Summary
Added a success toast notification when an entity is successfully deleted from the edit form page, improving user feedback for delete operations.

## Changes
- Display a success toast message after successful entity deletion, confirming the action to the user
- Message format: `"[Entity] deleted."` (e.g., "Course deleted.") with proper capitalization of the entity label

## Implementation Details
- The success toast is shown after cache invalidation, form skip, and navigation to the list completes
- Uses the existing `toast.success()` API consistent with the error handling already in place
- Entity label is capitalized dynamically using `charAt(0).toUpperCase() + slice(1)` to match the error message pattern

https://claude.ai/code/session_01Vjj36GoTDkHH2TDpC99pzY