### PR TITLE
refactor(client): Fixes #418: dedupe miscellaneous Storybook story pairs

### DIFF
--- a/packages/client/src/components/dailies/DailiesLimitSetting.stories.tsx
+++ b/packages/client/src/components/dailies/DailiesLimitSetting.stories.tsx
@@ -1,20 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { DailiesLimitSetting } from "./DailiesLimitSetting";
 
 import { SettingsProvider } from "@/context/SettingsProvider";
+import { providerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: DailiesLimitSetting,
-  decorators: [
-    Story => (
-      <SettingsProvider>
-        <Story />
-      </SettingsProvider>
-    ),
-  ],
+  decorators: [providerStoryDecorator(SettingsProvider)],
 } satisfies Meta<typeof DailiesLimitSetting>;
 
 export default meta;
@@ -22,14 +16,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByRole("button", {
-        name: /routine tracker settings/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "button",
+    name: /routine tracker settings/i,
+  }]),
 };

--- a/packages/client/src/components/dailies/DailiesViewModeToggle.stories.tsx
+++ b/packages/client/src/components/dailies/DailiesViewModeToggle.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { DailiesViewModeToggle } from "./DailiesViewModeToggle";
+
+import { clickButtonExpectChange } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof DailiesViewModeToggle> = {
   component: DailiesViewModeToggle,
@@ -17,28 +19,12 @@ export const TableSelected: Story = {
   args: {
     mode: "table",
   },
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "List view",
-    }));
-    await expect(args.onChange).toHaveBeenCalledWith("list");
-  },
+  play: clickButtonExpectChange("List view", "list"),
 };
 
 export const ListSelected: Story = {
   args: {
     mode: "list",
   },
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Table view",
-    }));
-    await expect(args.onChange).toHaveBeenCalledWith("table");
-  },
+  play: clickButtonExpectChange("Table view", "table"),
 };

--- a/packages/client/src/components/dailies/DailyResourceIndicator.stories.tsx
+++ b/packages/client/src/components/dailies/DailyResourceIndicator.stories.tsx
@@ -1,24 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { DailyResourceIndicator } from "./DailyResourceIndicator";
 
 import { makeDaily, makeResource } from "@/test-utils/dailiesFixtures";
-import { QueryStub } from "@/test-utils/QueryStub";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: DailyResourceIndicator,
-  decorators: [
-    Story => (
-      <RouterStub>
-        <QueryStub>
-          <Story />
-        </QueryStub>
-      </RouterStub>
-    ),
-  ],
+  decorators: [queryStoryDecorator()],
 } satisfies Meta<typeof DailyResourceIndicator>;
 
 export default meta;
@@ -33,16 +23,11 @@ export const WithResource: Story = {
       }),
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    // The resource link is always visible; the increment button next to it is
-    // visibility:hidden until hover, so we only assert the link here (the story
-    // still smoke-renders the whole component).
-    const link = await canvas.findByRole("link", {
-      name: /go to course duolingo spanish/i,
-    });
-    await expect(link).toBeInTheDocument();
-  },
+  // The resource link is always visible; the increment button next to it is
+  // visibility:hidden until hover, so we only assert the link here (the story
+  // still smoke-renders the whole component).
+  play: smokePlay([{
+    role: "link",
+    name: /go to course duolingo spanish/i,
+  }]),
 };

--- a/packages/client/src/components/dailies/DailyTaskIndicator.stories.tsx
+++ b/packages/client/src/components/dailies/DailyTaskIndicator.stories.tsx
@@ -1,21 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { DailyTaskIndicator } from "./DailyTaskIndicator";
 
 import { makeDaily, makeTask } from "@/test-utils/dailiesFixtures";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { routerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: DailyTaskIndicator,
-  decorators: [
-    Story => (
-      <RouterStub>
-        <Story />
-      </RouterStub>
-    ),
-  ],
+  decorators: [routerStoryDecorator()],
 } satisfies Meta<typeof DailyTaskIndicator>;
 
 export default meta;
@@ -30,13 +23,8 @@ export const WithTask: Story = {
       }),
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    const link = await canvas.findByRole("link", {
-      name: /go to task build the widget/i,
-    });
-    await expect(link).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "link",
+    name: /go to task build the widget/i,
+  }]),
 };

--- a/packages/client/src/components/layout/PageHeader.stories.tsx
+++ b/packages/client/src/components/layout/PageHeader.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { PlusIcon } from "lucide-react";
-import { expect, within } from "storybook/test";
 
 import { PageHeader } from "./PageHeader";
 
 import { Button } from "@/components/ui/button";
