### PR TITLE
refactor(client): Fixes #413: dedupe edit-row & button Storybook boilerplate

### DIFF
--- a/packages/client/src/components/EditFormActions.stories.tsx
+++ b/packages/client/src/components/EditFormActions.stories.tsx
@@ -1,8 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import { EditFormActions } from "./EditFormActions";
+
+import {
+  clickCancelFiresOnCancel,
+  clickRemoveFiresOnDelete,
+  expectRemoveHidden,
+  expectSaveDisabled,
+} from "@/test-utils/editRowStoryPlays";
 
 const meta: Meta<typeof EditFormActions> = {
   component: EditFormActions,
@@ -18,15 +25,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Cancel",
-    }));
-    await expect(args.onCancel).toHaveBeenCalled();
-  },
+  play: clickCancelFiresOnCancel,
 };
 
 // A new (unsaved) row hides the destructive Remove button.
@@ -34,29 +33,12 @@ export const NewRow: Story = {
   args: {
     isNew: true,
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.queryByRole("button", {
-        name: "Remove",
-      }),
-    ).not.toBeInTheDocument();
-  },
+  play: expectRemoveHidden,
 };
 
 // An existing row shows Remove and fires onDelete.
 export const ExistingRow: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Remove",
-    }));
-    await expect(args.onDelete).toHaveBeenCalled();
-  },
+  play: clickRemoveFiresOnDelete,
 };
 
 // While saving, the Save button is disabled.
@@ -64,14 +46,7 @@ export const Saving: Story = {
   args: {
     isSaving: true,
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByRole("button", {
-      name: "Save",
-    })).toBeDisabled();
-  },
+  play: expectSaveDisabled,
 };
 
 // Delete can be blocked with an explanatory reason.
@@ -84,9 +59,11 @@ export const DeleteDisabled: Story = {
     canvasElement,
   }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole("button", {
-      name: "Remove",
-    })).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", {
+        name: "Remove",
+      }),
+    ).toBeDisabled();
   },
 };
 

--- a/packages/client/src/components/EditModalFooter.stories.tsx
+++ b/packages/client/src/components/EditModalFooter.stories.tsx
@@ -1,8 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { EditModalFooter } from "./EditModalFooter";
+
+import {
+  clickCancelFiresOnCancel,
+  clickRemoveFiresOnDelete,
+  expectRemoveHidden,
+  expectSaveDisabled,
+} from "@/test-utils/editRowStoryPlays";
 
 const meta: Meta<typeof EditModalFooter> = {
   component: EditModalFooter,
@@ -17,15 +24,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Cancel",
-    }));
-    await expect(args.onCancel).toHaveBeenCalled();
-  },
+  play: clickCancelFiresOnCancel,
 };
 
 // A new entity hides the destructive Remove button.
@@ -33,41 +32,17 @@ export const NewEntity: Story = {
   args: {
     isNew: true,
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.queryByRole("button", {
-        name: "Remove",
-      }),
-    ).not.toBeInTheDocument();
-  },
+  play: expectRemoveHidden,
 };
 
 // An existing entity shows Remove and fires onDelete.
 export const Removable: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Remove",
-    }));
-    await expect(args.onDelete).toHaveBeenCalled();
-  },
+  play: clickRemoveFiresOnDelete,
 };
 
 export const Saving: Story = {
   args: {
     isSaving: true,
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByRole("button", {
-      name: "Save",
-    })).toBeDisabled();
-  },
+  play: expectSaveDisabled,
 };

--- a/packages/client/src/components/button.stories.tsx
+++ b/packages/client/src/components/button.stories.tsx
@@ -1,15 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
-
 import { Button } from "./button";
+
+import {
+  asChildArgs,
+  buttonMetaArgs,
+  buttonVariantArgs,
+  clickButtonFiresOnClick,
+  expectAsChildRendersLink,
+} from "@/test-utils/buttonStoryFixtures";
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  args: {
-    children: "Button",
-    onClick: fn(),
-  },
+  args: buttonMetaArgs(),
 };
 
 export default meta;
