### PR TITLE
fix(client): fixes: issue #399 add accessible descriptions to quick-add dialogs

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddIntegrationDialog.stories.tsx
@@ -13,6 +13,16 @@ const meta: Meta<typeof QuickAddIntegrationDialog> = {
     open: true,
     onOpenChange: fn(),
     title: "Save to Readwise",
+    // Mirrors the real Readwise dialog so the DialogContent has an accessible
+    // description (Radix warns when one is missing).
+    description: (
+      <>
+        The article is tagged
+        {" "}
+        <code>from-coursetracker</code>
+        .
+      </>
+    ),
     providerName: "Readwise",
     isPending: false,
     canSubmit: true,

--- a/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/input";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -17,6 +18,11 @@ interface QuickAddNameDialogProps {
   title: string;
   /** Slug for the input's id, e.g. "resource" → `quick-add-resource-name`. */
   entity: string;
+  /**
+   * Accessible description for the dialog. Defaults to a sentence derived from
+   * `entity` (e.g. "Enter a name to create a new resource.").
+   */
+  description?: React.ReactNode;
   /** Placeholder shown in the name input. */
   placeholder: string;
   /** Seeds the name input each time the dialog opens. */
@@ -37,6 +43,7 @@ export function QuickAddNameDialog({
   onOpenChange,
   title,
   entity,
+  description,
   placeholder,
   initialName,
   isPending,
@@ -59,6 +66,9 @@ export function QuickAddNameDialog({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {description ?? `Enter a name to create a new ${entity}.`}
+          </DialogDescription>
         </DialogHeader>
         <form
           className="flex flex-col gap-4"

--- a/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/input";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -72,6 +73,9 @@ export function QuickAddProviderDialog({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>Add Provider</DialogTitle>
+          <DialogDescription>
+            Enter a name and URL to add a new provider.
+          </DialogDescription>
         </DialogHeader>
         <form
           className="flex flex-col gap-4"

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
@@ -9,6 +9,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/radio-group";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -38,6 +39,9 @@ export function QuickAddRoutineDialog({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle>Add Routine</DialogTitle>
+          <DialogDescription>
+            Name your routine and choose whether it repeats weekly or daily.
+          </DialogDescription>
         </DialogHeader>
         <form
           className="flex flex-col gap-4"


### PR DESCRIPTION
## Summary
Adds accessible descriptions to all quick-add dialogs to comply with Radix UI's accessibility requirements. Each dialog now includes a `DialogDescription` component that provides context about the dialog's purpose.

## Changes
- **QuickAddNameDialog:** Added optional `description` prop (defaults to "Enter a name to create a new {entity}.") and renders `DialogDescription` in the dialog header
- **QuickAddProviderDialog:** Added `DialogDescription` with text "Enter a name and URL to add a new provider."
- **QuickAddRoutineDialog:** Added `DialogDescription` with text "Name your routine and choose whether it repeats weekly or daily."
- **QuickAddIntegrationDialog.stories.tsx:** Added `description` prop to the Readwise story to mirror the real dialog's accessible description

## Implementation Details
- The `description` prop in `QuickAddNameDialog` is optional and generates a sensible default based on the `entity` parameter, maintaining backward compatibility
- All descriptions are rendered using the `DialogDescription` component from the shared dialog UI component library
- The story update ensures Storybook renders match production behavior and eliminates Radix warnings about missing descriptions

https://claude.ai/code/session_01LmzZmFBvQJo1dbTxq2r1Zv