### PR TITLE
refactor(client): Fixes #419: dedupe duplicated source (data-table, nav/menu, list pages, dashboard)

### DIFF
--- a/packages/client/src/components/LayoutMenuActions.tsx
+++ b/packages/client/src/components/LayoutMenuActions.tsx
@@ -1,0 +1,50 @@
+import type { DashboardLayout } from "@emstack/types";
+
+import { BookmarkIcon, Trash2Icon } from "lucide-react";
+
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+interface LayoutMenuActionsProps {
+  layout: DashboardLayout;
+  onSaveAs: (layout: DashboardLayout) => void;
+  onDelete: (layout: DashboardLayout) => void;
+  saveAsLabel: string;
+  /** Hide the "Save as…" item (e.g. for template rows). Defaults to true. */
+  showSaveAs?: boolean;
+}
+
+/**
+ * Shared footer for a layout's dropdown menu: the "Save as…" action, a
+ * separator, and the destructive "Delete" action. Render inside a
+ * DropdownMenuContent. Used by the dashboard tab menu and the settings
+ * layouts/presets list so the two stay in sync.
+ */
+export function LayoutMenuActions({
+  layout,
+  onSaveAs,
+  onDelete,
+  saveAsLabel,
+  showSaveAs = true,
+}: LayoutMenuActionsProps) {
+  return (
+    <>
+      {showSaveAs && (
+        <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
+          <BookmarkIcon />
+          {saveAsLabel}
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        variant="destructive"
+        onSelect={() => onDelete(layout)}
+      >
+        <Trash2Icon />
+        Delete
+      </DropdownMenuItem>
+    </>
+  );
+}

--- a/packages/client/src/components/layout/NavDropdown.tsx
+++ b/packages/client/src/components/layout/NavDropdown.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useRef, useState } from "react";
-
 import { Link } from "@tanstack/react-router";
 import { ChevronDownIcon } from "lucide-react";
 
@@ -8,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useHoverPopover } from "@/hooks/useHoverPopover";
 
 interface NavDropdownProps {
   label: string;
@@ -18,23 +17,11 @@ interface NavDropdownProps {
 export function NavDropdown({
   label, to, children,
 }: NavDropdownProps) {
-  const [open, setOpen] = useState(false);
-  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleMouseEnter = useCallback(() => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-      closeTimeout.current = null;
-    }
-    setOpen(true);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-    }
-    closeTimeout.current = setTimeout(() => setOpen(false), 400);
-  }, []);
+  const {
+    open, setOpen, handleOpen, handleClose,
+  } = useHoverPopover({
+    closeDelay: 400,
+  });
 
   return (
     <DropdownMenu
@@ -43,8 +30,8 @@ export function NavDropdown({
     >
       <DropdownMenuTrigger asChild>
         <div
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onMouseEnter={handleOpen}
+          onMouseLeave={handleClose}
           className="
             inline-flex cursor-pointer items-center gap-0.5 outline-none
           "
@@ -83,8 +70,8 @@ export function NavDropdown({
         align="start"
         side="bottom"
         sideOffset={0}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
       >
         {children}
       </DropdownMenuContent>

--- a/packages/client/src/components/quickAdd/QuickAddMenu.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddMenu.tsx
@@ -1,6 +1,4 @@
-import type { QuickAddKey } from "./quickAddOptions";
-
-import { useCallback, useRef, useState } from "react";
+import type { QuickAddKey, QuickAddOption } from "./quickAddOptions";
 
 import { ChevronDownIcon } from "lucide-react";
 
@@ -14,9 +12,33 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useHoverPopover } from "@/hooks/useHoverPopover";
 
 interface QuickAddMenuProps {
   onSelect: (key: QuickAddKey) => void;
+}
+
+/** Renders one group of Quick Add options as selectable dropdown items. */
+function QuickAddGroup({
+  options,
+  onSelect,
+}: {
+  options: QuickAddOption[];
+  onSelect: (key: QuickAddKey) => void;
+}) {
+  return options.map((option) => {
+    const Icon = option.icon;
+    return (
+      <DropdownMenuItem
+        key={option.key}
+        className="cursor-pointer"
+        onSelect={() => onSelect(option.key)}
+      >
+        <Icon />
+        {option.label}
+      </DropdownMenuItem>
+    );
+  });
 }
 
 /**
@@ -27,23 +49,11 @@ interface QuickAddMenuProps {
 export function QuickAddMenu({
   onSelect,
 }: QuickAddMenuProps) {
-  const [open, setOpen] = useState(false);
-  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleMouseEnter = useCallback(() => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-      closeTimeout.current = null;
-    }
-    setOpen(true);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-    }
-    closeTimeout.current = setTimeout(() => setOpen(false), 400);
-  }, []);
+  const {
+    open, setOpen, handleOpen, handleClose,
+  } = useHoverPopover({
+    closeDelay: 400,
+  });
 
   const external = QUICK_ADD_OPTIONS.filter(o => o.group === "external");
   const tracker = QUICK_ADD_OPTIONS.filter(o => o.group === "tracker");
@@ -55,8 +65,8 @@ export function QuickAddMenu({
     >
       <DropdownMenuTrigger asChild>
         <div
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onMouseEnter={handleOpen}
+          onMouseLeave={handleClose}
           className="
             inline-flex cursor-pointer items-center gap-0.5 outline-none
           "
@@ -86,38 +96,20 @@ export function QuickAddMenu({
         align="end"
         side="bottom"
         sideOffset={0}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
       >
         <DropdownMenuLabel>Send to</DropdownMenuLabel>
-        {external.map((option) => {
-          const Icon = option.icon;
-          return (
-            <DropdownMenuItem
-              key={option.key}
-              className="cursor-pointer"
-              onSelect={() => onSelect(option.key)}
-            >
-              <Icon />
-              {option.label}
-            </DropdownMenuItem>
-          );
-        })}
+        <QuickAddGroup
+          options={external}
+          onSelect={onSelect}
+        />
         <DropdownMenuSeparator />
         <DropdownMenuLabel>New record</DropdownMenuLabel>
-        {tracker.map((option) => {
-          const Icon = option.icon;
-          return (
-            <DropdownMenuItem
-              key={option.key}
-              className="cursor-pointer"
-              onSelect={() => onSelect(option.key)}
-            >
-              <Icon />
-              {option.label}
-            </DropdownMenuItem>
-          );
-        })}
+        <QuickAddGroup
+          options={tracker}
+          onSelect={onSelect}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/client/src/components/ui/DeleteButton.stories.tsx
+++ b/packages/client/src/components/ui/DeleteButton.stories.tsx
@@ -16,16 +16,25 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Clicks the delete button and waits for the confirmation prompt to appear. */
+async function openDeleteConfirm(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole("button", {
+      name: /delete topic/i,
+    }),
+  );
+  await canvas.findByText("Are you sure?");
+  return canvas;
+}
+
 // Clicking the button swaps it for a confirmation prompt.
 export const Default: Story = {
   play: async ({
     canvasElement,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: /delete topic/i,
-    }));
-    await expect(await canvas.findByText("Are you sure?")).toBeInTheDocument();
+    const canvas = await openDeleteConfirm(canvasElement);
+    await expect(canvas.getByText("Are you sure?")).toBeInTheDocument();
   },
 };
 
@@ -34,11 +43,7 @@ export const Confirms: Story = {
   play: async ({
     canvasElement, args,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: /delete topic/i,
-    }));
-    await canvas.findByText("Are you sure?");
+    const canvas = await openDeleteConfirm(canvasElement);
     const [confirm] = canvas.getAllByRole("button");
     await userEvent.click(confirm);
     await expect(args.onClick).toHaveBeenCalled();
@@ -50,11 +55,7 @@ export const Cancels: Story = {
   play: async ({
     canvasElement, args,
   }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", {
-      name: /delete topic/i,
-    }));
-    await canvas.findByText("Are you sure?");
+    const canvas = await openDeleteConfirm(canvasElement);
     const buttons = canvas.getAllByRole("button");
     await userEvent.click(buttons[1]);
     await expect(canvas.queryByText("Are you sure?")).not.toBeInTheDocument();