@@ -17,43 +20,23 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Button",
-    }));
-    await expect(args.onClick).toHaveBeenCalled();
-  },
+  play: clickButtonFiresOnClick,
 };
 
 export const Secondary: Story = {
-  args: {
-    variant: "secondary",
-    children: "Secondary",
-  },
+  args: buttonVariantArgs.secondary,
 };
 
 export const Destructive: Story = {
-  args: {
-    variant: "destructive",
-    children: "Delete",
-  },
+  args: buttonVariantArgs.destructive,
 };
 
 export const Outline: Story = {
-  args: {
-    variant: "outline",
-    children: "Outline",
-  },
+  args: buttonVariantArgs.outline,
 };
 
 export const Ghost: Story = {
-  args: {
-    variant: "ghost",
-    children: "Ghost",
-  },
+  args: buttonVariantArgs.ghost,
 };
 
 export const Small: Story = {
@@ -63,21 +46,7 @@ export const Small: Story = {
   },
 };
 
-// `asChild` renders the child element with the button styling, so the rendered
-// node here is a link rather than a <button>.
 export const AsChild: Story = {
-  args: {
-    asChild: true,
-    children: <a href="/somewhere">Link button</a>,
-  },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByRole("link", {
-        name: "Link button",
-      }),
-    ).toBeInTheDocument();
-  },
+  args: asChildArgs,
+  play: expectAsChildRendersLink,
 };

--- a/packages/client/src/components/tasks/TaskResourceEditingRow.stories.tsx
+++ b/packages/client/src/components/tasks/TaskResourceEditingRow.stories.tsx
@@ -6,6 +6,10 @@ import { expect, fn, within } from "storybook/test";
 import { EditingRow } from "./TaskResourceEditingRow";
 
 import {
+  expectRemoveHidden,
+  expectSaveDisabled,
+} from "@/test-utils/editRowStoryPlays";
+import {
   makeModule,
   makeModuleGroup,
   makeTaskResource,
@@ -56,21 +60,15 @@ type Story = StoryObj<typeof meta>;
 
 /** A brand-new row: Save/Cancel only, no Remove. */
 export const NewRow: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
+  play: async (context) => {
+    const canvas = within(context.canvasElement);
     await expect(canvas.getByLabelText("Name")).toBeInTheDocument();
     await expect(
       canvas.getByRole("button", {
         name: "Save",
       }),
     ).toBeInTheDocument();
-    await expect(
-      canvas.queryByRole("button", {
-        name: "Remove",
-      }),
-    ).not.toBeInTheDocument();
+    await expectRemoveHidden(context);
   },
 };
 
@@ -100,14 +98,5 @@ export const Saving: Story = {
   args: {
     isSaving: true,
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByRole("button", {
-        name: "Save",
-      }),
-    ).toBeDisabled();
-  },
+  play: expectSaveDisabled,
 };

--- a/packages/client/src/components/ui/button.stories.tsx
+++ b/packages/client/src/components/ui/button.stories.tsx
@@ -1,15 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
-
 import { Button } from "./button";
+
+import {
+  asChildArgs,
+  buttonMetaArgs,
+  buttonVariantArgs,
+  clickButtonFiresOnClick,
+  expectAsChildRendersLink,
+} from "@/test-utils/buttonStoryFixtures";
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  args: {
-    children: "Button",
-    onClick: fn(),
-  },
+  args: buttonMetaArgs(),
 };
 
 export default meta;
@@ -17,43 +20,23 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement, args,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Button",
-    }));
-    await expect(args.onClick).toHaveBeenCalled();
-  },
+  play: clickButtonFiresOnClick,
 };
 
 export const Secondary: Story = {
-  args: {
-    variant: "secondary",
-    children: "Secondary",
-  },
+  args: buttonVariantArgs.secondary,
 };
 
 export const Destructive: Story = {
-  args: {
-    variant: "destructive",
-    children: "Delete",
-  },
+  args: buttonVariantArgs.destructive,
 };
 
 export const Outline: Story = {
-  args: {
-    variant: "outline",
-    children: "Outline",
-  },
+  args: buttonVariantArgs.outline,
 };
 
 export const Ghost: Story = {
-  args: {
-    variant: "ghost",
-    children: "Ghost",
-  },
+  args: buttonVariantArgs.ghost,
 };
 
 export const Link: Story = {
@@ -63,21 +46,7 @@ export const Link: Story = {
   },
 };
 