-import { RouterStub } from "@/test-utils/RouterStub";
+import { routerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof PageHeader> = {
   component: PageHeader,
@@ -14,13 +14,7 @@ const meta: Meta<typeof PageHeader> = {
     pageTitle: "Your Resources",
     description: "Everything you're learning from, in one place.",
   },
-  decorators: [
-    Story => (
-      <RouterStub>
-        <Story />
-      </RouterStub>
-    ),
-  ],
+  decorators: [routerStoryDecorator()],
 };
 
 export default meta;
@@ -28,16 +22,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("heading", {
-        name: "Your Resources",
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "heading",
+    name: "Your Resources",
+  }]),
 };
 
 // With a `pageSection` set, a breadcrumb-style section <Link> renders.
@@ -46,16 +34,10 @@ export const WithSectionLink: Story = {
     pageSection: "resources",
     pageTitle: "React Fundamentals",
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("link", {
-        name: "Resources",
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "link",
+    name: "Resources",
+  }]),
 };
 
 // Header actions render in the children slot.
@@ -68,16 +50,10 @@ export const WithAction: Story = {
       </Button>
     ),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("button", {
-        name: /New Course/,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "button",
+    name: /New Course/,
+  }]),
 };
 
 // A non-zero progress value renders the ProgressBar beneath the header.
@@ -87,14 +63,8 @@ export const WithProgress: Story = {
     progressTotal: 10,
     status: "active",
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("heading", {
-        name: "Your Resources",
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "heading",
+    name: "Your Resources",
+  }]),
 };

--- a/packages/client/src/components/layout/ViewModeToggle.stories.tsx
+++ b/packages/client/src/components/layout/ViewModeToggle.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 
 import { ViewModeToggle } from "./ViewModeToggle";
+
+import { clickButtonExpectChange } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof ViewModeToggle> = {
   component: ViewModeToggle,
@@ -47,13 +49,5 @@ export const TableSelected: Story = {
 };
 
 export const ClickSwitchesMode: Story = {
-  play: async ({
-    args, canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: "Table view",
-    }));
-    await expect(args.onChange).toHaveBeenCalledWith("table");
-  },
+  play: clickButtonExpectChange("Table view", "table"),
 };

--- a/packages/client/src/components/radar/RadarBlipDot.stories.tsx
+++ b/packages/client/src/components/radar/RadarBlipDot.stories.tsx
@@ -1,11 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { RadarBlipDot } from "./RadarBlipDot";
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { makeBlip } from "@/test-utils/radarFixtures";
+import { svgStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof RadarBlipDot> = {
   component: RadarBlipDot,
@@ -28,18 +29,11 @@ const meta: Meta<typeof RadarBlipDot> = {
     onHover: fn(),
     onClick: fn(),
   },
-  decorators: [
-    Story => (
-      <TooltipProvider>
-        <svg
-          width={200}
-          height={160}
-        >
-          <Story />
-        </svg>
-      </TooltipProvider>
-    ),
-  ],
+  decorators: [svgStoryDecorator({
+    width: 200,
+    height: 160,
+    tooltip: true,
+  })],
 };
 
 export default meta;
@@ -47,12 +41,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("1")).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    text: "1",
+  }]),
 };
 
 export const Active: Story = {

--- a/packages/client/src/components/radar/RadarBlipDotLayer.stories.tsx
+++ b/packages/client/src/components/radar/RadarBlipDotLayer.stories.tsx
@@ -1,15 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { RadarBlipDotLayer } from "./RadarBlipDotLayer";
 
-import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   makeBlips,
   makePositionedBlips,
   makeQuadrants,
 } from "@/test-utils/radarFixtures";
+import { svgStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof RadarBlipDotLayer> = {
   component: RadarBlipDotLayer,
@@ -26,18 +27,11 @@ const meta: Meta<typeof RadarBlipDotLayer> = {
     onHover: fn(),
     onClick: fn(),
   },
-  decorators: [
-    Story => (
-      <TooltipProvider>
-        <svg
-          width={400}
-          height={400}
-        >
-          <Story />
-        </svg>
-      </TooltipProvider>
-    ),
-  ],
+  decorators: [svgStoryDecorator({
+    width: 400,
+    height: 400,
+    tooltip: true,
+  })],
 };
 
 export default meta;
@@ -45,12 +39,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("1")).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    text: "1",
+  }]),
 };
 
 export const WithActiveBlip: Story = {

--- a/packages/client/src/components/resources/GroupEditCard.stories.tsx
+++ b/packages/client/src/components/resources/GroupEditCard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { GroupEditCard } from "./GroupEditCard";
 import { emptyGroupDraft, groupToDraft } from "./moduleDrafts";
@@ -9,6 +9,8 @@ import {
   makeModuleGroup,
   makeTagGroups,
 } from "@/test-utils/resourceModulesFixtures";
+import { constrainedStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof GroupEditCard> = {
   component: GroupEditCard,
@@ -21,13 +23,7 @@ const meta: Meta<typeof GroupEditCard> = {
     onSave: fn(),
     onCancel: fn(),
   },
-  decorators: [
-    Story => (
-      <div className="max-w-xl">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [constrainedStoryDecorator("max-w-xl")],
 };
 
 export default meta;
@@ -35,15 +31,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const New: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("Group Name")).toBeInTheDocument();
-    await expect(
-      canvas.getByPlaceholderText("e.g. Section 1: Fundamentals"),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      text: "Group Name",
+    },
+    {
+      placeholder: "e.g. Section 1: Fundamentals",
+    },
+  ]),
 };
 
 export const Editing: Story = {
@@ -58,17 +53,13 @@ export const Editing: Story = {
     isNew: false,
     onDelete: fn(),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByDisplayValue("Section 2: Advanced"),
-    ).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: "Remove Group",
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      displayValue: "Section 2: Advanced",
+    },
+    {
+      role: "button",
+      name: "Remove Group",
+    },
+  ]),
 };