--- a/packages/client/src/components/ui/data-table.stories.tsx
+++ b/packages/client/src/components/ui/data-table.stories.tsx
@@ -1,104 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import type { ColumnDef } from "@tanstack/react-table";
 
 import { expect, userEvent, within } from "storybook/test";
 
 import { DataTable } from "./data-table";
-import { DataTableColumnHeader } from "./data-table-column-header";
 
-interface Fruit {
-  id: string;
-  name: string;
-  count: number;
-}
-
-const columns: ColumnDef<Fruit>[] = [
-  {
-    id: "select",
-    enableSorting: false,
-    header: ({
-      table,
-    }) => (
-      <input
-        type="checkbox"
-        aria-label="Select all"
-        checked={table.getIsAllRowsSelected()}
-        ref={(el) => {
-          if (el) el.indeterminate = table.getIsSomeRowsSelected();
-        }}
-        onChange={table.getToggleAllRowsSelectedHandler()}
-      />
-    ),
-    cell: ({
-      row,
-    }) => (
-      <input
-        type="checkbox"
-        aria-label={`Select ${row.original.name}`}
-        checked={row.getIsSelected()}
-        onChange={row.getToggleSelectedHandler()}
-      />
-    ),
-  },
-  {
-    accessorKey: "name",
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Name"
-      />
-    ),
-    cell: ({
-      row,
-    }) => row.original.name,
-  },
-  {
-    accessorKey: "count",
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Count"
-        align="right"
-      />
-    ),
-    cell: ({
-      row,
-    }) => row.original.count,
-    meta: {
-      align: "right",
-    },
-  },
-];
-
-const data: Fruit[] = [
-  {
-    id: "a",
-    name: "Banana",
-    count: 2,
-  },
-  {
-    id: "b",
-    name: "Avocado",
-    count: 5,
-  },
-  {
-    id: "c",
-    name: "Cherry",
-    count: 1,
-  },
-];
+import {
+  dataTableSampleColumns,
+  dataTableSampleRows,
+} from "@/test-utils/dataTableSampleFixtures";
 
 /** Non-generic harness so the story can be typed against a concrete component. */
 function DataTableDemo() {
   return (
     <div className="w-full max-w-xl rounded-md border bg-card">
       <DataTable
-        columns={columns}
-        data={data}
+        columns={dataTableSampleColumns}
+        data={dataTableSampleRows}
         getRowId={r => r.id}
         enableSorting
         enableRowSelection
@@ -122,9 +39,11 @@ export const Default: Story = {
     const canvas = within(canvasElement);
 
     // Sorting: clicking the Name header orders rows ascending.
-    await userEvent.click(canvas.getByRole("button", {
-      name: /name/i,
-    }));
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: /name/i,
+      }),
+    );
     const firstRow = canvas.getAllByRole("row")[1];
     await expect(firstRow).toHaveTextContent("Avocado");
 

