### PR TITLE
feat: add self-provider option for resources

### DIFF
--- a/packages/client/src/routes/resources.$id.edit.tsx
+++ b/packages/client/src/routes/resources.$id.edit.tsx
@@ -71,6 +71,7 @@ const formSchema = z.object({
   dateExpires: z.date().nullable(),
   topicId: z.string(),
   courseProviderId: z.string(),
+  providerIsSelf: z.boolean(),
   modulesAreExhaustive: z.boolean(),
   easeOfStarting: z.enum(["", "low", "medium", "high"]),
   timeNeeded: z.enum(["", "low", "medium", "high"]),
@@ -185,6 +186,7 @@ function SingleResourceEdit() {
         || (isNew ? (search.topicId ?? "") : "")
         || "",
       courseProviderId: data?.provider?.id ?? "",
+      providerIsSelf: data?.providerIsSelf ?? false,
       modulesAreExhaustive: data?.modulesAreExhaustive ?? false,
       easeOfStarting: data?.easeOfStarting ?? "",
       timeNeeded: data?.timeNeeded ?? "",
@@ -221,6 +223,7 @@ function SingleResourceEdit() {
         isExpires: !!value.dateExpires,
         topicId: value.topicId || null,
         courseProviderId: value.courseProviderId || null,
+        providerIsSelf: value.providerIsSelf,
         modulesAreExhaustive: value.modulesAreExhaustive,
         easeOfStarting: value.easeOfStarting || null,
         timeNeeded: value.timeNeeded || null,
@@ -266,6 +269,9 @@ function SingleResourceEdit() {
   }));
   const isSubmitting = useStore(form.store, state => state.isSubmitting);
   const hasChanges = formHasChanges(currentValues, startingValues);
+  // A self-provider mirrors the resource's url, which a provider requires, so the
+  // option is only offered once the resource has a url.
+  const providerUrlMissing = !currentValues.url.trim();
   const selectedProvider = (providers ?? []).find(
     p => p.id === currentValues.courseProviderId,
   );
@@ -372,40 +378,84 @@ function SingleResourceEdit() {
           )}
         </form.AppField>
 
-        <form.AppField name="courseProviderId">
+        <form.Field name="providerIsSelf">
           {field => (
-            <field.ComboboxField
-              label="Provider"
-              options={providerOptions}
-              placeholder="Search providers..."
-              create={{
-                itemLabel: "provider",
-                fields: [
-                  {
-                    name: "name",
-                    label: "Name",
-                    required: true,
-                    isPrimary: true,
-                  },
-                  {
-                    name: "url",
-                    label: "URL",
-                    required: true,
-                    type: "url",
-                    placeholder: "https://...",
-                  },
-                ],
-                onCreate: async (values) => {
-                  const result = await createProvider(values);
-                  await queryClient.invalidateQueries({
-                    queryKey: ["providers"],
-                  });
-                  return result.id;
-                },
-              }}
-            />
+            <label
+              className={cn(
+                "flex items-start gap-2 text-sm",
+                !isNew && !field.state.meta.isDefaultValue && changedFieldClass,
+                providerUrlMissing && "opacity-60",
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                disabled={providerUrlMissing}
+                onChange={(e) => {
+                  field.handleChange(e.target.checked);
+                  if (e.target.checked) {
+                    form.setFieldValue("courseProviderId", "");
+                  }
+                }}
+                className="mt-0.5 size-4"
+              />
+              <span className="flex flex-col gap-0.5">
+                <span className="font-medium">
+                  This resource is its own provider
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {providerUrlMissing
+                    ? "Add a Resource URL to enable this."
+                    : "Creates a separate provider that mirrors this resource's "
+                      + "name and URL, kept in sync whenever you save."}
+                </span>
+              </span>
+            </label>
           )}
-        </form.AppField>
+        </form.Field>
+
+        {currentValues.providerIsSelf
+          ? (
+            <p className="text-sm text-muted-foreground">
+              Provider mirrors this resource — its name and URL will match.
+            </p>
+          )
+          : (
+            <form.AppField name="courseProviderId">
+              {field => (
+                <field.ComboboxField
+                  label="Provider"
+                  options={providerOptions}
+                  placeholder="Search providers..."
+                  create={{
+                    itemLabel: "provider",
+                    fields: [
+                      {
+                        name: "name",
+                        label: "Name",
+                        required: true,
+                        isPrimary: true,
+                      },
+                      {
+                        name: "url",
+                        label: "URL",
+                        required: true,
+                        type: "url",
+                        placeholder: "https://...",
+                      },
+                    ],
+                    onCreate: async (values) => {
+                      const result = await createProvider(values);
+                      await queryClient.invalidateQueries({
+                        queryKey: ["providers"],
+                      });
+                      return result.id;
+                    },
+                  }}
+                />
+              )}
+            </form.AppField>
+          )}
 
         <form.AppField name="status">
           {field => (

--- a/packages/middleware/src/db/schema/courses.ts
+++ b/packages/middleware/src/db/schema/courses.ts
@@ -46,6 +46,10 @@ export const resources = pgTable("resources", {
   status: statusEnum().default("active"),
   minutesLength: integer(),
   courseProviderId: varchar("course_provider_id"),
+  // When true, this resource is its own provider: a separate courseProviders row
+  // sharing this resource's id is kept in sync with its name/url (see
+  // upsertResource's afterUpsert).
+  providerIsSelf: boolean("provider_is_self").default(false).notNull(),
   // When true, completion is computed from finished modules rather than from
   // progressCurrent/progressTotal.
   modulesAreExhaustive: boolean("modules_are_exhaustive").default(false).notNull(),

--- a/packages/middleware/src/routes/api/resources/duplicateResource.ts
+++ b/packages/middleware/src/routes/api/resources/duplicateResource.ts
@@ -50,7 +50,11 @@ export default async function (server: FastifyInstance) {
         isExpires: source.isExpires ?? null,
         cost: source.cost ?? null,
         status: source.status ?? undefined,
-        courseProviderId: source.courseProviderId ?? null,
+        // A self-provider belongs to the source resource (it shares its id), so
+        // don't carry the link onto the copy; providerIsSelf defaults to false.
+        courseProviderId: source.providerIsSelf
+          ? null
+          : (source.courseProviderId ?? null),
         easeOfStarting: source.easeOfStarting ?? null,
         timeNeeded: source.timeNeeded ?? null,
         interactivity: source.interactivity ?? null,

--- a/packages/middleware/src/routes/api/resources/resourceProviderSelf.ts
+++ b/packages/middleware/src/routes/api/resources/resourceProviderSelf.ts
@@ -1,0 +1,34 @@
+// Helpers for the "resource is its own provider" feature. A self-provider is a
+// separate courseProviders row that shares the resource's id and mirrors its
+// title (name) + location (url). Kept free of `@/` alias imports so the unit
+// tests can load it under `node --test` (same convention as the *Rows.ts files).
+
+export interface SelfProviderBody {
+  name: string;
+  url?: string | null;
+  providerIsSelf?: boolean;
+  courseProviderId?: string | null;
+}
+
+/**
+ * A provider's url is required, and a self-provider mirrors the resource's url,
+ * so the resource must have a url before it can be its own provider. Returns an
+ * error message to abort the upsert with, or null when the body is valid.
+ */
+export function selfProviderError(body: SelfProviderBody): string | null {
+  return body.providerIsSelf && !body.url
+    ? "A resource URL is required to use it as its own provider."
+    : null;
+}
+
+/**
+ * The course-provider FK to persist on the resource row. A self-provider shares
+ * the resource's id, so the FK points at the resource id itself; otherwise it's
+ * the explicitly selected provider (or null when none is chosen).
+ */
+export function resolveCourseProviderId(
+  body: SelfProviderBody,
+  id: string,
+): string | null {
+  return body.providerIsSelf ? id : (body.courseProviderId ?? null);
+}

--- a/packages/middleware/src/routes/api/resources/upsertResource.ts
+++ b/packages/middleware/src/routes/api/resources/upsertResource.ts
@@ -1,6 +1,17 @@
+import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
-import { resources, resourceTags, topicsToResources } from "@/db/schema";
+import { db } from "@/db";
+import {
+  courseProviders,
+  resources,
+  resourceTags,
+  topicsToResources,
+} from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
+import {
+  resolveCourseProviderId,
+  selfProviderError,
+} from "./resourceProviderSelf";
 import {
   courseStatusEnum,
   nullableBoolean,
@@ -23,6 +34,7 @@ interface CourseBody {
   isExpires?: boolean | null;
   topicId?: string | null;
   courseProviderId?: string | null;
+  providerIsSelf?: boolean;
   modulesAreExhaustive?: boolean;
   easeOfStarting?: "low" | "medium" | "high" | null;
   timeNeeded?: "low" | "medium" | "high" | null;
@@ -42,6 +54,7 @@ const updateableColumns = [
   "dateExpires",
   "isExpires",
   "courseProviderId",
+  "providerIsSelf",
   "modulesAreExhaustive",
   "easeOfStarting",
   "timeNeeded",
@@ -51,6 +64,7 @@ const updateableColumns = [
 export default createUpsertHandler<CourseBody>({
   description: "Create or update a resource",
   table: resources,
+  validate: selfProviderError,
   bodySchema: {
     type: "object",
     required: ["name"],
@@ -71,6 +85,9 @@ export default createUpsertHandler<CourseBody>({
       isExpires: nullableBoolean,
       topicId: nullableString,
       courseProviderId: nullableString,
+      providerIsSelf: {
+        type: "boolean",
+      },
       modulesAreExhaustive: {
         type: "boolean",
       },
@@ -92,7 +109,8 @@ export default createUpsertHandler<CourseBody>({
     isCostFromPlatform: body.isCostFromPlatform ?? false,
     dateExpires: body.dateExpires ?? null,
     isExpires: body.isExpires ?? null,
-    courseProviderId: body.courseProviderId ?? null,
+    courseProviderId: resolveCourseProviderId(body, id),
+    providerIsSelf: body.providerIsSelf ?? false,
     modulesAreExhaustive: body.modulesAreExhaustive ?? false,
     easeOfStarting: body.easeOfStarting ?? null,
     timeNeeded: body.timeNeeded ?? null,
@@ -101,6 +119,31 @@ export default createUpsertHandler<CourseBody>({
   updateableColumns,
   generateIdIfMissing: true,
   returnId: true,
+  // Keep the self-provider in lockstep with the resource. The provider shares
+  // the resource's id, so the upsert re-syncs its title (name) + location (url)
+  // on every save; clearing the flag removes the auto-created provider (only a
+  // self-provider can share this id, so the delete is targeted).
+  afterUpsert: async (body, id) => {
+    if (body.providerIsSelf && body.url) {
+      await db
+        .insert(courseProviders)
+        .values({
+          id,
+          name: body.name,
+          url: body.url,
+        })
+        .onConflictDoUpdate({
+          target: courseProviders.id,
+          set: {
+            name: body.name,
+            url: body.url,
+          },
+        });
+    }
+    else {
+      await db.delete(courseProviders).where(eq(courseProviders.id, id));
+    }
+  },
   junctions: [
     {
       table: topicsToResources,

--- a/packages/middleware/src/tests/resourceProviderSelf.test.ts
+++ b/packages/middleware/src/tests/resourceProviderSelf.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import {
+  resolveCourseProviderId,
+  selfProviderError,
+} from "../routes/api/resources/resourceProviderSelf.ts";
+
+test("selfProviderError requires a url when the resource is its own provider", () => {
+  assert.strictEqual(
+    selfProviderError({
+      name: "Book",
+      providerIsSelf: true,
+      url: null,
+    }),
+    "A resource URL is required to use it as its own provider.",
+  );
+  assert.strictEqual(
+    selfProviderError({
+      name: "Book",
+      providerIsSelf: true,
+      url: "",
+    }),
+    "A resource URL is required to use it as its own provider.",
+  );
+});
+
+test("selfProviderError passes when self-provider has a url, or is not self", () => {
+  assert.strictEqual(
+    selfProviderError({
+      name: "Book",
+      providerIsSelf: true,
+      url: "https://example.com",
+    }),
+    null,
+  );
+  assert.strictEqual(
+    selfProviderError({
+      name: "Book",
+      providerIsSelf: false,
+      url: null,
+    }),
+    null,
+  );
+});
+
+test("resolveCourseProviderId points a self-provider at the resource's own id", () => {
+  assert.strictEqual(
+    resolveCourseProviderId({
+      name: "Book",
+      providerIsSelf: true,
+      url: "https://example.com",
+      courseProviderId: "ignored-when-self",
+    }, "r1"),
+    "r1",
+  );
+});
+
+test("resolveCourseProviderId uses the selected provider (or null) when not self", () => {
+  assert.strictEqual(
+    resolveCourseProviderId({
+      name: "Book",
+      providerIsSelf: false,
+      courseProviderId: "p9",
+    }, "r1"),
+    "p9",
+  );
+  assert.strictEqual(
+    resolveCourseProviderId({
+      name: "Book",
+    }, "r1"),
+    null,
+  );
+});

--- a/packages/middleware/src/utils/resourceProjection.ts
+++ b/packages/middleware/src/utils/resourceProjection.ts
@@ -20,6 +20,7 @@ interface ResourceProjectionRow {
   progressCurrent: number | null;
   progressTotal: number | null;
   status: Resource["status"] | null;
+  providerIsSelf: boolean | null;
   easeOfStarting: Resource["easeOfStarting"];
   timeNeeded: Resource["timeNeeded"];
   interactivity: Resource["interactivity"];
@@ -45,6 +46,7 @@ export function mapResource(resource: ResourceProjectionRow): Resource {
     progressCurrent: resource.progressCurrent ? resource.progressCurrent : 0,
     progressTotal: resource.progressTotal ? resource.progressTotal : 0,
     status: resource.status ?? "inactive",
+    providerIsSelf: resource.providerIsSelf ?? false,
     topics: processResourceLinks(resource.topicsToResources, "topic"),
     provider:
       resource.courseProvider?.name && resource.courseProvider?.id

--- a/packages/types/src/Resource.ts
+++ b/packages/types/src/Resource.ts
@@ -24,6 +24,8 @@ export interface Resource {
     name: string;
     id: string;
   };
+  /** When true, the provider is auto-created from and kept in sync with this resource. */
+  providerIsSelf?: boolean;
   moduleGroups?: ModuleGroup[];
   modules?: Module[];
   easeOfStarting?: TaskResourceLevel | null;


### PR DESCRIPTION
## Summary

Adds a "resource is its own provider" feature that allows a resource to automatically create and maintain a mirrored provider entry. When enabled, a separate `courseProviders` row is created sharing the resource's ID and kept in sync with the resource's name and URL on every save.

## Key Changes

- **Schema & Database:**
  - Added `providerIsSelf` boolean column to `resources` table (defaults to `false`)
  - Self-providers share the resource's ID with a `courseProviders` row

- **Backend API (`upsertResource`):**
  - Added validation via `selfProviderError()` to require a resource URL when `providerIsSelf` is true
  - Added `resolveCourseProviderId()` helper to point the FK at the resource's own ID when self-provider is enabled
  - Implemented `afterUpsert` hook to sync the mirrored provider on every save (upsert name/url, or delete if flag is cleared)
  - Updated `duplicateResource` to exclude self-provider links when copying resources

- **Frontend (`resources.$id.edit`):**
  - Added checkbox field to toggle "This resource is its own provider"
  - Checkbox is disabled until a resource URL is added
  - When enabled, hides the provider combobox and shows a status message instead
  - Form schema and submission logic updated to handle the new field

- **Types & Utilities:**
  - Added `providerIsSelf` to `Resource` interface with JSDoc
  - Updated `resourceProjection` to include the new field
  - Created `resourceProviderSelf.ts` with validation and resolution helpers (unit-tested)

## Implementation Details

- The self-provider feature is opt-in and only available once a resource has a URL (enforced both client-side via disabled state and server-side via validation)
- Self-providers are automatically cleaned up when the flag is disabled
- The feature integrates seamlessly with the existing provider selection UI—when enabled, the combobox is replaced with a read-only status message
- Comprehensive unit tests cover validation and ID resolution logic

https://claude.ai/code/session_015LkgR4EZC1Wk6c3adfcxcM