--- a/packages/client/src/components/resources/ModuleEditCard.stories.tsx
+++ b/packages/client/src/components/resources/ModuleEditCard.stories.tsx
@@ -9,6 +9,8 @@ import {
   makeModule,
   makeTagGroups,
 } from "@/test-utils/resourceModulesFixtures";
+import { constrainedStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof ModuleEditCard> = {
   component: ModuleEditCard,
@@ -21,13 +23,7 @@ const meta: Meta<typeof ModuleEditCard> = {
     onSave: fn(),
     onCancel: fn(),
   },
-  decorators: [
-    Story => (
-      <div className="max-w-xl">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [constrainedStoryDecorator("max-w-xl")],
 };
 
 export default meta;
@@ -35,12 +31,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const New: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("Module Name")).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    text: "Module Name",
+  }]),
 };
 
 export const Editing: Story = {
@@ -54,14 +47,9 @@ export const Editing: Story = {
     isNew: false,
     onDelete: fn(),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByDisplayValue("Variables and Types"),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    displayValue: "Variables and Types",
+  }]),
 };
 
 export const RangeLength: Story = {

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.stories.tsx
@@ -1,21 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { DashboardCoursesByAmortization } from "./-DashboardCoursesByAmortization";
 
 import { makeProvider, makeResources } from "@/test-utils/boxFixtures";
 import { makeTile } from "@/test-utils/dashboardFixtures";
-import { QueryStub } from "@/test-utils/QueryStub";
-import { RouterStub } from "@/test-utils/RouterStub";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
-
-function seededClient() {
-  return seededQueryClient([
-    [["resources"], makeResources()],
-    [["providers"], [makeProvider()]],
-  ]);
-}
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof DashboardCoursesByAmortization> = {
   component: DashboardCoursesByAmortization,
@@ -24,12 +17,11 @@ const meta: Meta<typeof DashboardCoursesByAmortization> = {
     onUpdateTile: fn(),
   },
   decorators: [
-    Story => (
-      <RouterStub>
-        <QueryStub client={seededClient()}>
-          <Story />
-        </QueryStub>
-      </RouterStub>
+    queryStoryDecorator(
+      seededQueryClient([
+        [["resources"], makeResources()],
+        [["providers"], [makeProvider()]],
+      ]),
     ),
   ],
 };
@@ -39,23 +31,20 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Courses tab (default): a cost-per-unit table of started courses.
+// "Cost per Unit" appears as both the card title and a column header, so assert
+// on the unambiguous tab + course-row signals instead.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    // "Cost per Unit" appears as both the card title and a column header, so
-    // assert on the unambiguous tab + course-row signals instead.
-    await expect(
-      await canvas.findByRole("tab", {
-        name: /courses/i,
-      }),
-    ).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("tab", {
-        name: /providers/i,
-      }),
-    ).toBeInTheDocument();
-    await expect(await canvas.findByText("Course 2")).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      role: "tab",
+      name: /courses/i,
+    },
+    {
+      role: "tab",
+      name: /providers/i,
+    },
+    {
+      text: "Course 2",
+    },
+  ]),
 };