-// `asChild` renders the child element (here an anchor) with the button styling
-// instead of a <button>, so the rendered node is a link.
 export const AsChild: Story = {
-  args: {
-    asChild: true,
-    children: <a href="/somewhere">Link button</a>,
-  },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByRole("link", {
-        name: "Link button",
-      }),
-    ).toBeInTheDocument();
-  },
+  args: asChildArgs,
+  play: expectAsChildRendersLink,
 };

--- a/packages/client/src/routes/settings.-components/-TaskTypeEditRow.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-TaskTypeEditRow.stories.tsx
@@ -1,9 +1,14 @@
 import type { TaskType } from "@emstack/types";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import { TaskTypeEditRow } from "./-TaskTypeEditRow";
+
+import {
+  clickCancelFiresOnCancel,
+  expectRemoveHidden,
+} from "@/test-utils/editRowStoryPlays";
 
 const taskType: TaskType = {
   id: "task-type-1",
@@ -56,26 +61,9 @@ export const NewType: Story = {
       tags: [],
     },
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.queryByRole("button", {
-        name: "Remove",
-      }),
-    ).not.toBeInTheDocument();
-  },
+  play: expectRemoveHidden,
 };
 
 export const Cancels: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Cancel",
-    }));
-    await expect(args.onCancel).toHaveBeenCalled();
-  },
+  play: clickCancelFiresOnCancel,
 };

--- a/packages/client/src/test-utils/buttonStoryFixtures.tsx
+++ b/packages/client/src/test-utils/buttonStoryFixtures.tsx
@@ -1,0 +1,77 @@
+import { expect, fn, userEvent, within } from "storybook/test";
+
+/**
+ * Shared Storybook scaffold for the two near-identical Button story files
+ * (`components/button.stories.tsx` and `components/ui/button.stories.tsx`).
+ * They document genuinely different Button components, so both files remain —
+ * this module just removes the duplicated args, variant args, and play bodies.
+ */
+
+interface PlayContext<TArgs = unknown> {
+  args: TArgs;
+  canvasElement: HTMLElement;
+}
+
+/**
+ * Default meta args both Button story files share. A function (not a shared
+ * object) so each file gets its own `fn()` spy instead of one shared instance.
+ */
+export function buttonMetaArgs() {
+  return {
+    children: "Button",
+    onClick: fn(),
+  };
+}
+
+/** Variant arg objects identical across both Button story files. */
+export const buttonVariantArgs = {
+  secondary: {
+    variant: "secondary",
+    children: "Secondary",
+  },
+  destructive: {
+    variant: "destructive",
+    children: "Delete",
+  },
+  outline: {
+    variant: "outline",
+    children: "Outline",
+  },
+  ghost: {
+    variant: "ghost",
+    children: "Ghost",
+  },
+} as const;
+
+// `asChild` renders the child element with the button styling, so the rendered
+// node is a link rather than a <button>.
+export const asChildArgs = {
+  asChild: true,
+  children: <a href="/somewhere">Link button</a>,
+} as const;
+
+/** Default story play: clicks the button and asserts `onClick` fired. */
+export async function clickButtonFiresOnClick({
+  args,
+  canvasElement,
+}: PlayContext<{ onClick?: (...args: never[]) => unknown }>) {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole("button", {
+      name: "Button",
+    }),
+  );
+  await expect(args.onClick).toHaveBeenCalled();
+}
+
+/** AsChild story play: asserts the child anchor renders as a link. */
+export async function expectAsChildRendersLink({
+  canvasElement,
+}: Pick<PlayContext, "canvasElement">) {
+  const canvas = within(canvasElement);
+  await expect(
+    canvas.getByRole("link", {
+      name: "Link button",
+    }),
+  ).toBeInTheDocument();
+}

