### PR TITLE
refactor: extract reusable list components from entity detail pages (#364)

### DIFF
--- a/packages/client/src/routes/domains.$id.-components/-ExcludedTopicsList.stories.tsx
+++ b/packages/client/src/routes/domains.$id.-components/-ExcludedTopicsList.stories.tsx
@@ -1,0 +1,55 @@
+import type { DomainExcludedTopic } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { ExcludedTopicsList } from "./-ExcludedTopicsList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const topics: DomainExcludedTopic[] = [
+  {
+    id: "topic-1",
+    name: "Legacy Mixins",
+    reason: "Superseded by hooks",
+  },
+  {
+    id: "topic-2",
+    name: "Class Components",
+  },
+];
+
+const meta: Meta<typeof ExcludedTopicsList> = {
+  component: ExcludedTopicsList,
+  args: {
+    topics,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Legacy Mixins")).toBeInTheDocument();
+    // The optional reason renders alongside the topic that has one.
+    await expect(canvas.getByText(/Superseded by hooks/)).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    topics: [],
+  },
+};

--- a/packages/client/src/routes/domains.$id.-components/-ExcludedTopicsList.tsx
+++ b/packages/client/src/routes/domains.$id.-components/-ExcludedTopicsList.tsx
@@ -1,0 +1,34 @@
+import type { DomainExcludedTopic } from "@emstack/types";
+
+import { Link } from "@tanstack/react-router";
+
+/** Bulleted list of topics excluded from the radar, each with an optional reason. */
+export function ExcludedTopicsList({
+  topics,
+}: { topics: DomainExcludedTopic[] }) {
+  return (
+    <ul className="ml-5 flex list-disc flex-col gap-1">
+      {topics.map(topic => (
+        <li key={topic.id}>
+          <Link
+            to="/topics/$id"
+            params={{
+              id: topic.id,
+            }}
+            className={`
+              font-bold text-blue-800
+              hover:text-blue-600
+            `}
+          >
+            {topic.name}
+          </Link>
+          {topic.reason && (
+            <span className="ml-2 text-sm text-muted-foreground">
+              — {topic.reason}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/domains.$id.-components/-TopicLinkList.stories.tsx
+++ b/packages/client/src/routes/domains.$id.-components/-TopicLinkList.stories.tsx
@@ -1,0 +1,75 @@
+import type { DomainTopic } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { TopicLinkList } from "./-TopicLinkList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const topics: DomainTopic[] = [
+  {
+    id: "topic-1",
+    name: "Reactivity",
+    courses: [
+      {
+        id: "c1",
+        name: "Course A",
+      },
+      {
+        id: "c2",
+        name: "Course B",
+      },
+    ],
+  },
+  {
+    id: "topic-2",
+    name: "Routing",
+    courses: [
+      {
+        id: "c3",
+        name: "Course C",
+      },
+    ],
+  },
+  {
+    id: "topic-3",
+    name: "Suspense",
+  },
+];
+
+const meta: Meta<typeof TopicLinkList> = {
+  component: TopicLinkList,
+  args: {
+    topics,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Reactivity")).toBeInTheDocument();
+    // A multi-course topic pluralizes the count; a single-course one does not.
+    await expect(canvas.getByText("(2 courses)")).toBeInTheDocument();
+    await expect(canvas.getByText("(1 course)")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    topics: [],
+  },
+};

--- a/packages/client/src/routes/domains.$id.-components/-TopicLinkList.tsx
+++ b/packages/client/src/routes/domains.$id.-components/-TopicLinkList.tsx
@@ -1,0 +1,34 @@
+import type { DomainTopic } from "@emstack/types";
+
+import { EntityLink } from "@/components/boxElements";
+
+/** Bulleted list of topic links with an optional course count. */
+export function TopicLinkList({
+  topics,
+}: { topics: DomainTopic[] }) {
+  return (
+    <ul className="ml-5 list-disc">
+      {topics.map(topic => (
+        <li key={topic.id}>
+          <EntityLink
+            entity="topics"
+            id={String(topic.id)}
+            className="
+              font-bold text-blue-800
+              hover:text-blue-600
+            "
+          >
+            {topic.name}
+          </EntityLink>
+          {topic.courses && topic.courses.length > 0 && (
+            <span className="ml-2 text-xs text-muted-foreground">
+              ({topic.courses.length}
+              {" course"}
+              {topic.courses.length === 1 ? "" : "s"})
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/domains.$id.index.tsx
+++ b/packages/client/src/routes/domains.$id.index.tsx
@@ -1,12 +1,11 @@
-import type { DomainTopic } from "@emstack/types";
-
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { EditIcon, RadarIcon } from "lucide-react";
 
+import { ExcludedTopicsList } from "./domains.$id.-components/-ExcludedTopicsList";
 import { RadarChart } from "./domains.$id.-components/-RadarChart";
+import { TopicLinkList } from "./domains.$id.-components/-TopicLinkList";
 
-import { EntityLink } from "@/components/boxElements";
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea, PageHeader } from "@/components/layout";
 import { Button } from "@/components/ui/button";
@@ -15,37 +14,6 @@ import { fetchRadar, fetchSingleDomain } from "@/utils";
 export const Route = createFileRoute("/domains/$id/")({
   component: SingleDomain,
 });
-
-/** Bulleted list of topic links with an optional course count. */
-function TopicLinkList({
-  topics,
-}: { topics: DomainTopic[] }) {
-  return (
-    <ul className="ml-5 list-disc">
-      {topics.map(topic => (
-        <li key={topic.id}>
-          <EntityLink
-            entity="topics"
-            id={String(topic.id)}
-            className="
-              font-bold text-blue-800
-              hover:text-blue-600
-            "
-          >
-            {topic.name}
-          </EntityLink>
-          {topic.courses && topic.courses.length > 0 && (
-            <span className="ml-2 text-xs text-muted-foreground">
-              ({topic.courses.length}
-              {" course"}
-              {topic.courses.length === 1 ? "" : "s"})
-            </span>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
 
 function SingleDomain() {
   const {
@@ -191,29 +159,7 @@ function SingleDomain() {
           header="Topics excluded from Radar"
           condition={excludedTopics.length > 0}
         >
-          <ul className="ml-5 flex list-disc flex-col gap-1">
-            {excludedTopics.map(topic => (
-              <li key={topic.id}>
-                <Link
-                  to="/topics/$id"
-                  params={{
-                    id: topic.id,
-                  }}
-                  className={`
-                    font-bold text-blue-800
-                    hover:text-blue-600
-                  `}
-                >
-                  {topic.name}
-                </Link>
-                {topic.reason && (
-                  <span className="ml-2 text-sm text-muted-foreground">
-                    — {topic.reason}
-                  </span>
-                )}
-              </li>
-            ))}
-          </ul>
+          <ExcludedTopicsList topics={excludedTopics} />
         </InfoArea>
       </div>
     </div>

--- a/packages/client/src/routes/settings.-components/-TagGroupsAdmin.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-TagGroupsAdmin.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient } from "@tanstack/react-query";
 import { expect, within } from "storybook/test";
 
-import { TagGroupsAdmin } from "./TagGroupsAdmin";
+import { TagGroupsAdmin } from "./-TagGroupsAdmin";
 
 import { QueryStub } from "@/test-utils/QueryStub";
 import { makeTagGroups } from "@/test-utils/resourceModulesFixtures";

--- a/packages/client/src/routes/settings.-components/-TaskTypeEditRow.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-TaskTypeEditRow.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, fn, userEvent, within } from "storybook/test";
 
-import { TaskTypeEditRow } from "./TaskTypeEditRow";
+import { TaskTypeEditRow } from "./-TaskTypeEditRow";
 
 const taskType: TaskType = {
   id: "task-type-1",

--- a/packages/client/src/routes/tasks.$id.-components/-LinkedRoutinesSection.stories.tsx
+++ b/packages/client/src/routes/tasks.$id.-components/-LinkedRoutinesSection.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { LinkedRoutinesSection } from "./-LinkedRoutinesSection";
+
+import { makeRoutine } from "@/test-utils/boxFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof LinkedRoutinesSection> = {
+  component: LinkedRoutinesSection,
+  args: {
+    taskId: "task-1",
+    routines: [
+      makeRoutine({
+        id: "routine-1",
+        name: "Morning practice",
+        mode: "daily",
+      }),
+      makeRoutine({
+        id: "routine-2",
+        name: "Weekly review",
+        mode: "weekly",
+      }),
+    ],
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Morning practice"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Daily")).toBeInTheDocument();
+    await expect(canvas.getByText("Weekly")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    routines: [],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("No routines include this task."),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /Create Routine for this Task/,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/tasks.$id.-components/-LinkedRoutinesSection.tsx
+++ b/packages/client/src/routes/tasks.$id.-components/-LinkedRoutinesSection.tsx
@@ -1,0 +1,79 @@
+import type { Routine } from "@emstack/types";
+
+import { Link } from "@tanstack/react-router";
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * "Routines" section body for a task: the routines that include this task, or a
+ * dashed empty state with a CTA to create one.
+ */
+export function LinkedRoutinesSection({
+  routines,
+  taskId,
+}: {
+  routines: Routine[];
+  taskId: string;
+}) {
+  if (routines.length === 0) {
+    return (
+      <div
+        className="
+          flex flex-row items-center justify-between gap-2 rounded-md border
+          border-dashed bg-card p-4
+        "
+      >
+        <span className="text-sm text-muted-foreground">
+          No routines include this task.
+        </span>
+        <Link
+          to="/routines/$id/edit"
+          params={{
+            id: "new",
+          }}
+          search={{
+            mode: "daily",
+            entryType: "task",
+            entryId: taskId,
+          }}
+        >
+          <Button>
+            <PlusIcon />
+            Create Routine for this Task
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {routines.map(r => (
+        <li
+          key={r.id}
+          className="
+            flex flex-row items-center justify-between gap-2 rounded-md border
+            bg-card p-3
+          "
+        >
+          <Link
+            to="/routines/$id"
+            params={{
+              id: r.id,
+            }}
+            className="
+              font-medium
+              hover:text-blue-600
+            "
+          >
+            {r.name}
+          </Link>
+          <span className="text-xs text-muted-foreground">
+            {r.mode === "daily" ? "Daily" : "Weekly"}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/tasks.$id.index.tsx
+++ b/packages/client/src/routes/tasks.$id.index.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { EditIcon, PlusIcon } from "lucide-react";
+import { EditIcon } from "lucide-react";
+
+import { LinkedRoutinesSection } from "./tasks.$id.-components/-LinkedRoutinesSection";
 
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import { InfoArea, PageHeader } from "@/components/layout";
@@ -81,64 +83,10 @@ function SingleTask() {
           header="Routines"
           condition={true}
         >
-          {linkedRoutines.length > 0
-            ? (
-              <ul className="flex flex-col gap-2">
-                {linkedRoutines.map(r => (
-                  <li
-                    key={r.id}
-                    className="
-                      flex flex-row items-center justify-between gap-2
-                      rounded-md border bg-card p-3
-                    "
-                  >
-                    <Link
-                      to="/routines/$id"
-                      params={{
-                        id: r.id,
-                      }}
-                      className="
-                        font-medium
-                        hover:text-blue-600
-                      "
-                    >
-                      {r.name}
-                    </Link>
-                    <span className="text-xs text-muted-foreground">
-                      {r.mode === "daily" ? "Daily" : "Weekly"}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )
-            : (
-              <div
-                className="
-                  flex flex-row items-center justify-between gap-2 rounded-md
-                  border border-dashed bg-card p-4
-                "
-              >
-                <span className="text-sm text-muted-foreground">
-                  No routines include this task.
-                </span>
-                <Link
-                  to="/routines/$id/edit"
-                  params={{
-                    id: "new",
-                  }}
-                  search={{
-                    mode: "daily",
-                    entryType: "task",
-                    entryId: data.id,
-                  }}
-                >
-                  <Button>
-                    <PlusIcon />
-                    Create Routine for this Task
-                  </Button>
-                </Link>
-              </div>
-            )}
+          <LinkedRoutinesSection
+            routines={linkedRoutines}
+            taskId={data.id}
+          />
         </InfoArea>
         <InfoArea
           header="Topic"

--- a/packages/client/src/routes/topics.$id.-components/-DomainLinkList.stories.tsx
+++ b/packages/client/src/routes/topics.$id.-components/-DomainLinkList.stories.tsx
@@ -1,0 +1,56 @@
+import type { TopicDomain } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { DomainLinkList } from "./-DomainLinkList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const domains: TopicDomain[] = [
+  {
+    id: "domain-1",
+    title: "Frontend Engineering",
+  },
+  {
+    id: "domain-2",
+    title: "Developer Tooling",
+  },
+];
+
+const meta: Meta<typeof DomainLinkList> = {
+  component: DomainLinkList,
+  args: {
+    domains,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "Frontend Engineering",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    domains: [],
+  },
+};

--- a/packages/client/src/routes/topics.$id.-components/-DomainLinkList.tsx
+++ b/packages/client/src/routes/topics.$id.-components/-DomainLinkList.tsx
@@ -1,0 +1,31 @@
+import type { TopicDomain } from "@emstack/types";
+
+import { Link } from "@tanstack/react-router";
+
+/** Bulleted list of links to the domains a topic belongs to. */
+export function DomainLinkList({
+  domains,
+}: { domains: TopicDomain[] }) {
+  return (
+    <ul className="ml-5 list-disc">
+      {domains
+        .filter(domain => domain.id !== undefined)
+        .map(domain => (
+          <li key={domain.id}>
+            <Link
+              to="/domains/$id"
+              params={{
+                id: domain.id + "",
+              }}
+              className={`
+                font-bold text-blue-800
+                hover:text-blue-600
+              `}
+            >
+              {domain.title}
+            </Link>
+          </li>
+        ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/topics.$id.-components/-RoutineLinkList.stories.tsx
+++ b/packages/client/src/routes/topics.$id.-components/-RoutineLinkList.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { RoutineLinkList } from "./-RoutineLinkList";
+
+import { makeRoutine } from "@/test-utils/boxFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof RoutineLinkList> = {
+  component: RoutineLinkList,
+  args: {
+    routines: [
+      makeRoutine({
+        id: "routine-1",
+        name: "Daily reading",
+      }),
+      makeRoutine({
+        id: "routine-2",
+        name: "Flashcards",
+      }),
+    ],
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: "Daily reading",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    routines: [],
+  },
+};

--- a/packages/client/src/routes/topics.$id.-components/-RoutineLinkList.tsx
+++ b/packages/client/src/routes/topics.$id.-components/-RoutineLinkList.tsx
@@ -1,0 +1,29 @@
+import type { Routine } from "@emstack/types";
+
+import { Link } from "@tanstack/react-router";
+
+/** Bulleted list of links to the routines connected to a topic. */
+export function RoutineLinkList({
+  routines,
+}: { routines: Routine[] }) {
+  return (
+    <ul className="ml-5 list-disc">
+      {routines.map(r => (
+        <li key={r.id}>
+          <Link
+            to="/routines/$id"
+            params={{
+              id: r.id,
+            }}
+            className={`
+              font-bold text-blue-800
+              hover:text-blue-600
+            `}
+          >
+            {r.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/topics.$id.index.tsx
+++ b/packages/client/src/routes/topics.$id.index.tsx
@@ -1,6 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { EditIcon } from "lucide-react";
+
+import { DomainLinkList } from "./topics.$id.-components/-DomainLinkList";
+import { RoutineLinkList } from "./topics.$id.-components/-RoutineLinkList";
 
 import { EntityError, EntityPending } from "@/components/EntityStates";
 import {
@@ -80,27 +83,7 @@ function SingleTopic() {
             header="Domains"
             condition={!!data?.domains && data.domains.length > 0}
           >
-            <ul className="ml-5 list-disc">
-              {data?.domains
-                && data.domains
-                  .filter(domain => domain.id !== undefined)
-                  .map(domain => (
-                    <li key={domain.id}>
-                      <Link
-                        to="/domains/$id"
-                        params={{
-                          id: domain.id + "",
-                        }}
-                        className={`
-                          font-bold text-blue-800
-                          hover:text-blue-600
-                        `}
-                      >
-                        {domain.title}
-                      </Link>
-                    </li>
-                  ))}
-            </ul>
+            <DomainLinkList domains={data?.domains ?? []} />
           </InfoArea>
         </div>
         <ResourceLinksSection
@@ -112,24 +95,7 @@ function SingleTopic() {
             header="Routines"
             condition={linkedRoutines.length > 0}
           >
-            <ul className="ml-5 list-disc">
-              {linkedRoutines.map(r => (
-                <li key={r.id}>
-                  <Link
-                    to="/routines/$id"
-                    params={{
-                      id: r.id,
-                    }}
-                    className={`
-                      font-bold text-blue-800
-                      hover:text-blue-600
-                    `}
-                  >
-                    {r.name}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+            <RoutineLinkList routines={linkedRoutines} />
           </InfoArea>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Extracted inline list rendering logic from entity detail pages into reusable, composable components with accompanying Storybook stories. This improves code maintainability, testability, and consistency across the application.

## Key Changes

- **New components:**
  - `LinkedRoutinesSection` — renders routines linked to a task, with empty state and CTA to create a routine
  - `TopicLinkList` — bulleted list of topics with optional course counts
  - `ExcludedTopicsList` — bulleted list of excluded topics with optional reasons
  - `DomainLinkList` — bulleted list of domain links
  - `RoutineLinkList` — bulleted list of routine links

- **Refactored pages:**
  - `tasks.$id.index.tsx` — replaced 54 lines of inline JSX with `<LinkedRoutinesSection>` component
  - `domains.$id.index.tsx` — extracted `TopicLinkList` and `ExcludedTopicsList` components
  - `topics.$id.index.tsx` — extracted `DomainLinkList` and `RoutineLinkList` components

- **Test coverage:**
  - Added Storybook stories for all new components with play tests validating rendering and empty states

## Implementation Details

- All components follow the existing pattern of accepting typed data arrays and rendering styled lists
- Components are colocated in `-components/` subdirectories alongside their parent routes
- `LinkedRoutinesSection` includes special handling for empty state with a CTA button that pre-populates routine creation with the task ID
- List components use consistent styling (bulleted lists with blue link colors) and support optional metadata (course counts, exclusion reasons)

https://claude.ai/code/session_011kovdGMYapVPQxrTQRFhKa