--- a/packages/client/src/components/ui/data-table.test.tsx
+++ b/packages/client/src/components/ui/data-table.test.tsx
@@ -1,3 +1,4 @@
+import type { DataTableSampleRow } from "@/test-utils/dataTableSampleFixtures";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 
 // Pulls in the jest-dom matcher type augmentation for Vitest's `expect`.
@@ -10,93 +11,10 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { DataTable } from "./data-table";
 import { DataTableColumnHeader } from "./data-table-column-header";
 
-interface Item {
-  id: string;
-  name: string;
-  count: number;
-}
-
-const columns: ColumnDef<Item>[] = [
-  {
-    id: "select",
-    enableSorting: false,
-    header: ({
-      table,
-    }) => (
-      <input
-        type="checkbox"
-        aria-label="Select all"
-        checked={table.getIsAllRowsSelected()}
-        ref={(el) => {
-          if (el) el.indeterminate = table.getIsSomeRowsSelected();
-        }}
-        onChange={table.getToggleAllRowsSelectedHandler()}
-      />
-    ),
-    cell: ({
-      row,
-    }) => (
-      <input
-        type="checkbox"
-        aria-label={`Select ${row.original.name}`}
-        checked={row.getIsSelected()}
-        onChange={row.getToggleSelectedHandler()}
-      />
-    ),
-  },
-  {
-    accessorKey: "name",
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Name"
-      />
-    ),
-    cell: ({
-      row,
-    }) => row.original.name,
-  },
-  {
-    accessorKey: "count",
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Count"
-        align="right"
-      />
-    ),
-    cell: ({
-      row,
-    }) => row.original.count,
-    meta: {
-      align: "right",
-    },
-  },
-];
-
-// Capitalized, distinct initials so ordering is unambiguous regardless of the
-// sort fn's case handling. Initial order is intentionally unsorted.
-const data: Item[] = [
-  {
-    id: "a",
-    name: "Banana",
-    count: 2,
-  },
-  {
-    id: "b",
-    name: "Avocado",
-    count: 5,
-  },
-  {
-    id: "c",
-    name: "Cherry",
-    count: 1,
-  },
-];
+import {
+  dataTableSampleColumns as columns,
+  dataTableSampleRows as data,
+} from "@/test-utils/dataTableSampleFixtures";
 
 /** Body-row text in DOM order (excludes the header row). */
 function bodyRowNames(): string[] {
@@ -178,10 +96,7 @@ describe("DataTable", () => {
     const rowCheckbox = screen.getByLabelText("Select Avocado");
     fireEvent.click(rowCheckbox);
 
-    expect(rowCheckbox.closest("tr")).toHaveAttribute(
-      "data-state",
-      "selected",
-    );
+    expect(rowCheckbox.closest("tr")).toHaveAttribute("data-state", "selected");
 
     // Partial selection → header checkbox is indeterminate, not checked.
     const selectAll = screen.getByLabelText("Select all") as HTMLInputElement;
@@ -192,8 +107,10 @@ describe("DataTable", () => {
     fireEvent.click(selectAll);
     expect(selectAll.checked).toBe(true);
     expect(
-      screen.getAllByRole("row").slice(1).every(row =>
-        row.getAttribute("data-state") === "selected"),
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .every(row => row.getAttribute("data-state") === "selected"),
     ).toBe(true);
   });
 
@@ -223,7 +140,7 @@ describe("DataTable", () => {
     // TanStack's getCanSort requires an accessor, so DataTable injects a no-op
     // one for display columns. Without it, manual-sort tables (Topics, Blip,
     // amortization, daily tracker) render dead headers.
-    const displayColumns: ColumnDef<Item>[] = [
+    const displayColumns: ColumnDef<DataTableSampleRow>[] = [
       {
         id: "name",
         header: ({

--- a/packages/client/src/hooks/useStoredViewMode.ts
+++ b/packages/client/src/hooks/useStoredViewMode.ts
@@ -1,0 +1,46 @@
+import type { ViewMode } from "@/components/listControls";
+
+import { useState } from "react";
+
+interface UseStoredViewModeOptions {
+  /** Pre-rename key to fall back to so existing preferences survive. */
+  legacyKey?: string;
+}
+
+interface UseStoredViewModeResult {
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => void;
+}
+
+/**
+ * Grid/table view-mode state persisted to localStorage. Lazily reads
+ * `storageKey` (then `legacyKey`, if given) on mount — SSR-guarded, treating a
+ * stored "table" as table and anything else as grid — and writes back on every
+ * change. Replaces the per-list-page getInitialViewMode + updateViewMode pair.
+ */
+export function useStoredViewMode(
+  storageKey: string,
+  {
+    legacyKey,
+  }: UseStoredViewModeOptions = {},
+): UseStoredViewModeResult {
+  const [viewMode, setViewModeState] = useState<ViewMode>(() => {
+    if (typeof window === "undefined") return "grid";
+    const stored
+      = window.localStorage.getItem(storageKey)
+        ?? (legacyKey ? window.localStorage.getItem(legacyKey) : null);
+    return stored === "table" ? "table" : "grid";
+  });
+
+  const setViewMode = (mode: ViewMode) => {
+    setViewModeState(mode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(storageKey, mode);
+    }
+  };
+
+  return {
+    viewMode,
+    setViewMode,
+  };
+}

--- a/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardCoursesByAmortization.tsx
@@ -1,7 +1,11 @@
 import type { SortDirection } from "@/components/ui/manualSort";
 import type { DashboardTileProps } from "@/lib/dashboardTiles";
 import type { ResourceInResources, CourseProvider } from "@emstack/types";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  ColumnMeta,
+  HeaderContext,
+} from "@tanstack/react-table";
 
 import { useMemo, useState } from "react";
 
@@ -27,7 +31,10 @@ import {
 
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
-import { makeManualSortHandler, toSortingState } from "@/components/ui/manualSort";
+import {
+  makeManualSortHandler,
+  toSortingState,
+} from "@/components/ui/manualSort";
 import {
   fetchProviders,
   fetchResources,
@@ -58,7 +65,9 @@ interface ProviderRow {
   costPerUnit: number | null;
 }
 
-function buildCourseRows(courses: ResourceInResources[] | undefined): CourseRow[] {
+function buildCourseRows(
+  courses: ResourceInResources[] | undefined,
+): CourseRow[] {
   if (!courses) return [];
   return courses.map((course) => {
     const rawCost = parseCost(course.cost?.cost);
@@ -169,6 +178,49 @@ function compareProviderRows(
   return compareAmortizationRows(a, b, key, dir, row => row.provider.name);
 }
 
+/** Name-column cell linking to an entity's detail page (course or provider). */
+function NameLink({
+  to,
+  id,
+  name,
+}: {
+  to: "/resources/$id" | "/providers/$id";
+  id: string;
+  name: string;
+}) {
+  return (
+    <Link
+      to={to}
+      params={{
+        id,
+      }}
+      className="hover:text-blue-600"
+    >
+      {name}
+    </Link>
+  );
+}
+
+// The cost-per-unit column's header and meta are identical for both tables;
+// only the cell body (course vs provider breakdown) differs.
+const costPerUnitMeta = {
+  align: "right",
+  headClassName: "whitespace-nowrap",
+  cellClassName: "whitespace-nowrap",
+} as const satisfies ColumnMeta<unknown, unknown>;
+
+function costPerUnitHeader<T>({
+  column,
+}: HeaderContext<T, unknown>) {
+  return (
+    <DataTableColumnHeader
+      column={column}
+      label="Cost per Unit"
+      align="right"
+    />
+  );
+}
+
 const courseColumns: ColumnDef<CourseRow>[] = [
   {
     id: "name",
@@ -189,34 +241,18 @@ const courseColumns: ColumnDef<CourseRow>[] = [
     cell: ({
       row,
     }) => (
-      <Link
+      <NameLink
         to="/resources/$id"
-        params={{
-          id: row.original.resource.id,
-        }}
-        className="hover:text-blue-600"
-      >
-        {row.original.resource.name}
-      </Link>
+        id={row.original.resource.id}
+        name={row.original.resource.name}
+      />
     ),
   },
   {
     id: "costPerUnit",
     sortDescFirst: true,
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Cost per Unit"
-        align="right"
-      />
-    ),
-    meta: {
-      align: "right",
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
+    header: costPerUnitHeader,
+    meta: costPerUnitMeta,
     cell: ({
       row,
     }) => {
@@ -320,44 +356,25 @@ const providerColumns: ColumnDef<ProviderRow>[] = [
     cell: ({
       row,
     }) => (
-      <Link
+      <NameLink
         to="/providers/$id"
-        params={{
-          id: row.original.provider.id,
-        }}
-        className="hover:text-blue-600"
-      >
-        {row.original.provider.name}
-      </Link>
+        id={row.original.provider.id}
+        name={row.original.provider.name}
+      />
     ),
   },
   {
     id: "costPerUnit",
     sortDescFirst: true,
-    header: ({
-      column,
-    }) => (
-      <DataTableColumnHeader
-        column={column}
-        label="Cost per Unit"
-        align="right"
-      />
-    ),
-    meta: {
-      align: "right",
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
-    },
+    header: costPerUnitHeader,
+    meta: costPerUnitMeta,
     cell: ({
       row,
     }) => {
       const {
-        courseCount,
-        completedUnits,
-        totalUnits,
-        cost,
-        costPerUnit,
-      } = row.original;
+        courseCount, completedUnits, totalUnits, cost, costPerUnit,
+      }
+        = row.original;
       return (
         <Popover>
           <PopoverTrigger
@@ -431,7 +448,8 @@ export function DashboardCoursesByAmortization({
   const [showUnstarted, setShowUnstarted] = useState(false);
   const [courseSortKey, setCourseSortKey] = useState<SortKey>("costPerUnit");
   const [courseSortDir, setCourseSortDir] = useState<SortDirection>("desc");
-  const [providerSortKey, setProviderSortKey] = useState<SortKey>("costPerUnit");
+  const [providerSortKey, setProviderSortKey]
+    = useState<SortKey>("costPerUnit");
   const [providerSortDir, setProviderSortDir] = useState<SortDirection>("desc");
 
   const courseRows = useMemo(() => {
@@ -458,13 +476,15 @@ export function DashboardCoursesByAmortization({
       ? isCoursesPending || isProvidersPending
       : isCoursesPending;
   const error
-    = viewMode === "providers" ? coursesError ?? providersError : coursesError;
+    = viewMode === "providers" ? (coursesError ?? providersError) : coursesError;
   const hasData
     = viewMode === "providers"
       ? providers !== undefined && courses !== undefined
       : courses !== undefined;
   const isEmpty
-    = viewMode === "providers" ? providerRows.length === 0 : courseRows.length === 0;
+    = viewMode === "providers"
+      ? providerRows.length === 0
+      : courseRows.length === 0;
 
   return (
     <DashboardCard
@@ -549,9 +569,11 @@ export function DashboardCoursesByAmortization({
         error={error}
         isEmpty={hasData && isEmpty}
         entity={viewMode === "providers" ? "providers" : "courses"}
-        emptyMessage={viewMode === "providers"
-          ? "No providers with shared course fees."
-          : "No courses to show."}
+        emptyMessage={
+          viewMode === "providers"
+            ? "No providers with shared course fees."
+            : "No courses to show."
+        }
       />
       {viewMode === "courses" && courseRows.length > 0 && (
         <DataTable

--- a/packages/client/src/routes/dashboard.-components/-LayoutTab.tsx
+++ b/packages/client/src/routes/dashboard.-components/-LayoutTab.tsx
@@ -1,14 +1,13 @@
 import type { DashboardLayout } from "@emstack/types";
 
 import {
-  BookmarkIcon,
   CopyIcon,
   LayoutGridIcon,
   MoreHorizontalIcon,
   PencilIcon,
-  Trash2Icon,
 } from "lucide-react";
 
+import { LayoutMenuActions } from "@/components/LayoutMenuActions";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -80,18 +79,12 @@ export function LayoutTab({
             <CopyIcon />
             Duplicate
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
-            <BookmarkIcon />
-            Save as layout…
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            variant="destructive"
-            onSelect={() => onDelete(layout)}
-          >
-            <Trash2Icon />
-            Delete
-          </DropdownMenuItem>
+          <LayoutMenuActions
+            layout={layout}
+            onSaveAs={onSaveAs}
+            onDelete={onDelete}
+            saveAsLabel="Save as layout…"
+          />
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/packages/client/src/routes/resources.-components/-ResourcesList.tsx
+++ b/packages/client/src/routes/resources.-components/-ResourcesList.tsx
@@ -1,4 +1,3 @@
-import type { ViewMode } from "@/components/listControls";
 import type {
   CourseProvider,
   ResourceInResources,
@@ -10,13 +9,16 @@ import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { ArrowDownAZIcon, ArrowUpAZIcon, PlusIcon } from "lucide-react";
 
-import { ContentBox, CourseBox, CoursesTable } from "@/components/contentBoxComponents";
+import {
+  ContentBox,
+  CourseBox,
+  CoursesTable,
+} from "@/components/contentBoxComponents";
 import {
   ClearFiltersButton,
   FilterSelect,
   ListSearchInput,
   OnboardingEmptyState,
-
   ViewModeToggle,
 } from "@/components/listControls";
 import { Button } from "@/components/ui/button";
@@ -27,20 +29,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useStoredViewMode } from "@/hooks/useStoredViewMode";
 
 type SortOption = "alpha" | "progress" | "provider" | "topic";
-
-const VIEW_MODE_STORAGE_KEY = "resources:viewMode";
-// Pre-rename key; fall back to it so existing preferences survive.
-const LEGACY_VIEW_MODE_STORAGE_KEY = "courses:viewMode";
-
-function getInitialViewMode(): ViewMode {
-  if (typeof window === "undefined") return "grid";
-  const stored
-    = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
-      ?? window.localStorage.getItem(LEGACY_VIEW_MODE_STORAGE_KEY);
-  return stored === "table" ? "table" : "grid";
-}
 
 function getProgressPercent(course: ResourceInResources): number {
   if (course.progressTotal === 0) return 0;
@@ -87,14 +78,14 @@ export function ResourcesList({
   );
   const [sortBy, setSortBy] = useState<SortOption>("alpha");
   const [sortAsc, setSortAsc] = useState(true);
-  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-
-  const updateViewMode = (mode: ViewMode) => {
-    setViewMode(mode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
-    }
-  };
+  const {
+    viewMode, setViewMode: updateViewMode,
+  } = useStoredViewMode(
+    "resources:viewMode",
+    {
+      legacyKey: "courses:viewMode",
+    },
+  );
 
   const filteredAndSorted = useMemo(() => {
     let result = resources;

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -6,12 +6,12 @@ import {
   MoreHorizontalIcon,
   PencilIcon,
   PlusIcon,
-  Trash2Icon,
 } from "lucide-react";
 
 import { useDashboardLayouts } from "./-useDashboardLayouts";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { LayoutMenuActions } from "@/components/LayoutMenuActions";
 import { LayoutNameDialog } from "@/components/LayoutNameDialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -85,20 +85,13 @@ function LayoutRow({
             <CopyIcon />
             Duplicate
           </DropdownMenuItem>
-          {!layout.isTemplate && (
-            <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
-              <BookmarkIcon />
-              Save as preset…
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            variant="destructive"
-            onSelect={() => onDelete(layout)}
-          >
-            <Trash2Icon />
-            Delete
-          </DropdownMenuItem>
+          <LayoutMenuActions
+            layout={layout}
+            onSaveAs={onSaveAs}
+            onDelete={onDelete}
+            saveAsLabel="Save as preset…"
+            showSaveAs={!layout.isTemplate}
+          />
         </DropdownMenuContent>
       </DropdownMenu>
     </li>

--- a/packages/client/src/routes/topics.-components/-TopicsList.tsx
+++ b/packages/client/src/routes/topics.-components/-TopicsList.tsx
@@ -1,5 +1,4 @@
 import type { TopicsTableSort } from "@/components/contentBoxComponents";
-import type { ViewMode } from "@/components/listControls";
 import type { Domain, TopicForTopicsPage } from "@emstack/types";
 
 import { useEffect, useMemo, useState } from "react";
@@ -8,7 +7,11 @@ import { Link } from "@tanstack/react-router";
 import { PlusIcon, Trash2Icon } from "lucide-react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { ContentBox, TopicBox, TopicsTable } from "@/components/contentBoxComponents";
+import {
+  ContentBox,
+  TopicBox,
+  TopicsTable,
+} from "@/components/contentBoxComponents";
 import {
   ClearFiltersButton,
   FilterSelect,
@@ -24,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useStoredViewMode } from "@/hooks/useStoredViewMode";
 
 type SortOption
   = | "alpha-asc"
@@ -85,14 +89,6 @@ function optionToSort(option: SortOption): TopicsTableSort {
   }
 }
 
-const VIEW_MODE_STORAGE_KEY = "topics:viewMode";
-
-function getInitialViewMode(): ViewMode {
-  if (typeof window === "undefined") return "grid";
-  const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
-  return stored === "table" ? "table" : "grid";
-}
-
 function firstDomainTitle(topic: TopicForTopicsPage): string {
   const first = topic.domains?.find(d => d.id !== undefined);
   return first?.title ?? "";
@@ -145,17 +141,13 @@ export function TopicsList({
   const [search, setSearch] = useState("");
   const [filterDomain, setFilterDomain] = useState<string | undefined>();
   const [sort, setSort] = useState<TopicsTableSort>(DEFAULT_SORT);
-  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+  const {
+    viewMode, setViewMode: updateViewMode,
+  }
+    = useStoredViewMode("topics:viewMode");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-
-  const updateViewMode = (mode: ViewMode) => {
-    setViewMode(mode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
-    }
-  };
 
   const filteredAndSorted = useMemo(() => {
     let result = topics.filter(t => t.name !== "");

--- a/packages/client/src/test-utils/dataTableSampleFixtures.tsx
+++ b/packages/client/src/test-utils/dataTableSampleFixtures.tsx
@@ -1,0 +1,96 @@
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
+
+export interface DataTableSampleRow {
+  id: string;
+  name: string;
+  count: number;
+}
+
+/**
+ * Select / Name / Count columns shared by the DataTable story and unit test so
+ * both exercise the same column shapes (sortable header, right-aligned numeric
+ * column, row-selection checkboxes) without re-declaring them.
+ */
+export const dataTableSampleColumns: ColumnDef<DataTableSampleRow>[] = [
+  {
+    id: "select",
+    enableSorting: false,
+    header: ({
+      table,
+    }) => (
+      <input
+        type="checkbox"
+        aria-label="Select all"
+        checked={table.getIsAllRowsSelected()}
+        ref={(el) => {
+          if (el) el.indeterminate = table.getIsSomeRowsSelected();
+        }}
+        onChange={table.getToggleAllRowsSelectedHandler()}
+      />
+    ),
+    cell: ({
+      row,
+    }) => (
+      <input
+        type="checkbox"
+        aria-label={`Select ${row.original.name}`}
+        checked={row.getIsSelected()}
+        onChange={row.getToggleSelectedHandler()}
+      />
+    ),
+  },
+  {
+    accessorKey: "name",
+    header: ({
+      column,
+    }) => (
+      <DataTableColumnHeader
+        column={column}
+        label="Name"
+      />
+    ),
+    cell: ({
+      row,
+    }) => row.original.name,
+  },
+  {
+    accessorKey: "count",
+    header: ({
+      column,
+    }) => (
+      <DataTableColumnHeader
+        column={column}
+        label="Count"
+        align="right"
+      />
+    ),
+    cell: ({
+      row,
+    }) => row.original.count,
+    meta: {
+      align: "right",
+    },
+  },
+];
+
+// Capitalized, distinct initials so ordering is unambiguous regardless of the
+// sort fn's case handling. Initial order is intentionally unsorted.
+export const dataTableSampleRows: DataTableSampleRow[] = [
+  {
+    id: "a",
+    name: "Banana",
+    count: 2,
+  },
+  {
+    id: "b",
+    name: "Avocado",
+    count: 5,
+  },
+  {
+    id: "c",
+    name: "Cherry",
+    count: 1,
+  },
+];


### PR DESCRIPTION
## ELI5

Several places in the app had the same chunks of code copy-pasted — the same sample table data in two test files, the same hover-to-open dropdown logic in two menus, the same "remember grid vs. table view" logic on two list pages, and a few blocks duplicated within a single file. This PR replaces each set of copies with one shared definition, so they can never accidentally drift apart, without changing how anything behaves.

## Summary

- Reuse the existing `useHoverPopover` hook in `NavDropdown`/`QuickAddMenu` instead of re-implementing the open/close timers (also gains unmount cleanup the inline copies lacked).
- Add shared `hooks/useStoredViewMode.ts`, `components/LayoutMenuActions.tsx`, and `test-utils/dataTableSampleFixtures.tsx`, adopted across the list pages, dashboard/settings layout menus, and the data-table story + test.
- Collapse the self-duplicated blocks in `QuickAddMenu`, `-DashboardCoursesByAmortization`, and `DeleteButton.stories` into local helpers.
- Clears all 8 `fallow dupes` fingerprints from #419 (`ae8e6cae`, `2103c033`, `ba40df9c`, `23ee8f5c`, `bd3888c5`, `06262198`, `47dc2756`, `40af2545`).

## Test plan

- [ ] `pnpm exec fallow dupes` — the 8 fingerprints above no longer appear, and none of the 10 touched files are listed
- [ ] `pnpm --filter=@emstack/client exec vitest run` — full client suite passes (742 tests)
- [ ] `pnpm --filter=@emstack/client run typecheck` — clean
- [ ] `pnpm lint` — 0 errors
- [ ] Manual spot-check: nav dropdowns hover-open/close with the 400ms grace, Quick Add lists both groups, Resources/Topics view-mode persists across reload, the dashboard "Cost per Unit" course & provider tables render with working name links + cost popovers, and layout/preset menus still Save-as/Delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #419