### PR TITLE
test(client): fixes #358: add Storybook stories for quick-add dialogs

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddDialogs.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddDialogs.stories.tsx
@@ -1,0 +1,76 @@
+import type { AppSettingsSummary } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { QuickAddDialogs } from "./QuickAddDialogs";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+// All six child dialogs mount at once; the Readwise/Todoist ones read settings
+// via useQuery, so seed the cache (staleTime Infinity) to avoid a network call.
+const client = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      staleTime: Infinity,
+    },
+  },
+});
+client.setQueryData(queryKeys.settings.detail(), {
+  readwiseConfigured: true,
+  readwiseKeyHint: "…aB3x",
+  todoistConfigured: true,
+  todoistKeyHint: "…aB3x",
+  focusedDomainIds: [],
+} satisfies AppSettingsSummary);
+
+const meta: Meta<typeof QuickAddDialogs> = {
+  component: QuickAddDialogs,
+  args: {
+    active: "resource",
+    onClose: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={client}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// active="resource" opens the resource quick-add dialog (portaled to body).
+export const ResourceActive: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Resource")).toBeInTheDocument();
+  },
+};
+
+// Switching `active` opens a different dialog from the same mounted set.
+export const ProviderActive: Story = {
+  args: {
+    active: "provider",
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Provider")).toBeInTheDocument();
+  },
+};
+
+// active=null renders the set with every dialog closed.
+export const Closed: Story = {
+  args: {
+    active: null,
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddMenu.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddMenu.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddMenu } from "./QuickAddMenu";
+
+const meta: Meta<typeof QuickAddMenu> = {
+  component: QuickAddMenu,
+  args: {
+    onSelect: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The trigger renders inline in the canvas.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Quick Add")).toBeInTheDocument();
+  },
+};
+
+// Opening the menu reveals the grouped options (portaled to document.body);
+// picking one fires onSelect with that option's key.
+export const Opens: Story = {
+  play: async ({
+    canvasElement,
+    args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByText("Quick Add"));
+    const body = within(document.body);
+    await expect(await body.findByText("Send to")).toBeInTheDocument();
+    await expect(await body.findByText("New record")).toBeInTheDocument();
+    await userEvent.click(
+      await body.findByRole("menuitem", {
+        name: "Resource",
+      }),
+    );
+    await expect(args.onSelect).toHaveBeenCalledWith("resource");
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddNameDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddNameDialog.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
+
+const meta: Meta<typeof QuickAddNameDialog> = {
+  component: QuickAddNameDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    title: "Add Resource",
+    entity: "resource",
+    placeholder: "Resource name",
+    isPending: false,
+    onSubmit: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The Radix dialog content portals to document.body, so assert against it.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Resource")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Name")).toBeInTheDocument();
+  },
+};
+
+// Submitting calls onSubmit with the trimmed, non-empty name.
+export const Submits: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.type(await body.findByLabelText("Name"), "  My Course  ");
+    await userEvent.click(body.getByRole("button", {
+      name: "Create",
+    }));
+    await expect(args.onSubmit).toHaveBeenCalledWith("My Course");
+  },
+};
+
+// While the create mutation is in flight the submit button is disabled.
+export const Pending: Story = {
+  args: {
+    isPending: true,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("button", {
+        name: "Create",
+      }),
+    ).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddProviderDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddProviderDialog.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddProviderDialog } from "./QuickAddProviderDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof QuickAddProviderDialog> = {
+  component: QuickAddProviderDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate → QueryStub + RouterStub.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Provider")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Name")).toBeInTheDocument();
+    await expect(await body.findByLabelText("URL")).toBeInTheDocument();
+  },
+};
+
+// Cancel closes the dialog via onOpenChange(false).
+export const Cancel: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};
+
+// Create stays disabled until both Name and URL are filled.
+export const EnablesOnFill: Story = {
+  play: async () => {
+    const body = within(document.body);
+    const create = await body.findByRole("button", {
+      name: "Create",
+    });
+    await expect(create).toBeDisabled();
+    await userEvent.type(await body.findByLabelText("Name"), "Acme Learning");
+    await userEvent.type(
+      await body.findByLabelText("URL"),
+      "https://example.com",
+    );
+    await expect(create).toBeEnabled();
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.stories.tsx
@@ -1,0 +1,99 @@
+import type { AppSettingsSummary } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { QuickAddReadwiseDialog } from "./QuickAddReadwiseDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Seed the settings query the dialog reads via useQuery so it renders the right
+// branch without a network call. staleTime Infinity keeps the seed fresh.
+function settingsClient(over: Partial<AppSettingsSummary> = {}): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), {
+    readwiseConfigured: false,
+    readwiseKeyHint: null,
+    todoistConfigured: false,
+    todoistKeyHint: null,
+    focusedDomainIds: [],
+    ...over,
+  } satisfies AppSettingsSummary);
+  return client;
+}
+
+const meta: Meta<typeof QuickAddReadwiseDialog> = {
+  component: QuickAddReadwiseDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// With Readwise configured the save form is shown. Dialog portals to body.
+export const Configured: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub
+          client={settingsClient({
+            readwiseConfigured: true,
+          })}
+        >
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Save to Readwise")).toBeInTheDocument();
+    await expect(await body.findByLabelText("URL")).toBeInTheDocument();
+    await expect(
+      await body.findByRole("button", {
+        name: "Save",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Without a Readwise key the dialog points the user to Settings. (The footer's
+// "Close" button shares its accessible name with the dialog's built-in X, so we
+// assert on the Settings link + helper text, which are unique to this branch.)
+export const Unconfigured: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={settingsClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Save to Readwise")).toBeInTheDocument();
+    await expect(
+      await body.findByText(/Add a Readwise API key in/),
+    ).toBeInTheDocument();
+    await expect(
+      await body.findByRole("link", {
+        name: "Settings",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddResourceDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddResourceDialog.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddResourceDialog } from "./QuickAddResourceDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof QuickAddResourceDialog> = {
+  component: QuickAddResourceDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate → QueryStub + RouterStub.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Resource")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Name")).toBeInTheDocument();
+  },
+};
+
+// initialName seeds the name input when the dialog opens.
+export const WithInitialName: Story = {
+  args: {
+    initialName: "Structured Query Language",
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByLabelText("Name")).toHaveValue(
+      "Structured Query Language",
+    );
+  },
+};
+
+// Cancel closes the dialog via onOpenChange(false).
+export const Cancel: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddRoutineDialog } from "./QuickAddRoutineDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof QuickAddRoutineDialog> = {
+  component: QuickAddRoutineDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate (via useQuickAddRoutine) → QueryStub + RouterStub.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body; the mode radios default to weekly.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Routine")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Name")).toBeInTheDocument();
+    await expect(
+      await body.findByRole("radio", {
+        name: "Weekly Schedule",
+      }),
+    ).toBeChecked();
+    await expect(
+      await body.findByRole("radio", {
+        name: "Daily Task",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Naming the routine and choosing the daily mode enables Create.
+export const SelectsDailyMode: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.type(await body.findByLabelText("Name"), "Read for 30m");
+    const daily = await body.findByRole("radio", {
+      name: "Daily Task",
+    });
+    await userEvent.click(daily);
+    await expect(daily).toBeChecked();
+    await expect(
+      await body.findByRole("button", {
+        name: "Create",
+      }),
+    ).toBeEnabled();
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddTaskDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTaskDialog.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddTaskDialog } from "./QuickAddTaskDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof QuickAddTaskDialog> = {
+  component: QuickAddTaskDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate → QueryStub + RouterStub.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Task")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Name")).toBeInTheDocument();
+  },
+};
+
+// Cancel closes the dialog via onOpenChange(false).
+export const Cancel: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddTodoistDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTodoistDialog.stories.tsx
@@ -1,0 +1,99 @@
+import type { AppSettingsSummary } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { QuickAddTodoistDialog } from "./QuickAddTodoistDialog";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Seed the settings query the hook reads via useQuery so the dialog renders the
+// right branch without a network call. staleTime Infinity keeps the seed fresh.
+function settingsClient(over: Partial<AppSettingsSummary> = {}): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), {
+    readwiseConfigured: false,
+    readwiseKeyHint: null,
+    todoistConfigured: false,
+    todoistKeyHint: null,
+    focusedDomainIds: [],
+    ...over,
+  } satisfies AppSettingsSummary);
+  return client;
+}
+
+const meta: Meta<typeof QuickAddTodoistDialog> = {
+  component: QuickAddTodoistDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// With Todoist configured the create-task form is shown. Dialog portals to body.
+export const Configured: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub
+          client={settingsClient({
+            todoistConfigured: true,
+          })}
+        >
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Todoist task")).toBeInTheDocument();
+    await expect(await body.findByLabelText("Title")).toBeInTheDocument();
+    await expect(
+      await body.findByRole("button", {
+        name: "Add",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Without a Todoist key the dialog points the user to Settings. (The footer's
+// "Close" button shares its accessible name with the dialog's built-in X, so we
+// assert on the Settings link + helper text, which are unique to this branch.)
+export const Unconfigured: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={settingsClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Add Todoist task")).toBeInTheDocument();
+    await expect(
+      await body.findByText(/Add a Todoist API key in/),
+    ).toBeInTheDocument();
+    await expect(
+      await body.findByRole("link", {
+        name: "Settings",
+      }),
+    ).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
Add comprehensive Storybook stories for all quick-add dialog components and the menu that triggers them.

## Summary
This adds visual and interactive test coverage for the quick-add feature set via Storybook, enabling developers to verify dialog behavior, form states, and integration with settings/routing without running the full app.

## Key Changes
- **QuickAddMenu.stories.tsx**: Stories for the trigger button and menu opening/selection behavior
- **QuickAddNameDialog.stories.tsx**: Base dialog component with submission and pending states
- **QuickAddResourceDialog.stories.tsx**: Resource creation with initial name seeding and cancellation
- **QuickAddTaskDialog.stories.tsx**: Task creation dialog with cancel interaction
- **QuickAddRoutineDialog.stories.tsx**: Routine creation with mode selection (weekly/daily) and form validation
- **QuickAddProviderDialog.stories.tsx**: Provider creation with name/URL fields and enable-on-fill logic
- **QuickAddReadwiseDialog.stories.tsx**: Configured vs. unconfigured states with settings integration
- **QuickAddTodoistDialog.stories.tsx**: Configured vs. unconfigured states with settings integration
- **QuickAddDialogs.stories.tsx**: Parent component managing multiple dialogs with active state switching

## Implementation Details
- All stories use `QueryStub` and `RouterStub` test utilities to mock dependencies (mutations, navigation, settings queries)
- Settings-dependent dialogs (Readwise/Todoist) seed the React Query cache with `staleTime: Infinity` to avoid network calls
- Dialog content assertions target `document.body` since Radix dialogs portal their content
- Play functions verify both rendered UI and interactive behavior (form filling, button states, callbacks)
- Follows existing Storybook patterns in the codebase with `@storybook/react-vite` and `storybook/test` utilities

https://claude.ai/code/session_01F82pLLuUNeFs1NAgih4tCk