### PR TITLE
docs: reorganize skill area notes into separate reference files

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   storybook/test play smoke tests, test-utils fixture factories,
   RouterStub/QueryStub decorators). Use when asked to "add/write storybook
   stories", "cover this component in storybook", "story coverage", "missing
-  stories", or to resolve an area under the story-coverage tracker (#351).
+  stories", or to resolve an area under the story-coverage tracker.
   Pairs with `condense-components` — that skill stories the components it
   extracts; this one fills coverage gaps wholesale.
 ---
@@ -19,9 +19,10 @@ vitest project (the CI gate). **Story-only — no behavior changes** to the
 components themselves. The one exception is route shells (Tier C below), where
 the prescribed move is a behavior-preserving *extract* before storying.
 
-Coverage is tracked in **#351**, split into per-area sub-issues (formFields,
-layout, resources, routes, …) — same model as the import cleanup tracker #312.
-This skill is the repeatable procedure for one such area.
+Coverage is tracked in a **story-coverage tracker** issue, split into per-area
+sub-issues (formFields, layout, resources, routes, …) — same model as the
+import/max-dependencies cleanup tracker. This skill is the repeatable procedure
+for one such area.
 
 Stories already exist for ~40-50% of components; whole areas are done
 (`contentBoxComponents/`, `boxElements/`, `dailies/`, `radar/`, `tables/`). Don't
@@ -30,8 +31,9 @@ re-story those. The shared infra is already in place — reuse it, don't reinven
 > _Components, files, and fixtures named below (e.g. `InfoRow`,
 > `-ResourcesList.stories.tsx`, `useResourceModules`) are illustrations — they
 > show the **shape** of the pattern, not required targets. Apply the method to
-> whatever's in your scope; the **Area notes** section is per-issue worked
-> examples, not core procedure._
+> whatever's in your scope. Per-area worked examples (fixtures added, tricky
+> decorators) live in `references/area-notes.md` — illustrative reference, not
+> core procedure._
 
 ## 1. Inventory the target area — what's actually uncovered
 
