### PR TITLE
refactor(client): Fixes #420: dedupe duplicated test helpers

### DIFF
--- a/packages/client/src/hooks/useHoverPopover.test.ts
+++ b/packages/client/src/hooks/useHoverPopover.test.ts
@@ -3,6 +3,19 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { useHoverPopover } from "./useHoverPopover";
 
+function renderClosingPopover(
+  options?: Parameters<typeof useHoverPopover>[0],
+) {
+  const view = renderHook(() => useHoverPopover(options));
+  act(() => {
+    view.result.current.handleOpen();
+  });
+  act(() => {
+    view.result.current.handleClose();
+  });
+  return view;
+}
+
 describe("useHoverPopover", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -33,13 +46,7 @@ describe("useHoverPopover", () => {
   test("handleClose keeps it open until the close delay elapses", () => {
     const {
       result,
-    } = renderHook(() => useHoverPopover());
-    act(() => {
-      result.current.handleOpen();
-    });
-    act(() => {
-      result.current.handleClose();
-    });
+    } = renderClosingPopover();
 
     // still open just before the 120ms grace period ends
     act(() => {
@@ -57,13 +64,7 @@ describe("useHoverPopover", () => {
   test("cancelClose aborts a pending close", () => {
     const {
       result,
-    } = renderHook(() => useHoverPopover());
-    act(() => {
-      result.current.handleOpen();
-    });
-    act(() => {
-      result.current.handleClose();
-    });
+    } = renderClosingPopover();
     act(() => {
       result.current.cancelClose();
     });
@@ -77,14 +78,8 @@ describe("useHoverPopover", () => {
   test("honours a custom closeDelay", () => {
     const {
       result,
-    } = renderHook(() => useHoverPopover({
+    } = renderClosingPopover({
       closeDelay: 300,
-    }));
-    act(() => {
-      result.current.handleOpen();
-    });
-    act(() => {
-      result.current.handleClose();
     });
 
     act(() => {
@@ -115,14 +110,8 @@ describe("useHoverPopover", () => {
   test("clears a pending close timer on unmount", () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
     const {
-      result, unmount,
-    } = renderHook(() => useHoverPopover());
-    act(() => {
-      result.current.handleOpen();
-    });
-    act(() => {
-      result.current.handleClose();
-    });
+      unmount,
+    } = renderClosingPopover();
 
     unmount();
     expect(clearTimeoutSpy).toHaveBeenCalled();

--- a/packages/client/src/lib/dashboardTiles.test.ts
+++ b/packages/client/src/lib/dashboardTiles.test.ts
@@ -4,6 +4,10 @@ import { DASHBOARD_TILE_IDS } from "@emstack/types";
 import { describe, expect, test } from "vitest";
 
 import {
+  expectTilesRespectMinSize,
+  tilesOverlap,
+} from "@/test-utils/dashboardTileAssertions";
+import {
   buildDefaultTiles,
   layoutItemsToTiles,
   needsNormalization,
@@ -16,12 +20,6 @@ import {
   TILE_META,
   toggleTile,
 } from "./dashboardTiles";
-
-function overlaps(a: DashboardLayoutTile, b: DashboardLayoutTile): boolean {
-  return (
-    a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
-  );
-}
 
 describe("buildDefaultTiles", () => {
   test("contains every tile exactly once", () => {
@@ -46,16 +44,13 @@ describe("buildDefaultTiles", () => {
       expect(tile.x + tile.w).toBeLessThanOrEqual(4);
       for (const other of tiles) {
         if (other.tileId === tile.tileId) continue;
-        expect(overlaps(tile, other)).toBe(false);
+        expect(tilesOverlap(tile, other)).toBe(false);
       }
     }
   });
 
   test("respects each tile's minimum size", () => {
-    for (const tile of buildDefaultTiles()) {
-      expect(tile.w).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minW);
-      expect(tile.h).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minH);
-    }
+    expectTilesRespectMinSize(buildDefaultTiles());
   });
 });
 

--- a/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
+++ b/packages/client/src/routes/dashboard.-components/-layoutPresets.test.ts
@@ -1,18 +1,10 @@
-import type { DashboardLayoutTile } from "@emstack/types";
-
 import { describe, expect, test } from "vitest";
 
-import { TILE_META } from "@/lib/dashboardTiles";
+import {
+  expectTilesRespectMinSize,
+  tilesOverlap,
+} from "@/test-utils/dashboardTileAssertions";
 import { LAYOUT_PRESETS } from "./-layoutPresets";
-
-function overlaps(a: DashboardLayoutTile, b: DashboardLayoutTile): boolean {
-  return (
-    a.x < b.x + b.w
-    && b.x < a.x + a.w
-    && a.y < b.y + b.h
-    && b.y < a.y + a.h
-  );
-}
 
 describe("LAYOUT_PRESETS", () => {
   test("includes a blank preset that yields no tiles", () => {
@@ -46,16 +38,13 @@ describe("LAYOUT_PRESETS", () => {
         for (const tile of tiles) {
           for (const other of tiles) {
             if (other === tile) continue;
-            expect(overlaps(tile, other)).toBe(false);
+            expect(tilesOverlap(tile, other)).toBe(false);
           }
         }
       });
 
       test("respects each tile's minimum size", () => {
-        for (const tile of preset.buildTiles()) {
-          expect(tile.w).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minW);
-          expect(tile.h).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minH);
-        }
+        expectTilesRespectMinSize(preset.buildTiles());
       });
     });
   }

--- a/packages/client/src/test-utils/dashboardTileAssertions.ts
+++ b/packages/client/src/test-utils/dashboardTileAssertions.ts
@@ -1,0 +1,23 @@
+import type { DashboardLayoutTile } from "@emstack/types";
+
+import { expect } from "vitest";
+
+import { TILE_META } from "@/lib/dashboardTiles";
+
+/** Axis-aligned overlap test for two grid tiles. */
+export function tilesOverlap(
+  a: DashboardLayoutTile,
+  b: DashboardLayoutTile,
+): boolean {
+  return (
+    a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+  );
+}
+
+/** Assert every tile meets its TILE_META minimum width/height. */
+export function expectTilesRespectMinSize(tiles: DashboardLayoutTile[]): void {
+  for (const tile of tiles) {
+    expect(tile.w).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minW);
+    expect(tile.h).toBeGreaterThanOrEqual(TILE_META[tile.tileId].minH);
+  }
+}

--- a/packages/middleware/src/tests/googleCalendar.test.ts
+++ b/packages/middleware/src/tests/googleCalendar.test.ts
@@ -23,6 +23,13 @@ function calendar(...vevents: string[]): string {
   ].join("\r\n");
 }
 
+const RANGE_START = new Date("2026-06-14T00:00:00Z");
+const RANGE_END = new Date("2026-06-28T00:00:00Z");
+
+function expand(ics: string, end: Date = RANGE_END) {
+  return expandIcsToEvents(ics, RANGE_START, end, FEED);
+}
+
 test("expandIcsToEvents maps a single timed event in range", () => {
   const ics = calendar(
     [
@@ -36,12 +43,7 @@ test("expandIcsToEvents maps a single timed event in range", () => {
       "END:VEVENT",
     ].join("\r\n"),
   );
-  const events = expandIcsToEvents(
-    ics,
-    new Date("2026-06-14T00:00:00Z"),
-    new Date("2026-06-28T00:00:00Z"),
-    FEED,
-  );
+  const events = expand(ics);
   assert.strictEqual(events.length, 1);
   assert.strictEqual(events[0].summary, "One off");
   assert.strictEqual(events[0].allDay, false);
@@ -62,12 +64,7 @@ test("expandIcsToEvents flags all-day events with a date-only start", () => {
       "END:VEVENT",
     ].join("\r\n"),
   );
-  const events = expandIcsToEvents(
-    ics,
-    new Date("2026-06-14T00:00:00Z"),
-    new Date("2026-06-28T00:00:00Z"),
-    FEED,
-  );
+  const events = expand(ics);
   assert.strictEqual(events.length, 1);
   assert.strictEqual(events[0].allDay, true);
   assert.strictEqual(events[0].start, "2026-06-16");
@@ -87,12 +84,7 @@ test("expandIcsToEvents expands a weekly recurrence within the window", () => {
       "END:VEVENT",
     ].join("\r\n"),
   );
-  const events = expandIcsToEvents(
-    ics,
-    new Date("2026-06-14T00:00:00Z"),
-    new Date("2026-07-05T00:00:00Z"),
-    FEED,
-  );
+  const events = expand(ics, new Date("2026-07-05T00:00:00Z"));
   assert.strictEqual(events.length, 3);
   assert.ok(events.every(e => e.summary === "Standup"));
   // Distinct occurrences a week apart.


### PR DESCRIPTION
## ELI5
Some of our automated tests had the same setup code copy-pasted in a few places. This tidies that up by writing each piece of setup once and reusing it, so the tests are shorter and won't drift apart over time. Nothing about how the app behaves changes — only the test code.

## Summary
- `useHoverPopover.test`: extracted a `renderClosingPopover()` helper for the repeated open-then-close hook setup.
- `dashboardTiles` / `-layoutPresets`: moved the duplicated `tilesOverlap()` and min-size assertion into a shared `test-utils/dashboardTileAssertions.ts` (the two specs live in different directories, so a local helper couldn't be shared).
- `googleCalendar.test`: added an `expand()` helper plus shared range constants so the date window is defined once.
- Resolves all four clone fingerprints flagged by `fallow dupes` (`ef10a5b3`, `fc9ea846`, `38c44f6c`, `8f269548`).

## Test plan
- [x] `pnpm --filter=@emstack/client exec vitest run` on the three affected client specs — pass
- [x] `pnpm --filter=@emstack/middleware exec node --test src/tests/googleCalendar.test.ts` — pass
- [x] Full client suite (`pnpm --filter=@emstack/client test`) — 741 pass
- [x] `pnpm typecheck` and `pnpm lint` — clean (0 errors)
- [x] `pnpm exec fallow dupes` — none of the four fingerprints remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #420