### PR TITLE
refactor(client): Fixes #370: dedupe quick-add integration dialogs

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddDialogFooter.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddDialogFooter.tsx
@@ -1,0 +1,45 @@
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+
+interface QuickAddDialogFooterProps {
+  /** Label on the submit button, e.g. "Save", "Add", "Create". */
+  submitLabel: string;
+  /** Whether the create mutation is in flight (disables submit, shows a spinner). */
+  isPending: boolean;
+  /** Whether the form has enough input to submit. */
+  canSubmit: boolean;
+  /** Closes the dialog when Cancel is clicked. */
+  onCancel: () => void;
+}
+
+/**
+ * Shared Cancel/submit footer for the quick-add dialogs: an outline Cancel
+ * button plus a submit button that shows a spinner while the mutation runs.
+ */
+export function QuickAddDialogFooter({
+  submitLabel,
+  isPending,
+  canSubmit,
+  onCancel,
+}: QuickAddDialogFooterProps) {
+  return (
+    <DialogFooter>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onCancel}
+      >
+        Cancel
+      </Button>
+      <Button
+        type="submit"
+        disabled={!canSubmit || isPending}
+      >
+        {isPending && <Loader2 className="animate-spin" />}
+        {submitLabel}
+      </Button>
+    </DialogFooter>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { QuickAddIntegrationDialog } from "./QuickAddIntegrationDialog";
+
+import { Input } from "@/components/input";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof QuickAddIntegrationDialog> = {
+  component: QuickAddIntegrationDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    title: "Save to Readwise",
+    providerName: "Readwise",
+    isPending: false,
+    canSubmit: true,
+    submitLabel: "Save",
+    onSubmit: fn(),
+    children: (
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="quick-add-integration-url"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          URL
+        </label>
+        <Input id="quick-add-integration-url" />
+      </div>
+    ),
+  },
+  // The Settings link renders a TanStack <Link>, so the router context is needed.
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Configured → the form (children + submit footer) is shown. Dialog portals to body.
+export const Configured: Story = {
+  args: {
+    configured: true,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Save to Readwise")).toBeInTheDocument();
+    await expect(await body.findByLabelText("URL")).toBeInTheDocument();
+    await expect(
+      await body.findByRole("button", {
+        name: "Save",
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Unconfigured → the dialog points the user to Settings instead of the form.
+export const Unconfigured: Story = {
+  args: {
+    configured: false,
+  },
+  play: async () => {
+    const body = within(document.body);
+    await expect(await body.findByText("Save to Readwise")).toBeInTheDocument();
+    await expect(
+      await body.findByText(/Add a Readwise API key in/),
+    ).toBeInTheDocument();
+    await expect(
+      await body.findByRole("link", {
+        name: "Settings",
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.tsx
@@ -1,0 +1,121 @@
+import type { ControlledDialogProps } from "@/components/dialogProps";
+
+import { Link } from "@tanstack/react-router";
+
+import { QuickAddDialogFooter } from "./QuickAddDialogFooter";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface QuickAddIntegrationDialogProps extends ControlledDialogProps {
+  /** Dialog heading, e.g. "Save to Readwise". */
+  title: string;
+  /** Optional sub-heading, e.g. the "tagged from-coursetracker" line. */
+  description?: React.ReactNode;
+  /** Integration name shown in the "add an API key" prompt, e.g. "Readwise". */
+  providerName: string;
+  /** Whether the integration's API key is set; gates the form vs. the Settings prompt. */
+  configured: boolean;
+  /** Whether the create mutation is in flight (disables submit, shows a spinner). */
+  isPending: boolean;
+  /** Whether the form has enough input to submit. */
+  canSubmit: boolean;
+  /** Label on the submit button, e.g. "Save", "Add". */
+  submitLabel: string;
+  /** Form submit handler owned by the caller's hook. */
+  onSubmit: (e: React.FormEvent) => void;
+  /** The integration-specific input fields. */
+  children: React.ReactNode;
+}
+
+/**
+ * Presentational shell for the integration quick-add dialogs (Readwise, Todoist)
+ * that gate behind a configured API key. Owns the dialog chrome, header, the
+ * configured/unconfigured branch, and — when configured — the form wrapper and
+ * footer; callers pass the input fields as children plus the mutation state.
+ */
+export function QuickAddIntegrationDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  providerName,
+  configured,
+  isPending,
+  canSubmit,
+  submitLabel,
+  onSubmit,
+  children,
+}: QuickAddIntegrationDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        {configured
+          ? (
+            <form
+              className="flex flex-col gap-4"
+              onSubmit={onSubmit}
+            >
+              {children}
+              <QuickAddDialogFooter
+                submitLabel={submitLabel}
+                isPending={isPending}
+                canSubmit={canSubmit}
+                onCancel={() => onOpenChange(false)}
+              />
+            </form>
+          )
+          : (
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Add a
+                {" "}
+                {providerName}
+                {" "}
+                API key in
+                {" "}
+                <Link
+                  to="/settings"
+                  search={{
+                    tab: "connections",
+                  }}
+                  onClick={() => onOpenChange(false)}
+                  className="
+                    text-primary underline-offset-2
+                    hover:underline
+                  "
+                >
+                  Settings
+                </Link>
+                {" "}
+                to enable this.
+              </p>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Close
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useState } from "react";
 
-import { Loader2 } from "lucide-react";
+import { QuickAddDialogFooter } from "./QuickAddDialogFooter";
 
 import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -85,22 +83,12 @@ export function QuickAddNameDialog({
               maxLength={255}
             />
           </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!trimmed || isPending}
-            >
-              {isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
-          </DialogFooter>
+          <QuickAddDialogFooter
+            submitLabel="Create"
+            isPending={isPending}
+            canSubmit={Boolean(trimmed)}
+            onCancel={() => onOpenChange(false)}
+          />
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
@@ -4,15 +4,14 @@ import { useEffect, useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { QuickAddDialogFooter } from "./QuickAddDialogFooter";
+
 import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -118,22 +117,12 @@ export function QuickAddProviderDialog({
               maxLength={255}
             />
           </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!canSubmit || mutation.isPending}
-            >
-              {mutation.isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
-          </DialogFooter>
+          <QuickAddDialogFooter
+            submitLabel="Create"
+            isPending={mutation.isPending}
+            canSubmit={canSubmit}
+            onCancel={() => onOpenChange(false)}
+          />
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddReadwiseDialog.tsx
@@ -1,175 +1,78 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 
-import { useEffect, useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { QuickAddIntegrationDialog } from "./QuickAddIntegrationDialog";
+import { useQuickAddReadwise } from "./useQuickAddReadwise";
 
 import { Input } from "@/components/input";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { fetchSettings, saveReadwiseArticle } from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
 
 export function QuickAddReadwiseDialog({
   open,
   onOpenChange,
 }: ControlledDialogProps) {
-  const queryClient = useQueryClient();
-  const [url, setUrl] = useState("");
-  const [title, setTitle] = useState("");
-
-  useEffect(() => {
-    if (open) {
-      setUrl("");
-      setTitle("");
-    }
-  }, [open]);
-
-  const settingsQuery = useQuery({
-    queryKey: queryKeys.settings.detail(),
-    queryFn: () => fetchSettings(),
+  const {
+    url,
+    setUrl,
+    title,
+    setTitle,
+    configured,
+    handleSubmit,
+    isPending,
+    canSubmit,
+  } = useQuickAddReadwise({
+    open,
+    onOpenChange,
   });
-  const configured = settingsQuery.data?.readwiseConfigured ?? false;
-
-  const mutation = useMutation({
-    mutationFn: (input: { url: string;
-      title?: string; }) =>
-      saveReadwiseArticle(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.readwise.readingList(),
-      });
-      onOpenChange(false);
-      toast.success("Saved to Readwise");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const trimmedUrl = url.trim();
-  const trimmedTitle = title.trim();
 
   return (
-    <Dialog
+    <QuickAddIntegrationDialog
       open={open}
       onOpenChange={onOpenChange}
+      title="Save to Readwise"
+      description={(
+        <>
+          The article is tagged
+          {" "}
+          <code>from-coursetracker</code>
+          .
+        </>
+      )}
+      providerName="Readwise"
+      configured={configured}
+      isPending={isPending}
+      canSubmit={canSubmit}
+      submitLabel="Save"
+      onSubmit={handleSubmit}
     >
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Save to Readwise</DialogTitle>
-          <DialogDescription>
-            The article is tagged
-            {" "}
-            <code>from-coursetracker</code>
-            .
-          </DialogDescription>
-        </DialogHeader>
-        {configured
-          ? (
-            <form
-              className="flex flex-col gap-4"
-              onSubmit={(e) => {
-                e.preventDefault();
-                if (trimmedUrl) {
-                  mutation.mutate({
-                    url: trimmedUrl,
-                    title: trimmedTitle || undefined,
-                  });
-                }
-              }}
-            >
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="quick-add-readwise-url"
-                  className="text-xs font-medium text-muted-foreground"
-                >
-                  URL
-                </label>
-                <Input
-                  id="quick-add-readwise-url"
-                  type="url"
-                  autoFocus
-                  value={url}
-                  onChange={e => setUrl(e.target.value)}
-                  placeholder="https://example.com/article"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="quick-add-readwise-title"
-                  className="text-xs font-medium text-muted-foreground"
-                >
-                  Title (optional)
-                </label>
-                <Input
-                  id="quick-add-readwise-title"
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  placeholder="Leave blank to use the page title"
-                />
-              </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => onOpenChange(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={!trimmedUrl || mutation.isPending}
-                >
-                  {mutation.isPending && <Loader2 className="animate-spin" />}
-                  Save
-                </Button>
-              </DialogFooter>
-            </form>
-          )
-          : (
-            <div className="flex flex-col gap-4">
-              <p className="text-sm text-muted-foreground">
-                Add a Readwise API key in
-                {" "}
-                <Link
-                  to="/settings"
-                  search={{
-                    tab: "connections",
-                  }}
-                  onClick={() => onOpenChange(false)}
-                  className="
-                    text-primary underline-offset-2
-                    hover:underline
-                  "
-                >
-                  Settings
-                </Link>
-                {" "}
-                to enable this.
-              </p>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => onOpenChange(false)}
-                >
-                  Close
-                </Button>
-              </DialogFooter>
-            </div>
-          )}
-      </DialogContent>
-    </Dialog>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="quick-add-readwise-url"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          URL
+        </label>
+        <Input
+          id="quick-add-readwise-url"
+          type="url"
+          autoFocus
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="https://example.com/article"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="quick-add-readwise-title"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Title (optional)
+        </label>
+        <Input
+          id="quick-add-readwise-title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Leave blank to use the page title"
+        />
+      </div>
+    </QuickAddIntegrationDialog>
   );
 }

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
@@ -1,17 +1,14 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 import type { RoutineMode } from "@emstack/types";
 
-import { Loader2 } from "lucide-react";
-
+import { QuickAddDialogFooter } from "./QuickAddDialogFooter";
 import { useQuickAddRoutine } from "./useQuickAddRoutine";
 
 import { Input } from "@/components/input";
 import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -92,22 +89,12 @@ export function QuickAddRoutineDialog({
               </label>
             </RadioGroup>
           </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={!canSubmit || isPending}
-            >
-              {isPending && <Loader2 className="animate-spin" />}
-              Create
-            </Button>
-          </DialogFooter>
+          <QuickAddDialogFooter
+            submitLabel="Create"
+            isPending={isPending}
+            canSubmit={canSubmit}
+            onCancel={() => onOpenChange(false)}
+          />
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddTodoistDialog.tsx
@@ -1,21 +1,10 @@
 import type { ControlledDialogProps } from "@/components/dialogProps";
 
-import { Link } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
-
+import { QuickAddIntegrationDialog } from "./QuickAddIntegrationDialog";
 import { useQuickAddTodoist } from "./useQuickAddTodoist";
 
 import { Input } from "@/components/input";
 import { Textarea } from "@/components/textarea";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 export function QuickAddTodoistDialog({
   open,
@@ -36,106 +25,54 @@ export function QuickAddTodoistDialog({
   });
 
   return (
-    <Dialog
+    <QuickAddIntegrationDialog
       open={open}
       onOpenChange={onOpenChange}
+      title="Add Todoist task"
+      description={(
+        <>
+          The task is labeled
+          {" "}
+          <code>from-coursetracker</code>
+          .
+        </>
+      )}
+      providerName="Todoist"
+      configured={configured}
+      isPending={isPending}
+      canSubmit={canSubmit}
+      submitLabel="Add"
+      onSubmit={handleSubmit}
     >
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Add Todoist task</DialogTitle>
-          <DialogDescription>
-            The task is labeled
-            {" "}
-            <code>from-coursetracker</code>
-            .
-          </DialogDescription>
-        </DialogHeader>
-        {configured
-          ? (
-            <form
-              className="flex flex-col gap-4"
-              onSubmit={handleSubmit}
-            >
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="quick-add-todoist-content"
-                  className="text-xs font-medium text-muted-foreground"
-                >
-                  Title
-                </label>
-                <Input
-                  id="quick-add-todoist-content"
-                  autoFocus
-                  value={content}
-                  onChange={e => setContent(e.target.value)}
-                  placeholder="What needs doing?"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="quick-add-todoist-description"
-                  className="text-xs font-medium text-muted-foreground"
-                >
-                  Description (optional)
-                </label>
-                <Textarea
-                  id="quick-add-todoist-description"
-                  value={description}
-                  onChange={e => setDescription(e.target.value)}
-                  placeholder="Add any extra detail"
-                />
-              </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => onOpenChange(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={!canSubmit || isPending}
-                >
-                  {isPending && <Loader2 className="animate-spin" />}
-                  Add
-                </Button>
-              </DialogFooter>
-            </form>
-          )
-          : (
-            <div className="flex flex-col gap-4">
-              <p className="text-sm text-muted-foreground">
-                Add a Todoist API key in
-                {" "}
-                <Link
-                  to="/settings"
-                  search={{
-                    tab: "connections",
-                  }}
-                  onClick={() => onOpenChange(false)}
-                  className="
-                    text-primary underline-offset-2
-                    hover:underline
-                  "
-                >
-                  Settings
-                </Link>
-                {" "}
-                to enable this.
-              </p>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => onOpenChange(false)}
-                >
-                  Close
-                </Button>
-              </DialogFooter>
-            </div>
-          )}
-      </DialogContent>
-    </Dialog>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="quick-add-todoist-content"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Title
+        </label>
+        <Input
+          id="quick-add-todoist-content"
+          autoFocus
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="What needs doing?"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="quick-add-todoist-description"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Description (optional)
+        </label>
+        <Textarea
+          id="quick-add-todoist-description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Add any extra detail"
+        />
+      </div>
+    </QuickAddIntegrationDialog>
   );
 }

--- a/packages/client/src/components/quickAdd/useQuickAddReadwise.ts
+++ b/packages/client/src/components/quickAdd/useQuickAddReadwise.ts
@@ -1,0 +1,75 @@
+import type { ControlledDialogProps } from "@/components/dialogProps";
+
+import { useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { fetchSettings, saveReadwiseArticle } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Bundles the form state, settings lookup, and create mutation for
+ * {@link QuickAddReadwiseDialog} so the component stays presentational.
+ */
+export function useQuickAddReadwise({
+  open,
+  onOpenChange,
+}: ControlledDialogProps) {
+  const queryClient = useQueryClient();
+  const [url, setUrl] = useState("");
+  const [title, setTitle] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setUrl("");
+      setTitle("");
+    }
+  }, [open]);
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: () => fetchSettings(),
+  });
+  const configured = settingsQuery.data?.readwiseConfigured ?? false;
+
+  const mutation = useMutation({
+    mutationFn: (input: { url: string;
+      title?: string; }) =>
+      saveReadwiseArticle(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.readwise.readingList(),
+      });
+      onOpenChange(false);
+      toast.success("Saved to Readwise");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const trimmedUrl = url.trim();
+  const trimmedTitle = title.trim();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (trimmedUrl) {
+      mutation.mutate({
+        url: trimmedUrl,
+        title: trimmedTitle || undefined,
+      });
+    }
+  };
+
+  return {
+    url,
+    setUrl,
+    title,
+    setTitle,
+    configured,
+    handleSubmit,
+    isPending: mutation.isPending,
+    canSubmit: Boolean(trimmedUrl),
+  };
+}


### PR DESCRIPTION
## ELI5
The little "quick add" popups for saving things to Readwise, Todoist, and creating routines were each carrying their own copy of the same buttons and "you need an API key" message. This PR pulls those shared pieces into a couple of reusable building blocks, so the same code isn't written out five times. Nothing looks or behaves differently — there's just a lot less duplicated code to maintain.

## Summary
- Add `QuickAddIntegrationDialog` — a presentational shell that owns the dialog chrome, header, and the configured/"add an API key in Settings" gate shared by the Readwise and Todoist dialogs.
- Add `QuickAddDialogFooter` — the shared Cancel + spinner-submit footer, reused by the integration shell plus the Routine, Name, and Provider dialogs.
- Add `useQuickAddReadwise` — extracts Readwise's previously-inlined mutation into a hook matching the existing `useQuickAddTodoist`, making both integration dialogs symmetric hook-+-shell wrappers.
- Net result: the two clone groups fallow flagged in #370 are gone (~196 fewer lines in the rewritten dialogs), with rendered DOM unchanged.

## Test plan
- [ ] `pnpm --filter=@emstack/client exec vitest run src/components/quickAdd` — 24/24 story/play tests pass (incl. the new `QuickAddIntegrationDialog` configured/unconfigured stories).
- [ ] `pnpm typecheck` — clean.
- [ ] `pnpm lint` on the touched files — clean.
- [ ] `pnpm exec fallow dupes` — neither #370 clone group remains (no clone group involves the Readwise/Todoist/Routine dialog bodies).
- [ ] Manual: open the quick-add menu and exercise Readwise/Todoist in both configured and unconfigured states + Routine create; confirm toasts and list invalidation behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)