--- a/packages/client/src/test-utils/editRowStoryPlays.ts
+++ b/packages/client/src/test-utils/editRowStoryPlays.ts
@@ -1,0 +1,70 @@
+import { expect, userEvent, within } from "storybook/test";
+
+/**
+ * Reusable Storybook `play` smoke-tests shared by the edit-row / footer story
+ * families (EditFormActions, EditModalFooter, TaskResourceEditingRow,
+ * TaskTypeEditRow), which all render the same Save / Cancel / Remove controls.
+ *
+ * Each helper reads only the slice of the story context it needs, and types the
+ * callbacks as optional so the full StoryContext — whose `args` declare those
+ * callbacks as optional props — stays assignable to these parameter types.
+ */
+
+interface CancelArgs { onCancel?: (...args: never[]) => unknown }
+interface DeleteArgs { onDelete?: (...args: never[]) => unknown }
+interface PlayContext<TArgs = unknown> {
+  args: TArgs;
+  canvasElement: HTMLElement;
+}
+
+/** Clicks the Cancel button and asserts `onCancel` fired. */
+export async function clickCancelFiresOnCancel({
+  args,
+  canvasElement,
+}: PlayContext<CancelArgs>) {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole("button", {
+      name: "Cancel",
+    }),
+  );
+  await expect(args.onCancel).toHaveBeenCalled();
+}
+
+/** Asserts the destructive Remove button is absent (new / unsaved rows). */
+export async function expectRemoveHidden({
+  canvasElement,
+}: Pick<PlayContext, "canvasElement">) {
+  const canvas = within(canvasElement);
+  await expect(
+    canvas.queryByRole("button", {
+      name: "Remove",
+    }),
+  ).not.toBeInTheDocument();
+}
+
+/** Clicks the Remove button and asserts `onDelete` fired (existing rows). */
+export async function clickRemoveFiresOnDelete({
+  args,
+  canvasElement,
+}: PlayContext<DeleteArgs>) {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole("button", {
+      name: "Remove",
+    }),
+  );
+  await expect(args.onDelete).toHaveBeenCalled();
+}
+
+/** Asserts the Save button is disabled while saving. */
+export async function expectSaveDisabled({
+  canvasElement,
+}: Pick<PlayContext, "canvasElement">) {
+  const canvas = within(canvasElement);
+  await expect(
+    canvas.getByRole("button", {
+      name: "Save",
+    }),
+  ).toBeDisabled();
+}


### PR DESCRIPTION
## ELI5
Several Storybook example files for buttons and edit-form rows had the same little test snippets copy-pasted over and over. This moves those shared snippets into one place so there's a single copy to maintain, without changing what any example actually shows or tests.

## Summary
- Extracted the repeated Save/Cancel/Remove `play()` smoke-tests into `test-utils/editRowStoryPlays.ts` and adopted them in `EditFormActions`, `EditModalFooter`, `TaskResourceEditingRow`, and `-TaskTypeEditRow` stories.
- Extracted the shared button meta args, variant args, and `play()` helpers into `test-utils/buttonStoryFixtures.tsx`, adopted by both `components/button.stories.tsx` and `components/ui/button.stories.tsx`.
- Kept **both** button story files: they document genuinely different Button components (root vendored copy used by 2 files vs. the `ui/` primitive used in 84 files), so neither loses coverage — only their shared scaffold is single-sourced.
- Clears all 9 clone fingerprints listed in #413. The one remaining clone is the inherent A↔B mirror of the two retained button files, which was an accepted trade-off.

## Test plan
- [x] `pnpm --filter=@emstack/client typecheck` passes
- [x] `pnpm --filter=@emstack/client exec eslint` clean on touched files
- [x] `pnpm --filter=@emstack/client exec vitest run` for the 6 touched story files — 30 tests pass
- [x] `pnpm exec fallow dupes` — the 9 fingerprints from #413 no longer appear
- [ ] Optional: `pnpm storybook` and eyeball Button + edit-row variants render

🤖 Generated with [Claude Code](https://claude.com/claude-code)