### PR TITLE
refactor(client): fixes #361: split radar legend stories and extract test fixtures

### DIFF
--- a/packages/client/src/components/radar/BlipLegendItem.stories.tsx
+++ b/packages/client/src/components/radar/BlipLegendItem.stories.tsx
@@ -1,58 +1,35 @@
-import type { RadarBlip } from "@emstack/types";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, fn, within } from "storybook/test";
 
-import { BlipLegendItem, BlipLegendSection } from "./radarLegendItem";
+import { BlipLegendItem } from "./radarLegendItem";
 
+import { makeBlip } from "@/test-utils/radarFixtures";
 import { RouterStub } from "@/test-utils/RouterStub";
 
-function makeBlip(id: string, topicName: string, description?: string): RadarBlip {
-  return {
-    id,
-    domainId: "domain-1",
-    quadrantId: "q-1",
-    ringId: "r-1",
-    topicId: `topic-${id}`,
-    topicName,
-    description,
-  };
-}
-
-const blips = [
-  makeBlip("a", "Kubernetes", "Container orchestration"),
-  makeBlip("b", "Terraform"),
-  makeBlip("c", "Prometheus", "Metrics + alerting"),
-];
-
-const meta: Meta<typeof BlipLegendSection> = {
-  component: BlipLegendSection,
+const meta: Meta<typeof BlipLegendItem> = {
+  component: BlipLegendItem,
   args: {
-    title: "Tools",
-    headingClassName: "text-sm font-semibold uppercase",
-    activeBlipId: null,
-    selectedBlipId: null,
+    blip: makeBlip({
+      id: "solo",
+      topicId: "topic-solo",
+      topicName: "Kubernetes",
+      description: "Container orchestration",
+    }),
+    label: <span className="font-medium">Kubernetes</span>,
+    isActive: false,
+    isSelected: true,
     registerRef: fn(),
     onHover: fn(),
     onBlipClick: fn(),
     onDescriptionChange: fn(),
-    items: blips.map((blip, idx) => ({
-      blip,
-      label: (
-        <>
-          <span className="mr-1 inline-block font-mono text-xs">
-            {idx + 1}
-            .
-          </span>
-          <span className="font-medium">{blip.topicName}</span>
-        </>
-      ),
-    })),
   },
   decorators: [
     Story => (
       <RouterStub>
-        <Story />
+        <ul>
+          <Story />
+        </ul>
       </RouterStub>
     ),
   ],
@@ -62,48 +39,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Section: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
-    await expect(canvas.getByText("Terraform")).toBeInTheDocument();
-  },
-};
-
-export const Empty: Story = {
-  args: {
-    items: [],
-    emptyMessage: "No blips yet.",
-  },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(await canvas.findByText("No blips yet.")).toBeInTheDocument();
-  },
-};
-
 /** A single legend row in isolation (selected, so its actions are visible). */
