### PR TITLE
fix(client): clarify routine assignment warning to include resources

### DIFF
--- a/packages/client/src/components/contentBoxComponents/RoutineBox.stories.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.stories.tsx
@@ -62,9 +62,32 @@ export const DailyNoTask: Story = {
     canvasElement,
   }) => {
     const canvas = within(canvasElement);
-    // The "no task assigned" caution surfaces an accessible label.
+    // The "nothing assigned" caution surfaces an accessible label.
     await expect(
-      await canvas.findByLabelText("No task assigned"),
+      await canvas.findByLabelText("Nothing assigned"),
     ).toBeInTheDocument();
+  },
+};
+
+export const DailyResourceNoWarning: Story = {
+  args: makeRoutine({
+    name: "Read the docs",
+    connections: [],
+    // A daily routine assigned a resource (not a task) still counts as
+    // assigned, so the caution must not appear.
+    weekly: {
+      1: {
+        type: "resource",
+        id: "res-1",
+      },
+    },
+  }),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByLabelText("Nothing assigned"),
+    ).not.toBeInTheDocument();
   },
 };

--- a/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
@@ -76,12 +76,12 @@ export function RoutineBox({
   todayAction,
 }: Routine & { todayAction?: RoutineTodayAction | null }) {
   const isDaily = mode === "daily";
-  // A daily routine mirrors the same entry on every weekday, so "no task
-  // assigned" means none of the grid's entries is a task (it may be a
-  // resource, freeform, or empty). Flag it so the card can caution the user.
-  const dailyHasNoTask
+  // A daily routine mirrors the same entry on every weekday, so the caution
+  // only applies when the grid is empty — i.e. no task, resource, or freeform
+  // item is assigned at all. (connections are categorical, not the assignment.)
+  const dailyHasNoAssignment
     = isDaily
-      && !Object.values(weekly ?? {}).some(entry => entry?.type === "task");
+      && !Object.values(weekly ?? {}).some(entry => !!entry?.id);
   const scheduledCount = weekly
     ? Object.values(weekly).filter(Boolean).length
     : 0;
@@ -131,7 +131,7 @@ export function RoutineBox({
             <span
               className={cn(
                 "rounded-sm border px-2 py-0.5 text-xs",
-                dailyHasNoTask
+                dailyHasNoAssignment
                   ? `
                     border-amber-400 bg-amber-100 text-amber-900
                     dark:border-amber-500/50 dark:bg-amber-900/40
@@ -139,7 +139,7 @@ export function RoutineBox({
                   `
                   : "text-muted-foreground",
               )}
-              title={dailyHasNoTask ? "No task assigned" : undefined}
+              title={dailyHasNoAssignment ? "Nothing assigned" : undefined}
             >
               {isDaily ? "Daily" : "Weekly"}
             </span>
@@ -176,17 +176,17 @@ export function RoutineBox({
                   name
                 )}
             </Link>
-            {dailyHasNoTask && (
+            {dailyHasNoAssignment && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span
                     className="inline-flex shrink-0 text-amber-500"
-                    aria-label="No task assigned"
+                    aria-label="Nothing assigned"
                   >
                     <AlertTriangleIcon className="size-4" />
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>No task assigned</TooltipContent>
+                <TooltipContent>Nothing assigned</TooltipContent>
               </Tooltip>
             )}
           </h3>

--- a/packages/client/src/test-utils/boxFixtures.ts
+++ b/packages/client/src/test-utils/boxFixtures.ts
@@ -134,8 +134,8 @@ export function makeRoutine(
         name: "Read a chapter",
       },
     ],
-    // A task on a few weekdays: keeps daily mode free of the "no task" warning
-    // and gives weekly mode a populated day strip.
+    // A task on a few weekdays: keeps daily mode free of the "nothing assigned"
+    // warning and gives weekly mode a populated day strip.
     weekly: {
       1: {
         type: "task",


### PR DESCRIPTION
## Summary
Updates the "no task assigned" warning on daily routines to more accurately reflect when a routine is truly unassigned. The warning now only appears when a daily routine has no assignment at all (task, resource, or freeform), rather than only checking for tasks.

## Changes
- **Logic fix:** Changed `dailyHasNoTask` to `dailyHasNoAssignment` and updated the condition from checking `entry?.type === "task"` to checking `!!entry?.id`. This ensures the warning appears only when the routine is completely empty, not when it has a resource or freeform item assigned.
- **Label updates:** Renamed all user-facing text from "No task assigned" to "Nothing assigned" to accurately reflect the new behavior (title attribute, aria-label, and tooltip content).
- **Test coverage:** Added `DailyResourceNoWarning` story to verify that a daily routine with a resource assignment does not trigger the warning, ensuring the fix works as intended.
- **Documentation:** Updated comments in both the component and test fixtures to clarify that the warning applies to completely unassigned routines, not just those without tasks.

## Implementation Details
The key insight is that a daily routine's grid entry can contain a task, resource, or freeform item—all of which count as valid assignments. The warning should only surface when the grid is entirely empty (no `id` present), not when it lacks a specific type. This change makes the component's intent clearer and prevents false warnings when users intentionally assign resources instead of tasks.

https://claude.ai/code/session_01WwXUdtBrL3xmbYoFzGSKca