### PR TITLE
docs: clarify gh issue command portability in check-components skill

### DIFF
--- a/.claude/skills/check-components/SKILL.md
+++ b/.claude/skills/check-components/SKILL.md
@@ -155,15 +155,16 @@ Each finding states: the component, its **current path → proposed path**, and 
 **consumer evidence** (which route families import it, with `file:line`).
 
 **Do not create issues automatically.** For each (category × feature/path-group)
-bucket, emit a ready-to-run command using the existing **`refactor`** label
-(repo `emilyeserven/course-tracker`):
+bucket, emit a ready-to-run command using the existing **`refactor`** label in
+the **current repo** — omit `--repo` so `gh` infers it from the local git remote,
+which keeps the skill portable if it's copied to another project:
 
 Pass the body as a plain multi-line string (not a `$(cat <<EOF …)` heredoc — a
 heredoc-substituted command doesn't start with `gh`, so the `Bash(gh:*)`
 permission pattern won't match):
 
 ```bash
-gh issue create --repo emilyeserven/course-tracker --label refactor \
+gh issue create --label refactor \
   --title "refactor(client): colocate <feature> components into *.-components" \
   --body "Components used by only the <feature> route that should move out of shared components/:
 


### PR DESCRIPTION
## Summary
Updated the `check-components` skill documentation to clarify how the `gh issue create` command should be invoked to remain portable across projects.

## Changes
- Removed the hardcoded `--repo emilyeserven/course-tracker` flag from the example `gh issue create` command
- Added explanation that omitting `--repo` allows `gh` to infer the repository from the local git remote, making the skill portable if copied to another project
- Clarified that this approach keeps the skill usable in any repository without modification

## Details
The skill generates ready-to-run commands for creating refactor issues. By relying on `gh`'s automatic repository inference (via the local git remote) instead of hardcoding a specific repository, the skill becomes reusable across different projects without requiring manual edits to the command template.

https://claude.ai/code/session_017n8oVVbyBbR6GBz5byveAi