### PR TITLE
docs: clarify skill illustrations and add Skills section to CLAUDE.md

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -27,6 +27,12 @@ Stories already exist for ~40-50% of components; whole areas are done
 (`contentBoxComponents/`, `boxElements/`, `dailies/`, `radar/`, `tables/`). Don't
 re-story those. The shared infra is already in place — reuse it, don't reinvent.
 
+> _Components, files, and fixtures named below (e.g. `InfoRow`,
+> `-ResourcesList.stories.tsx`, `useResourceModules`) are illustrations — they
+> show the **shape** of the pattern, not required targets. Apply the method to
+> whatever's in your scope; the **Area notes** section is per-issue worked
+> examples, not core procedure._
+
 ## 1. Inventory the target area — what's actually uncovered
 
 Story files are **co-located** next to the component and a story's filename
@@ -191,6 +197,9 @@ below for anything learned (new fixture file, a tricky decorator).
 - **Skip generated files:** `routeTree.gen.ts`, anything under `dist/`.
 
 ## Area notes
+
+_Per-issue worked examples — what a real pass through each area turned up
+(fixtures added, tricky decorators). Illustrative reference, not steps to follow._
 
 ### layout (#352)
 First batch. All 12 covered components are Tier A/B — no fixtures needed.

--- a/.claude/skills/condense-components/SKILL.md
+++ b/.claude/skills/condense-components/SKILL.md
@@ -24,6 +24,10 @@ and the root-level `components/*.tsx` vendored files. Feature components live in
 pulling hand-rolled markup back toward a primitive, or lifting a copy-pasted
 block into one shared component.
 
+> _Components named below (e.g. `BlipLegendItem`, `SelectAllCheckbox`) are
+> illustrations from earlier runs of this skill — they show the **shape** of a
+> fix, not required targets. Apply the method to whatever's in your scope._
+
 ## 1. Inventory the target area
 
 List the components in scope and look for repeated JSX structure across files —
@@ -86,9 +90,10 @@ content/render slots so it stays dumb.
 ## 3. Guardrails (when NOT to condense)
 
 - **Similar markup ≠ same component.** Two bars/cards that look alike but have
-  different *interaction models* must stay separate. `BlipBulkBar` (controlled,
-  single shared Apply, `NO_CHANGE` sentinel) and `BulkEditBar` (internal pending
-  state, per-control Apply, placeholder) were deliberately **not** merged — one
+  different *interaction models* must stay separate. Example: `BlipBulkBar`
+  (controlled, single shared Apply, `NO_CHANGE` sentinel) and `BulkEditBar`
+  (internal pending state, per-control Apply, placeholder) were deliberately
+  **not** merged — one
   configurable component would need a flag for every divergence and read worse
   than two. If unifying needs an ever-growing pile of `variant`/boolean props,
   stop and leave them apart.

--- a/.claude/skills/condense-types/SKILL.md
+++ b/.claude/skills/condense-types/SKILL.md
@@ -18,6 +18,10 @@ The single source of truth for cross-package shapes is **`packages/types/src/`**
 (`@emstack/types`). The client and middleware both consume it; local
 re-declarations drift. Most condensing is pulling things back toward that.
 
+> _Types named below (e.g. `BlipLegendHandlers`, `RadarQuadrant`) are
+> illustrations from earlier runs of this skill — they show the **shape** of a
+> fix, not required targets. Apply the method to whatever's in your scope._
+
 ## 1. Inventory the target area
 
 List every type/interface in scope and where each is used:
@@ -77,8 +81,8 @@ interface they each `extend`. Adding/changing a field then touches one place.
   (`*Payload`, `BulkBlipEntry`) deliberately differ from persisted shapes.
   Leave them.
 - **Don't force an `extends` when a member is sourced differently.** Verify the
-  candidate actually *receives* every base field. `RadarLegend` looked like it
-  could extend `BlipLegendHandlers`, but it builds `registerRef` internally
+  candidate actually *receives* every base field. Example: `RadarLegend` looked
+  like it could extend `BlipLegendHandlers`, but it builds `registerRef` internally
   (`useCallback`) rather than taking it as a prop — so it shares the callbacks
   but not the full set. The typecheck catches this; if forcing the fit needs
   ever-smaller tiers, stop and leave it separate.

--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -17,6 +17,12 @@ issues (dailies, resources, routines, routes, …). This skill is the repeatable
 procedure for one such area. Quality only — behavior must not change. For
 behavior cleanups use `/simplify`; for bugs use `/code-review`.
 
+> _Hooks, files, and components named below (e.g. `useResourceModules`,
+> `DailyRecentDaysStrip`) are illustrations — they show the **shape** of a fix,
+> not required targets. Apply the method to whatever's in your scope; the
+> **Area notes** and **Learnings** sections are per-issue worked examples, not
+> core procedure._
+
 ## How the rule actually counts (read this first)
 
 Config: `@emilyeserven/eslint-config/configs/import.js` →
@@ -66,7 +72,7 @@ state, move that logic into a `use…` hook under `src/hooks/`. The hook absorbs
 those imports; the component is left rendering JSX from a
 presentational-ready return value.
 
