### PR TITLE
test(client): fix QuickAddMenu story flakiness with fireEvent

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddMenu.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fireEvent, fn, userEvent, within } from "storybook/test";
 
 import { QuickAddMenu } from "./QuickAddMenu";
 
@@ -32,8 +32,20 @@ export const Opens: Story = {
     canvasElement,
     args,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(await canvas.findByText("Quick Add"));
+    // Open via hover, through the component's own state — the trigger fires
+    // setOpen(true) on mouseenter. Dispatch that with fireEvent.mouseOver
+    // (React synthesizes onMouseEnter from mouseover) rather than
+    // userEvent.hover/click: those assert hit-testable pointer events, and
+    // Radix's open modal layer leaves document.body at `pointer-events: none`,
+    // which the trigger inherits — making the opening click flaky. fireEvent
+    // dispatches directly, so it's immune to that (see NavDropdown.stories).
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      "[data-slot=\"dropdown-menu-trigger\"]",
+    );
+    if (!trigger) throw new Error("dropdown-menu-trigger did not render");
+    fireEvent.mouseOver(trigger);
+
+    // Content portals to document.body and mounts async — assert with findBy*.
     const body = within(document.body);
     await expect(await body.findByText("Send to")).toBeInTheDocument();
     await expect(await body.findByText("New record")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
Fixed flaky Storybook test in `QuickAddMenu.stories.tsx` by replacing `userEvent.click()` with `fireEvent.mouseOver()` to open the menu, addressing a pointer-events issue with Radix's modal layer.

## Changes
- **Import update:** Added `fireEvent` to the Storybook test utilities import
- **Test logic refactor:** Replaced the click-based menu opening with a more reliable hover-based approach:
  - Query the dropdown trigger element directly using `data-slot="dropdown-menu-trigger"`
  - Dispatch `mouseOver` event via `fireEvent` instead of `userEvent.click()`
  - Added explanatory comments documenting why this approach is necessary

## Implementation Details
The original test was flaky because `userEvent.hover()` and `userEvent.click()` assert hit-testable pointer events. When Radix's open modal layer is present, it sets `pointer-events: none` on `document.body`, which the trigger inherits—making pointer-based user events unreliable.

`fireEvent.mouseOver()` dispatches events directly without hit-testing, so it's immune to this CSS constraint. This pattern is already used successfully in `NavDropdown.stories` and aligns with the component's own state management (the trigger fires `setOpen(true)` on `mouseenter`).

The content still correctly asserts with `findBy*` since it portals to `document.body` and mounts asynchronously.

https://claude.ai/code/session_01MvHFeKuEfs3JyLMFNw8mRZ