### PR TITLE
test(client): add Storybook stories for QuickAddDialogFooter

### DIFF
--- a/packages/client/src/components/quickAdd/QuickAddDialogFooter.stories.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddDialogFooter.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { QuickAddDialogFooter } from "./QuickAddDialogFooter";
+
+const meta: Meta<typeof QuickAddDialogFooter> = {
+  component: QuickAddDialogFooter,
+  args: {
+    submitLabel: "Save",
+    isPending: false,
+    canSubmit: true,
+    onCancel: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Both buttons render, submit is enabled, and Cancel calls onCancel.
+export const Default: Story = {
+  play: async ({
+    args,
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Save",
+    })).toBeEnabled();
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Cancel",
+    }));
+    await expect(args.onCancel).toHaveBeenCalled();
+  },
+};
+
+// While the create mutation is in flight the submit button is disabled.
+export const Pending: Story = {
+  args: {
+    isPending: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Save",
+    })).toBeDisabled();
+  },
+};
+
+// With insufficient input the submit button is disabled.
+export const CannotSubmit: Story = {
+  args: {
+    canSubmit: false,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", {
+      name: "Save",
+    })).toBeDisabled();
+  },
+};


### PR DESCRIPTION
## Summary
Add comprehensive Storybook stories for the `QuickAddDialogFooter` component with interactive play tests to verify button states and user interactions.

## Changes
- **New file:** `packages/client/src/components/quickAdd/QuickAddDialogFooter.stories.tsx`
  - `Default` story: verifies both buttons render, submit button is enabled, and Cancel button triggers the `onCancel` callback
  - `Pending` story: confirms submit button is disabled while a mutation is in flight (`isPending: true`)
  - `CannotSubmit` story: confirms submit button is disabled when form validation fails (`canSubmit: false`)

## Implementation Details
- Uses Storybook's play function API with Testing Library queries to verify component behavior
- Tests cover all critical user-facing states: default enabled state, loading state, and validation failure state
- Follows the project's Storybook 10 + Testing Library testing patterns

https://claude.ai/code/session_01FgQB7G26Tbkq3bdTUXQQHP