### PR TITLE
refactor(client): dedupe dashboard integration-tile story shells

### DIFF
--- a/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardGoogleCalendar.stories.tsx
@@ -1,47 +1,22 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-
-import { fn } from "storybook/test";
-
 import { DashboardGoogleCalendar } from "./-DashboardGoogleCalendar";
 
-import { makeTile } from "@/test-utils/dashboardFixtures";
-import { seededQueryClient } from "@/test-utils/seededQueryClient";
-import { queryStoryDecorator } from "@/test-utils/storyDecorators";
-import { smokeText } from "@/test-utils/storyPlay";
+import { integrationTileStories } from "@/test-utils/integrationTileStories";
 import { queryKeys } from "@/utils/queryKeys";
 
-function clientWith(configured: boolean) {
-  return seededQueryClient([
-    [
-      queryKeys.googleCalendar.events(),
-      {
-        configured,
-        events: [],
-      },
-    ],
-  ]);
-}
-
-const meta: Meta<typeof DashboardGoogleCalendar> = {
+const stories = integrationTileStories({
   component: DashboardGoogleCalendar,
-  args: {
-    tile: makeTile("googleCalendar"),
-    onUpdateTile: fn(),
+  tileId: "googleCalendar",
+  queryKey: queryKeys.googleCalendar.events(),
+  emptyData: {
+    events: [],
   },
-  decorators: [queryStoryDecorator(clientWith(false))],
+  connectText: /add a calendar feed/i,
+  emptyText: /no upcoming events/i,
+});
+
+// Spread so the default export stays a literal object the CSF indexer can read.
+export default {
+  ...stories.meta,
 };
-
-export default meta;
-
-type Story = StoryObj<typeof meta>;
-
-// No feed subscribed: the card prompts the user to add one.
-export const ConnectPrompt: Story = {
-  play: smokeText(/add a calendar feed/i),
-};
-
-// Connected with no upcoming events shows the empty state.
-export const ConfiguredEmpty: Story = {
-  decorators: [queryStoryDecorator(clientWith(true))],
-  play: smokeText(/no upcoming events/i),
-};
+export const ConnectPrompt = stories.ConnectPrompt;
+export const ConfiguredEmpty = stories.ConfiguredEmpty;

--- a/packages/client/src/routes/dashboard.-components/-DashboardReadwise.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardReadwise.stories.tsx
@@ -1,48 +1,23 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-
-import { fn } from "storybook/test";
-
 import { DashboardReadwise } from "./-DashboardReadwise";
 
-import { makeTile } from "@/test-utils/dashboardFixtures";
-import { seededQueryClient } from "@/test-utils/seededQueryClient";
-import { queryStoryDecorator } from "@/test-utils/storyDecorators";
-import { smokeText } from "@/test-utils/storyPlay";
+import { integrationTileStories } from "@/test-utils/integrationTileStories";
 import { queryKeys } from "@/utils/queryKeys";
 
-function clientWith(configured: boolean) {
-  return seededQueryClient([
-    [
-      queryKeys.readwise.readingList(),
-      {
-        configured,
-        started: [],
-        unstarted: [],
-      },
-    ],
-  ]);
-}
-
-const meta: Meta<typeof DashboardReadwise> = {
+const stories = integrationTileStories({
   component: DashboardReadwise,
-  args: {
-    tile: makeTile("readwise"),
-    onUpdateTile: fn(),
+  tileId: "readwise",
+  queryKey: queryKeys.readwise.readingList(),
+  emptyData: {
+    started: [],
+    unstarted: [],
   },
-  decorators: [queryStoryDecorator(clientWith(false))],
+  connectText: /add your readwise api key/i,
+  emptyText: /no articles in progress/i,
+});
+
+// Spread so the default export stays a literal object the CSF indexer can read.
+export default {
+  ...stories.meta,
 };
-
-export default meta;
-
-type Story = StoryObj<typeof meta>;
-
-// Not connected: the card prompts the user to add an API key.
-export const ConnectPrompt: Story = {
-  play: smokeText(/add your readwise api key/i),
-};
-
-// Connected but with no articles yet shows the empty in-progress state.
-export const ConfiguredEmpty: Story = {
-  decorators: [queryStoryDecorator(clientWith(true))],
-  play: smokeText(/no articles in progress/i),
-};
+export const ConnectPrompt = stories.ConnectPrompt;
+export const ConfiguredEmpty = stories.ConfiguredEmpty;

--- a/packages/client/src/routes/dashboard.-components/-DashboardTodoist.stories.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardTodoist.stories.tsx
@@ -1,48 +1,23 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-
-import { fn } from "storybook/test";
-
 import { DashboardTodoist } from "./-DashboardTodoist";
 
-import { makeTile } from "@/test-utils/dashboardFixtures";
-import { seededQueryClient } from "@/test-utils/seededQueryClient";
-import { queryStoryDecorator } from "@/test-utils/storyDecorators";
-import { smokeText } from "@/test-utils/storyPlay";
+import { integrationTileStories } from "@/test-utils/integrationTileStories";
 import { queryKeys } from "@/utils/queryKeys";
 
-function clientWith(configured: boolean) {
-  return seededQueryClient([
-    [
-      queryKeys.todoist.tasks(),
-      {
-        configured,
-        overdue: [],
-        today: [],
-      },
-    ],
-  ]);
-}
-
-const meta: Meta<typeof DashboardTodoist> = {
+const stories = integrationTileStories({
   component: DashboardTodoist,
-  args: {
-    tile: makeTile("todoist"),
-    onUpdateTile: fn(),
+  tileId: "todoist",
+  queryKey: queryKeys.todoist.tasks(),
+  emptyData: {
+    overdue: [],
+    today: [],
   },
-  decorators: [queryStoryDecorator(clientWith(false))],
+  connectText: /add your todoist api key/i,
+  emptyText: /nothing due today/i,
+});
+
+// Spread so the default export stays a literal object the CSF indexer can read.
+export default {
+  ...stories.meta,
 };
-
-export default meta;
-
-type Story = StoryObj<typeof meta>;
-
-// Not connected: the card prompts the user to add an API key.
-export const ConnectPrompt: Story = {
-  play: smokeText(/add your todoist api key/i),
-};
-
-// Connected with nothing due shows the celebratory empty state.
-export const ConfiguredEmpty: Story = {
-  decorators: [queryStoryDecorator(clientWith(true))],
-  play: smokeText(/nothing due today/i),
-};
+export const ConnectPrompt = stories.ConnectPrompt;
+export const ConfiguredEmpty = stories.ConfiguredEmpty;

--- a/packages/client/src/test-utils/integrationTileStories.ts
+++ b/packages/client/src/test-utils/integrationTileStories.ts
@@ -1,0 +1,85 @@
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
+import type { DashboardTileId } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { QueryKey } from "@tanstack/react-query";
+import type { ComponentType } from "react";
+
+import { fn } from "storybook/test";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+import { seededQueryClient } from "@/test-utils/seededQueryClient";
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokeText } from "@/test-utils/storyPlay";
+
+/** A dashboard integration tile renders the shared `DashboardTileProps` card. */
+type IntegrationTile = ComponentType<DashboardTileProps>;
+
+interface IntegrationTileStoriesConfig {
+  /** The integration tile component under story. */
+  component: IntegrationTile;
+  /** Tile id passed to `makeTile` for the story args. */
+  tileId: DashboardTileId;
+  /** Query key the tile reads — seeded with `{ configured, ...emptyData }`. */
+  queryKey: QueryKey;
+  /** Empty collections the tile reads besides `configured` (e.g. `{ events: [] }`). */
+  emptyData?: Record<string, unknown>;
+  /** Copy asserted by the not-configured connect prompt. */
+  connectText: string | RegExp;
+  /** Copy asserted by the configured-but-empty state. */
+  emptyText: string | RegExp;
+}
+
+interface IntegrationTileStories {
+  meta: Meta<IntegrationTile>;
+  ConnectPrompt: StoryObj<IntegrationTile>;
+  ConfiguredEmpty: StoryObj<IntegrationTile>;
+}
+
+/**
+ * Builds the shared Storybook shell for a dashboard integration tile. The three
+ * integration tiles (Google Calendar, Readwise, Todoist) all render the same
+ * not-configured `ConnectPrompt` and configured-but-empty `ConfiguredEmpty` pair
+ * off a single seeded query — only the component, tile id, query key/shape, and
+ * smoke-text copy differ. This returns their identical `meta` + `ConnectPrompt` +
+ * `ConfiguredEmpty` stories so each `*.stories.tsx` only declares those specifics.
+ * Built on the shared `seededQueryClient` / `queryStoryDecorator` / `smokeText`
+ * fixtures (see #410) rather than re-inventing the seeded QueryClient.
+ *
+ * Spread the returned `meta` into the file's default export
+ * (`export default { ...stories.meta }`) so the Storybook CSF indexer still sees
+ * a literal object, and re-export `ConnectPrompt` / `ConfiguredEmpty` directly.
+ */
+export function integrationTileStories({
+  component,
+  tileId,
+  queryKey,
+  emptyData = {},
+  connectText,
+  emptyText,
+}: IntegrationTileStoriesConfig): IntegrationTileStories {
+  const clientWith = (configured: boolean) =>
+    seededQueryClient([[queryKey, {
+      configured,
+      ...emptyData,
+    }]]);
+
+  return {
+    meta: {
+      component,
+      args: {
+        tile: makeTile(tileId),
+        onUpdateTile: fn(),
+      },
+      decorators: [queryStoryDecorator(clientWith(false))],
+    },
+    // Not configured: the card prompts the user to connect the integration.
+    ConnectPrompt: {
+      play: smokeText(connectText),
+    },
+    // Configured but with no data shows the empty state.
+    ConfiguredEmpty: {
+      decorators: [queryStoryDecorator(clientWith(true))],
+      play: smokeText(emptyText),
+    },
+  };
+}


### PR DESCRIPTION
The three integration tiles (Google Calendar, Readwise, Todoist) shared an
identical meta + ConnectPrompt + ConfiguredEmpty story shell off a single
seeded query — only the component, tile id, query key/shape, and smoke-text
copy differed (fallow dup:14b4f737, 20 lines × 3).

Extract a shared `integrationTileStories({ component, tileId, queryKey,
emptyData, connectText, emptyText })` helper in test-utils that returns the
meta + both stories, built on the existing seededQueryClient /
queryStoryDecorator / smokeText fixtures. Each story file now just declares
its specifics and spreads the returned meta into its default export (kept a
literal object so the Storybook CSF indexer still reads it).

Closes #445