--- a/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGrid.stories.tsx
@@ -56,21 +56,27 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// Both regression stories first need the grid-positioned tile element: it must
+// carry the injected `dnd-grid-item` class and the absolute positioning the grid
+// applies inline (proof the cloned `style` was forwarded — the #279 fix).
+async function findPositionedTile(canvasElement: HTMLElement) {
+  const item = await waitFor(() => {
+    const el = canvasElement.querySelector<HTMLElement>(".dnd-grid-item");
+    if (!el) throw new Error("tile did not receive the dnd-grid-item class");
+    return el;
+  });
+  await waitFor(() => expect(getComputedStyle(item).position).toBe("absolute"));
+  return item;
+}
+
 export const ForwardsGridProps: Story = {
   play: async ({
     canvasElement,
   }) => {
-    // The grid's injected class must reach the rendered tile element.
-    const item = await waitFor(() => {
-      const el = canvasElement.querySelector<HTMLElement>(".dnd-grid-item");
-      if (!el) throw new Error("tile did not receive the dnd-grid-item class");
-      return el;
-    });
+    const item = await findPositionedTile(canvasElement);
 
-    // Geometry is applied inline by the grid (position:absolute + a pixel width
-    // narrower than the container) — proof the cloned `style` was forwarded.
-    await waitFor(() =>
-      expect(getComputedStyle(item).position).toBe("absolute"));
+    // Geometry is applied inline by the grid (a pixel width narrower than the
+    // container) — further proof the cloned `style` was forwarded.
     await expect(item.getBoundingClientRect().width).toBeLessThan(640);
 
     // The SE (bottom-right) resize handle exists and is hidden by default — the
@@ -140,15 +146,7 @@ export const AutoHeightSizesToContent: Story = {
   play: async ({
     canvasElement,
   }) => {
-    const item = await waitFor(() => {
-      const el = canvasElement.querySelector<HTMLElement>(".dnd-grid-item");
-      if (!el) throw new Error("tile did not receive the dnd-grid-item class");
-      return el;
-    });
-
-    // Still positioned by the forwarded geometry (the #279 fix must hold).
-    await waitFor(() =>
-      expect(getComputedStyle(item).position).toBe("absolute"));
+    const item = await findPositionedTile(canvasElement);
 
     // The tile grows to its ~600px content rather than being clamped to the
     // layout's 4-row (~256px) imposed height. A regressed build leaves the

--- a/packages/client/src/routes/domains.$id.edit.-components/-ConfigTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ConfigTab.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { ConfigTab } from "./-ConfigTab";
 
 import { makeRadar } from "@/test-utils/radarFixtures";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof ConfigTab> = {
   component: ConfigTab,
@@ -21,17 +22,15 @@ type Story = StoryObj<typeof meta>;
 
 // Hydrates the slice/ring editors from the persisted radar config.
 export const FromConfig: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByDisplayValue("Techniques")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /save configuration/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      displayValue: "Techniques",
+    },
+    {
+      role: "button",
+      name: /save configuration/i,
+    },
+  ]),
 };
 
 // With no persisted radar the container seeds the default slices and rings.
@@ -43,10 +42,7 @@ export const Defaults: Story = {
       blips: [],
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByDisplayValue("Adopt")).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    displayValue: "Adopt",
+  }]),
 };

--- a/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { DetailsTab } from "./-DetailsTab";
 
 import { makeDomain, makeTopicRows } from "@/test-utils/boxFixtures";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof DetailsTab> = {
   component: DetailsTab,
@@ -22,20 +23,18 @@ type Story = StoryObj<typeof meta>;
 
 // Hydrates the form from the domain's persisted title/description/topics.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByDisplayValue("Frontend Engineering"),
-    ).toBeInTheDocument();
-    await expect(canvas.getByText("Topics in domain")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /save details/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      displayValue: "Frontend Engineering",
+    },
+    {
+      text: "Topics in domain",
+    },
+    {
+      role: "button",
+      name: /save details/i,
+    },
+  ]),
 };
 
 // A brand-new-ish domain with no description still renders the editable form.
@@ -46,12 +45,7 @@ export const EmptyDescription: Story = {
       description: null,
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByDisplayValue("Backend Engineering"),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    displayValue: "Backend Engineering",
+  }]),
 };

--- a/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.stories.tsx
@@ -1,20 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { NewDomainForm } from "./-NewDomainForm";
 
-import { RouterStub } from "@/test-utils/RouterStub";
+import { routerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: NewDomainForm,
-  decorators: [
-    Story => (
-      <RouterStub>
-        <Story />
-      </RouterStub>
-    ),
-  ],
+  decorators: [routerStoryDecorator()],
 } satisfies Meta<typeof NewDomainForm>;
 
 export default meta;
@@ -24,20 +17,17 @@ type Story = StoryObj<typeof meta>;
 // The empty create form: title/description fields and the create action. We
 // don't submit — that would call createDomain and navigate.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("heading", {
-        name: /new domain/i,
-      }),
-    ).toBeInTheDocument();
-    await expect(canvas.getByText("Domain Title")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /create domain/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      role: "heading",
+      name: /new domain/i,
+    },
+    {
+      text: "Domain Title",
+    },
+    {
+      role: "button",
+      name: /create domain/i,
+    },
+  ]),
 };

