### PR TITLE
refactor(client): fold Rename/Duplicate items into LayoutMenuActions

### DIFF
--- a/packages/client/src/components/LayoutMenuActions.tsx
+++ b/packages/client/src/components/LayoutMenuActions.tsx
@@ -1,6 +1,6 @@
 import type { DashboardLayout } from "@emstack/types";
 
-import { BookmarkIcon, Trash2Icon } from "lucide-react";
+import { BookmarkIcon, CopyIcon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import {
   DropdownMenuItem,
@@ -9,6 +9,8 @@ import {
 
 interface LayoutMenuActionsProps {
   layout: DashboardLayout;
+  onRename: (layout: DashboardLayout) => void;
+  onDuplicate: (layout: DashboardLayout) => void;
   onSaveAs: (layout: DashboardLayout) => void;
   onDelete: (layout: DashboardLayout) => void;
   saveAsLabel: string;
@@ -17,13 +19,17 @@ interface LayoutMenuActionsProps {
 }
 
 /**
- * Shared footer for a layout's dropdown menu: the "Save as…" action, a
- * separator, and the destructive "Delete" action. Render inside a
- * DropdownMenuContent. Used by the dashboard tab menu and the settings
- * layouts/presets list so the two stay in sync.
+ * Shared body for a layout's dropdown menu: a leading separator, the Rename
+ * and Duplicate actions, the "Save as…" action, a separator, and the
+ * destructive "Delete" action. Render inside a DropdownMenuContent after any
+ * caller-specific items (e.g. the dashboard tab's "Visible tiles…"). Used by
+ * the dashboard tab menu and the settings layouts/presets list so the two
+ * stay in sync.
  */
 export function LayoutMenuActions({
   layout,
+  onRename,
+  onDuplicate,
   onSaveAs,
   onDelete,
   saveAsLabel,
@@ -31,6 +37,15 @@ export function LayoutMenuActions({
 }: LayoutMenuActionsProps) {
   return (
     <>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem onSelect={() => onRename(layout)}>
+        <PencilIcon />
+        Rename
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={() => onDuplicate(layout)}>
+        <CopyIcon />
+        Duplicate
+      </DropdownMenuItem>
       {showSaveAs && (
         <DropdownMenuItem onSelect={() => onSaveAs(layout)}>
           <BookmarkIcon />

--- a/packages/client/src/routes/dashboard.-components/-LayoutTab.tsx
+++ b/packages/client/src/routes/dashboard.-components/-LayoutTab.tsx
@@ -1,18 +1,12 @@
 import type { DashboardLayout } from "@emstack/types";
 
-import {
-  CopyIcon,
-  LayoutGridIcon,
-  MoreHorizontalIcon,
-  PencilIcon,
-} from "lucide-react";
+import { LayoutGridIcon, MoreHorizontalIcon } from "lucide-react";
 
 import { LayoutMenuActions } from "@/components/LayoutMenuActions";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { TabsTrigger } from "@/components/ui/tabs";
@@ -70,17 +64,10 @@ export function LayoutTab({
             <LayoutGridIcon />
             Visible tiles…
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => onRename(layout)}>
-            <PencilIcon />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onDuplicate(layout)}>
-            <CopyIcon />
-            Duplicate
-          </DropdownMenuItem>
           <LayoutMenuActions
             layout={layout}
+            onRename={onRename}
+            onDuplicate={onDuplicate}
             onSaveAs={onSaveAs}
             onDelete={onDelete}
             saveAsLabel="Save as layout…"

--- a/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
+++ b/packages/client/src/routes/settings.-components/-DashboardLayoutsSection.tsx
@@ -1,12 +1,6 @@
 import type { DashboardLayout, DashboardTileId } from "@emstack/types";
 
-import {
-  BookmarkIcon,
-  CopyIcon,
-  MoreHorizontalIcon,
-  PencilIcon,
-  PlusIcon,
-} from "lucide-react";
+import { BookmarkIcon, MoreHorizontalIcon, PlusIcon } from "lucide-react";
 
 import { useDashboardLayouts } from "./-useDashboardLayouts";
 
@@ -18,7 +12,6 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -76,17 +69,10 @@ function LayoutRow({
               {title}
             </DropdownMenuCheckboxItem>
           ))}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => onRename(layout)}>
-            <PencilIcon />
-            Rename
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onDuplicate(layout)}>
-            <CopyIcon />
-            Duplicate
-          </DropdownMenuItem>
           <LayoutMenuActions
             layout={layout}
+            onRename={onRename}
+            onDuplicate={onDuplicate}
             onSaveAs={onSaveAs}
             onDelete={onDelete}
             saveAsLabel="Save as preset…"


### PR DESCRIPTION
Both layout dropdown menus hand-rolled the same leading-separator +
Rename + Duplicate block before LayoutMenuActions (flagged as
dup:9aa019f0). Move those into LayoutMenuActions via new onRename/
onDuplicate props so it renders the full Rename -> Duplicate -> Save-as
-> Delete body, and drop the duplicated block from both callers.

Closes #444