### PR TITLE
test: add Storybook stories for UI components (#362)

### DIFF
--- a/packages/client/src/components/ConfirmDialog.stories.tsx
+++ b/packages/client/src/components/ConfirmDialog.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+// Controlled AlertDialog: render with `open: true`. The content portals to
+// document.body, so assertions query there rather than the canvas.
+const meta: Meta<typeof ConfirmDialog> = {
+  component: ConfirmDialog,
+  args: {
+    open: true,
+    title: "Delete this routine?",
+    description: "This can't be undone.",
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByText("Delete this routine?"),
+    ).toBeInTheDocument();
+    await expect(body.getByText("This can't be undone.")).toBeInTheDocument();
+  },
+};
+
+// The confirm button runs the confirm handler.
+export const Confirms: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", {
+      name: "Yes",
+    }));
+    await expect(args.onConfirm).toHaveBeenCalled();
+  },
+};
+
+// The cancel button runs the cancel handler.
+export const Cancels: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole("button", {
+      name: "No",
+    }));
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+// Custom labels and no description.
+export const CustomLabels: Story = {
+  args: {
+    title: "Discard changes?",
+    description: undefined,
+    confirmLabel: "Discard",
+    cancelLabel: "Keep editing",
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByRole("button", {
+        name: "Discard",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/EditFormActions.stories.tsx
+++ b/packages/client/src/components/EditFormActions.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { EditFormActions } from "./EditFormActions";
+
+const meta: Meta<typeof EditFormActions> = {
+  component: EditFormActions,
+  args: {
+    isSaving: false,
+    onCancel: fn(),
+    onDelete: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+// A new (unsaved) row hides the destructive Remove button.
+export const NewRow: Story = {
+  args: {
+    isNew: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("button", {
+        name: "Remove",
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// An existing row shows Remove and fires onDelete.
+export const ExistingRow: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Remove",
+    }));
+    await expect(args.onDelete).toHaveBeenCalled();
+  },
+};
+
+// While saving, the Save button is disabled.
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Save",
+    })).toBeDisabled();
+  },
+};
+
+// Delete can be blocked with an explanatory reason.
+export const DeleteDisabled: Story = {
+  args: {
+    deleteDisabled: true,
+    deleteDisabledReason: "Remove all tags first",
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Remove",
+    })).toBeDisabled();
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "sm",
+  },
+};

--- a/packages/client/src/components/EditModalFooter.stories.tsx
+++ b/packages/client/src/components/EditModalFooter.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { EditModalFooter } from "./EditModalFooter";
+
+const meta: Meta<typeof EditModalFooter> = {
+  component: EditModalFooter,
+  args: {
+    onCancel: fn(),
+    onDelete: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+// A new entity hides the destructive Remove button.
+export const NewEntity: Story = {
+  args: {
+    isNew: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("button", {
+        name: "Remove",
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// An existing entity shows Remove and fires onDelete.
+export const Removable: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Remove",
+    }));
+    await expect(args.onDelete).toHaveBeenCalled();
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Save",
+    })).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/EntityStates.stories.tsx
+++ b/packages/client/src/components/EntityStates.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { EntityError, EntityPending } from "./EntityStates";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+// `EntityPending` is the meta component; `EntityError` renders a router <Link>,
+// so it's shown as a separate story wrapped in RouterStub.
+const meta: Meta<typeof EntityPending> = {
+  component: EntityPending,
+  args: {
+    entity: "courses",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/loading your courses/i)).toBeInTheDocument();
+  },
+};
+
+// EntityError renders a TanStack <Link>, so it needs router context. RouterStub
+// mounts async, so assert with findBy*.
+export const Error: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+  render: () => <EntityError entity="topics" />,
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/error loading your topics/i),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("link", {
+        name: "Onboarding Wizard",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/FilterOptionCount.stories.tsx
+++ b/packages/client/src/components/FilterOptionCount.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { FilterOptionCount } from "./FilterOptionCount";
+
+const meta = {
+  component: FilterOptionCount,
+  args: {
+    count: 12,
+  },
+} satisfies Meta<typeof FilterOptionCount>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("12")).toBeInTheDocument();
+  },
+};
+
+export const Zero: Story = {
+  args: {
+    count: 0,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("0")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/LayoutNameDialog.stories.tsx
+++ b/packages/client/src/components/LayoutNameDialog.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { LayoutNameDialog } from "./LayoutNameDialog";
+
+// Controlled Dialog: render with `open: true`. The content portals to
+// document.body, so assertions query there.
+const meta: Meta<typeof LayoutNameDialog> = {
+  component: LayoutNameDialog,
+  args: {
+    open: true,
+    title: "New layout",
+    onOpenChange: fn(),
+    onSubmit: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// An empty name keeps Save disabled.
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("New layout")).toBeInTheDocument();
+    await expect(body.getByRole("button", {
+      name: "Save",
+    })).toBeDisabled();
+  },
+};
+
+// Typing a name enables Save and submits the trimmed value.
+export const TypeAndSubmit: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+    const input = await body.findByPlaceholderText("Layout name");
+    await userEvent.type(input, "Focus mode");
+    const save = body.getByRole("button", {
+      name: "Save",
+    });
+    await expect(save).toBeEnabled();
+    await userEvent.click(save);
+    await expect(args.onSubmit).toHaveBeenCalledWith("Focus mode");
+  },
+};
+
+// Renaming prefills the field and uses a custom submit label.
+export const Rename: Story = {
+  args: {
+    title: "Rename layout",
+    initialName: "Morning routine",
+    submitLabel: "Rename",
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByDisplayValue("Morning routine"),
+    ).toBeInTheDocument();
+    await expect(body.getByRole("button", {
+      name: "Rename",
+    })).toBeEnabled();
+  },
+};