--- a/packages/client/src/routes/domains.$id.edit.-components/-RadarConfigTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-RadarConfigTab.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { RadarConfigTab } from "./-RadarConfigTab";
 
 import { makeQuadrants, makeRings } from "@/test-utils/radarFixtures";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const quadrantDrafts = makeQuadrants().map((q, i) => ({
   id: q.id,
@@ -43,17 +44,15 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByDisplayValue("Techniques")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /save configuration/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      displayValue: "Techniques",
+    },
+    {
+      role: "button",
+      name: /save configuration/i,
+    },
+  ]),
 };
 
 export const Saving: Story = {

--- a/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.stories.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-ScopeTab.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { ScopeTab } from "./-ScopeTab";
 
@@ -9,6 +9,7 @@ import {
   makeScopedDomain,
   makeTopics,
 } from "@/test-utils/radarFixtures";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof ScopeTab> = {
   component: ScopeTab,
@@ -26,18 +27,18 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByText("Within Scope")).toBeInTheDocument();
-    await expect(canvas.getByText(/Out of Scope/)).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /save scope/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      text: "Within Scope",
+    },
+    {
+      text: /Out of Scope/,
+    },
+    {
+      role: "button",
+      name: /save scope/i,
+    },
+  ]),
 };
 
 // A domain whose radar already has ignored blips renders pre-filled

--- a/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
@@ -5,31 +5,23 @@ import { expect, within } from "storybook/test";
 import { RoutineDetailsContent } from "./-RoutineDetailsContent";
 
 import { makeRoutine, makeResources, makeTask } from "@/test-utils/boxFixtures";
-import { QueryStub } from "@/test-utils/QueryStub";
-import { RouterStub } from "@/test-utils/RouterStub";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
-
-// useTaskResourceNames reads the task/resource lists to resolve weekly-schedule
-// entry names.
-function seededClient() {
-  return seededQueryClient([
-    [["tasks"], [makeTask()]],
-    [["resources"], makeResources()],
-  ]);
-}
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: RoutineDetailsContent,
   args: {
     data: makeRoutine(),
   },
+  // useTaskResourceNames reads the task/resource lists to resolve weekly-schedule
+  // entry names.
   decorators: [
-    Story => (
-      <RouterStub>
-        <QueryStub client={seededClient()}>
-          <Story />
-        </QueryStub>
-      </RouterStub>
+    queryStoryDecorator(
+      seededQueryClient([
+        [["tasks"], [makeTask()]],
+        [["resources"], makeResources()],
+      ]),
     ),
   ],
 } satisfies Meta<typeof RoutineDetailsContent>;
@@ -40,14 +32,17 @@ type Story = StoryObj<typeof meta>;
 
 // Daily routine (fixture default): Type/Status/Stats tiles + connected entities.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(await canvas.findByText("Daily Task")).toBeInTheDocument();
-    await expect(canvas.getByText("Connected To")).toBeInTheDocument();
-    await expect(canvas.getByText("Read a chapter")).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      text: "Daily Task",
+    },
+    {
+      text: "Connected To",
+    },
+    {
+      text: "Read a chapter",
+    },
+  ]),
 };
 
 // Weekly routine adds the day-by-day schedule section.

--- a/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { RoutineTodayCard } from "./-RoutineTodayCard";
 
 import { SettingsProvider } from "@/context/SettingsProvider";
@@ -9,13 +7,7 @@ import { makeRoutine, makeResources, makeTask } from "@/test-utils/boxFixtures";
 import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
-
-function seededClient() {
-  return seededQueryClient([
-    [["tasks"], [makeTask()]],
-    [["resources"], makeResources()],
-  ]);
-}
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: RoutineTodayCard,
@@ -26,7 +18,12 @@ const meta = {
     Story => (
       <RouterStub>
         <SettingsProvider>
-          <QueryStub client={seededClient()}>
+          <QueryStub
+            client={seededQueryClient([
+              [["tasks"], [makeTask()]],
+              [["resources"], makeResources()],
+            ])}
+          >
             <Story />
           </QueryStub>
         </SettingsProvider>
@@ -41,12 +38,9 @@ type Story = StoryObj<typeof meta>;
 
 // Daily routine: today's entry plus the today-status control.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(await canvas.findByText("Today's Task")).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    text: "Today's Task",
+  }]),
 };
 
 // A routine with nothing scheduled today shows the rest-day copy.
@@ -57,12 +51,7 @@ export const NothingToday: Story = {
       weekly: {},
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByText(/nothing, take a break/i),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    text: /nothing, take a break/i,
+  }]),
 };

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.stories.tsx
@@ -1,26 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { fn } from "storybook/test";
 
 import { DetailsTab } from "./-DetailsTab";
 
 import { makeRoutine } from "@/test-utils/boxFixtures";
