### PR TITLE
test(client): add Storybook stories for route-private components

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -297,3 +297,35 @@ assert with `findBy*`. `ResourcesTable` drives the `useTaskResources` hook
 only needs `QueryStub` (it calls `useQueryClient`/`useMutation`, no reads).
 `ResourceLinkInput` in `ResourceLinksPicker` is a non-exported local interface —
 `Meta<typeof X>` checks the `value` literals structurally, so no export needed.
+
+### route-private (#363)
+All `routes/*.-components/*` leaves covered (dashboard 16, settings 11, the three
+remaining `domains.$id.edit`, routines-edit 5, routines.$id 2, routines.tracker 1,
+topics.$id.edit 1). The issue's per-folder counts were a stale snapshot —
+`domains.$id.edit` was already 8/11 stored, so re-inventory before starting. New
+fixtures: **`dashboardFixtures.ts`** (`makeTile(tileId, overrides)` →
+`DashboardLayoutTile`), **`settingsFixtures.ts`** (`makeAppSettings`,
+`makeTaskType`, `makeCalendarFeed`, `makeLayout`), **`templatesFixtures.ts`**
+(`makeCriteriaTemplate` only — routine templates already live in
+`routinesFixtures.makeRoutineTemplate`; don't re-add). Key patterns:
+**Dashboard tiles** take `DashboardTileProps` (`tile` + `onUpdateTile`) but
+**self-fetch**, so they're Tier B not Tier A: nest `RouterStub > QueryStub` and
+seed each tile's key (`["domains"]`, `["resources"]`+`["dailies"]`, `["providers"]`,
+…) on a `staleTime: Infinity` client. **Integration tiles**
+(`-DashboardReadwise`/`-DashboardTodoist`/`-DashboardGoogleCalendar`) cover both
+branches without fabricating full API payloads: seed `{ configured: false, …[] }`
+for the connect-prompt and `{ configured: true, …[] }` for the configured-empty
+state — `setQueryData` on an untyped/`as const` key takes a plain object, so no
+payload-type import. `-DashboardChangelog` is pure render-only (build-time
+`@root/CHANGELOG.md`, no decorators). **`-DashboardDailiesBody`** and
+**`-TrackerTables`** take a whole hook-return bundle (`DashboardDailiesData` /
+`RoutineTrackerState`): build it inline and cast `as unknown as <T>`, stubbing
+`mutation` as `{ isPending: false, mutate: fn() }`. **Route-shell-like leaves**
+(`-ExistingDomainEditor`, `-TopicForm`) are storied by seeding their `useEditFormPage`
++ list queries plus a loading/unseeded variant — `useEditFormPage`'s detail query
+is `enabled: !isNew`, so the `isNew`/New story skips the detail seed.
+`-ThemeSection` needs `ThemeProvider` (`@/context/ThemeProvider`). `useSettings`
+needs `SettingsProvider` but never fetches (local state), so no seeding. Watch
+ambiguous `getByText`: "Weekly Schedule" (Type-tile value **and** schedule header)
+and "Cost per Unit" (card title **and** column header) both match twice — assert on
+a unique `role`/`tab`/count signal instead.

