### PR TITLE
fix(client): fixes: issue #401 add screen-reader descriptions to dialogs

### DIFF
--- a/packages/client/src/components/ConfirmDialog.tsx
+++ b/packages/client/src/components/ConfirmDialog.tsx
@@ -35,9 +35,13 @@ export function ConfirmDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
-          {description && (
-            <AlertDialogDescription>{description}</AlertDialogDescription>
-          )}
+          {description
+            ? <AlertDialogDescription>{description}</AlertDialogDescription>
+            : (
+              <AlertDialogDescription className="sr-only">
+                Confirm or cancel this action.
+              </AlertDialogDescription>
+            )}
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={() => onCancel()}>

--- a/packages/client/src/components/LayoutNameDialog.tsx
+++ b/packages/client/src/components/LayoutNameDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -51,6 +52,9 @@ export function LayoutNameDialog({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Enter a name for this layout.
+          </DialogDescription>
         </DialogHeader>
         <form
           className="flex flex-col gap-4"


### PR DESCRIPTION
## Summary
Improves accessibility by ensuring all dialogs have proper descriptions for screen readers, even when user-provided descriptions are absent.

## Changes
- **ConfirmDialog:** Added a fallback `sr-only` description ("Confirm or cancel this action.") when no description is provided, ensuring screen readers always have context for the dialog's purpose
- **LayoutNameDialog:** Added a `sr-only` description ("Enter a name for this layout.") to provide screen reader users with guidance on the dialog's function

## Implementation Details
Both changes follow the pattern of using the `sr-only` utility class to hide descriptions visually while keeping them available to assistive technologies. This ensures WCAG compliance and improves the experience for screen reader users without affecting the visual design.

https://claude.ai/code/session_015X2cnzwpysD1HwJFb72Bc9