-import { QueryStub } from "@/test-utils/QueryStub";
-import { RouterStub } from "@/test-utils/RouterStub";
 import { makeRoutineTemplate } from "@/test-utils/routinesFixtures";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
-
-// useRoutineDetailsForm reads topics/tasks/resources for its combobox options,
-// and the weekly-mode Quick Fill menu reads the routine templates. Empty lists
-// are enough — the form renders its fields regardless.
-function seededClient() {
-  return seededQueryClient([
-    [["topics"], []],
-    [["tasks"], []],
-    [["resources"], []],
-    [["routineTemplates"], [makeRoutineTemplate()]],
-  ]);
-}
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof DetailsTab> = {
   component: DetailsTab,
@@ -29,13 +17,17 @@ const meta: Meta<typeof DetailsTab> = {
     onSaved: fn(() => Promise.resolve()),
     onChangeStateChange: fn(),
   },
+  // useRoutineDetailsForm reads topics/tasks/resources for its combobox options,
+  // and the weekly-mode Quick Fill menu reads the routine templates. Empty lists
+  // are enough — the form renders its fields regardless.
   decorators: [
-    Story => (
-      <RouterStub>
-        <QueryStub client={seededClient()}>
-          <Story />
-        </QueryStub>
-      </RouterStub>
+    queryStoryDecorator(
+      seededQueryClient([
+        [["topics"], []],
+        [["tasks"], []],
+        [["resources"], []],
+        [["routineTemplates"], [makeRoutineTemplate()]],
+      ]),
     ),
   ],
 };
@@ -47,20 +39,18 @@ type Story = StoryObj<typeof meta>;
 // Daily mode (the fixture default): name/type/status fields and the single-item
 // daily editor.
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByDisplayValue("Daily reading"),
-    ).toBeInTheDocument();
-    await expect(canvas.getByText("Routine Name")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /save details/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      displayValue: "Daily reading",
+    },
+    {
+      text: "Routine Name",
+    },
+    {
+      role: "button",
+      name: /save details/i,
+    },
+  ]),
 };
 
 // Weekly mode swaps in the full weekly schedule grid + the Quick Fill menu.