-Mirror the existing bundled-hook pattern:
+Mirror the existing bundled-hook pattern — for example:
 - `hooks/useResourceModules.ts` — rich `{ data…, mutations…, handlers… }` return.
 - `hooks/useDailyTracker.tsx`, `hooks/useDailyCompletions.ts` — feature hooks
   returning pre-derived rows + action callbacks. Return *computed* values
@@ -82,8 +88,8 @@ real barrel/aggregator, never to dodge restructuring a component.
 ## Guardrails (don't break behavior to win the count)
 
 - **Don't swap inline markup for a similar existing component** unless it's
-  truly equivalent. The dailies row files inline a recent-days strip; the
-  `DailyRecentDaysStrip` component looks similar but renders different
+  truly equivalent. Example: the dailies row files inline a recent-days strip;
+  the `DailyRecentDaysStrip` component looks similar but renders different
   table/list markup — reusing it would change behavior. Group the imports; keep
   the markup.
 - **Keep public props identical** so `*.stories.tsx` and tests keep passing.
@@ -121,6 +127,9 @@ sub-barrel extraction and the hook extraction into separate commits reads
 better.
 
 ## Area notes: app shell & quick-add dialogs (#311)
+
+_Per-issue worked examples — what a real pass turned up. Illustrative reference,
+not steps to follow; the same goes for the Learnings section below._
 
 Worked counts (non-type value imports): `routes/__root.tsx` = **12** (shed 2);
 `components/quickAdd/QuickAddRoutineDialog.tsx` = **11** (shed 1);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,20 @@ Schema changes: edit `packages/middleware/src/db/schema/` and run `pnpm push:dev
 - **Dependency checks:** syncpack for version consistency
 - **TypeScript:** Strict mode, ES2022 target, incremental typecheck
 
+## Skills
+
+Project skills live in `.claude/skills/<name>/SKILL.md`. The `/`-command name comes from the **directory name**, not the `name` field. See the [official skill docs](https://code.claude.com/docs/en/skills) for the full frontmatter reference.
+
+**Frontmatter schema** — the repo baseline every skill follows:
+
+- **`name`** *(required here)* — matches the directory name.
+- **`description`** *(required here)* — a folded block scalar (`>-`) stating **what the skill does AND when to use it** (include the trigger phrases users say). Claude reads this to decide when to auto-invoke, so keep it specific. Combined with `when_to_use` it's truncated at ~1,536 characters in skill listings.
+
+**Optional fields** — add only when a skill actually needs them (all are valid Claude Code fields; see the docs above): `disable-model-invocation`, `allowed-tools` / `disallowed-tools`, `context: fork` (with optional `agent`), `model`, `effort`, `argument-hint` / `arguments`, `paths`, `when_to_use`, `user-invocable`.
+
+- **`review-pr` is the deliberate exception.** It's the only skill carrying `disable-model-invocation: true`, `allowed-tools`, and `context: fork`. These are intentional, not drift: `review-pr` is a **manual** `/review-pr` (never auto-invoked) that runs in a **forked subagent** with a scoped toolset. Leave them in place.
+- **`fallow/` is vendored** (see the fallow note under Code Quality). Its frontmatter carries upstream `license` and `metadata` keys that are **not** part of Claude's schema — don't hand-edit; re-sync with `pnpm fallow:sync-skill`.
+
 ## Environment Variables
 
 | Variable | Package | Purpose | Default |


### PR DESCRIPTION
Adds clarifying notes to four skill documents and introduces a new "Skills" section to the root CLAUDE.md to document the skill frontmatter schema and conventions.

## Summary

This is a documentation-only change that improves clarity around how skills work in this codebase and makes it explicit that named examples in skill procedures are illustrative, not prescriptive targets.

## Key changes

- **CLAUDE.md:** Added a new "Skills" section documenting:
  - Where skills live (`.claude/skills/<name>/SKILL.md`)
  - How the `/`-command name is derived from directory name
  - Required frontmatter fields (`name`, `description`)
  - Optional fields and when to use them
  - Special handling for `review-pr` (manual, forked, scoped toolset)
  - Vendored `fallow/` skill sync instructions

- **reduce-imports/SKILL.md:** Added a disclaimer block clarifying that hooks and components named in the procedure (e.g., `useResourceModules`, `DailyRecentDaysStrip`) are illustrations showing the **shape** of a fix, not required targets. Also added context labels to the "Area notes" section and improved phrasing in the bundled-hook pattern and guardrails sections.

- **condense-components/SKILL.md:** Added a similar disclaimer block for component examples (`BlipLegendItem`, `SelectAllCheckbox`) and improved phrasing in the guardrails section to use "Example:" for clarity.

- **add-stories/SKILL.md:** Added a disclaimer block for component and fixture examples, and labeled the "Area notes" section as per-issue worked examples.

- **condense-types/SKILL.md:** Added a disclaimer block for type examples (`BlipLegendHandlers`, `RadarQuadrant`) and improved phrasing in the guardrails section.

## Implementation details

All changes are non-breaking documentation updates. The new Skills section in CLAUDE.md references the official Claude Code skill docs and establishes a baseline schema that all skills in this repo follow, with explicit callouts for the two exceptions (`review-pr` and `fallow/`). The disclaimer blocks use blockquote formatting (`> _..._`) for visual distinction and are placed early in each skill to set expectations before readers encounter named examples.

https://claude.ai/code/session_01Qnso5mPHXBn4EvnSbvK2W8