@@ -178,8 +180,9 @@ Typecheck must be clean apart from pre-existing unrelated errors (confirm with
 
 Commit with a `test(<scope>):` Conventional Commit (stories are tests here), e.g.
 `test(client): add storybook stories for layout components`. One area per commit
-reads best. Check off the area's sub-issue under #351 and add an Area-notes entry
-below for anything learned (new fixture file, a tricky decorator).
+reads best. Check off the area's sub-issue under the story-coverage tracker and
+add an entry to `references/area-notes.md` for anything learned (new fixture file,
+a tricky decorator).
 
 ## Gotchas (learned the hard way)
 
@@ -195,146 +198,3 @@ below for anything learned (new fixture file, a tricky decorator).
   reusable `test-utils` helper on first use rather than per-story boilerplate.
 - **Don't add global decorators** in `preview.ts`.
 - **Skip generated files:** `routeTree.gen.ts`, anything under `dist/`.
-
-## Area notes
-
-_Per-issue worked examples — what a real pass through each area turned up
-(fixtures added, tricky decorators). Illustrative reference, not steps to follow._
-
-### layout (#352)
-First batch. All 12 covered components are Tier A/B — no fixtures needed.
-Tier B (need `RouterStub`): `PageHeader` (renders a section `<Link>` only when
-`pageSection` is set), `EntityHeaderButton`, `OnboardingEmptyState`,
-`ResourceLinksSection`, `NavDropdown`, `DropdownNavItem`. `DropdownNavItem` also
-needs the `DropdownMenu`/`DropdownMenuContent` parent and asserts via
-`document.body`. The rest (`InfoRow`, `InfoArea`, `EditForm`, `PageTabs`,
-`ViewModeToggle`, `EditPageFooter`) are Tier A with `fn()` handlers.
-
-### ui primitives (#353)
-13 new stories; no fixtures needed (inline literals only). Radix composites
-(`select`, `dialog`, `alert-dialog`, `dropdown-menu`, `tooltip`, `tabs`) use a
-small non-generic `*Demo` harness as `meta.component` (same trick as
-`data-table.stories.tsx`'s `DataTableDemo`) — it sidesteps the multi-export Root
-typing and lets spies ride in as harness props. Dialog/AlertDialog **don't export
-their `Trigger`**, so drive them with a controlled `open` prop and assert content
-via `within(document.body)`. Tooltip self-wraps its provider — assert
-`findByRole("tooltip")` in the body. `data-table-column-header` mocks just the
-`Column` methods it calls (`getCanSort`/`getIsSorted`/`getToggleSortingHandler`)
-cast `as unknown as Column<unknown, unknown>`. **`toHaveStyle({ width: "30%" })`
-fails** in the browser project — computed style resolves `%` to px; assert the
-inline `el.style.width` string instead. `table.tsx` was left unstoried: it's
-already exercised transitively by `data-table.stories.tsx`.
-
-### formFields + forms (#354)
-The 7 TanStack-Form fields (`InputField`, `TextareaField`, `NumberField`,
-`RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) read
-`useFieldContext()`, so they need form context. Added a reusable
-**`test-utils/FormFieldHarness.tsx`**: it mounts a one-field `useAppForm` and
-renders the field via `form.AppField`. Import the field directly (there's **no
-lint ban** — `eslint.config.js` only restricts `@emstack/types/*` subpaths) and
-wrap it with the harness as a meta decorator; seed the field's value per story
-via `parameters.fieldValue` (read in the decorator) so Default/Filled/… states
-need no extra wiring. **Gotcha:** the harness `children` is a **render function**
-(`() => ReactNode`), passed straight through as `AppField`'s render prop — a
-static element hits React's same-element bailout and freezes the field on its
-initial value, so interaction `play`s (typing, selecting) never update. In a
-regular `.tsx` an inline parameterless function child also trips
-`react/no-children-prop` ("pass it as a prop") — pass the identifier
-(`{children}`), not `{() => …}` (story files are exempt via the storybook config,
-but the harness isn't). Option fixtures live in `test-utils/formFieldFixtures.ts`
-(`makeSelectOptions`, `makeGroupedSelectOptions`, `makeCreateConfig`). The two
-presentational `formFields` (`ComboboxCreatePanel`, `ComboboxAddNewRow`) are
-Tier A with `fn()` spies (`const meta: Meta<…>`). In `forms/`, `field.tsx`'s
-primitives are pure Tier A; `CourseFields` takes a whole `form`, so its story uses
-a tiny inline wrapper that builds the form and casts it
-(`as unknown as ReturnType<typeof useAppForm>`, mirroring the onboarding route)
-and types the meta against the wrapper to keep the required `form` out of args.
-
-### resources (#355)
-All 10 covered. New fixture file `test-utils/resourceModulesFixtures.ts`
-(`makeTag`/`makeTagGroup`/`makeTagGroups`/`makeModule`/`makeModuleGroup`/
-`makeInteraction`, defaults keyed to `resourceId: "resource-1"`). Reuse the
-draft factories from `resources/moduleDrafts` (`emptyGroupDraft`, `groupToDraft`,
-`emptyModuleDraft`, `moduleToDraft`) for the edit-card drafts — don't hand-roll.
-Tier A (no decorator): `OptionalSelectField`, `LevelTriad`, `ModuleDisplayRow`
-(host in a `<ul>`), `LevelAndTagsFields`, `GroupEditCard`, `ModuleEditCard` — the
-last three pull in `TagPicker` (Base UI `Combobox`), which is self-contained, so
-just don't open the combobox in `play`. Tier B: `InteractionQuickLog` +
-`ModuleSuggestDialog` need only a bare `QueryStub` (mutations, no reads — don't
-fire the submit so the real network mutation never runs); `ModuleSuggestDialog`
-is a Radix `Dialog` so set `open: true` and assert via `within(document.body)`.
-`ResourceInteractionsLog` and `ResourceModulesAdmin` read through hooks
-(`useInteractionsLog` / `useResourceModules`), so seed a `QueryClient`
-(`staleTime: Infinity`) for their keys — interactions/moduleGroups/modules, plus
-`tagGroups.list()` and `resources.detail()` for the admin — and pass it as the
-`QueryStub client`. Neither renders a `<Link>` (plain `<a>`), so no `RouterStub`.
-
-### routines (#356)
-All 5 covered. New fixture file `test-utils/routinesFixtures.ts`
-(`taskOptions`/`resourceOptions` `SelectOption[]`, `taskNames`/`resourceNames`
-id→name maps, `makeReferenceItem`, `makeRoutineTemplate`) — the existing
-`boxFixtures.makeRoutine` is the content-box `Routine` shape, not the
-`RoutineReferenceItem`/`RoutineTemplate`/`SelectOption` shapes these editors use.
-Build `WeeklyRow[]` from the exported `weeklyToRows(weekly)` helper rather than
-hand-rolling row literals. Tier B all round: `RoutineEntryLabel` renders an
-`EntityLink` → `RouterStub` (assert with `findBy*`). `WeeklyScheduleField`,
-`WeeklyEntryEditor`, and `RoutineTemplateEditModal` **unconditionally** mount
-`QuickAddResourceDialog` (`useNavigate` + `useQueryClient` + `useMutation`), so
-they need `RouterStub > QueryStub` even when the dialog stays closed. The modal is
-a Radix `Dialog` → set `open: true` and assert via `within(document.body)`.
-`TaskResourceComboboxContent` is a base-ui combobox popup: it portals and renders
-only inside an **open** `Combobox` root, so wrap it in a decorator that reads
-`ctx.args.optionsMap` for the root's `items` and sets `defaultOpen`, then assert
-in `document.body`.
-
-### tasks (#357)
-All 9 `components/tasks/*` stored. Added **`test-utils/tasksFixtures.ts`**
-(`makeTaskResource`, `makeTaskTodo`, `makeModule`, `makeModuleGroup`,
-`makeTagGroup`); the `Task` shell reuses `boxFixtures.makeTask` with a
-`resources`/`todos` override. Tiers: `LevelBadge`/`TagChip` pure Tier A
-(`satisfies`); `TagPicker`/`TagsInput`/`ResourceLinksPicker` are presentational
-with `fn()` spies (`const meta`) — the two Combobox pickers need no provider, a
-`max-w-sm` sizing wrapper is enough, and `TagsInput`'s add-tag `play` types
-`"graphql{Enter}"` and asserts the `onChange` spy. The `<tr>` rows
-(`TaskResourceRow`, `EditingRow`) need a `<table><tbody>` decorator;
-`TaskResourceRow` also renders an `EntityLink` so it wraps in `RouterStub` →
-assert with `findBy*`. `ResourcesTable` drives the `useTaskResources` hook
-(three `useQuery`s + a mutation) and renders linked rows, so it nests
-`RouterStub > QueryStub` with a module-level `QueryClient` seeded
-(`setQueryData`) for `queryKeys.resources.list()`, `["module-groups-all"]`,
-`["modules-all"]` at `staleTime: Infinity` so nothing refetches. `TodosChecklist`
-only needs `QueryStub` (it calls `useQueryClient`/`useMutation`, no reads).
-`ResourceLinkInput` in `ResourceLinksPicker` is a non-exported local interface —
-`Meta<typeof X>` checks the `value` literals structurally, so no export needed.
-
-### route-private (#363)
-All `routes/*.-components/*` leaves covered (dashboard 16, settings 11, the three
-remaining `domains.$id.edit`, routines-edit 5, routines.$id 2, routines.tracker 1,
-topics.$id.edit 1). The issue's per-folder counts were a stale snapshot —
-`domains.$id.edit` was already 8/11 stored, so re-inventory before starting. New
-fixtures: **`dashboardFixtures.ts`** (`makeTile(tileId, overrides)` →
-`DashboardLayoutTile`), **`settingsFixtures.ts`** (`makeAppSettings`,
-`makeTaskType`, `makeCalendarFeed`, `makeLayout`), **`templatesFixtures.ts`**
-(`makeCriteriaTemplate` only — routine templates already live in
-`routinesFixtures.makeRoutineTemplate`; don't re-add). Key patterns:
-**Dashboard tiles** take `DashboardTileProps` (`tile` + `onUpdateTile`) but
-**self-fetch**, so they're Tier B not Tier A: nest `RouterStub > QueryStub` and
-seed each tile's key (`["domains"]`, `["resources"]`+`["dailies"]`, `["providers"]`,
-…) on a `staleTime: Infinity` client. **Integration tiles**
-(`-DashboardReadwise`/`-DashboardTodoist`/`-DashboardGoogleCalendar`) cover both
-branches without fabricating full API payloads: seed `{ configured: false, …[] }`
-for the connect-prompt and `{ configured: true, …[] }` for the configured-empty
-state — `setQueryData` on an untyped/`as const` key takes a plain object, so no
-payload-type import. `-DashboardChangelog` is pure render-only (build-time
-`@root/CHANGELOG.md`, no decorators). **`-DashboardDailiesBody`** and
-**`-TrackerTables`** take a whole hook-return bundle (`DashboardDailiesData` /
-`RoutineTrackerState`): build it inline and cast `as unknown as <T>`, stubbing
-`mutation` as `{ isPending: false, mutate: fn() }`. **Route-shell-like leaves**
-(`-ExistingDomainEditor`, `-TopicForm`) are storied by seeding their `useEditFormPage`
-+ list queries plus a loading/unseeded variant — `useEditFormPage`'s detail query
-is `enabled: !isNew`, so the `isNew`/New story skips the detail seed.
-`-ThemeSection` needs `ThemeProvider` (`@/context/ThemeProvider`). `useSettings`
-needs `SettingsProvider` but never fetches (local state), so no seeding. Watch
-ambiguous `getByText`: "Weekly Schedule" (Type-tile value **and** schedule header)
-and "Cost per Unit" (card title **and** column header) both match twice — assert on
-a unique `role`/`tab`/count signal instead.

--- a/.claude/skills/add-stories/references/area-notes.md
+++ b/.claude/skills/add-stories/references/area-notes.md
@@ -1,0 +1,147 @@
+# add-stories — area notes
+
+Per-issue worked examples for the [`add-stories`](../SKILL.md) skill — what a real
+pass through each area turned up (fixtures added, tricky decorators). **Illustrative
+reference, not steps to follow;** the core procedure lives in `SKILL.md`.
+
+The `#N` headings below are this repo's story-coverage tracker sub-issues — this is
+the per-tracker scratchpad, so issue numbers are expected here. Add an entry when
+you finish an area.
+
+### layout (#352)
+First batch. All 12 covered components are Tier A/B — no fixtures needed.
+Tier B (need `RouterStub`): `PageHeader` (renders a section `<Link>` only when
+`pageSection` is set), `EntityHeaderButton`, `OnboardingEmptyState`,
+`ResourceLinksSection`, `NavDropdown`, `DropdownNavItem`. `DropdownNavItem` also
+needs the `DropdownMenu`/`DropdownMenuContent` parent and asserts via
+`document.body`. The rest (`InfoRow`, `InfoArea`, `EditForm`, `PageTabs`,
+`ViewModeToggle`, `EditPageFooter`) are Tier A with `fn()` handlers.
+
+### ui primitives (#353)
+13 new stories; no fixtures needed (inline literals only). Radix composites
+(`select`, `dialog`, `alert-dialog`, `dropdown-menu`, `tooltip`, `tabs`) use a
+small non-generic `*Demo` harness as `meta.component` (same trick as
+`data-table.stories.tsx`'s `DataTableDemo`) — it sidesteps the multi-export Root
+typing and lets spies ride in as harness props. Dialog/AlertDialog **don't export
+their `Trigger`**, so drive them with a controlled `open` prop and assert content
+via `within(document.body)`. Tooltip self-wraps its provider — assert
+`findByRole("tooltip")` in the body. `data-table-column-header` mocks just the
+`Column` methods it calls (`getCanSort`/`getIsSorted`/`getToggleSortingHandler`)
+cast `as unknown as Column<unknown, unknown>`. **`toHaveStyle({ width: "30%" })`
+fails** in the browser project — computed style resolves `%` to px; assert the
+inline `el.style.width` string instead. `table.tsx` was left unstoried: it's
+already exercised transitively by `data-table.stories.tsx`.
+
+### formFields + forms (#354)
+The 7 TanStack-Form fields (`InputField`, `TextareaField`, `NumberField`,
+`RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField`) read
+`useFieldContext()`, so they need form context. Added a reusable
+**`test-utils/FormFieldHarness.tsx`**: it mounts a one-field `useAppForm` and
+renders the field via `form.AppField`. Import the field directly (there's **no
+lint ban** — `eslint.config.js` only restricts `@emstack/types/*` subpaths) and
+wrap it with the harness as a meta decorator; seed the field's value per story
+via `parameters.fieldValue` (read in the decorator) so Default/Filled/… states
+need no extra wiring. **Gotcha:** the harness `children` is a **render function**
+(`() => ReactNode`), passed straight through as `AppField`'s render prop — a
+static element hits React's same-element bailout and freezes the field on its
+initial value, so interaction `play`s (typing, selecting) never update. In a
+regular `.tsx` an inline parameterless function child also trips
+`react/no-children-prop` ("pass it as a prop") — pass the identifier
+(`{children}`), not `{() => …}` (story files are exempt via the storybook config,
+but the harness isn't). Option fixtures live in `test-utils/formFieldFixtures.ts`
+(`makeSelectOptions`, `makeGroupedSelectOptions`, `makeCreateConfig`). The two
+presentational `formFields` (`ComboboxCreatePanel`, `ComboboxAddNewRow`) are
+Tier A with `fn()` spies (`const meta: Meta<…>`). In `forms/`, `field.tsx`'s
+primitives are pure Tier A; `CourseFields` takes a whole `form`, so its story uses
+a tiny inline wrapper that builds the form and casts it
+(`as unknown as ReturnType<typeof useAppForm>`, mirroring the onboarding route)
+and types the meta against the wrapper to keep the required `form` out of args.
+
+### resources (#355)
+All 10 covered. New fixture file `test-utils/resourceModulesFixtures.ts`
+(`makeTag`/`makeTagGroup`/`makeTagGroups`/`makeModule`/`makeModuleGroup`/
+`makeInteraction`, defaults keyed to `resourceId: "resource-1"`). Reuse the
+draft factories from `resources/moduleDrafts` (`emptyGroupDraft`, `groupToDraft`,
+`emptyModuleDraft`, `moduleToDraft`) for the edit-card drafts — don't hand-roll.
+Tier A (no decorator): `OptionalSelectField`, `LevelTriad`, `ModuleDisplayRow`
+(host in a `<ul>`), `LevelAndTagsFields`, `GroupEditCard`, `ModuleEditCard` — the
+last three pull in `TagPicker` (Base UI `Combobox`), which is self-contained, so
+just don't open the combobox in `play`. Tier B: `InteractionQuickLog` +
+`ModuleSuggestDialog` need only a bare `QueryStub` (mutations, no reads — don't
+fire the submit so the real network mutation never runs); `ModuleSuggestDialog`
+is a Radix `Dialog` so set `open: true` and assert via `within(document.body)`.
+`ResourceInteractionsLog` and `ResourceModulesAdmin` read through hooks
+(`useInteractionsLog` / `useResourceModules`), so seed a `QueryClient`
+(`staleTime: Infinity`) for their keys — interactions/moduleGroups/modules, plus
+`tagGroups.list()` and `resources.detail()` for the admin — and pass it as the
+`QueryStub client`. Neither renders a `<Link>` (plain `<a>`), so no `RouterStub`.
+
+### routines (#356)
+All 5 covered. New fixture file `test-utils/routinesFixtures.ts`
+(`taskOptions`/`resourceOptions` `SelectOption[]`, `taskNames`/`resourceNames`
+id→name maps, `makeReferenceItem`, `makeRoutineTemplate`) — the existing
+`boxFixtures.makeRoutine` is the content-box `Routine` shape, not the
+`RoutineReferenceItem`/`RoutineTemplate`/`SelectOption` shapes these editors use.
+Build `WeeklyRow[]` from the exported `weeklyToRows(weekly)` helper rather than
+hand-rolling row literals. Tier B all round: `RoutineEntryLabel` renders an
+`EntityLink` → `RouterStub` (assert with `findBy*`). `WeeklyScheduleField`,
+`WeeklyEntryEditor`, and `RoutineTemplateEditModal` **unconditionally** mount
+`QuickAddResourceDialog` (`useNavigate` + `useQueryClient` + `useMutation`), so
+they need `RouterStub > QueryStub` even when the dialog stays closed. The modal is
+a Radix `Dialog` → set `open: true` and assert via `within(document.body)`.
+`TaskResourceComboboxContent` is a base-ui combobox popup: it portals and renders
+only inside an **open** `Combobox` root, so wrap it in a decorator that reads
+`ctx.args.optionsMap` for the root's `items` and sets `defaultOpen`, then assert
+in `document.body`.
+
+### tasks (#357)
+All 9 `components/tasks/*` stored. Added **`test-utils/tasksFixtures.ts`**
+(`makeTaskResource`, `makeTaskTodo`, `makeModule`, `makeModuleGroup`,
+`makeTagGroup`); the `Task` shell reuses `boxFixtures.makeTask` with a
+`resources`/`todos` override. Tiers: `LevelBadge`/`TagChip` pure Tier A
+(`satisfies`); `TagPicker`/`TagsInput`/`ResourceLinksPicker` are presentational
+with `fn()` spies (`const meta`) — the two Combobox pickers need no provider, a
+`max-w-sm` sizing wrapper is enough, and `TagsInput`'s add-tag `play` types
+`"graphql{Enter}"` and asserts the `onChange` spy. The `<tr>` rows
+(`TaskResourceRow`, `EditingRow`) need a `<table><tbody>` decorator;
+`TaskResourceRow` also renders an `EntityLink` so it wraps in `RouterStub` →
+assert with `findBy*`. `ResourcesTable` drives the `useTaskResources` hook
+(three `useQuery`s + a mutation) and renders linked rows, so it nests
+`RouterStub > QueryStub` with a module-level `QueryClient` seeded
+(`setQueryData`) for `queryKeys.resources.list()`, `["module-groups-all"]`,
+`["modules-all"]` at `staleTime: Infinity` so nothing refetches. `TodosChecklist`
+only needs `QueryStub` (it calls `useQueryClient`/`useMutation`, no reads).
+`ResourceLinkInput` in `ResourceLinksPicker` is a non-exported local interface —
+`Meta<typeof X>` checks the `value` literals structurally, so no export needed.
+
+### route-private (#363)
+All `routes/*.-components/*` leaves covered (dashboard 16, settings 11, the three
+remaining `domains.$id.edit`, routines-edit 5, routines.$id 2, routines.tracker 1,
+topics.$id.edit 1). The issue's per-folder counts were a stale snapshot —
+`domains.$id.edit` was already 8/11 stored, so re-inventory before starting. New
+fixtures: **`dashboardFixtures.ts`** (`makeTile(tileId, overrides)` →
+`DashboardLayoutTile`), **`settingsFixtures.ts`** (`makeAppSettings`,
+`makeTaskType`, `makeCalendarFeed`, `makeLayout`), **`templatesFixtures.ts`**
+(`makeCriteriaTemplate` only — routine templates already live in
+`routinesFixtures.makeRoutineTemplate`; don't re-add). Key patterns:
+**Dashboard tiles** take `DashboardTileProps` (`tile` + `onUpdateTile`) but
+**self-fetch**, so they're Tier B not Tier A: nest `RouterStub > QueryStub` and
+seed each tile's key (`["domains"]`, `["resources"]`+`["dailies"]`, `["providers"]`,
+…) on a `staleTime: Infinity` client. **Integration tiles**
+(`-DashboardReadwise`/`-DashboardTodoist`/`-DashboardGoogleCalendar`) cover both
+branches without fabricating full API payloads: seed `{ configured: false, …[] }`
+for the connect-prompt and `{ configured: true, …[] }` for the configured-empty
+state — `setQueryData` on an untyped/`as const` key takes a plain object, so no
+payload-type import. `-DashboardChangelog` is pure render-only (build-time
+`@root/CHANGELOG.md`, no decorators). **`-DashboardDailiesBody`** and
+**`-TrackerTables`** take a whole hook-return bundle (`DashboardDailiesData` /
+`RoutineTrackerState`): build it inline and cast `as unknown as <T>`, stubbing
+`mutation` as `{ isPending: false, mutate: fn() }`. **Route-shell-like leaves**
+(`-ExistingDomainEditor`, `-TopicForm`) are storied by seeding their `useEditFormPage`
++ list queries plus a loading/unseeded variant — `useEditFormPage`'s detail query
+is `enabled: !isNew`, so the `isNew`/New story skips the detail seed.
+`-ThemeSection` needs `ThemeProvider` (`@/context/ThemeProvider`). `useSettings`
+needs `SettingsProvider` but never fetches (local state), so no seeding. Watch
+ambiguous `getByText`: "Weekly Schedule" (Type-tile value **and** schedule header)
+and "Cost per Unit" (card title **and** column header) both match twice — assert on
+a unique `role`/`tab`/count signal instead.

--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -6,22 +6,23 @@ description: >-
   extracting logic-heavy hooks — without changing behavior. Use when asked to
   "reduce imports", "fix max-dependencies", "too many imports/dependencies in
   this file", or to resolve an issue under the import/max-dependencies cleanup
-  tracker (#312).
+  tracker.
 ---
 
 # Reduce imports (course-tracker)
 
 `pnpm lint` warns on `import/max-dependencies` for many files in
-`packages/client`. The cleanup is tracked in **#312**, split into per-area
-issues (dailies, resources, routines, routes, …). This skill is the repeatable
-procedure for one such area. Quality only — behavior must not change. For
-behavior cleanups use `/simplify`; for bugs use `/code-review`.
+`packages/client`. The cleanup is tracked in an **import/max-dependencies
+cleanup tracker** issue, split into per-area issues (dailies, resources,
+routines, routes, …). This skill is the repeatable procedure for one such area.
+Quality only — behavior must not change. For behavior cleanups use `/simplify`;
+for bugs use `/code-review`.
 
 > _Hooks, files, and components named below (e.g. `useResourceModules`,
 > `DailyRecentDaysStrip`) are illustrations — they show the **shape** of a fix,
-> not required targets. Apply the method to whatever's in your scope; the
-> **Area notes** and **Learnings** sections are per-issue worked examples, not
-> core procedure._
+> not required targets. Apply the method to whatever's in your scope. Per-area
+> worked examples and learnings live in `references/area-notes.md` — illustrative
+> reference, not core procedure._
 
 ## How the rule actually counts (read this first)
 
@@ -124,98 +125,5 @@ problem. If you must scope it, add `--rule '{"better-tailwindcss/no-unknown-clas
 Commit with a `refactor(<scope>):` Conventional Commit (e.g.
 `refactor(client): reduce imports in dailies components`). Splitting the
 sub-barrel extraction and the hook extraction into separate commits reads
-better.
-
-## Area notes: app shell & quick-add dialogs (#311)
-
-_Per-issue worked examples — what a real pass turned up. Illustrative reference,
-not steps to follow; the same goes for the Learnings section below._
-
-Worked counts (non-type value imports): `routes/__root.tsx` = **12** (shed 2);
-`components/quickAdd/QuickAddRoutineDialog.tsx` = **11** (shed 1);
-`QuickAddTodoistDialog.tsx` = **11** (shed 1). Both dialogs cleared the line via
-Strategy 2 (a per-dialog bundled hook); `__root` used Strategy 1 (a folder
-barrel) **plus** Strategy 2 (a query hook).
-
-### `queryKeys` is NOT in the `@/utils` barrel
-`@/utils/queryKeys` is imported as its own line everywhere — it is deliberately
-**not** re-exported from `utils/index.ts`. So `@/utils` + `@/utils/queryKeys` are
-always two distinct sources you can't merge. The only way to drop the
-`queryKeys` line from a component is to move the query/mutation logic that uses
-it into a hook (Strategy 2). Don't try to "fix" this by adding it to the barrel —
-that bloats the barrel's own dep count and fights the convention.
-
-### Preserve query keys verbatim when extracting a query hook
-Keys in this repo are inconsistent by accretion — some use the factory
-(`queryKeys.resources.list()`), some are inline arrays (`["topics"]`,
-`["providers"]`, `["domains"]`). When you lift `useQuery` calls into a hook
-(e.g. `useShowOnboard` pulling the four onboarding fetches out of `__root`),
-**copy each key exactly as-is**. "Tidying" an inline array into a factory call
-while extracting silently breaks invalidation elsewhere that still uses the old
-key. Behavior-preserving means key-preserving.
-
-### Per-dialog bundled hook — the big collapse
-A quick-add dialog drags in `react` (`useState`/`useEffect`) +
-`@tanstack/react-query` (`useMutation`/`useQuery`/`useQueryClient`) +
-`@tanstack/react-router` (`useNavigate`) + `sonner` + `@/utils` (the create fn) +
-`@/utils/queryKeys` — **six** sources — purely to run one form+mutation. Fold all
-of it into one `use…` hook returning a presentational-ready object
-(`{ name, setName, mode, setMode, handleSubmit, isPending, canSubmit }`, with
-`handleSubmit` owning `preventDefault` + trim-guard + `mutate`). The component is
-left importing only render deps (a `lucide` icon, the form primitives,
-`ui/button`, `ui/dialog`, the hook — and a `<Link>` if the JSX still navigates).
-
-- **Placement:** the established home is `src/hooks/` (matches `useResourceModules`,
-  `useDailyTracker`). A hook used by exactly one dialog may co-locate next to it
-  (`components/quickAdd/useQuickAddRoutine.ts`) and stay **out** of the feature
-  barrel — it's internal, not public surface. Either is fine; default to
-  `src/hooks/` unless the hook is single-consumer and feature-private.
-- `react`/`useState` only leaves the component if **all** its uses leave. In
-  `__root` the `activeQuickAdd` state stays, so `react` stays — don't count it as
-  shed.
-
-### Folder barrel where none exists yet (Strategy 1, app-shell flavor)
-`__root` imported two nav primitives by full path
-(`@/components/layout/DropdownNavItem`, `…/NavDropdown`). There was no
-`components/layout/index.ts`, so creating a cohesive one (export just the nav
-set, not all ~13 layout files) merged them to a single `@/components/layout`
-import. A barrel only pays off at ≥2 sources sharing a folder; re-exporting one
-component buys nothing.
-
-## Learnings: route layout + sections (settings, #308)
-
-- **A route layout that renders N route-private sections → barrel the folder.**
-  `foo.tsx` importing 10 `<XSection/>` from `foo.-components/-XSection.tsx`
-  collapses to one import via a `foo.-components/index.ts` that
-  `export { XSection } from "./-XSection"` for each. The un-prefixed `index.ts`
-  is **router-safe** — the `.-` on the *folder* already excludes the whole
-  directory from routing, so the barrel never becomes a route. Confirm with
-  `pnpm --filter=@emstack/client run routeTree` (expect no diff). Generalizes
-  #337's `dashboard.-components/index.ts`. Keep it cohesive: re-export just the
-  route's own sections (stops at exactly the section count — no disable needed)
-  rather than also folding in `@/components/*` chrome, which would push the
-  barrel over 10 and force a scoped disable on it.
-
-- **Colocate a route-private hook as `-use*.ts` inside the `.-components/`
-  folder**, not `src/hooks/`, when only that route uses it (precedent:
-  `dashboard.-components/-useDashboardDailies.ts`). Reserve `src/hooks/` for
-  genuinely cross-route hooks (`useResourceModules`, `useEditFormPage`).
-
-- **When extracting a hook, move the UI state its mutations reset.** Mutation
-  `onSuccess` commonly calls component `setState` (close a dialog, clear a
-  `*TargetId`/`creatingKind`). Move that state **into the hook** alongside the
-  mutations and return `open*/close*/submit*` handlers plus `is*Pending` flags —
-  otherwise the hook can't reset it and you'd have to thread setters back in.
-  (`-useDashboardLayouts` owns its dialog-target + `creatingKind` state for
-  exactly this reason.)
-
-- **One hook can serve a parent + child split.** A section that's a thin
-  fetch-wrapper around a form child: call the data/mutation hook once in the
-  parent and pass the mutation **down as a prop**, rather than re-calling the
-  hook (and re-importing react-query/utils) inside the child. (`FocusedDomains`:
-  `useFocusedDomains()` in the section, `saveMutation` passed to the form.)
-
-- **`lucide-react` is already one dependency** — multiple icons from it are one
-  import line, so "consolidate the icons" advice is a no-op for the count. Look
-  for whole *modules* to shed (react-query, sonner, `@/utils/api`,
-  `@/utils/queryKeys`), which a hook absorbs in one move.
+better. Check off the area's issue under the cleanup tracker and record anything
+learned in `references/area-notes.md`.

--- a/.claude/skills/reduce-imports/references/area-notes.md
+++ b/.claude/skills/reduce-imports/references/area-notes.md
@@ -1,0 +1,100 @@
+# reduce-imports — area notes
+
+Per-issue worked examples and learnings for the [`reduce-imports`](../SKILL.md)
+skill — what real passes turned up. **Illustrative reference, not steps to follow;**
+the core procedure lives in `SKILL.md`.
+
+The `#N` headings below are this repo's import/max-dependencies cleanup tracker
+sub-issues — this is the per-tracker scratchpad, so issue numbers are expected
+here. Add an entry when you finish an area.
+
+## App shell & quick-add dialogs (#311)
+
+Worked counts (non-type value imports): `routes/__root.tsx` = **12** (shed 2);
+`components/quickAdd/QuickAddRoutineDialog.tsx` = **11** (shed 1);
+`QuickAddTodoistDialog.tsx` = **11** (shed 1). Both dialogs cleared the line via
+Strategy 2 (a per-dialog bundled hook); `__root` used Strategy 1 (a folder
+barrel) **plus** Strategy 2 (a query hook).
+
+### `queryKeys` is NOT in the `@/utils` barrel
+`@/utils/queryKeys` is imported as its own line everywhere — it is deliberately
+**not** re-exported from `utils/index.ts`. So `@/utils` + `@/utils/queryKeys` are
+always two distinct sources you can't merge. The only way to drop the
+`queryKeys` line from a component is to move the query/mutation logic that uses
+it into a hook (Strategy 2). Don't try to "fix" this by adding it to the barrel —
+that bloats the barrel's own dep count and fights the convention.
+
+### Preserve query keys verbatim when extracting a query hook
+Keys in this repo are inconsistent by accretion — some use the factory
+(`queryKeys.resources.list()`), some are inline arrays (`["topics"]`,
+`["providers"]`, `["domains"]`). When you lift `useQuery` calls into a hook
+(e.g. `useShowOnboard` pulling the four onboarding fetches out of `__root`),
+**copy each key exactly as-is**. "Tidying" an inline array into a factory call
+while extracting silently breaks invalidation elsewhere that still uses the old
+key. Behavior-preserving means key-preserving.
+
+### Per-dialog bundled hook — the big collapse
+A quick-add dialog drags in `react` (`useState`/`useEffect`) +
+`@tanstack/react-query` (`useMutation`/`useQuery`/`useQueryClient`) +
+`@tanstack/react-router` (`useNavigate`) + `sonner` + `@/utils` (the create fn) +
+`@/utils/queryKeys` — **six** sources — purely to run one form+mutation. Fold all
+of it into one `use…` hook returning a presentational-ready object
+(`{ name, setName, mode, setMode, handleSubmit, isPending, canSubmit }`, with
+`handleSubmit` owning `preventDefault` + trim-guard + `mutate`). The component is
+left importing only render deps (a `lucide` icon, the form primitives,
+`ui/button`, `ui/dialog`, the hook — and a `<Link>` if the JSX still navigates).
+
+- **Placement:** the established home is `src/hooks/` (matches `useResourceModules`,
+  `useDailyTracker`). A hook used by exactly one dialog may co-locate next to it
+  (`components/quickAdd/useQuickAddRoutine.ts`) and stay **out** of the feature
+  barrel — it's internal, not public surface. Either is fine; default to
+  `src/hooks/` unless the hook is single-consumer and feature-private.
+- `react`/`useState` only leaves the component if **all** its uses leave. In
+  `__root` the `activeQuickAdd` state stays, so `react` stays — don't count it as
+  shed.
+
+### Folder barrel where none exists yet (Strategy 1, app-shell flavor)
+`__root` imported two nav primitives by full path
+(`@/components/layout/DropdownNavItem`, `…/NavDropdown`). There was no
+`components/layout/index.ts`, so creating a cohesive one (export just the nav
+set, not all ~13 layout files) merged them to a single `@/components/layout`
+import. A barrel only pays off at ≥2 sources sharing a folder; re-exporting one
+component buys nothing.
+
+## Route layout + sections (settings, #308)
+
+- **A route layout that renders N route-private sections → barrel the folder.**
+  `foo.tsx` importing 10 `<XSection/>` from `foo.-components/-XSection.tsx`
+  collapses to one import via a `foo.-components/index.ts` that
+  `export { XSection } from "./-XSection"` for each. The un-prefixed `index.ts`
+  is **router-safe** — the `.-` on the *folder* already excludes the whole
+  directory from routing, so the barrel never becomes a route. Confirm with
+  `pnpm --filter=@emstack/client run routeTree` (expect no diff). Generalizes
+  #337's `dashboard.-components/index.ts`. Keep it cohesive: re-export just the
+  route's own sections (stops at exactly the section count — no disable needed)
+  rather than also folding in `@/components/*` chrome, which would push the
+  barrel over 10 and force a scoped disable on it.
+
+- **Colocate a route-private hook as `-use*.ts` inside the `.-components/`
+  folder**, not `src/hooks/`, when only that route uses it (precedent:
+  `dashboard.-components/-useDashboardDailies.ts`). Reserve `src/hooks/` for
+  genuinely cross-route hooks (`useResourceModules`, `useEditFormPage`).
+
+- **When extracting a hook, move the UI state its mutations reset.** Mutation
+  `onSuccess` commonly calls component `setState` (close a dialog, clear a
+  `*TargetId`/`creatingKind`). Move that state **into the hook** alongside the
+  mutations and return `open*/close*/submit*` handlers plus `is*Pending` flags —
+  otherwise the hook can't reset it and you'd have to thread setters back in.
+  (`-useDashboardLayouts` owns its dialog-target + `creatingKind` state for
+  exactly this reason.)
+
+- **One hook can serve a parent + child split.** A section that's a thin
+  fetch-wrapper around a form child: call the data/mutation hook once in the
+  parent and pass the mutation **down as a prop**, rather than re-calling the
+  hook (and re-importing react-query/utils) inside the child. (`FocusedDomains`:
+  `useFocusedDomains()` in the section, `saveMutation` passed to the form.)
+
+- **`lucide-react` is already one dependency** — multiple icons from it are one
+  import line, so "consolidate the icons" advice is a no-op for the count. Look
+  for whole *modules* to shed (react-query, sonner, `@/utils/api`,
+  `@/utils/queryKeys`), which a hook absorbs in one move.


### PR DESCRIPTION
## Summary

Extracted per-issue worked examples and learnings from the `add-stories` and `reduce-imports` skill documentation into dedicated `references/area-notes.md` files. This keeps the core procedure in `SKILL.md` focused and moves illustrative examples to a separate scratchpad that's easier to maintain and extend.

## Changes

- **`add-stories/SKILL.md`**: Removed the "Area notes" section (146 lines of per-issue worked examples) and updated references to point to the new `references/area-notes.md` file. Updated the introductory note to clarify that per-area examples live in the reference file, not in the core procedure.

- **`add-stories/references/area-notes.md`** (new): Created a dedicated reference file containing all 7 area notes (#352–#363) with the same content, plus a header explaining this is the per-tracker scratchpad for illustrative examples.

- **`reduce-imports/SKILL.md`**: Removed the "Area notes" and "Learnings" sections (98 lines) and updated references to point to `references/area-notes.md`. Updated the introductory note to clarify that per-area examples and learnings live in the reference file.

- **`reduce-imports/references/area-notes.md`** (new): Created a dedicated reference file containing the two area notes (#311, #308) and learnings with the same content, plus a header explaining this is the per-tracker scratchpad.

## Rationale

This reorganization:
- Keeps `SKILL.md` focused on the **core repeatable procedure** (steps 1–5, gotchas)
- Moves **illustrative examples** to a dedicated scratchpad that's easier to append to as new areas are completed
- Makes it clear that area notes are **reference material, not required steps**
- Aligns with the pattern already established in the codebase (e.g., `dashboard.-components/` structure)
- Improves discoverability: users looking for "what did the last person learn?" now have a dedicated file

No behavior or procedure changes — purely organizational.

https://claude.ai/code/session_01AYnWGgY3jL3gANVQjNXgLh