@@ -70,16 +60,10 @@ export const Weekly: Story = {
       mode: "weekly",
     }),
   },
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    // The Quick Fill menu is rendered only in weekly mode (the schedule grid),
-    // so it's the unambiguous signal the weekly branch is active.
-    await expect(
-      await canvas.findByRole("button", {
-        name: /quick fill/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  // The Quick Fill menu is rendered only in weekly mode (the schedule grid), so
+  // it's the unambiguous signal the weekly branch is active.
+  play: smokePlay([{
+    role: "button",
+    name: /quick fill/i,
+  }]),
 };

--- a/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.stories.tsx
@@ -4,7 +4,8 @@ import { expect, fn, userEvent, within } from "storybook/test";
 
 import { NewRoutineForm } from "./-NewRoutineForm";
 
-import { RouterStub } from "@/test-utils/RouterStub";
+import { routerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta: Meta<typeof NewRoutineForm> = {
   component: NewRoutineForm,
@@ -13,13 +14,7 @@ const meta: Meta<typeof NewRoutineForm> = {
     onCreated: fn(() => Promise.resolve()),
     onCancel: fn(),
   },
-  decorators: [
-    Story => (
-      <RouterStub>
-        <Story />
-      </RouterStub>
-    ),
-  ],
+  decorators: [routerStoryDecorator()],
 };
 
 export default meta;
@@ -29,22 +24,19 @@ type Story = StoryObj<typeof meta>;
 // The empty create form: name + type, with create/cancel actions. We don't
 // submit (that would call createRoutine).
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      await canvas.findByRole("heading", {
-        name: /new routine/i,
-      }),
-    ).toBeInTheDocument();
-    await expect(canvas.getByText("Routine Name")).toBeInTheDocument();
-    await expect(
-      canvas.getByRole("button", {
-        name: /create routine/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([
+    {
+      role: "heading",
+      name: /new routine/i,
+    },
+    {
+      text: "Routine Name",
+    },
+    {
+      role: "button",
+      name: /create routine/i,
+    },
+  ]),
 };
 
 // Cancel fires the caller's onCancel handler.

--- a/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-QuickFillMenu.stories.tsx
@@ -14,6 +14,15 @@ function clientWith(key: string, data: unknown) {
   return seededQueryClient([[[key], data]]);
 }
 
+// Each story opens the menu the same way (click the trigger) before asserting on
+// its contents.
+async function openQuickFill(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole("button", {
+    name: /quick fill/i,
+  }));
+}
+
 const meta: Meta<typeof QuickFillMenu> = {
   component: QuickFillMenu,
   args: {
@@ -40,12 +49,7 @@ export const RoutineTemplates: Story = {
   play: async ({
     canvasElement, args,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(
-      canvas.getByRole("button", {
-        name: /quick fill/i,
-      }),
-    );
+    await openQuickFill(canvasElement);
     const item = await screen.findByText("Summer Japanese");
     await userEvent.click(item);
     await expect(args.onSelect).toHaveBeenCalled();
@@ -69,12 +73,7 @@ export const CriteriaTemplates: Story = {
   play: async ({
     canvasElement,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(
-      canvas.getByRole("button", {
-        name: /quick fill/i,
-      }),
-    );
+    await openQuickFill(canvasElement);
     await expect(await screen.findByText("Reading goals")).toBeInTheDocument();
   },
 };
@@ -94,14 +93,7 @@ export const NoTemplates: Story = {
   play: async ({
     canvasElement,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(
-      canvas.getByRole("button", {
-        name: /quick fill/i,
-      }),
-    );
-    await expect(
-      await screen.findByText(/no templates/i),
-    ).toBeInTheDocument();
+    await openQuickFill(canvasElement);
+    await expect(await screen.findByText(/no templates/i)).toBeInTheDocument();
   },
 };

--- a/packages/client/src/routes/settings.-components/-ThemeSection.stories.tsx
+++ b/packages/client/src/routes/settings.-components/-ThemeSection.stories.tsx
@@ -1,20 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, within } from "storybook/test";
-
 import { ThemeSection } from "./-ThemeSection";
 
 import { ThemeProvider } from "@/context/ThemeProvider";
+import { providerStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
 
 const meta = {
   component: ThemeSection,
-  decorators: [
-    Story => (
-      <ThemeProvider>
-        <Story />
-      </ThemeProvider>
-    ),
-  ],
+  decorators: [providerStoryDecorator(ThemeProvider)],
 } satisfies Meta<typeof ThemeSection>;
 
 export default meta;
@@ -23,14 +17,8 @@ type Story = StoryObj<typeof meta>;
 
 // The single light/dark toggle button (label depends on the active theme).
 export const Default: Story = {
-  play: async ({
-    canvasElement,
-  }) => {
-    const canvas = within(canvasElement);
-    await expect(
-      canvas.getByRole("button", {
-        name: /set to (dark|light) mode/i,
-      }),
-    ).toBeInTheDocument();
-  },
+  play: smokePlay([{
+    role: "button",
+    name: /set to (dark|light) mode/i,
+  }]),
 };

--- a/packages/client/src/test-utils/storyDecorators.tsx
+++ b/packages/client/src/test-utils/storyDecorators.tsx
@@ -1,6 +1,9 @@
 import type { Decorator } from "@storybook/react-vite";
+import type { QueryClient } from "@tanstack/react-query";
+import type { ComponentType, ReactNode } from "react";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
 
 /** Bare stub-router wrapper — for stories whose only context need is `<Link>`. */
@@ -44,5 +47,82 @@ export function cardStoryDecorator(
       content = <TooltipProvider>{content}</TooltipProvider>;
     }
     return <RouterStub>{content}</RouterStub>;
+  };
+}
+
+/** Wraps the story in a stub router so its `<Link>`s resolve. */
+export function routerStoryDecorator(): Decorator {
+  return function RouterStoryWrapper(Story) {
+    return (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    );
+  };
+}
+
+/**
+ * Wraps the story in a stub router + QueryClientProvider. Pass a
+ * `seededQueryClient([...])` when the component reads seeded query data; omit
+ * for an empty client.
+ */
+export function queryStoryDecorator(client?: QueryClient): Decorator {
+  return function QueryStoryWrapper(Story) {
+    return (
+      <RouterStub>
+        <QueryStub client={client}>
+          <Story />
+        </QueryStub>
+      </RouterStub>
+    );
+  };
+}
+
+/**
+ * Wraps an SVG-child story (e.g. radar blips) in an `<svg>` canvas of the given
+ * size, optionally inside a TooltipProvider for blips that show tooltips.
+ */
+export function svgStoryDecorator(options: {
+  width: number;
+  height: number;
+  tooltip?: boolean;
+}): Decorator {
+  const {
+    width, height, tooltip = false,
+  } = options;
+  return function SvgStoryWrapper(Story) {
+    const svg = (
+      <svg
+        width={width}
+        height={height}
+      >
+        <Story />
+      </svg>
+    );
+    return tooltip ? <TooltipProvider>{svg}</TooltipProvider> : svg;
+  };
+}
+
+/** Wraps the story in a width-constrained container (defaults to `max-w-sm`). */
+export function constrainedStoryDecorator(className = "max-w-sm"): Decorator {
+  return function ConstrainedStoryWrapper(Story) {
+    return (
+      <div className={className}>
+        <Story />
+      </div>
+    );
+  };
+}
+
+/** Wraps the story in a single context provider component. */
+export function providerStoryDecorator(
+  Provider: ComponentType<{ children: ReactNode }>,
+): Decorator {
+  return function ProviderStoryWrapper(Story) {
+    return (
+      <Provider>
+        <Story />
+      </Provider>
+    );
   };
 }

--- a/packages/client/src/test-utils/storyPlay.ts
+++ b/packages/client/src/test-utils/storyPlay.ts
@@ -1,4 +1,4 @@
-import { expect, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 
 interface PlayContext { canvasElement: HTMLElement }
 
@@ -35,5 +35,79 @@ export function smokeLink(...names: (string | RegExp)[]) {
           });
       await expect(el).toBeInTheDocument();
     }
+  };
+}
+
+type Canvas = ReturnType<typeof within>;
+type RoleMatcher = Parameters<Canvas["findByRole"]>[0];
+
+/**
+ * A single "is this rendered?" assertion, identified by query kind. Mirrors the
+ * Testing Library `findBy*` queries the stories already used by hand. Use when a
+ * story mixes query kinds (heading + text + button); reach for {@link smokeText}
+ * / {@link smokeLink} when every assertion is the same kind.
+ */
+export type SmokeMatcher
+  = | { text: string | RegExp }
+    | { role: RoleMatcher;
+      name?: string | RegExp; }
+      | { displayValue: string | RegExp }
+      | { placeholder: string | RegExp };
+
+function resolve(canvas: Canvas, matcher: SmokeMatcher) {
+  if ("text" in matcher) return canvas.findByText(matcher.text);
+  if ("displayValue" in matcher) {
+    return canvas.findByDisplayValue(matcher.displayValue);
+  }
+  if ("placeholder" in matcher) {
+    return canvas.findByPlaceholderText(matcher.placeholder);
+  }
+  return canvas.findByRole(
+    matcher.role,
+    matcher.name
+      ? {
+        name: matcher.name,
+      }
+      : undefined,
+  );
+}
+
+/**
+ * Builds a CSF3 `play` smoke test that asserts each matcher resolves and is in
+ * the document. `findBy*` is used for every matcher so it tolerates async
+ * first-render. Use for render-only stories; keep interaction-heavy plays
+ * (clicks, multi-step flows, custom assertions) hand-written.
+ */
+export function smokePlay(matchers: SmokeMatcher[]) {
+  return async ({
+    canvasElement,
+  }: PlayContext) => {
+    const canvas = within(canvasElement);
+    for (const matcher of matchers) {
+      await expect(await resolve(canvas, matcher)).toBeInTheDocument();
+    }
+  };
+}
+
+/**
+ * Builds a CSF3 `play` that clicks a button and asserts the story's `onChange`
+ * arg fired with the expected value — the shared shape of the view-mode toggle
+ * interaction stories.
+ */
+export function clickButtonExpectChange(
+  buttonName: string | RegExp,
+  expected: unknown,
+) {
+  return async ({
+    args,
+    canvasElement,
+  }: PlayContext & {
+    args: { onChange: (...callArgs: never[]) => unknown };
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: buttonName,
+    }));
+    await expect(args.onChange).toHaveBeenCalledWith(expected);
   };
 }


### PR DESCRIPTION
## ELI5
A bunch of our component "story" files (used for previewing and smoke-testing UI pieces) were copying the same setup boilerplate over and over. This PR moves that shared setup into a few small reusable helpers and updates the stories to use them, so there's less duplicated code to maintain — without changing what any story actually tests.

## Summary
- Added five decorator factories to `test-utils/storyDecorators.tsx` (`routerStoryDecorator`, `queryStoryDecorator`, `svgStoryDecorator`, `constrainedStoryDecorator`, `providerStoryDecorator`), all reusing the existing `RouterStub`/`QueryStub`/`seededQueryClient` helpers.
- Extended `test-utils/storyPlay.ts` with a matcher-list `smokePlay([...])` and `clickButtonExpectChange(...)` for the view-mode toggle interactions (merged alongside the existing `smokeText`/`smokeLink` helpers).
- Adopted these across the 23 flagged story files; the two internal clones got small file-local helpers (`findPositionedTile`, `openQuickFill`). Each story keeps its unique args/assertions.

## Test plan
- [x] `pnpm exec fallow dupes` — all 14 fingerprints from #418 no longer appear, and none of the 23 touched files remain in any clone group
- [x] `pnpm --filter=@emstack/client typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter=@emstack/client exec vitest run` — 742 tests pass (incl. Storybook play tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)