### PR TITLE
feat(client): fixes: issue #400 add dialog descriptions to template edit modals

### DIFF
--- a/packages/client/src/routes/settings.-components/-DailyCriteriaTemplateEditModal.tsx
+++ b/packages/client/src/routes/settings.-components/-DailyCriteriaTemplateEditModal.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/textarea";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -100,6 +101,11 @@ export function DailyCriteriaTemplateEditModal({
           <DialogTitle>
             {isNew ? "Add Criteria Template" : "Edit Criteria Template"}
           </DialogTitle>
+          <DialogDescription>
+            {isNew
+              ? "Name the template and describe what each daily status means."
+              : "Update the template's label and the descriptions for each daily status."}
+          </DialogDescription>
         </DialogHeader>
         <form
           onSubmit={handleSubmit}

--- a/packages/client/src/routes/settings.-components/-RoutineTemplateEditModal.tsx
+++ b/packages/client/src/routes/settings.-components/-RoutineTemplateEditModal.tsx
@@ -12,6 +12,7 @@ import { WeeklyScheduleField } from "@/components/routines/WeeklyScheduleField";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -71,6 +72,11 @@ export function RoutineTemplateEditModal({
           <DialogTitle>
             {isNew ? "Add Routine Template" : "Edit Routine Template"}
           </DialogTitle>
+          <DialogDescription>
+            {isNew
+              ? "Name the template and set its weekly schedule of tasks and resources."
+              : "Update the template's label and weekly schedule of tasks and resources."}
+          </DialogDescription>
         </DialogHeader>
         <form
           onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
Added `DialogDescription` components to the Daily Criteria Template and Routine Template edit modals to provide contextual guidance to users about what they're doing in each dialog.

## Changes
- **DailyCriteriaTemplateEditModal:** Added a conditional description that explains users should "Name the template and describe what each daily status means" when adding, or "Update the template's label and the descriptions for each daily status" when editing
- **RoutineTemplateEditModal:** Added a conditional description that explains users should "Name the template and set its weekly schedule of tasks and resources" when adding, or "Update the template's label and weekly schedule of tasks and resources" when editing

## Implementation Details
- Imported `DialogDescription` from the shadcn/ui dialog component library in both files
- Used conditional rendering (`isNew` ternary) to display context-appropriate descriptions for create vs. edit workflows
- Descriptions are placed in the `DialogHeader` immediately after `DialogTitle`, following shadcn/ui dialog conventions

https://claude.ai/code/session_017gpqqQCqJuHjLC81npGA8t