--- a/packages/client/src/components/ListPageControls.stories.tsx
+++ b/packages/client/src/components/ListPageControls.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import {
+  ClearFiltersButton,
+  FilterSelect,
+  ListEmptyStates,
+  ListSearchInput,
+} from "./ListPageControls";
+
+// This file exports several list-filter-bar primitives. `meta.component` is the
+// search input; the others are exercised via per-story `render`.
+const meta: Meta<typeof ListSearchInput> = {
+  component: ListSearchInput,
+  args: {
+    placeholder: "Search resources...",
+    value: "",
+    onChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SearchInput: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText("Search resources...");
+    await userEvent.type(input, "react");
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};
+
+// Radix Select-based filter dropdown. Its options render in a body portal only
+// once opened, so the closed-state smoke test asserts the trigger.
+export const Filter: Story = {
+  render: () => (
+    <FilterSelect
+      placeholder="Filter by topic"
+      value={undefined}
+      onChange={fn()}
+      allLabel="All topics"
+      totalCount={42}
+      options={[
+        {
+          value: "react",
+          label: "React",
+          count: 12,
+        },
+        {
+          value: "css",
+          label: "CSS",
+          count: 7,
+        },
+      ]}
+    />
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("combobox")).toBeInTheDocument();
+  },
+};
+
+export const ClearFilters: Story = {
+  render: () => <ClearFiltersButton onClick={fn()} />,
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Clear filters",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// No items at all.
+export const EmptyNoneYet: Story = {
+  render: () => (
+    <ListEmptyStates
+      entityLabel="resources"
+      total={0}
+      filteredCount={0}
+    />
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No resources yet/)).toBeInTheDocument();
+  },
+};
+
+// Items exist, but none match the active filters.
+export const EmptyNoMatch: Story = {
+  render: () => (
+    <ListEmptyStates
+      entityLabel="resources"
+      total={10}
+      filteredCount={0}
+    />
+  ),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/No resources match your filters/),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/TagGroupsAdmin.stories.tsx
+++ b/packages/client/src/components/TagGroupsAdmin.stories.tsx
@@ -1,0 +1,72 @@
+import type { TagGroup } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { TagGroupsAdmin } from "./TagGroupsAdmin";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeTagGroups } from "@/test-utils/resourceModulesFixtures";
+
+// Reads tag groups via useQuery(["tagGroups"]); seed a client so it renders
+// without a network call. Mutations are never fired, so they stay inert.
+function seededClient(groups: TagGroup[]): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["tagGroups"], groups);
+  return client;
+}
+
+const meta = {
+  component: TagGroupsAdmin,
+} satisfies Meta<typeof TagGroupsAdmin>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithGroups: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient(makeTagGroups(2))}>
+        <div className="max-w-2xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Tag Groups")).toBeInTheDocument();
+    await expect(canvas.getByText("Tag Group 1")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient([])}>
+        <div className="max-w-2xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/No tag groups yet/),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/TaskTypeEditRow.stories.tsx
+++ b/packages/client/src/components/TaskTypeEditRow.stories.tsx
@@ -1,0 +1,81 @@
+import type { TaskType } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { TaskTypeEditRow } from "./TaskTypeEditRow";
+
+const taskType: TaskType = {
+  id: "task-type-1",
+  name: "Practice",
+  whenToUse: "When drilling a specific skill.",
+  tags: ["skill:listening", "format:audio"],
+};
+
+// Renders an <li> with a self-contained TagsInput combobox; host it in a <ul>
+// and don't open the combobox in play tests.
+const meta: Meta<typeof TaskTypeEditRow> = {
+  component: TaskTypeEditRow,
+  args: {
+    taskType,
+    onSave: fn(),
+    onCancel: fn(),
+    onDelete: fn(),
+  },
+  decorators: [
+    Story => (
+      <ul className="max-w-xl">
+        <Story />
+      </ul>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByDisplayValue("Practice")).toBeInTheDocument();
+    await expect(canvas.getByText("When to Use")).toBeInTheDocument();
+  },
+};
+
+// A new task type hides the destructive Remove button.
+export const NewType: Story = {
+  args: {
+    isNew: true,
+    taskType: {
+      id: "__new__",
+      name: "",
+      whenToUse: "",
+      tags: [],
+    },
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("button", {
+        name: "Remove",
+      }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Cancels: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/components/UnsavedChangesDialog.stories.tsx
+++ b/packages/client/src/components/UnsavedChangesDialog.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+// `useBlocker` needs router context. The AlertDialog only appears when a
+// navigation is actually blocked, which can't happen in the context-only
+// RouterStub (navigation is a no-op), so this is a mount smoke test: the
+// component renders without throwing and shows no dialog.
+const meta: Meta<typeof UnsavedChangesDialog> = {
+  component: UnsavedChangesDialog,
+  args: {
+    shouldBlockFn: fn(() => false),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  play: async () => {
+    const body = within(document.body);
+    // No blocked navigation → the dialog is not shown.
+    await expect(body.queryByText("Unsaved changes")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/button.stories.tsx
+++ b/packages/client/src/components/button.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { Button } from "./button";
+
+const meta: Meta<typeof Button> = {
+  component: Button,
+  args: {
+    children: "Button",
+    onClick: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    args, canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Button",
+    }));
+    await expect(args.onClick).toHaveBeenCalled();
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+    children: "Secondary",
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    variant: "destructive",
+    children: "Delete",
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: "outline",
+    children: "Outline",
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: "ghost",
+    children: "Ghost",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: "sm",
+    children: "Small",
+  },
+};
+
+// `asChild` renders the child element with the button styling, so the rendered
+// node here is a link rather than a <button>.
+export const AsChild: Story = {
+  args: {
+    asChild: true,
+    children: <a href="/somewhere">Link button</a>,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("link", {
+        name: "Link button",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/calendar.stories.tsx
+++ b/packages/client/src/components/calendar.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { Calendar } from "./calendar";
+
+// `Calendar` proxies DayPicker, whose props are a wide discriminated union, so
+// story args can't be inferred. Wrap it in a fixed demo to keep typing simple.
+function CalendarDemo() {
+  return (
+    <Calendar
+      mode="single"
+      defaultMonth={new Date(2026, 5, 1)}
+    />
+  );
+}
+
+const meta: Meta<typeof CalendarDemo> = {
+  component: CalendarDemo,
+  decorators: [
+    Story => (
+      <div className="w-fit">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // A full month grid renders a day button per day plus prev/next nav.
+    await expect(canvas.getAllByRole("button").length).toBeGreaterThan(20);
+  },
+};

--- a/packages/client/src/components/combobox.stories.tsx
+++ b/packages/client/src/components/combobox.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "./combobox";
+
+const FRUITS = ["Apple", "Banana", "Cherry"];
+
+function ComboboxDemo({
+  defaultOpen,
+}: { defaultOpen?: boolean }) {
+  return (
+    <Combobox
+      items={FRUITS}
+      defaultOpen={defaultOpen}
+    >
+      <ComboboxInput placeholder="Pick a fruit" />
+      <ComboboxContent>
+        <ComboboxEmpty>No fruit found.</ComboboxEmpty>
+        <ComboboxList>
+          {(item: string) => (
+            <ComboboxItem
+              key={item}
+              value={item}
+            >
+              {item}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+const meta: Meta<typeof ComboboxDemo> = {
+  component: ComboboxDemo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Closed: only the input is shown.
+export const Closed: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByPlaceholderText("Pick a fruit")).toBeInTheDocument();
+  },
+};
+
+// Open: the list portals to document.body and shows every option.
+export const Open: Story = {
+  args: {
+    defaultOpen: true,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Apple")).toBeInTheDocument();
+    await expect(body.getByText("Cherry")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/input-group.stories.tsx
+++ b/packages/client/src/components/input-group.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SearchIcon } from "lucide-react";
+import { expect, within } from "storybook/test";
+
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "./input-group";
+
+function InputGroupDemo() {
+  return (
+    <InputGroup className="max-w-sm">
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Search..." />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton>Go</InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}
+
+const meta: Meta<typeof InputGroupDemo> = {
+  component: InputGroupDemo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByPlaceholderText("Search...")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", {
+      name: "Go",
+    })).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/input.stories.tsx
+++ b/packages/client/src/components/input.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { Input } from "./input";
+
+const meta = {
+  component: Input,
+  args: {
+    placeholder: "Type here...",
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByPlaceholderText("Type here..."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Typing: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+    await userEvent.type(input, "Hello");
+    await expect(input).toHaveValue("Hello");
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("textbox")).toBeDisabled();
+  },
+};

--- a/packages/client/src/components/popover.stories.tsx
+++ b/packages/client/src/components/popover.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+function PopoverDemo({
+  defaultOpen,
+}: { defaultOpen?: boolean }) {
+  return (
+    <Popover defaultOpen={defaultOpen}>
+      <PopoverTrigger>Open popover</PopoverTrigger>
+      <PopoverContent>
+        <p>Popover content here.</p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+const meta: Meta<typeof PopoverDemo> = {
+  component: PopoverDemo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Closed: only the trigger is shown.
+export const Closed: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: "Open popover",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Clicking the trigger opens content, which portals to document.body.
+export const Opens: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Open popover",
+    }));
+    const body = within(document.body);
+    await expect(
+      await body.findByText("Popover content here."),
+    ).toBeInTheDocument();
+  },
+};
+
+// Pre-opened via defaultOpen.
+export const DefaultOpen: Story = {
+  args: {
+    defaultOpen: true,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(
+      await body.findByText("Popover content here."),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/radio-group.stories.tsx
+++ b/packages/client/src/components/radio-group.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+
+const OPTIONS = ["comfortable", "compact", "spacious"];
+
+function RadioGroupDemo({
+  defaultValue,
+}: { defaultValue?: string }) {
+  return (
+    <RadioGroup defaultValue={defaultValue}>
+      {OPTIONS.map(value => (
+        <label
+          key={value}
+          className="flex items-center gap-2 text-sm"
+        >
+          <RadioGroupItem
+            value={value}
+            aria-label={value}
+          />
+          {value}
+        </label>
+      ))}
+    </RadioGroup>
+  );
+}
+
+const meta: Meta<typeof RadioGroupDemo> = {
+  component: RadioGroupDemo,
+  args: {
+    defaultValue: "comfortable",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const options = canvas.getAllByRole("radio");
+    await expect(options).toHaveLength(3);
+    await expect(
+      canvas.getByRole("radio", {
+        name: "comfortable",
+      }),
+    ).toBeChecked();
+  },
+};
+
+export const SelectAnother: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const compact = canvas.getByRole("radio", {
+      name: "compact",
+    });
+    await userEvent.click(compact);
+    await expect(compact).toBeChecked();
+  },
+};

--- a/packages/client/src/components/sonner.stories.tsx
+++ b/packages/client/src/components/sonner.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { toast } from "sonner";
+import { expect, userEvent, within } from "storybook/test";
+
+import { Toaster } from "./sonner";
+
+import { Button } from "@/components/button";
+
+// The Toaster renders toasts in a portal; a trigger button fires one so the
+// story has something to assert.
+function ToasterDemo() {
+  return (
+    <>
+      <Button onClick={() => toast.success("Saved your changes")}>
+        Notify
+      </Button>
+      <Toaster />
+    </>
+  );
+}
+
+const meta: Meta<typeof ToasterDemo> = {
+  component: ToasterDemo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ShowsToast: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Notify",
+    }));
+    const body = within(document.body);
+    await expect(
+      await body.findByText("Saved your changes"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/textarea.stories.tsx
+++ b/packages/client/src/components/textarea.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { Textarea } from "./textarea";
+
+const meta = {
+  component: Textarea,
+  args: {
+    placeholder: "Write a note...",
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByPlaceholderText("Write a note..."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Typing: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole("textbox");
+    await userEvent.type(textarea, "First line");
+    await expect(textarea).toHaveValue("First line");
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("textbox")).toBeDisabled();
+  },
+};


### PR DESCRIPTION
## Summary

Add comprehensive Storybook stories for 20 UI components across the client package, enabling visual testing and interactive documentation of component behavior.

## Key Changes

- **ListPageControls.stories.tsx**: Stories for search input, filter dropdown, clear filters button, and empty states (no items vs. no matches)
- **EditFormActions.stories.tsx**: Stories covering default state, new rows (hidden delete), existing rows, saving state, and disabled delete with reason
- **button.stories.tsx**: Stories for all button variants (default, secondary, destructive, outline, ghost), sizes, and `asChild` rendering
- **TaskTypeEditRow.stories.tsx**: Stories for default display, new task types, and cancel interaction
- **ConfirmDialog.stories.tsx**: Stories for default state, confirm/cancel handlers, and custom labels
- **EditModalFooter.stories.tsx**: Stories for default, new entity (hidden delete), removable entity, and saving states
- **TagGroupsAdmin.stories.tsx**: Stories for populated and empty states with seeded React Query client
- **combobox.stories.tsx**: Stories for closed and open states with portal rendering
- **popover.stories.tsx**: Stories for closed, opened via click, and pre-opened states
- **LayoutNameDialog.stories.tsx**: Stories for empty state (disabled save), type-and-submit flow, and rename with prefilled field
- **radio-group.stories.tsx**: Stories for default selection and selection change
- **EntityStates.stories.tsx**: Stories for pending and error states with router context
- **input.stories.tsx**: Stories for default, typing, and disabled states
- **textarea.stories.tsx**: Stories for default, typing, and disabled states
- **input-group.stories.tsx**: Story for input group with icon and button addons
- **sonner.stories.tsx**: Story for toast notification display
- **calendar.stories.tsx**: Story for calendar grid rendering
- **FilterOptionCount.stories.tsx**: Stories for non-zero and zero counts
- **UnsavedChangesDialog.stories.tsx**: Smoke test for idle state with router context

## Implementation Details

- Stories use Storybook 10's `play` functions for interactive testing with Testing Library assertions
- Portal-rendering components (dialogs, popovers, comboboxes) query `document.body` in play tests
- Components requiring context (router, React Query) use appropriate test stubs and decorators
- Mock functions (`fn()`) track handler calls for interaction verification
- Decorators wrap components in necessary containers (lists, divs, router/query stubs) for proper rendering

https://claude.ai/code/session_01UpfR79NEbXnMg9u53xHATj