### PR TITLE
refactor(client): decompose filterAndSortBlips into filter/sort helpers

### DIFF
--- a/packages/client/src/components/radar/blipTableFilters.test.ts
+++ b/packages/client/src/components/radar/blipTableFilters.test.ts
@@ -6,8 +6,11 @@ import type { BlipFilterCriteria, BlipFilterLookups } from "./blipTableFilters";
 
 import {
   ALL,
+  blipSortValue,
   countByField,
   filterAndSortBlips,
+  filterBlips,
+  sortBlips,
   UNASSIGNED,
 } from "./blipTableFilters";
 
@@ -460,6 +463,111 @@ describe("filterAndSortBlips topic-name tiebreak", () => {
       makeLookups(),
     );
     expect(ids(result)).toEqual(["b", "c", "a"]);
+  });
+});
+
+describe("filterBlips (standalone, no sorting)", () => {
+  const blips = [
+    makeBlip({
+      id: "a",
+      quadrantId: "q1",
+      ringId: "r1",
+    }),
+    makeBlip({
+      id: "b",
+      quadrantId: null,
+      ringId: "r2",
+    }),
+  ];
+
+  test("filters without reordering or copying when nothing matches out", () => {
+    const result = filterBlips(blips, makeCriteria());
+    expect(ids(result)).toEqual(["a", "b"]);
+  });
+
+  test("applies the unassigned-quadrant branch", () => {
+    const result = filterBlips(
+      blips,
+      makeCriteria({
+        filterQuadrant: UNASSIGNED,
+      }),
+    );
+    expect(ids(result)).toEqual(["b"]);
+  });
+
+  test("applies a specific-ring branch", () => {
+    const result = filterBlips(
+      blips,
+      makeCriteria({
+        filterRing: "r1",
+      }),
+    );
+    expect(ids(result)).toEqual(["a"]);
+  });
+});
+
+describe("blipSortValue", () => {
+  const lookups = makeLookups({
+    "topic-x": 5,
+  });
+  const blip = makeBlip({
+    id: "x",
+    topicName: "Xylophone",
+    quadrantId: "q2",
+    ringId: "r2",
+    topicId: "topic-x",
+  });
+
+  test("returns the lowercased topic name for the topic key", () => {
+    expect(blipSortValue(blip, "topic", lookups)).toBe("xylophone");
+  });
+
+  test("returns the quadrant position for the slice key", () => {
+    expect(blipSortValue(blip, "slice", lookups)).toBe(1);
+  });
+
+  test("returns the ring position for the ring key", () => {
+    expect(blipSortValue(blip, "ring", lookups)).toBe(1);
+  });
+
+  test("returns the topic item count for the items key", () => {
+    expect(blipSortValue(blip, "items", lookups)).toBe(5);
+  });
+
+  test("falls back to MAX_SAFE_INTEGER for an unassigned slice", () => {
+    const unassigned = makeBlip({
+      id: "u",
+      quadrantId: null,
+    });
+    expect(blipSortValue(unassigned, "slice", lookups)).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+});
+
+describe("sortBlips (standalone, no filtering)", () => {
+  const blips = [
+    makeBlip({
+      id: "a",
+      topicName: "Charlie",
+    }),
+    makeBlip({
+      id: "b",
+      topicName: "Alpha",
+    }),
+  ];
+
+  test("orders by topic name ascending and copies the input", () => {
+    const result = sortBlips(
+      blips,
+      makeCriteria({
+        sortKey: "topic",
+        sortDir: "asc",
+      }),
+      makeLookups(),
+    );
+    expect(ids(result)).toEqual(["b", "a"]);
+    expect(result).not.toBe(blips);
   });
 });
 

--- a/packages/client/src/components/radar/blipTableFilters.ts
+++ b/packages/client/src/components/radar/blipTableFilters.ts
@@ -26,31 +26,26 @@ export interface BlipFilterLookups {
   topicItemCount: (topicId: string) => number;
 }
 
-export function filterAndSortBlips(
+function matchesFieldFilter(
+  value: string | null,
+  filterValue: string,
+): boolean {
+  if (filterValue === UNASSIGNED) return value === null;
+  if (filterValue === ALL) return true;
+  return value === filterValue;
+}
+
+export function filterBlips(
   blips: RadarBlip[],
   criteria: BlipFilterCriteria,
-  lookups: BlipFilterLookups,
 ): RadarBlip[] {
   const {
-    search, filterQuadrant, filterRing, sortKey, sortDir,
+    search, filterQuadrant, filterRing,
   } = criteria;
-  const {
-    quadrantById, ringById, topicItemCount,
-  } = lookups;
   const query = search.trim().toLowerCase();
-  const filtered = blips.filter((b) => {
-    if (filterQuadrant === UNASSIGNED) {
-      if (b.quadrantId !== null) return false;
-    }
-    else if (filterQuadrant !== ALL && b.quadrantId !== filterQuadrant) {
-      return false;
-    }
-    if (filterRing === UNASSIGNED) {
-      if (b.ringId !== null) return false;
-    }
-    else if (filterRing !== ALL && b.ringId !== filterRing) {
-      return false;
-    }
+  return blips.filter((b) => {
+    if (!matchesFieldFilter(b.quadrantId, filterQuadrant)) return false;
+    if (!matchesFieldFilter(b.ringId, filterRing)) return false;
     if (query) {
       const topicName = b.topicName?.toLowerCase() ?? "";
       const note = b.description?.toLowerCase() ?? "";
@@ -60,39 +55,59 @@ export function filterAndSortBlips(
     }
     return true;
   });
+}
+
+function positionOf(
+  byId: Map<string, { position: number }>,
+  id: string | null,
+): number {
+  return byId.get(id ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
+}
+
+export function blipSortValue(
+  blip: RadarBlip,
+  sortKey: SortKey,
+  lookups: BlipFilterLookups,
+): number | string {
+  const {
+    quadrantById, ringById, topicItemCount,
+  } = lookups;
+  switch (sortKey) {
+    case "topic":
+      return (blip.topicName ?? "").toLowerCase();
+    case "slice":
+      return positionOf(quadrantById, blip.quadrantId);
+    case "items":
+      return topicItemCount(blip.topicId);
+    default:
+      return positionOf(ringById, blip.ringId);
+  }
+}
+
+export function sortBlips(
+  blips: RadarBlip[],
+  criteria: BlipFilterCriteria,
+  lookups: BlipFilterLookups,
+): RadarBlip[] {
+  const {
+    sortKey, sortDir,
+  } = criteria;
   const dir = sortDir === "asc" ? 1 : -1;
-  const sorted = filtered.slice().sort((a, b) => {
-    let av: number | string;
-    let bv: number | string;
-    if (sortKey === "topic") {
-      av = (a.topicName ?? "").toLowerCase();
-      bv = (b.topicName ?? "").toLowerCase();
-    }
-    else if (sortKey === "slice") {
-      av
-        = quadrantById.get(a.quadrantId ?? "")?.position
-          ?? Number.MAX_SAFE_INTEGER;
-      bv
-        = quadrantById.get(b.quadrantId ?? "")?.position
-          ?? Number.MAX_SAFE_INTEGER;
-    }
-    else if (sortKey === "items") {
-      av = topicItemCount(a.topicId);
-      bv = topicItemCount(b.topicId);
-    }
-    else {
-      av = ringById.get(a.ringId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
-      bv = ringById.get(b.ringId ?? "")?.position ?? Number.MAX_SAFE_INTEGER;
-    }
-    if (av < bv) {
-      return -1 * dir;
-    }
-    if (av > bv) {
-      return 1 * dir;
-    }
+  return blips.slice().sort((a, b) => {
+    const av = blipSortValue(a, sortKey, lookups);
+    const bv = blipSortValue(b, sortKey, lookups);
+    if (av < bv) return -1 * dir;
+    if (av > bv) return 1 * dir;
     return (a.topicName ?? "").localeCompare(b.topicName ?? "");
   });
-  return sorted;
+}
+
+export function filterAndSortBlips(
+  blips: RadarBlip[],
+  criteria: BlipFilterCriteria,
+  lookups: BlipFilterLookups,
+): RadarBlip[] {
+  return sortBlips(filterBlips(blips, criteria), criteria, lookups);
 }
 
 export function countByField(


### PR DESCRIPTION
Split filterAndSortBlips into filterBlips and sortBlips, extract a
blipSortValue accessor and matchesFieldFilter/positionOf helpers, and
keep filterAndSortBlips as a thin composition so callers are unchanged.
Adds direct unit tests for the new helpers to clear the CRAP score.

Closes #455