### PR TITLE
refactor(client): Fixes #372: dedupe radar LLM-assist code

### DIFF
--- a/packages/client/src/components/radar/BlipLlmAssist.tsx
+++ b/packages/client/src/components/radar/BlipLlmAssist.tsx
@@ -1,11 +1,4 @@
-import type {
-  DomainExcludedTopic,
-  DomainTopic,
-  RadarBlip,
-  RadarQuadrant,
-  RadarRing,
-  TopicForTopicsPage,
-} from "@emstack/types";
+import type { UseBlipLlmAssistArgs } from "@/hooks/useBlipLlmAssist";
 
 import { CopyIcon, Loader2 } from "lucide-react";
 
@@ -16,22 +9,7 @@ import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
 import { useBlipLlmAssist } from "@/hooks/useBlipLlmAssist";
 
-interface BlipLlmAssistProps {
-  domainId: string;
-  domainTitle: string;
-  domainDescription?: string | null;
-  domainTopics?: DomainTopic[];
-  excludedTopics?: DomainExcludedTopic[];
-  withinScopeDescription?: string | null;
-  outOfScopeDescription?: string | null;
-  withinScopeTopicNames?: string[];
-  outOfScopeTopicNames?: string[];
-  quadrants: RadarQuadrant[];
-  rings: RadarRing[];
-  topics: TopicForTopicsPage[];
-  existingBlips: RadarBlip[];
-  onComplete: () => void;
-}
+export type BlipLlmAssistProps = UseBlipLlmAssistArgs;
 
 export function BlipLlmAssist(props: BlipLlmAssistProps) {
   const {

--- a/packages/client/src/components/radar/BlipTable.tsx
+++ b/packages/client/src/components/radar/BlipTable.tsx
@@ -39,6 +39,7 @@ import {
   TableCell,
   TableRow,
 } from "@/components/ui/table";
+import { useIndexById } from "@/hooks/useIndexBy";
 
 interface BlipTableProps {
   blips: RadarBlip[];
@@ -81,23 +82,9 @@ export function BlipTable({
   const [bulkPending, setBulkPending] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const quadrantById = useMemo(() => {
-    const map = new Map<string, RadarQuadrant>();
-    quadrants.forEach(q => map.set(q.id, q));
-    return map;
-  }, [quadrants]);
-
-  const ringById = useMemo(() => {
-    const map = new Map<string, RadarRing>();
-    rings.forEach(r => map.set(r.id, r));
-    return map;
-  }, [rings]);
-
-  const topicById = useMemo(() => {
-    const map = new Map<string, TopicForTopicsPage>();
-    topics.forEach(t => map.set(t.id, t));
-    return map;
-  }, [topics]);
+  const quadrantById = useIndexById(quadrants);
+  const ringById = useIndexById(rings);
+  const topicById = useIndexById(topics);
 
   const sliceCounts = useMemo(() => countByField(blips, "quadrantId"), [blips]);
 

--- a/packages/client/src/hooks/useBlipLlmAssist.ts
+++ b/packages/client/src/hooks/useBlipLlmAssist.ts
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { buildCleanupPrompt, buildLlmPrompt } from "@/components/radar/blipLlmPrompts";
 import { descriptionChanged, parseLlmEntries } from "@/components/radar/blipLlmReview";
 import { useBlipLlmReview } from "@/hooks/useBlipLlmReview";
+import { useIndexById, useIndexByLowerName } from "@/hooks/useIndexBy";
 import {
   bulkCreateRadarBlips,
   copyTextToClipboard,
@@ -61,11 +62,12 @@ export function useBlipLlmAssist({
 }: UseBlipLlmAssistArgs) {
   const [mode, setMode] = useState<PromptMode>("setup");
 
+  const quadrantById = useIndexById(quadrants);
+  const ringById = useIndexById(rings);
+  const topicById = useIndexById(topics);
+
   const prompt = useMemo(
     () => {
-      const topicById = new Map(topics.map(t => [t.id, t]));
-      const quadrantById = new Map(quadrants.map(q => [q.id, q]));
-      const ringById = new Map(rings.map(r => [r.id, r]));
       if (mode === "cleanup") {
         const unassignedBlips = existingBlips
           .filter(b => !b.quadrantId || !b.ringId)
@@ -125,7 +127,9 @@ export function useBlipLlmAssist({
       quadrants,
       rings,
       existingBlips,
-      topics,
+      quadrantById,
+      ringById,
+      topicById,
     ],
   );
 
@@ -138,29 +142,9 @@ export function useBlipLlmAssist({
   const [parseError, setParseError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const topicByLowerName = useMemo(() => {
-    const map = new Map<string, TopicForTopicsPage>();
-    topics.forEach((t) => {
-      map.set(t.name.toLowerCase(), t);
-    });
-    return map;
-  }, [topics]);
-
-  const quadrantByLowerName = useMemo(() => {
-    const map = new Map<string, RadarQuadrant>();
-    quadrants.forEach((q) => {
-      map.set(q.name.toLowerCase(), q);
-    });
-    return map;
-  }, [quadrants]);
-
-  const ringByLowerName = useMemo(() => {
-    const map = new Map<string, RadarRing>();
-    rings.forEach((r) => {
-      map.set(r.name.toLowerCase(), r);
-    });
-    return map;
-  }, [rings]);
+  const topicByLowerName = useIndexByLowerName(topics);
+  const quadrantByLowerName = useIndexByLowerName(quadrants);
+  const ringByLowerName = useIndexByLowerName(rings);
 
   const existingBlipByTopicId = useMemo(() => {
     const map = new Map<string, RadarBlip>();
@@ -169,24 +153,6 @@ export function useBlipLlmAssist({
     });
     return map;
   }, [existingBlips]);
-
-  const quadrantById = useMemo(() => {
-    const map = new Map<string, RadarQuadrant>();
-    quadrants.forEach(q => map.set(q.id, q));
-    return map;
-  }, [quadrants]);
-
-  const ringById = useMemo(() => {
-    const map = new Map<string, RadarRing>();
-    rings.forEach(r => map.set(r.id, r));
-    return map;
-  }, [rings]);
-
-  const topicById = useMemo(() => {
-    const map = new Map<string, TopicForTopicsPage>();
-    topics.forEach(t => map.set(t.id, t));
-    return map;
-  }, [topics]);
 
   const excludedNamesLower = useMemo(() => {
     const set = new Set<string>();

--- a/packages/client/src/hooks/useIndexBy.ts
+++ b/packages/client/src/hooks/useIndexBy.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+
+function indexBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T> {
+  const map = new Map<string, T>();
+  items.forEach(item => map.set(keyFn(item), item));
+  return map;
+}
+
+export function useIndexById<T extends { id: string }>(items: T[]): Map<string, T> {
+  return useMemo(() => indexBy(items, i => i.id), [items]);
+}
+
+export function useIndexByLowerName<T extends { name: string }>(items: T[]): Map<string, T> {
+  return useMemo(() => indexBy(items, i => i.name.toLowerCase()), [items]);
+}


### PR DESCRIPTION
## ELI5
Two parts of the radar feature were carrying around near-identical copies of the same setup code. This PR teaches them to share a single copy instead, so there's less code to maintain and nothing duplicated. Nothing the user sees changes.

## Summary
- Replaced `BlipLlmAssist`'s hand-written 16-field props interface with a type alias of the hook's already-exported `UseBlipLlmAssistArgs` (kills the largest clone fallow flagged).
- Extracted shared `useIndexById` / `useIndexByLowerName` hooks (`hooks/useIndexBy.ts`) and used them in both `BlipTable` and `useBlipLlmAssist`, removing the duplicated id→object map `useMemo` blocks.
- Reused the memoized id-maps inside the prompt `useMemo` to drop a redundant ephemeral rebuild.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (one pre-existing-style `import/max-dependencies` warning on `BlipTable`, non-blocking; sanctioned fix is /reduce-imports tracker #312)
- [x] `pnpm exec fallow dupes` — both #372 clone groups gone
- [x] `pnpm --filter=@emstack/client exec vitest run` — 606 tests / 183 files pass
- [ ] Manual smoke: domain edit → LLM tab → parse/review/apply, and Blips tab filter/sort/inline-edit/bulk-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)