--- a/packages/client/src/routes/dashboard.-components/-AddLayoutDialog.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-AddLayoutDialog.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen, userEvent } from "storybook/test";
+
+import { AddLayoutDialog } from "./-AddLayoutDialog";
+
+const meta: Meta<typeof AddLayoutDialog> = {
+  component: AddLayoutDialog,
+  args: {
+    open: true,
+    savedPresets: [],
+    onOpenChange: fn(),
+    onSubmit: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The add-tab dialog: a starting-layout select + a (preset-seeded) name field.
+export const Open: Story = {
+  play: async ({
+    args,
+  }) => {
+    await expect(await screen.findByText("Add layout")).toBeInTheDocument();
+    const name = await screen.findByPlaceholderText("Layout name");
+    await userEvent.clear(name);
+    await userEvent.type(name, "My layout");
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: "Add",
+      }),
+    );
+    await expect(args.onSubmit).toHaveBeenCalled();
+  },
+};
+
+// Closed: nothing rendered.
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  play: async () => {
+    await expect(screen.queryByText("Add layout")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardCardSettings.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCardSettings.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen, userEvent, within } from "storybook/test";
+
+import { CardSettingsFlyout, SettingToggle } from "./-DashboardCardSettings";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+
+const meta: Meta<typeof CardSettingsFlyout> = {
+  component: CardSettingsFlyout,
+  args: {
+    tile: makeTile("todoist"),
+    onUpdateTile: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The gear flyout: opening it reveals the Auto/Fixed height chooser (portaled).
+export const Flyout: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /card settings/i,
+      }),
+    );
+    await expect(await screen.findByText("Height")).toBeInTheDocument();
+  },
+};
+
+// The standalone switch row used in the flyout's per-card settings.
+export const Toggle: StoryObj<typeof SettingToggle> = {
+  render: args => <SettingToggle {...args} />,
+  args: {
+    label: "Show project",
+    checked: false,
+    onChange: fn(),
+  },
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole("switch", {
+      name: /show project/i,
+    });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(toggle);
+    await expect(args.onChange).toHaveBeenCalledWith(true);
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardChangelog.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardChangelog.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardChangelog } from "./-DashboardChangelog";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+
+const meta: Meta<typeof DashboardChangelog> = {
+  component: DashboardChangelog,
+  args: {
+    tile: makeTile("changelog"),
+    onUpdateTile: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Renders the build-time CHANGELOG.md (no fetch). We don't assert on specific
+// entries since the content changes over time.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("Changelog"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", {
+        name: /view on github/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardCoursesByAmortization } from "./-DashboardCoursesByAmortization";
+
+import { makeProvider, makeResources } from "@/test-utils/boxFixtures";
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["resources"], makeResources());
+  client.setQueryData(["providers"], [makeProvider()]);
+  return client;
+}
+
+const meta: Meta<typeof DashboardCoursesByAmortization> = {
+  component: DashboardCoursesByAmortization,
+  args: {
+    tile: makeTile("coursesByAmortization"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={seededClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Courses tab (default): a cost-per-unit table of started courses.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // "Cost per Unit" appears as both the card title and a column header, so
+    // assert on the unambiguous tab + course-row signals instead.
+    await expect(
+      await canvas.findByRole("tab", {
+        name: /courses/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("tab", {
+        name: /providers/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText("Course 2")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesInProgress.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardCoursesInProgress } from "./-DashboardCoursesInProgress";
+
+import { makeResources } from "@/test-utils/boxFixtures";
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function clientWith(resources: unknown) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["resources"], resources);
+  client.setQueryData(["dailies"], []);
+  return client;
+}
+
+const meta: Meta<typeof DashboardCoursesInProgress> = {
+  component: DashboardCoursesInProgress,
+  args: {
+    tile: makeTile("coursesInProgress"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(makeResources())}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Active courses without an active daily are listed as links.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Resources in Progress"),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText("Course 1")).toBeInTheDocument();
+  },
+};
+
+// No active courses shows the empty message.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith([])}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no courses in progress/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailies.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailies.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardDoneForDay, DashboardDoNow } from "./-DashboardDailies";
+
+import { SettingsProvider } from "@/context/SettingsProvider";
+import { makeDaily } from "@/test-utils/dailiesFixtures";
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["dailies"], [
+    makeDaily({
+      status: "active",
+    }),
+  ]);
+  return client;
+}
+
+const meta: Meta<typeof DashboardDoNow> = {
+  component: DashboardDoNow,
+  args: {
+    tile: makeTile("doNow"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <SettingsProvider>
+          <QueryStub client={seededClient()}>
+            <Story />
+          </QueryStub>
+        </SettingsProvider>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The "Do Now" card with its view-mode toggle and "View all" link.
+export const DoNow: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Do Now")).toBeInTheDocument();
+  },
+};
+
+// The companion "Done for the Day" card.
+export const DoneForDay: Story = {
+  render: args => <DashboardDoneForDay {...args} />,
+  args: {
+    tile: makeTile("doneForDay"),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Done for the Day"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailiesBody.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailiesBody.stories.tsx
@@ -1,0 +1,68 @@
+import type { DashboardDailiesData } from "./-useDashboardDailies";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardDailiesBody } from "./-DashboardDailiesBody";
+
+import { SettingsProvider } from "@/context/SettingsProvider";
+import { makeDaily } from "@/test-utils/dailiesFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { getTodayKey } from "@/utils";
+
+// A minimal stand-in for the hook's return value: the body only reads
+// mode/mutation/dayHeaders/todayKey/sorting/onSortingChange.
+const data = {
+  bucket: () => [],
+  isPending: false,
+  error: null,
+  hasData: true,
+  activeCount: 1,
+  dayHeaders: [],
+  todayKey: getTodayKey(),
+  mode: "list",
+  setMode: fn(),
+  sorting: [],
+  onSortingChange: fn(),
+  mutation: {
+    isPending: false,
+    mutate: fn(),
+  },
+  maxActiveDailies: 5,
+} as unknown as DashboardDailiesData;
+
+const meta: Meta<typeof DashboardDailiesBody> = {
+  component: DashboardDailiesBody,
+  args: {
+    list: [makeDaily()],
+    data,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <SettingsProvider>
+          <QueryStub>
+            <Story />
+          </QueryStub>
+        </SettingsProvider>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// List mode: the active-list view of a dailies bucket.
+export const ListMode: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Morning reading"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardExplore.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardExplore.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardExplore } from "./-DashboardExplore";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { makeAppSettings } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.domains.explore(), {
+    rings: ["Trial"],
+    items: [
+      {
+        topicId: "topic-1",
+        topicName: "React Hooks",
+        domainId: "domain-1",
+        domainTitle: "Frontend Engineering",
+        ringName: "Trial",
+        description: "Worth a look.",
+      },
+    ],
+  });
+  client.setQueryData(queryKeys.settings.detail(), makeAppSettings());
+  client.setQueryData(queryKeys.domains.list(), []);
+  return client;
+}
+
+const meta: Meta<typeof DashboardExplore> = {
+  component: DashboardExplore,
+  args: {
+    tile: makeTile("exploreSomething"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={seededClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  // The selected ring is persisted in localStorage; reset it so the fixture's
+  // "Trial" ring is the one shown.
+  beforeEach: () => {
+    window.localStorage.clear();
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The "All Domains" tab lists topics in the current (Trial) ring.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Explore Something"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("tab", {
+        name: /all domains/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByText("React Hooks")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardGoogleCalendar } from "./-DashboardGoogleCalendar";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+function clientWith(configured: boolean) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.googleCalendar.events(), {
+    configured,
+    events: [],
+  });
+  return client;
+}
+
+const meta: Meta<typeof DashboardGoogleCalendar> = {
+  component: DashboardGoogleCalendar,
+  args: {
+    tile: makeTile("googleCalendar"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(false)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No feed subscribed: the card prompts the user to add one.
+export const ConnectPrompt: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/add a calendar feed/i),
+    ).toBeInTheDocument();
+  },
+};
+
+// Connected with no upcoming events shows the empty state.
+export const ConfiguredEmpty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(true)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no upcoming events/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardIntegrationCard.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardIntegrationCard.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import {
+  DashboardIntegrationCard,
+  SettingsLink,
+} from "./-DashboardIntegrationCard";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof DashboardIntegrationCard> = {
+  component: DashboardIntegrationCard,
+  args: {
+    tile: makeTile("readwise"),
+    onUpdateTile: fn(),
+    title: "Readwise",
+    settingsLink: <SettingsLink className="text-sm">Set API key</SettingsLink>,
+    configured: false,
+    isPending: false,
+    error: null,
+    connectPrompt: <p>Add your API key in Settings to connect.</p>,
+    children: <div>Integration content</div>,
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Not configured yet: the card shows the connect prompt instead of content.
+export const ConnectPrompt: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/add your api key in settings/i),
+    ).toBeInTheDocument();
+  },
+};
+
+// Configured: the card renders its data content.
+export const Configured: Story = {
+  args: {
+    configured: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Integration content"),
+    ).toBeInTheDocument();
+  },
+};
+
+// The shared "go to Settings" link used across the integration tiles.
+export const SettingsLinkOnly: StoryObj<typeof SettingsLink> = {
+  render: () => <SettingsLink>Open settings</SettingsLink>,
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("link", {
+        name: /open settings/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardRadars.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardRadars.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardRadars } from "./-DashboardRadars";
+
+import { makeDomain } from "@/test-utils/boxFixtures";
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function clientWith(domains: unknown) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["domains"], domains);
+  return client;
+}
+
+const meta: Meta<typeof DashboardRadars> = {
+  component: DashboardRadars,
+  args: {
+    tile: makeTile("radars"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith([makeDomain()])}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Lists the domains as radar links.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Frontend Engineering"),
+    ).toBeInTheDocument();
+  },
+};
+
+// No domains yet shows the empty message.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith([])}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no radars yet/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardReadwise } from "./-DashboardReadwise";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+function clientWith(configured: boolean) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.readwise.readingList(), {
+    configured,
+    started: [],
+    unstarted: [],
+  });
+  return client;
+}
+
+const meta: Meta<typeof DashboardReadwise> = {
+  component: DashboardReadwise,
+  args: {
+    tile: makeTile("readwise"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(false)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Not connected: the card prompts the user to add an API key.
+export const ConnectPrompt: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/add your readwise api key/i),
+    ).toBeInTheDocument();
+  },
+};
+
+// Connected but with no articles yet shows the empty in-progress state.
+export const ConfiguredEmpty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(true)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no articles in progress/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardTodoist } from "./-DashboardTodoist";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { queryKeys } from "@/utils/queryKeys";
+
+function clientWith(configured: boolean) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.todoist.tasks(), {
+    configured,
+    overdue: [],
+    today: [],
+  });
+  return client;
+}
+
+const meta: Meta<typeof DashboardTodoist> = {
+  component: DashboardTodoist,
+  args: {
+    tile: makeTile("todoist"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(false)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Not connected: the card prompts the user to add an API key.
+export const ConnectPrompt: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/add your todoist api key/i),
+    ).toBeInTheDocument();
+  },
+};
+
+// Connected with nothing due shows the celebratory empty state.
+export const ConfiguredEmpty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith(true)}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/nothing due today/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardUnderutilizedProviders.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DashboardUnderutilizedProviders } from "./-DashboardUnderutilizedProviders";
+
+import { makeProvider } from "@/test-utils/boxFixtures";
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function clientWith(providers: unknown) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["providers"], providers);
+  return client;
+}
+
+const meta: Meta<typeof DashboardUnderutilizedProviders> = {
+  component: DashboardUnderutilizedProviders,
+  args: {
+    tile: makeTile("underutilizedProviders"),
+    onUpdateTile: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub
+          client={clientWith([
+            makeProvider({
+              completeCount: 2,
+            }),
+          ])}
+        >
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A paid provider with no active courses shows in the underutilized table.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Acme Learning")).toBeInTheDocument();
+  },
+};
+
+// No qualifying providers shows the empty message.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={clientWith([])}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no underutilized providers/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-LayoutTab.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-LayoutTab.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen, userEvent, within } from "storybook/test";
+
+import { LayoutTab } from "./-LayoutTab";
+
+import { Tabs, TabsList } from "@/components/ui/tabs";
+import { makeLayout } from "@/test-utils/settingsFixtures";
+
+const meta: Meta<typeof LayoutTab> = {
+  component: LayoutTab,
+  args: {
+    layout: makeLayout(),
+    onEditTiles: fn(),
+    onRename: fn(),
+    onDuplicate: fn(),
+    onSaveAs: fn(),
+    onDelete: fn(),
+  },
+  // TabsTrigger must render inside Tabs/TabsList context.
+  decorators: [
+    Story => (
+      <Tabs defaultValue="layout-1">
+        <TabsList>
+          <Story />
+        </TabsList>
+      </Tabs>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The tab plus its "More" menu (menu content portals to the body).
+export const Default: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("tab", {
+        name: "Main",
+      }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /main options/i,
+      }),
+    );
+    await userEvent.click(await screen.findByText("Rename"));
+    await expect(args.onRename).toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-VisibleTilesDialog.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen, userEvent } from "storybook/test";
+
+import { VisibleTilesDialog } from "./-VisibleTilesDialog";
+
+import { makeLayout } from "@/test-utils/settingsFixtures";
+
+const meta: Meta<typeof VisibleTilesDialog> = {
+  component: VisibleTilesDialog,
+  args: {
+    open: true,
+    layout: makeLayout(),
+    onOpenChange: fn(),
+    onToggleTile: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The tile-visibility checklist (dialog content portals to the body).
+export const Open: Story = {
+  play: async ({
+    args,
+  }) => {
+    await expect(await screen.findByText("Visible tiles")).toBeInTheDocument();
+    const checkboxes = screen.getAllByRole("checkbox");
+    await expect(checkboxes.length).toBeGreaterThan(0);
+    // Toggling a tile calls back to the parent.
+    await userEvent.click(checkboxes[0]);
+    await expect(args.onToggleTile).toHaveBeenCalled();
+  },
+};
+
+// Closed: nothing rendered.
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+  play: async () => {
+    await expect(screen.queryByText("Visible tiles")).not.toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { DetailsTab } from "./-DetailsTab";
+
+import { makeDomain, makeTopicRows } from "@/test-utils/boxFixtures";
+
+const meta: Meta<typeof DetailsTab> = {
+  component: DetailsTab,
+  args: {
+    domain: makeDomain(),
+    topics: makeTopicRows(),
+    onSaved: fn(() => Promise.resolve()),
+    onChangeStateChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Hydrates the form from the domain's persisted title/description/topics.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("Frontend Engineering"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Topics in domain")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save details/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// A brand-new-ish domain with no description still renders the editable form.
+export const EmptyDescription: Story = {
+  args: {
+    domain: makeDomain({
+      title: "Backend Engineering",
+      description: null,
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("Backend Engineering"),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/domains.$id.edit.-components/-ExistingDomainEditor.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ExistingDomainEditor.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { ExistingDomainEditor } from "./-ExistingDomainEditor";
+
+import { makeDomain, makeTopicRows } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeRadar } from "@/test-utils/radarFixtures";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const DOMAIN_ID = "domain-1";
+
+// Seeds the three reads the editor makes (domain / radar / topics) so it renders
+// the loaded tab UI without hitting the network. staleTime keeps the seeded data
+// from triggering a background refetch.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["domain", DOMAIN_ID], makeDomain());
+  client.setQueryData(["radar", DOMAIN_ID], makeRadar());
+  client.setQueryData(["topics"], makeTopicRows());
+  return client;
+}
+
+const meta = {
+  component: ExistingDomainEditor,
+  args: {
+    id: DOMAIN_ID,
+    tab: "details",
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof ExistingDomainEditor>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// With the queries seeded the editor shows its header, tab strip, and the
+// (default) Details tab body.
+export const Loaded: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: /edit domain/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("tab", {
+      name: /details/i,
+    })).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save details/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Before the domain query resolves the editor renders its loading placeholder.
+export const Loading: Story = {
+  decorators: [
+    Story => (
+      <QueryStub>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/loading domain/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/domains.$id.edit.-components/-LlmTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-LlmTab.stories.tsx
@@ -4,13 +4,17 @@ import { expect, fn, within } from "storybook/test";
 
 import { LlmTabContainer } from "./-LlmTab";
 
-import { makeDomain, makeRadar, makeTopics } from "@/test-utils/radarFixtures";
+import {
+  makeRadar,
+  makeScopedDomain,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
 
 const meta: Meta<typeof LlmTabContainer> = {
   component: LlmTabContainer,
   args: {
     radar: makeRadar(),
-    domain: makeDomain(),
+    domain: makeScopedDomain(),
     topics: makeTopics(),
     onComplete: fn(() => Promise.resolve()),
   },

--- a/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { NewDomainForm } from "./-NewDomainForm";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta = {
+  component: NewDomainForm,
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof NewDomainForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The empty create form: title/description fields and the create action. We
+// don't submit — that would call createDomain and navigate.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: /new domain/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Domain Title")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /create domain/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.stories.tsx
@@ -4,12 +4,16 @@ import { expect, fn, within } from "storybook/test";
 
 import { ScopeTab } from "./-ScopeTab";
 
-import { makeDomain, makeRadar, makeTopics } from "@/test-utils/radarFixtures";
+import {
+  makeRadar,
+  makeScopedDomain,
+  makeTopics,
+} from "@/test-utils/radarFixtures";
 
 const meta: Meta<typeof ScopeTab> = {
   component: ScopeTab,
   args: {
-    domain: makeDomain(),
+    domain: makeScopedDomain(),
     radar: makeRadar(),
     topics: makeTopics(),
     onSaved: fn(() => Promise.resolve()),

--- a/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { RoutineDetailsContent } from "./-RoutineDetailsContent";
+
+import { makeRoutine, makeResources, makeTask } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+// useTaskResourceNames reads the task/resource lists to resolve weekly-schedule
+// entry names.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["tasks"], [makeTask()]);
+  client.setQueryData(["resources"], makeResources());
+  return client;
+}
+
+const meta = {
+  component: RoutineDetailsContent,
+  args: {
+    data: makeRoutine(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={seededClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof RoutineDetailsContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Daily routine (fixture default): Type/Status/Stats tiles + connected entities.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Daily Task")).toBeInTheDocument();
+    await expect(canvas.getByText("Connected To")).toBeInTheDocument();
+    await expect(canvas.getByText("Read a chapter")).toBeInTheDocument();
+  },
+};
+
+// Weekly routine adds the day-by-day schedule section.
+export const Weekly: Story = {
+  args: {
+    data: makeRoutine({
+      mode: "weekly",
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // "Weekly Schedule" appears twice in weekly mode: the Type tile value and
+    // the schedule section header.
+    const headings = await canvas.findAllByText("Weekly Schedule");
+    await expect(headings.length).toBeGreaterThanOrEqual(2);
+  },
+};

--- a/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { RoutineTodayCard } from "./-RoutineTodayCard";
+
+import { SettingsProvider } from "@/context/SettingsProvider";
+import { makeRoutine, makeResources, makeTask } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["tasks"], [makeTask()]);
+  client.setQueryData(["resources"], makeResources());
+  return client;
+}
+
+const meta = {
+  component: RoutineTodayCard,
+  args: {
+    data: makeRoutine(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <SettingsProvider>
+          <QueryStub client={seededClient()}>
+            <Story />
+          </QueryStub>
+        </SettingsProvider>
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof RoutineTodayCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Daily routine: today's entry plus the today-status control.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Today's Task")).toBeInTheDocument();
+  },
+};
+
+// A routine with nothing scheduled today shows the rest-day copy.
+export const NothingToday: Story = {
+  args: {
+    data: makeRoutine({
+      mode: "weekly",
+      weekly: {},
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/nothing, take a break/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { CriteriaTab } from "./-CriteriaTab";
+
+import { makeRoutine } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeCriteriaTemplate } from "@/test-utils/templatesFixtures";
+
+// The embedded Quick Fill menu reads the criteria templates.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["dailyCriteriaTemplates"], [makeCriteriaTemplate()]);
+  return client;
+}
+
+const meta: Meta<typeof CriteriaTab> = {
+  component: CriteriaTab,
+  args: {
+    routine: makeRoutine(),
+    onSaved: fn(() => Promise.resolve()),
+    onChangeStateChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The five per-status criteria textareas plus the Quick Fill + save controls.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Incomplete")).toBeInTheDocument();
+    await expect(canvas.getByText("Completed (Goal)")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save status criteria/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// A routine with persisted criteria hydrates the textareas from its values.
+export const WithCriteria: Story = {
+  args: {
+    routine: makeRoutine({
+      criteria: {
+        incomplete: "Skipped today.",
+        touched: "Did a little.",
+        goal: "Hit the goal.",
+        exceeded: "Went above and beyond.",
+        freeze: "Rest day.",
+      },
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("Hit the goal."),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, within } from "storybook/test";
+
+import { DetailsTab } from "./-DetailsTab";
+
+import { makeRoutine } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { makeRoutineTemplate } from "@/test-utils/templatesFixtures";
+
+// useRoutineDetailsForm reads topics/tasks/resources for its combobox options,
+// and the weekly-mode Quick Fill menu reads the routine templates. Empty lists
+// are enough — the form renders its fields regardless.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["topics"], []);
+  client.setQueryData(["tasks"], []);
+  client.setQueryData(["resources"], []);
+  client.setQueryData(["routineTemplates"], [makeRoutineTemplate()]);
+  return client;
+}
+
+const meta: Meta<typeof DetailsTab> = {
+  component: DetailsTab,
+  args: {
+    routine: makeRoutine(),
+    onSaved: fn(() => Promise.resolve()),
+    onChangeStateChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub client={seededClient()}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Daily mode (the fixture default): name/type/status fields and the single-item
+// daily editor.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByDisplayValue("Daily reading"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Routine Name")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save details/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Weekly mode swaps in the full weekly schedule grid + the Quick Fill menu.
+export const Weekly: Story = {
+  args: {
+    routine: makeRoutine({
+      mode: "weekly",
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // The Quick Fill menu is rendered only in weekly mode (the schedule grid),
+    // so it's the unambiguous signal the weekly branch is active.
+    await expect(
+      await canvas.findByRole("button", {
+        name: /quick fill/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
@@ -8,7 +8,7 @@ import { DetailsTab } from "./-DetailsTab";
 import { makeRoutine } from "@/test-utils/boxFixtures";
 import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
-import { makeRoutineTemplate } from "@/test-utils/templatesFixtures";
+import { makeRoutineTemplate } from "@/test-utils/routinesFixtures";
 
 // useRoutineDetailsForm reads topics/tasks/resources for its combobox options,
 // and the weekly-mode Quick Fill menu reads the routine templates. Empty lists

--- a/packages/client/src/routes/routines.$id.edit.-components/-EntriesTab.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-EntriesTab.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { EntriesTab } from "./-EntriesTab";
+
+import { makeDaily, makeRecentCompletions } from "@/test-utils/dailiesFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+
+const DAILY_ID = "daily-1";
+
+// Seeds the daily projection the tab reads so the completions manager renders
+// instead of the pending/error placeholder.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(
+    ["daily", DAILY_ID],
+    makeDaily({
+      completions: makeRecentCompletions(["goal", "touched", "goal"]),
+    }),
+  );
+  return client;
+}
+
+const meta = {
+  component: EntriesTab,
+  args: {
+    id: DAILY_ID,
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof EntriesTab>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The self-saving completions manager (reused from the routine View page).
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Logged entries")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /next month/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { NewRoutineForm } from "./-NewRoutineForm";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta: Meta<typeof NewRoutineForm> = {
+  component: NewRoutineForm,
+  args: {
+    search: {},
+    onCreated: fn(() => Promise.resolve()),
+    onCancel: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The empty create form: name + type, with create/cancel actions. We don't
+// submit (that would call createRoutine).
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: /new routine/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Routine Name")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /create routine/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Cancel fires the caller's onCancel handler.
+export const CancelClickable: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const cancel = await canvas.findByRole("button", {
+      name: /cancel/i,
+    });
+    await userEvent.click(cancel);
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};

--- a/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
@@ -6,10 +6,8 @@ import { expect, fn, screen, userEvent, within } from "storybook/test";
 import { QuickFillMenu } from "./-QuickFillMenu";
 
 import { QueryStub } from "@/test-utils/QueryStub";
-import {
-  makeCriteriaTemplate,
-  makeRoutineTemplate,
-} from "@/test-utils/templatesFixtures";
+import { makeRoutineTemplate } from "@/test-utils/routinesFixtures";
+import { makeCriteriaTemplate } from "@/test-utils/templatesFixtures";
 
 // Seeds one template list so the menu renders its items without a network call.
 function clientWith(key: string, data: unknown) {
@@ -57,7 +55,7 @@ export const RoutineTemplates: Story = {
         name: /quick fill/i,
       }),
     );
-    const item = await screen.findByText("Weekday mornings");
+    const item = await screen.findByText("Summer Japanese");
     await userEvent.click(item);
     await expect(args.onSelect).toHaveBeenCalled();
   },

--- a/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
+
+import { QuickFillMenu } from "./-QuickFillMenu";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import {
+  makeCriteriaTemplate,
+  makeRoutineTemplate,
+} from "@/test-utils/templatesFixtures";
+
+// Seeds one template list so the menu renders its items without a network call.
+function clientWith(key: string, data: unknown) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData([key], data);
+  return client;
+}
+
+const meta: Meta<typeof QuickFillMenu> = {
+  component: QuickFillMenu,
+  args: {
+    onSelect: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Routine kind: opens the menu and applies a chosen weekly template.
+export const RoutineTemplates: Story = {
+  args: {
+    kind: "routine",
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith("routineTemplates", [makeRoutineTemplate()])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /quick fill/i,
+      }),
+    );
+    const item = await screen.findByText("Weekday mornings");
+    await userEvent.click(item);
+    await expect(args.onSelect).toHaveBeenCalled();
+  },
+};
+
+// Criteria kind fetches the criteria templates instead.
+export const CriteriaTemplates: Story = {
+  args: {
+    kind: "criteria",
+  },
+  decorators: [
+    Story => (
+      <QueryStub
+        client={clientWith("dailyCriteriaTemplates", [makeCriteriaTemplate()])}
+      >
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /quick fill/i,
+      }),
+    );
+    await expect(await screen.findByText("Reading goals")).toBeInTheDocument();
+  },
+};
+
+// With no templates the menu shows a disabled hint pointing at Settings.
+export const NoTemplates: Story = {
+  args: {
+    kind: "routine",
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith("routineTemplates", [])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /quick fill/i,
+      }),
+    );
+    await expect(
+      await screen.findByText(/no templates/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/routines.tracker.-components/-TrackerTables.stories.tsx
+++ b/packages/client/src/routes/routines.tracker.-components/-TrackerTables.stories.tsx
@@ -1,0 +1,108 @@
+import type { RoutineTrackerState } from "@/hooks/useRoutineTracker";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, within } from "storybook/test";
+
+import { TrackerTables } from "./-TrackerTables";
+
+import { SettingsProvider } from "@/context/SettingsProvider";
+import { makeDaily, makeRecentCompletions } from "@/test-utils/dailiesFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { getTodayKey } from "@/utils";
+
+// Builds the bundle the tables consume. The tracker hook is bypassed: we supply
+// the buckets directly and stub the mutation/handlers (the body only reads them,
+// and stories never fire the real status mutation).
+function makeTrackerState(
+  overrides: Partial<RoutineTrackerState> = {},
+): RoutineTrackerState {
+  return {
+    maxActiveDailies: 5,
+    mode: "list",
+    setMode: fn(),
+    sorting: [],
+    onSortingChange: fn(),
+    mutation: {
+      isPending: false,
+      mutate: fn(),
+    },
+    baseSorted: [],
+    activeDailies: [],
+    pausedDailies: [],
+    completedDailies: [],
+    dayHeaders: [],
+    todayKey: getTodayKey(),
+    recentDaysCount: 6,
+    ...overrides,
+  } as unknown as RoutineTrackerState;
+}
+
+const activeDaily = makeDaily({
+  id: "daily-active",
+  name: "Morning reading",
+  status: "active",
+  completions: makeRecentCompletions(["goal", "touched", "goal"]),
+});
+const pausedDaily = makeDaily({
+  id: "daily-paused",
+  name: "Evening review",
+  status: "paused",
+});
+const completedDaily = makeDaily({
+  id: "daily-complete",
+  name: "Finished course",
+  status: "complete",
+});
+
+const meta: Meta<typeof TrackerTables> = {
+  component: TrackerTables,
+  decorators: [
+    Story => (
+      <RouterStub>
+        <SettingsProvider>
+          <QueryStub>
+            <Story />
+          </QueryStub>
+        </SettingsProvider>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// All three sections populated (Active list view, Paused, Completed).
+export const Default: Story = {
+  args: makeTrackerState({
+    baseSorted: [activeDaily, pausedDaily, completedDaily],
+    activeDailies: [activeDaily],
+    pausedDailies: [pausedDaily],
+    completedDailies: [completedDaily],
+  }),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("Active Routines"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Paused Routines")).toBeInTheDocument();
+    await expect(canvas.getByText("Completed Routines")).toBeInTheDocument();
+  },
+};
+
+// No routines at all shows the empty-state copy.
+export const Empty: Story = {
+  args: makeTrackerState(),
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText(/no routines yet/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { CriteriaTemplatesSection } from "./-CriteriaTemplatesSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeCriteriaTemplate } from "@/test-utils/templatesFixtures";
+
+function clientWith(templates = [makeCriteriaTemplate()]) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["dailyCriteriaTemplates"], templates);
+  return client;
+}
+
+const meta = {
+  component: CriteriaTemplatesSection,
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof CriteriaTemplatesSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A saved criteria template with its goal preview.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: /status criteria templates/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Reading goals")).toBeInTheDocument();
+  },
+};
+
+// The empty state prompts the user to create one.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith([])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/no templates yet/i)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { DashboardLayoutsSection } from "./-DashboardLayoutsSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeLayout } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Seeds one tab layout + one saved preset so both lists render.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.dashboardLayouts.list(), [
+    makeLayout({
+      name: "Main",
+    }),
+    makeLayout({
+      id: "layout-2",
+      name: "Reading preset",
+      isTemplate: true,
+      position: null,
+    }),
+  ]);
+  return client;
+}
+
+const meta = {
+  component: DashboardLayoutsSection,
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof DashboardLayoutsSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The tabs + saved-presets lists, each with its row actions menu.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Tabs",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Saved presets",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Main")).toBeInTheDocument();
+    await expect(canvas.getByText("Reading preset")).toBeInTheDocument();
+  },
+};
+
+// Before the layouts query resolves the section shows its loading placeholder.
+export const Loading: Story = {
+  decorators: [
+    Story => (
+      <QueryStub>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Loading...")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-DataToolsSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-DataToolsSection.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { DataToolsSection } from "./-DataToolsSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const meta = {
+  component: DataToolsSection,
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof DataToolsSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The two dev-data actions. We don't click them — they fetch + navigate.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("button", {
+        name: /clear data/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /clear & seed data/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-FocusedDomainsSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-FocusedDomainsSection.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { FocusedDomainsSection } from "./-FocusedDomainsSection";
+
+import { makeDomain } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeAppSettings } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Seeds settings + domains so the form (rather than the loading placeholder)
+// renders.
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), makeAppSettings());
+  client.setQueryData(queryKeys.domains.list(), [
+    makeDomain(),
+    makeDomain({
+      id: "domain-2",
+      title: "Backend Engineering",
+    }),
+  ]);
+  return client;
+}
+
+const meta = {
+  component: FocusedDomainsSection,
+} satisfies Meta<typeof FocusedDomainsSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The focused-domains picker + save action once the queries resolve.
+export const Default: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Focused domains")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save focused domains/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Before the queries resolve the section shows its loading placeholder.
+export const Loading: Story = {
+  decorators: [
+    Story => (
+      <QueryStub>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/loading domains/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-GoogleCalendarSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-GoogleCalendarSection.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { GoogleCalendarSection } from "./-GoogleCalendarSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeCalendarFeed } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+function clientWith(feeds = [makeCalendarFeed()]) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.googleCalendar.feeds(), feeds);
+  return client;
+}
+
+const meta = {
+  component: GoogleCalendarSection,
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof GoogleCalendarSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A subscribed feed plus the add-feed form.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Calendar",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Personal")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /add calendar/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// No feeds subscribed yet — just the add-feed form.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith([])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByPlaceholderText(/calendar name/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-IntegrationKeySection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-IntegrationKeySection.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { IntegrationKeySection } from "./-IntegrationKeySection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeAppSettings } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Seeds the settings detail the section reads so the configured/unconfigured
+// banner resolves without a network call.
+function clientWith(settings = makeAppSettings()) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), settings);
+  return client;
+}
+
+const meta = {
+  component: IntegrationKeySection,
+  args: {
+    title: "Readwise",
+    placeholder: "Paste your Readwise token",
+    description: "Connect your Readwise account to show your reading list.",
+    buildUpdate: (key: string | null) => ({
+      readwiseApiKey: key,
+    }),
+    selectStatus: data => ({
+      configured: data?.readwiseConfigured ?? false,
+      hint: data?.readwiseKeyHint ?? null,
+    }),
+    dataQueryKey: queryKeys.readwise.readingList(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof IntegrationKeySection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No key saved yet: the input plus a "Save key" action.
+export const Unconfigured: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Readwise",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save key/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// A saved key surfaces the masked hint plus Update/Remove actions.
+export const Configured: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={clientWith(
+          makeAppSettings({
+            readwiseConfigured: true,
+            readwiseKeyHint: "aB3x",
+          }),
+        )}
+      >
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/ending aB3x/i),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /remove/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-ReadwiseSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-ReadwiseSection.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { ReadwiseSection } from "./-ReadwiseSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeAppSettings } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), makeAppSettings());
+  return client;
+}
+
+const meta = {
+  component: ReadwiseSection,
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof ReadwiseSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The Readwise integration wraps IntegrationKeySection with its preset copy.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Readwise",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("link", {
+        name: /readwise\.io\/access_token/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { RoutineTemplatesSection } from "./-RoutineTemplatesSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeRoutineTemplate } from "@/test-utils/templatesFixtures";
+
+function clientWith(templates = [makeRoutineTemplate()]) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["routineTemplates"], templates);
+  // The edit modal's option lists; empty is fine for the section render.
+  client.setQueryData(["tasks"], []);
+  client.setQueryData(["resources"], []);
+  return client;
+}
+
+const meta = {
+  component: RoutineTemplatesSection,
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof RoutineTemplatesSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A saved routine template with its scheduled-day count.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: /routine templates/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Weekday mornings")).toBeInTheDocument();
+  },
+};
+
+// The empty state prompts the user to create one.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith([])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/no templates yet/i)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.stories.tsx
@@ -6,7 +6,7 @@ import { expect, within } from "storybook/test";
 import { RoutineTemplatesSection } from "./-RoutineTemplatesSection";
 
 import { QueryStub } from "@/test-utils/QueryStub";
-import { makeRoutineTemplate } from "@/test-utils/templatesFixtures";
+import { makeRoutineTemplate } from "@/test-utils/routinesFixtures";
 
 function clientWith(templates = [makeRoutineTemplate()]) {
   const client = new QueryClient({
@@ -50,7 +50,7 @@ export const Default: Story = {
         name: /routine templates/i,
       }),
     ).toBeInTheDocument();
-    await expect(canvas.getByText("Weekday mornings")).toBeInTheDocument();
+    await expect(canvas.getByText("Summer Japanese")).toBeInTheDocument();
   },
 };
 

--- a/packages/client/src/routes/settings.-components/-TaskTypesSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-TaskTypesSection.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { TaskTypesSection } from "./-TaskTypesSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeTaskType } from "@/test-utils/settingsFixtures";
+
+function clientWith(taskTypes = [makeTaskType()]) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(["taskTypes"], taskTypes);
+  return client;
+}
+
+const meta = {
+  component: TaskTypesSection,
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof TaskTypesSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A saved task type with its tag chips.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Task Types",
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Deep work")).toBeInTheDocument();
+  },
+};
+
+// The empty state prompts the user to create one.
+export const Empty: Story = {
+  decorators: [
+    Story => (
+      <QueryStub client={clientWith([])}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/no task types yet/i),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-ThemeSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-ThemeSection.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { ThemeSection } from "./-ThemeSection";
+
+import { ThemeProvider } from "@/context/ThemeProvider";
+
+const meta = {
+  component: ThemeSection,
+  decorators: [
+    Story => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof ThemeSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The single light/dark toggle button (label depends on the active theme).
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", {
+        name: /set to (dark|light) mode/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings.-components/-TodoistSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-TodoistSection.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { TodoistSection } from "./-TodoistSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { makeAppSettings } from "@/test-utils/settingsFixtures";
+import { queryKeys } from "@/utils/queryKeys";
+
+function seededClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(queryKeys.settings.detail(), makeAppSettings());
+  return client;
+}
+
+const meta = {
+  component: TodoistSection,
+  decorators: [
+    Story => (
+      <QueryStub client={seededClient()}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof TodoistSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The Todoist integration wraps IntegrationKeySection with its preset copy.
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Todoist",
+      }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save key/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.stories.tsx
+++ b/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.stories.tsx
@@ -1,0 +1,127 @@
+import type { Topic } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QueryClient } from "@tanstack/react-query";
+import { expect, within } from "storybook/test";
+
+import { TopicForm } from "./-TopicForm";
+
+import { makeDomain, makeResources } from "@/test-utils/boxFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+
+const TOPIC_ID = "topic-1";
+
+const topicDetail: Topic = {
+  id: TOPIC_ID,
+  name: "TypeScript",
+  description: "Static typing for JavaScript.",
+  reason: "Career growth.",
+  domains: [
+    {
+      id: "domain-1",
+      title: "Frontend Engineering",
+    },
+  ],
+  tags: [],
+  resourceLinks: [],
+};
+
+// Seeds the option lists every variant needs; `seedDetail` adds the topic detail
+// for the edit form (the create form leaves it out — its query is disabled).
+function buildClient(seedDetail: boolean) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  if (seedDetail) {
+    client.setQueryData(["topic", TOPIC_ID], topicDetail);
+  }
+  client.setQueryData(["domains"], [makeDomain()]);
+  client.setQueryData(["tagGroups"], []);
+  client.setQueryData(["resources"], makeResources());
+  client.setQueryData(["module-groups-all"], []);
+  client.setQueryData(["modules-all"], []);
+  return client;
+}
+
+const meta = {
+  component: TopicForm,
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+} satisfies Meta<typeof TopicForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Edit an existing topic: fields hydrate from the seeded detail.
+export const Edit: Story = {
+  args: {
+    id: TOPIC_ID,
+    isNew: false,
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={buildClient(true)}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: /edit topic/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue("TypeScript")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /save changes/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// Create a new topic: empty form, no detail fetch.
+export const New: Story = {
+  args: {
+    id: "new",
+    isNew: true,
+  },
+  decorators: [
+    Story => (
+      <QueryStub client={buildClient(false)}>
+        <Story />
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole("heading", {
+        name: /new topic/i,
+      }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Topic Name")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /create topic/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/test-utils/dashboardFixtures.ts
+++ b/packages/client/src/test-utils/dashboardFixtures.ts
@@ -1,0 +1,21 @@
+import type { DashboardLayoutTile, DashboardTileId } from "@emstack/types";
+
+/**
+ * Mock-data factory for the dashboard tiles. Each tile component receives a
+ * `DashboardLayoutTile` (its grid position/size + per-card settings); this fills
+ * in sensible defaults so a story only specifies the id and any setting it cares
+ * about. Mirrors the other `test-utils/*Fixtures.ts` factories.
+ */
+export function makeTile(
+  tileId: DashboardTileId,
+  overrides: Partial<DashboardLayoutTile> = {},
+): DashboardLayoutTile {
+  return {
+    tileId,
+    x: 0,
+    y: 0,
+    w: 4,
+    h: 7,
+    ...overrides,
+  };
+}

--- a/packages/client/src/test-utils/radarFixtures.ts
+++ b/packages/client/src/test-utils/radarFixtures.ts
@@ -123,8 +123,10 @@ export function makeRadar(overrides: Partial<Radar> = {}): Radar {
   };
 }
 
-/** A domain with scope topics, mirroring what the edit route passes its tabs. */
-export function makeDomain(overrides: Partial<Domain> = {}): Domain {
+/** A domain with scope topics, mirroring what the edit route passes its tabs.
+ * Distinct from `boxFixtures.makeDomain` (the minimal content-box `Domain`):
+ * this one carries the scope/topic fields the domain edit tabs read. */
+export function makeScopedDomain(overrides: Partial<Domain> = {}): Domain {
   const asDomainTopics = (topics: TopicForTopicsPage[]): DomainTopic[] =>
     topics.map(t => ({
       id: t.id,

--- a/packages/client/src/test-utils/settingsFixtures.ts
+++ b/packages/client/src/test-utils/settingsFixtures.ts
@@ -1,0 +1,68 @@
+import type {
+  AppSettingsSummary,
+  CalendarFeedSummary,
+  DashboardLayout,
+  TaskType,
+} from "@emstack/types";
+
+/**
+ * Mock-data factories for the Settings page sections and the dashboard
+ * layout dialogs. Each `make*` takes a partial override and fills in sensible
+ * defaults, mirroring the other `test-utils/*Fixtures.ts` factories.
+ */
+
+export function makeAppSettings(
+  overrides: Partial<AppSettingsSummary> = {},
+): AppSettingsSummary {
+  return {
+    readwiseConfigured: false,
+    readwiseKeyHint: null,
+    todoistConfigured: false,
+    todoistKeyHint: null,
+    focusedDomainIds: [],
+    ...overrides,
+  };
+}
+
+export function makeTaskType(overrides: Partial<TaskType> = {}): TaskType {
+  return {
+    id: "tt-1",
+    name: "Deep work",
+    whenToUse: "Focused, uninterrupted sessions.",
+    tags: ["focus", "deep-work"],
+    ...overrides,
+  };
+}
+
+export function makeCalendarFeed(
+  overrides: Partial<CalendarFeedSummary> = {},
+): CalendarFeedSummary {
+  return {
+    id: "feed-1",
+    name: "Personal",
+    urlHint: "calendar.google.com/…/basic.ics",
+    color: "#2563eb",
+    ...overrides,
+  };
+}
+
+export function makeLayout(
+  overrides: Partial<DashboardLayout> = {},
+): DashboardLayout {
+  return {
+    id: "layout-1",
+    name: "Main",
+    position: 0,
+    tiles: [
+      {
+        tileId: "doNow",
+        x: 0,
+        y: 0,
+        w: 4,
+        h: 6,
+      },
+    ],
+    isTemplate: false,
+    ...overrides,
+  };
+}

--- a/packages/client/src/test-utils/templatesFixtures.ts
+++ b/packages/client/src/test-utils/templatesFixtures.ts
@@ -1,49 +1,11 @@
-import type { DailyCriteriaTemplate, RoutineTemplate } from "@emstack/types";
+import type { DailyCriteriaTemplate } from "@emstack/types";
 
 /**
- * Mock-data builders for routine + daily-criteria templates. Used by the
- * Settings template sections and the routine edit tabs' Quick Fill menu. Each
- * `make*` takes a partial override and fills in sensible defaults, mirroring the
- * other `test-utils/*Fixtures.ts` factories.
+ * Mock-data builder for daily-criteria templates (the per-status copy reused by
+ * the Settings criteria-templates section and the routine Status Criteria tab's
+ * Quick Fill menu). Routine templates have their own `makeRoutineTemplate` in
+ * `routinesFixtures.ts`; this file only covers the criteria shape.
  */
-
-export function makeRoutineTemplate(
-  overrides: Partial<RoutineTemplate> = {},
-): RoutineTemplate {
-  return {
-    id: "rtpl-1",
-    label: "Weekday mornings",
-    weekly: {
-      1: {
-        type: "task",
-        id: "task-1",
-      },
-      3: {
-        type: "task",
-        id: "task-1",
-      },
-      5: {
-        type: "task",
-        id: "task-1",
-      },
-    },
-    ...overrides,
-  };
-}
-
-export function makeRoutineTemplates(count = 2): RoutineTemplate[] {
-  return Array.from(
-    {
-      length: count,
-    },
-    (_, i) =>
-      makeRoutineTemplate({
-        id: `rtpl-${i + 1}`,
-        label: `Routine template ${i + 1}`,
-      }),
-  );
-}
-
 export function makeCriteriaTemplate(
   overrides: Partial<DailyCriteriaTemplate> = {},
 ): DailyCriteriaTemplate {
@@ -57,17 +19,4 @@ export function makeCriteriaTemplate(
     freeze: "Rest day — streak preserved.",
     ...overrides,
   };
-}
-
-export function makeCriteriaTemplates(count = 2): DailyCriteriaTemplate[] {
-  return Array.from(
-    {
-      length: count,
-    },
-    (_, i) =>
-      makeCriteriaTemplate({
-        id: `crit-${i + 1}`,
-        label: `Criteria template ${i + 1}`,
-      }),
-  );
 }

--- a/packages/client/src/test-utils/templatesFixtures.ts
+++ b/packages/client/src/test-utils/templatesFixtures.ts
@@ -1,0 +1,73 @@
+import type { DailyCriteriaTemplate, RoutineTemplate } from "@emstack/types";
+
+/**
+ * Mock-data builders for routine + daily-criteria templates. Used by the
+ * Settings template sections and the routine edit tabs' Quick Fill menu. Each
+ * `make*` takes a partial override and fills in sensible defaults, mirroring the
+ * other `test-utils/*Fixtures.ts` factories.
+ */
+
+export function makeRoutineTemplate(
+  overrides: Partial<RoutineTemplate> = {},
+): RoutineTemplate {
+  return {
+    id: "rtpl-1",
+    label: "Weekday mornings",
+    weekly: {
+      1: {
+        type: "task",
+        id: "task-1",
+      },
+      3: {
+        type: "task",
+        id: "task-1",
+      },
+      5: {
+        type: "task",
+        id: "task-1",
+      },
+    },
+    ...overrides,
+  };
+}
+
+export function makeRoutineTemplates(count = 2): RoutineTemplate[] {
+  return Array.from(
+    {
+      length: count,
+    },
+    (_, i) =>
+      makeRoutineTemplate({
+        id: `rtpl-${i + 1}`,
+        label: `Routine template ${i + 1}`,
+      }),
+  );
+}
+
+export function makeCriteriaTemplate(
+  overrides: Partial<DailyCriteriaTemplate> = {},
+): DailyCriteriaTemplate {
+  return {
+    id: "crit-1",
+    label: "Reading goals",
+    incomplete: "Didn't open the book.",
+    touched: "Read a page or two.",
+    goal: "Read for 20 minutes.",
+    exceeded: "Read for 45+ minutes.",
+    freeze: "Rest day — streak preserved.",
+    ...overrides,
+  };
+}
+
+export function makeCriteriaTemplates(count = 2): DailyCriteriaTemplate[] {
+  return Array.from(
+    {
+      length: count,
+    },
+    (_, i) =>
+      makeCriteriaTemplate({
+        id: `crit-${i + 1}`,
+        label: `Criteria template ${i + 1}`,
+      }),
+  );
+}


### PR DESCRIPTION
Adds comprehensive Storybook story coverage for all remaining route-private components across the dashboard, settings, domains, and routines sections.

## Summary

This PR completes the Storybook story coverage for route-private components (those in `routes/*.-components/` directories). All 40+ component stories are now in place, enabling visual testing and documentation of the UI in isolation.

## Key Changes

- **Dashboard components (16 stories):** DashboardExplore, DashboardReadwise, DashboardTodoist, DashboardUnderutilizedProviders, DashboardGoogleCalendar, DashboardCoursesInProgress, DashboardIntegrationCard, DashboardDailies (DoNow/DoneForDay), DashboardRadars, DashboardCoursesByAmortization, DashboardDailiesBody, DashboardChangelog, CardSettingsFlyout, LayoutTab, AddLayoutDialog, VisibleTilesDialog

- **Settings components (11 stories):** IntegrationKeySection, DashboardLayoutsSection, FocusedDomainsSection, GoogleCalendarSection, RoutineTemplatesSection, TaskTypesSection, CriteriaTemplatesSection, ReadwiseSection, TodoistSection, DataToolsSection, ThemeSection

- **Domains edit components (3 stories):** ExistingDomainEditor, DetailsTab, NewDomainForm

- **Routines edit/view components (10 stories):** DetailsTab, CriteriaTab, EntriesTab, NewRoutineForm, QuickFillMenu, RoutineDetailsContent, RoutineTodayCard

- **Tracker components (1 story):** TrackerTables

- **New test fixtures:** Added `settingsFixtures.ts`, `templatesFixtures.ts`, and `dashboardFixtures.ts` to support story setup with seeded QueryClient data

## Implementation Details

- Each story seeds a QueryClient with the minimal data needed for the component to render its loaded state, avoiding network calls during visual testing
- Stories use `RouterStub` and `QueryStub` decorators to provide required context
- Play functions verify key UI elements render correctly (headings, form fields, buttons, etc.)
- Fixtures follow the existing pattern from `boxFixtures.ts` and `routinesFixtures.ts`, providing `make*` factory functions with sensible defaults and override support
- Updated `.claude/skills/add-stories/SKILL.md` to document the completion of route-private component coverage

https://claude.ai/code/session_0168GLq2oRyRXihe1dnLjq6h