### PR TITLE
refactor(middleware): Fixes #373: dedupe self-duplicated status blocks in readwise/todoist services

### DIFF
--- a/packages/middleware/src/services/readwise.ts
+++ b/packages/middleware/src/services/readwise.ts
@@ -63,6 +63,23 @@ export async function getReadwiseToken(): Promise<string | null> {
   return fromEnv ? fromEnv : null;
 }
 
+/**
+ * Translate a non-OK Readwise response into a friendly ReadwiseError.
+ * Shared by every Readwise call so they map statuses consistently. Readwise
+ * answers 401 (missing auth) or 403 (bad token) for auth failures.
+ */
+function assertReadwiseOk(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new ReadwiseError("Readwise rejected the API key.", 401);
+  }
+  if (response.status === 429) {
+    throw new ReadwiseError("Readwise rate limit reached — try again shortly.", 429);
+  }
+  if (!response.ok) {
+    throw new ReadwiseError(`Readwise request failed (${response.status}).`, 502);
+  }
+}
+
 // Readwise documents reading_progress as a 0–1 float, but some clients report
 // 0–100; normalize defensively so the partition logic is scale-independent.
 function normalizeProgress(value: number | null | undefined): number {
@@ -111,16 +128,7 @@ async function fetchLocation(
       throw new ReadwiseError("Could not reach Readwise.", 502);
     }
 
-    // Readwise answers 401 (missing auth) or 403 (bad token) for auth failures.
-    if (response.status === 401 || response.status === 403) {
-      throw new ReadwiseError("Readwise rejected the API key.", 401);
-    }
-    if (response.status === 429) {
-      throw new ReadwiseError("Readwise rate limit reached — try again shortly.", 429);
-    }
-    if (!response.ok) {
-      throw new ReadwiseError(`Readwise request failed (${response.status}).`, 502);
-    }
+    assertReadwiseOk(response);
 
     const body = (await response.json()) as RawListResponse;
     collected.push(...(body.results ?? []));
@@ -208,15 +216,7 @@ export async function saveReadwiseDocument(
     throw new ReadwiseError("Could not reach Readwise.", 502);
   }
 
-  if (response.status === 401 || response.status === 403) {
-    throw new ReadwiseError("Readwise rejected the API key.", 401);
-  }
-  if (response.status === 429) {
-    throw new ReadwiseError("Readwise rate limit reached — try again shortly.", 429);
-  }
-  if (!response.ok) {
-    throw new ReadwiseError(`Readwise request failed (${response.status}).`, 502);
-  }
+  assertReadwiseOk(response);
 
   const body = (await response.json()) as {
     id?: string;

--- a/packages/middleware/src/services/todoist.ts
+++ b/packages/middleware/src/services/todoist.ts
@@ -307,15 +307,7 @@ export async function createTodoistTask(
     throw new TodoistError("Could not reach Todoist.", 502);
   }
 
-  if (response.status === 401 || response.status === 403) {
-    throw new TodoistError("Todoist rejected the API key.", 401);
-  }
-  if (response.status === 429) {
-    throw new TodoistError("Todoist rate limit reached — try again shortly.", 429);
-  }
-  if (!response.ok) {
-    throw new TodoistError(`Todoist request failed (${response.status}).`, 502);
-  }
+  assertTodoistOk(response);
 
   const body = (await response.json()) as {
     id?: string;


### PR DESCRIPTION
## ELI5

Two parts of the app that talk to outside services (Readwise and Todoist) had the same little chunk of "here's how to react when the request goes wrong" copy-pasted in several places. This PR moves that chunk into one named spot per file so there's a single place to read and update it, with no change to how the app behaves.

## Summary

- `readwise.ts`: added an `assertReadwiseOk(response)` helper and replaced the two inlined 401/403/429/`!ok` status blocks in `fetchLocation` and `saveReadwiseDocument`.
- `todoist.ts`: replaced the inlined status block in `createTodoistTask` with the already-existing `assertTodoistOk(response)` helper.
- No behavior change — the same statuses still map to the same `*Error` types. The differing `fetch`/`try-catch` request wrappers were intentionally left alone (issue scoped only the status block).

## Test plan

- [ ] `pnpm --filter=@emstack/middleware run typecheck` passes
- [ ] `pnpm exec eslint packages/middleware/src/services/readwise.ts packages/middleware/src/services/todoist.ts` is clean
- [ ] `pnpm exec fallow dupes` no longer reports clone groups under `services/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)