-export const SingleItem: StoryObj<typeof BlipLegendItem> = {
-  render: args => (
-    <RouterStub>
-      <ul>
-        <BlipLegendItem {...args} />
-      </ul>
-    </RouterStub>
-  ),
-  args: {
-    blip: makeBlip("solo", "Kubernetes", "Container orchestration"),
-    label: <span className="font-medium">Kubernetes</span>,
-    isActive: false,
-    isSelected: true,
-    registerRef: fn(),
-    onHover: fn(),
-    onBlipClick: fn(),
-    onDescriptionChange: fn(),
-  },
+export const Default: Story = {
   play: async ({
     canvasElement,
   }) => {
@@ -112,5 +49,11 @@ export const SingleItem: StoryObj<typeof BlipLegendItem> = {
     await expect(
       canvas.getByText("Container orchestration"),
     ).toBeInTheDocument();
+  },
+};
+
+export const Active: Story = {
+  args: {
+    isActive: true,
   },
 };

--- a/packages/client/src/components/radar/BlipLegendSection.stories.tsx
+++ b/packages/client/src/components/radar/BlipLegendSection.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { BlipLegendSection } from "./radarLegendItem";
+
+import { makeBlip } from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const blips = [
+  makeBlip({
+    id: "a",
+    topicId: "topic-a",
+    topicName: "Kubernetes",
+    description: "Container orchestration",
+  }),
+  makeBlip({
+    id: "b",
+    topicId: "topic-b",
+    topicName: "Terraform",
+  }),
+  makeBlip({
+    id: "c",
+    topicId: "topic-c",
+    topicName: "Prometheus",
+    description: "Metrics + alerting",
+  }),
+];
+
+const meta: Meta<typeof BlipLegendSection> = {
+  component: BlipLegendSection,
+  args: {
+    title: "Tools",
+    headingClassName: "text-sm font-semibold uppercase",
+    activeBlipId: null,
+    selectedBlipId: null,
+    registerRef: fn(),
+    onHover: fn(),
+    onBlipClick: fn(),
+    onDescriptionChange: fn(),
+    items: blips.map((blip, idx) => ({
+      blip,
+      label: (
+        <>
+          <span className="mr-1 inline-block font-mono text-xs">
+            {idx + 1}
+            .
+          </span>
+          <span className="font-medium">{blip.topicName}</span>
+        </>
+      ),
+    })),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Section: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Kubernetes")).toBeInTheDocument();
+    await expect(canvas.getByText("Terraform")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    emptyMessage: "No blips yet.",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("No blips yet.")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radar/BlipTableToolbar.stories.tsx
+++ b/packages/client/src/components/radar/BlipTableToolbar.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { BlipTableToolbar } from "./BlipTableToolbar";
+
+import { ALL } from "@/components/radar/blipTableFilters";
+import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+
+const quadrants = makeQuadrants();
+const rings = makeRings();
+
+const sliceCounts = {
+  unassigned: 1,
+  counts: new Map(quadrants.map((q, i) => [q.id, i + 1])),
+};
+const ringCounts = {
+  unassigned: 1,
+  counts: new Map(rings.map((r, i) => [r.id, i + 1])),
+};
+
+const meta: Meta<typeof BlipTableToolbar> = {
+  component: BlipTableToolbar,
+  args: {
+    search: "",
+    filterQuadrant: ALL,
+    filterRing: ALL,
+    showItemsColumn: true,
+    quadrants,
+    rings,
+    blipCount: 6,
+    sliceCounts,
+    ringCounts,
+    onSearchChange: fn(),
+    onFilterQuadrantChange: fn(),
+    onFilterRingChange: fn(),
+    onShowItemsColumnChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByPlaceholderText("Search topic or note"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Topic Items")).toBeInTheDocument();
+  },
+};
+
+export const WithSearch: Story = {
+  args: {
+    search: "kube",
+  },
+};
+
+export const ItemsHidden: Story = {
+  args: {
+    showItemsColumn: false,
+  },
+};

--- a/packages/client/src/components/radar/RadarConfigIllustrations.stories.tsx
+++ b/packages/client/src/components/radar/RadarConfigIllustrations.stories.tsx
@@ -2,12 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, within } from "storybook/test";
 
-import {
-  QuadrantsIllustration,
-  RingsIllustration,
-} from "./RadarConfigIllustrations";
+import { QuadrantsIllustration } from "./RadarConfigIllustrations";
 
-import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+import { makeQuadrants } from "@/test-utils/radarFixtures";
 
 const meta: Meta<typeof QuadrantsIllustration> = {
   component: QuadrantsIllustration,
@@ -26,15 +23,5 @@ export const Quadrants: Story = {
   }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText("Techniques")).toBeInTheDocument();
-  },
-};
-
-export const Rings: StoryObj<typeof RingsIllustration> = {
-  render: () => <RingsIllustration names={makeRings().map(r => r.name)} />,
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("Adopt")).toBeInTheDocument();
   },
 };

--- a/packages/client/src/components/radar/RingsIllustration.stories.tsx
+++ b/packages/client/src/components/radar/RingsIllustration.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { RingsIllustration } from "./RadarConfigIllustrations";
+
+import { makeRings } from "@/test-utils/radarFixtures";
+
+const meta: Meta<typeof RingsIllustration> = {
+  component: RingsIllustration,
+  args: {
+    names: makeRings().map(r => r.name),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Adopt")).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
Reorganized Storybook stories for radar legend components and extracted common test fixture helpers into a shared utilities module for better maintainability and reusability.

## Key Changes
- **Split `BlipLegendItem.stories.tsx`:** Removed `BlipLegendSection` stories and refactored to focus solely on `BlipLegendItem` component testing
  - Simplified component meta to use `BlipLegendItem` directly
  - Renamed `SingleItem` story to `Default` for consistency
  - Added new `Active` story variant to test active state
  - Updated decorator to wrap story in `<ul>` (appropriate for list item context)

- **Created `BlipLegendSection.stories.tsx`:** New dedicated story file for `BlipLegendSection` component
  - Moved `Section` and `Empty` stories from `BlipLegendItem.stories.tsx`
  - Maintains all original test coverage and play functions

- **Created `BlipTableToolbar.stories.tsx`:** New story file for toolbar component with three variants
  - `Default`: Basic toolbar with all controls visible
  - `WithSearch`: Demonstrates search input with text
  - `ItemsHidden`: Shows toolbar with items column toggled off

- **Created `RingsIllustration.stories.tsx`:** New dedicated story file for rings illustration component
  - Extracted from `RadarConfigIllustrations.stories.tsx`
  - Single `Default` story with play test

- **Updated `RadarConfigIllustrations.stories.tsx`:** Removed `RingsIllustration` story (moved to dedicated file)

- **Extracted `makeBlip` helper:** Moved from `BlipLegendItem.stories.tsx` to `@/test-utils/radarFixtures`
  - Updated signature to accept object parameter for better flexibility
  - Now reusable across all radar-related stories and tests

## Implementation Details
- All stories maintain their original test coverage via play functions
- Fixture extraction reduces duplication and centralizes test data creation
- Story organization now follows a one-component-per-file pattern for clarity
- Backward compatibility maintained through consistent prop interfaces

https://claude.ai/code/session_015YPhCWYyiEvwbGbdrx3gFM