### PR TITLE
test(client): cover uncovered utility functions

### DIFF
--- a/packages/client/src/components/resources/moduleDrafts.test.ts
+++ b/packages/client/src/components/resources/moduleDrafts.test.ts
@@ -1,8 +1,17 @@
-import type { Module } from "@emstack/types";
+import type { Module, ModuleGroup, TagGroup } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import { draftToLength, moduleToDraft, parseCount } from "./moduleDrafts";
+import {
+  draftToLength,
+  emptyGroupDraft,
+  emptyModuleDraft,
+  groupToDraft,
+  levelChipClass,
+  lookupTagsByIds,
+  moduleToDraft,
+  parseCount,
+} from "./moduleDrafts";
 
 const baseModule: Module = {
   id: "mod-1",
@@ -74,5 +83,145 @@ describe("parseCount", () => {
 
   test("a decimal is floored to an integer", () => {
     expect(parseCount("3.7")).toBe(3);
+  });
+});
+
+describe("emptyGroupDraft", () => {
+  test("creates a blank group draft with the new-id sentinel", () => {
+    const draft = emptyGroupDraft();
+    expect(draft.id).toBe("__new__");
+    expect(draft.name).toBe("");
+    expect(draft.totalCount).toBe("");
+    expect(draft.completedCount).toBe("");
+    expect(draft.easeOfStarting).toBe("");
+    expect(draft.tagIds).toEqual([]);
+  });
+});
+
+describe("groupToDraft", () => {
+  test("stringifies counts and carries levels and tag ids", () => {
+    const group: ModuleGroup = {
+      id: "g-1",
+      resourceId: "res-1",
+      name: "Group",
+      description: "desc",
+      url: "https://example.com",
+      totalCount: 10,
+      completedCount: 4,
+      easeOfStarting: "high",
+      timeNeeded: "medium",
+      interactivity: "low",
+      tags: [
+        {
+          id: "t-1",
+          groupId: "tg-1",
+          name: "Tag",
+        },
+      ],
+    };
+    expect(groupToDraft(group)).toEqual({
+      id: "g-1",
+      name: "Group",
+      description: "desc",
+      url: "https://example.com",
+      totalCount: "10",
+      completedCount: "4",
+      easeOfStarting: "high",
+      timeNeeded: "medium",
+      interactivity: "low",
+      tagIds: ["t-1"],
+    });
+  });
+
+  test("falls back to empty strings/arrays for absent fields", () => {
+    const group: ModuleGroup = {
+      id: "g-2",
+      resourceId: "res-1",
+      name: "Bare",
+    };
+    const draft = groupToDraft(group);
+    expect(draft.description).toBe("");
+    expect(draft.url).toBe("");
+    expect(draft.totalCount).toBe("");
+    expect(draft.completedCount).toBe("");
+    expect(draft.easeOfStarting).toBe("");
+    expect(draft.tagIds).toEqual([]);
+  });
+});
+
+describe("emptyModuleDraft", () => {
+  test("creates a blank module draft defaulting to minutes mode", () => {
+    const draft = emptyModuleDraft();
+    expect(draft.id).toBe("__new__");
+    expect(draft.durationMode).toBe("minutes");
+    expect(draft.minutesValue).toBe("");
+    expect(draft.bucketValue).toBe("");
+    expect(draft.tagIds).toEqual([]);
+  });
+});
+
+describe("levelChipClass", () => {
+  test("returns a distinct class per known level", () => {
+    expect(levelChipClass("low")).toContain("emerald");
+    expect(levelChipClass("medium")).toContain("amber");
+    expect(levelChipClass("high")).toContain("rose");
+  });
+
+  test("returns the muted fallback for an absent level", () => {
+    expect(levelChipClass(null)).toContain("muted");
+    expect(levelChipClass(undefined)).toContain("muted");
+  });
+});
+
+describe("lookupTagsByIds", () => {
+  const tagGroups: TagGroup[] = [
+    {
+      id: "tg-1",
+      name: "Group 1",
+      tags: [
+        {
+          id: "t-1",
+          groupId: "tg-1",
+          name: "One",
+        },
+        {
+          id: "t-2",
+          groupId: "tg-1",
+          name: "Two",
+        },
+      ],
+    },
+    {
+      id: "tg-2",
+      name: "Group 2",
+      tags: [
+        {
+          id: "t-3",
+          groupId: "tg-2",
+          name: "Three",
+        },
+      ],
+    },
+  ];
+
+  test("resolves ids to tags in request order across groups", () => {
+    expect(lookupTagsByIds(["t-3", "t-1"], tagGroups).map(t => t.name)).toEqual([
+      "Three",
+      "One",
+    ]);
+  });
+
+  test("silently drops unknown ids", () => {
+    expect(lookupTagsByIds(["t-1", "missing"], tagGroups).map(t => t.id)).toEqual(
+      ["t-1"],
+    );
+  });
+
+  test("handles groups with no tags and an empty id list", () => {
+    expect(lookupTagsByIds([], tagGroups)).toEqual([]);
+    expect(lookupTagsByIds(["t-1"], [{
+      id: "tg-3",
+      name: "Empty",
+    }])).toEqual([]);
   });
 });

--- a/packages/client/src/components/tasks/resourceMeta.test.ts
+++ b/packages/client/src/components/tasks/resourceMeta.test.ts
@@ -2,7 +2,12 @@ import type { Module, ModuleGroup, TaskResource } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import { inheritedLevel, linkedResourceLabel } from "./resourceMeta";
+import {
+  getResourceLevelClass,
+  getResourceLevelLabel,
+  inheritedLevel,
+  linkedResourceLabel,
+} from "./resourceMeta";
 
 function makeTaskResource(overrides: Partial<TaskResource> = {}): TaskResource {
   return {
@@ -213,5 +218,35 @@ describe("linkedResourceLabel", () => {
 
   test("returns null when the row is not linked", () => {
     expect(linkedResourceLabel(makeTaskResource())).toBeNull();
+  });
+});
+
+describe("getResourceLevelLabel", () => {
+  test("returns the human label for each level", () => {
+    expect(getResourceLevelLabel("low")).toBe("Low");
+    expect(getResourceLevelLabel("medium")).toBe("Medium");
+    expect(getResourceLevelLabel("high")).toBe("High");
+  });
+
+  test("returns an em dash for a missing level", () => {
+    expect(getResourceLevelLabel(null)).toBe("—");
+    expect(getResourceLevelLabel(undefined)).toBe("—");
+  });
+});
+
+describe("getResourceLevelClass", () => {
+  test("returns a distinct class string per known level", () => {
+    const low = getResourceLevelClass("low");
+    const medium = getResourceLevelClass("medium");
+    const high = getResourceLevelClass("high");
+    expect(low).toContain("emerald");
+    expect(medium).toContain("amber");
+    expect(high).toContain("rose");
+    expect(new Set([low, medium, high]).size).toBe(3);
+  });
+
+  test("returns the muted fallback class for an unknown/absent level", () => {
+    expect(getResourceLevelClass(null)).toContain("muted");
+    expect(getResourceLevelClass(undefined)).toContain("muted");
   });
 });

--- a/packages/client/src/utils/api/client.test.ts
+++ b/packages/client/src/utils/api/client.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createEntityClient,
+  deleteJson,
+  fetchJson,
+  postJson,
+  putJson,
+} from "./client.ts";
+
+interface FakeResponseInit {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  json?: unknown;
+  text?: string;
+}
+
+function fakeResponse({
+  ok = true,
+  status = 200,
+  statusText = "OK",
+  json = {},
+  text = "",
+}: FakeResponseInit = {}): Response {
+  return {
+    ok,
+    status,
+    statusText,
+    json: () => Promise.resolve(json),
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchJson", () => {
+  test("returns the parsed body on success", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        a: 1,
+      },
+    }));
+    await expect(fetchJson("/api/x")).resolves.toEqual({
+      a: 1,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/x");
+  });
+
+  test("throws with status details on a failed response", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+    await expect(fetchJson("/api/x")).rejects.toThrow(
+      "Request to /api/x failed (404 Not Found)",
+    );
+  });
+});
+
+describe("postJson", () => {
+  test("sends JSON headers and a serialized body when data is provided", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        id: "1",
+      },
+    }));
+    await postJson("/api/x", {
+      name: "n",
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/x", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "n",
+      }),
+    });
+  });
+
+  test("omits the body when no data is provided", async () => {
+    fetchMock.mockResolvedValue(fakeResponse());
+    await postJson("/api/x");
+    expect(fetchMock).toHaveBeenCalledWith("/api/x", {
+      method: "POST",
+    });
+  });
+
+  test("throws using the error label and response body on failure", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: "boom",
+      }),
+    );
+    await expect(postJson("/api/x", {}, "Create failed")).rejects.toThrow(
+      "Create failed failed (500 Server Error): boom",
+    );
+  });
+
+  test("falls back to a default label when none is given", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+      }),
+    );
+    await expect(postJson("/api/x", {})).rejects.toThrow(
+      "POST /api/x failed (500 Server Error)",
+    );
+  });
+});
+
+describe("putJson", () => {
+  test("sends a PUT with JSON headers and body", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        status: "ok",
+      },
+    }));
+    await putJson("/api/x/1", {
+      name: "n",
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/x/1", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "n",
+      }),
+    });
+  });
+
+  test("throws with label and body on failure", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: "nope",
+      }),
+    );
+    await expect(putJson("/api/x/1", {}, "Update failed")).rejects.toThrow(
+      "Update failed failed (400 Bad Request): nope",
+    );
+  });
+});
+
+describe("deleteJson", () => {
+  test("issues a DELETE and returns the parsed body", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        status: "ok",
+      },
+    }));
+    await expect(deleteJson("/api/x/1")).resolves.toEqual({
+      status: "ok",
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/x/1", {
+      method: "DELETE",
+    });
+  });
+
+  test("surfaces a JSON server message on failure", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        text: JSON.stringify({
+          message: "still in use",
+        }),
+      }),
+    );
+    await expect(deleteJson("/api/x/1")).rejects.toThrow("still in use");
+  });
+
+  test("uses raw text when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: "plain error",
+      }),
+    );
+    await expect(deleteJson("/api/x/1")).rejects.toThrow("plain error");
+  });
+
+  test("falls back to the label when there is no error body", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+      }),
+    );
+    await expect(deleteJson("/api/x/1", "Delete failed")).rejects.toThrow(
+      "Delete failed failed (500 Server Error)",
+    );
+  });
+});
+
+describe("createEntityClient", () => {
+  const client = createEntityClient("widgets", "widget");
+
+  test("list and get hit the right URLs", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: [],
+    }));
+    await client.list();
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/widgets");
+
+    await client.get("7");
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/widgets/7");
+  });
+
+  test("create posts to the base endpoint", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        id: "1",
+      },
+    }));
+    await client.create({
+      name: "n",
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/widgets", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "n",
+      }),
+    });
+  });
+
+  test("upsert puts to the id endpoint", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        status: "ok",
+      },
+    }));
+    await client.upsert("7", {
+      name: "n",
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/widgets/7",
+      expect.objectContaining({
+        method: "PUT",
+      }),
+    );
+  });
+
+  test("delete removes the id endpoint", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        status: "ok",
+      },
+    }));
+    await client.delete("7");
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/widgets/7", {
+      method: "DELETE",
+    });
+  });
+
+  test("duplicate posts to the duplicate sub-endpoint with no body", async () => {
+    fetchMock.mockResolvedValue(fakeResponse({
+      json: {
+        id: "2",
+      },
+    }));
+    await client.duplicate("7");
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/widgets/7/duplicate", {
+      method: "POST",
+    });
+  });
+});

--- a/packages/client/src/utils/copyTextToClipboard.test.ts
+++ b/packages/client/src/utils/copyTextToClipboard.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { copyTextToClipboard } from "./copyTextToClipboard.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // jsdom doesn't implement execCommand, so tests assign it directly.
+  delete (document as { execCommand?: unknown }).execCommand;
+});
+
+describe("copyTextToClipboard", () => {
+  test("uses the async Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText,
+      },
+    });
+
+    expect(await copyTextToClipboard("hello")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  test("falls back to execCommand when the Clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText,
+      },
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    expect(await copyTextToClipboard("hello")).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // The temporary textarea is cleaned up.
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  test("uses the textarea fallback when the Clipboard API is absent", async () => {
+    vi.stubGlobal("navigator", {});
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    expect(await copyTextToClipboard("hello")).toBe(true);
+  });
+
+  test("returns the execCommand result when the copy is rejected", async () => {
+    vi.stubGlobal("navigator", {});
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    expect(await copyTextToClipboard("hello")).toBe(false);
+  });
+
+  test("returns false when the fallback throws", async () => {
+    vi.stubGlobal("navigator", {});
+    document.execCommand = vi.fn().mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(await copyTextToClipboard("hello")).toBe(false);
+  });
+});

--- a/packages/client/src/utils/dailyHelpers.test.ts
+++ b/packages/client/src/utils/dailyHelpers.test.ts
@@ -1,15 +1,38 @@
-import type { DailyCompletion, RoutineWeekly } from "@emstack/types";
+import type { Daily, DailyCompletion, RoutineWeekly } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
 import {
   classifyDaily,
+  dailyLinkTooltip,
+  findStatusForDate,
   getCompletedDaysThisWeek,
+  getCurrentChain,
+  getDailyProgressPercent,
+  getDaysBetweenFirstAndLastEntry,
+  getLastEntryDate,
+  getLongestStreak,
+  getRecentDays,
+  getReferenceDateKey,
+  getTodayKey,
+  getTotalCompletedDays,
   hasStatusForDay,
   hasTaskForDay,
   isScheduledForDay,
   isWeeklyTargetMet,
+  shiftDateKey,
+  withCompletion,
+  withCompletionNote,
 } from "./dailyHelpers.ts";
+
+function makeDaily(overrides: Partial<Daily> = {}): Daily {
+  return {
+    id: "daily-1",
+    name: "A daily",
+    completions: [],
+    ...overrides,
+  };
+}
 
 // 2026-06-11 is a Thursday. The three windows that contain it:
 //   sunday   -> 2026-06-07 (Sun) … 2026-06-13 (Sat)
@@ -289,5 +312,481 @@ describe("classifyDaily", () => {
         weeklyTarget: null,
       }, TODAY, "sunday"),
     ).toBe("done");
+  });
+});
+
+describe("getTodayKey", () => {
+  test("returns a YYYY-MM-DD key matching the local date", () => {
+    const key = getTodayKey();
+    expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const now = new Date();
+    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    expect(key).toBe(expected);
+  });
+});
+
+describe("dailyLinkTooltip", () => {
+  test("returns the entity name when it differs from the daily title", () => {
+    expect(dailyLinkTooltip("Read a book", "Daily reading", "Go to task")).toBe(
+      "Read a book",
+    );
+  });
+
+  test("returns the go-label when the titles match (case/space-insensitively)", () => {
+    expect(dailyLinkTooltip("  Daily Reading ", "daily reading", "Go")).toBe(
+      "Go",
+    );
+  });
+});
+
+describe("shiftDateKey", () => {
+  test("shifts a date key forward and back across month boundaries", () => {
+    expect(shiftDateKey("2026-06-11", 1)).toBe("2026-06-12");
+    expect(shiftDateKey("2026-06-11", -1)).toBe("2026-06-10");
+    expect(shiftDateKey("2026-06-30", 1)).toBe("2026-07-01");
+    expect(shiftDateKey("2026-01-01", -1)).toBe("2025-12-31");
+  });
+
+  test("is a no-op for a zero delta", () => {
+    expect(shiftDateKey("2026-06-11", 0)).toBe("2026-06-11");
+  });
+});
+
+describe("findStatusForDate", () => {
+  const daily = {
+    completions: [
+      {
+        date: "2026-06-10",
+        status: "goal" as const,
+      },
+    ],
+  };
+
+  test("returns the status for a matching date", () => {
+    expect(findStatusForDate(daily, "2026-06-10")).toBe("goal");
+  });
+
+  test("returns null when no completion matches", () => {
+    expect(findStatusForDate(daily, "2026-06-11")).toBeNull();
+  });
+});
+
+describe("getCurrentChain", () => {
+  test("counts a run ending today", () => {
+    const completions: DailyCompletion[] = [
+      {
+        date: "2026-06-09",
+        status: "goal",
+      },
+      {
+        date: "2026-06-10",
+        status: "goal",
+      },
+      {
+        date: "2026-06-11",
+        status: "exceeded",
+      },
+    ];
+    expect(getCurrentChain({
+      completions,
+    }, "2026-06-11")).toBe(3);
+  });
+
+  test("still counts when today is blank but yesterday is done", () => {
+    const completions: DailyCompletion[] = [
+      {
+        date: "2026-06-09",
+        status: "goal",
+      },
+      {
+        date: "2026-06-10",
+        status: "goal",
+      },
+    ];
+    expect(getCurrentChain({
+      completions,
+    }, "2026-06-11")).toBe(2);
+  });
+
+  test("returns 0 when neither today nor yesterday is done", () => {
+    const completions: DailyCompletion[] = [
+      {
+        date: "2026-06-08",
+        status: "goal",
+      },
+    ];
+    expect(getCurrentChain({
+      completions,
+    }, "2026-06-11")).toBe(0);
+  });
+
+  test("ignores incomplete and unset statuses", () => {
+    const completions: DailyCompletion[] = [
+      {
+        date: "2026-06-11",
+        status: "incomplete",
+      },
+      {
+        date: "2026-06-10",
+      },
+    ];
+    expect(getCurrentChain({
+      completions,
+    }, "2026-06-11")).toBe(0);
+  });
+});
+
+describe("getTotalCompletedDays", () => {
+  test("counts only real (non-incomplete) statuses", () => {
+    const completions: DailyCompletion[] = [
+      {
+        date: "2026-06-09",
+        status: "goal",
+      },
+      {
+        date: "2026-06-10",
+        status: "incomplete",
+      },
+      {
+        date: "2026-06-11",
+        status: "freeze",
+      },
+      {
+        date: "2026-06-12",
+      },
+    ];
+    expect(getTotalCompletedDays({
+      completions,
+    })).toBe(2);
+  });
+});
+
+describe("getLongestStreak", () => {
+  test("finds the longest consecutive run regardless of order", () => {
+    const daily = makeDaily({
+      completions: [
+        {
+          date: "2026-06-11",
+          status: "goal",
+        },
+        {
+          date: "2026-06-09",
+          status: "goal",
+        },
+        {
+          date: "2026-06-10",
+          status: "goal",
+        },
+        // gap, then a shorter run
+        {
+          date: "2026-06-13",
+          status: "exceeded",
+        },
+        {
+          date: "2026-06-14",
+          status: "goal",
+        },
+      ],
+    });
+    expect(getLongestStreak(daily)).toBe(3);
+  });
+
+  test("returns 0 when there are no real completions", () => {
+    expect(getLongestStreak(makeDaily())).toBe(0);
+    expect(
+      getLongestStreak(
+        makeDaily({
+          completions: [{
+            date: "2026-06-11",
+            status: "incomplete",
+          }],
+        }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("getLastEntryDate", () => {
+  test("returns the latest entry date irrespective of order or status", () => {
+    const daily = makeDaily({
+      completions: [
+        {
+          date: "2026-06-09",
+          status: "goal",
+        },
+        {
+          date: "2026-06-12",
+          status: "incomplete",
+        },
+        {
+          date: "2026-06-10",
+        },
+      ],
+    });
+    expect(getLastEntryDate(daily)).toBe("2026-06-12");
+  });
+
+  test("returns null with no completions", () => {
+    expect(getLastEntryDate(makeDaily())).toBeNull();
+  });
+});
+
+describe("getDaysBetweenFirstAndLastEntry", () => {
+  test("returns the inclusive day span between first and last entry", () => {
+    const daily = makeDaily({
+      completions: [
+        {
+          date: "2026-06-10",
+          status: "goal",
+        },
+        {
+          date: "2026-06-01",
+          status: "goal",
+        },
+        {
+          date: "2026-06-05",
+        },
+      ],
+    });
+    // 2026-06-01 .. 2026-06-10 inclusive = 10 days.
+    expect(getDaysBetweenFirstAndLastEntry(daily)).toBe(10);
+  });
+
+  test("is 1 for a single entry and 0 for none", () => {
+    expect(
+      getDaysBetweenFirstAndLastEntry(
+        makeDaily({
+          completions: [{
+            date: "2026-06-05",
+            status: "goal",
+          }],
+        }),
+      ),
+    ).toBe(1);
+    expect(getDaysBetweenFirstAndLastEntry(makeDaily())).toBe(0);
+  });
+});
+
+describe("getReferenceDateKey", () => {
+  test("returns today when the daily is not complete", () => {
+    const daily = makeDaily({
+      status: "active",
+      completions: [{
+        date: "2026-06-01",
+        status: "goal",
+      }],
+    });
+    expect(getReferenceDateKey(daily, "2026-06-11")).toBe("2026-06-11");
+  });
+
+  test("returns the last entry date for a completed daily", () => {
+    const daily = makeDaily({
+      status: "complete",
+      completions: [
+        {
+          date: "2026-06-01",
+          status: "goal",
+        },
+        {
+          date: "2026-06-08",
+          status: "goal",
+        },
+      ],
+    });
+    expect(getReferenceDateKey(daily, "2026-06-11")).toBe("2026-06-08");
+  });
+
+  test("falls back to today for a completed daily with no entries", () => {
+    const daily = makeDaily({
+      status: "complete",
+    });
+    expect(getReferenceDateKey(daily, "2026-06-11")).toBe("2026-06-11");
+  });
+});
+
+describe("getRecentDays", () => {
+  test("returns `count` days ending today, oldest first", () => {
+    const daily = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "goal",
+      }],
+    });
+    const days = getRecentDays(daily, 3, "2026-06-11");
+    expect(days.map(d => d.dateKey)).toEqual([
+      "2026-06-09",
+      "2026-06-10",
+      "2026-06-11",
+    ]);
+    expect(days.map(d => d.dayLabel)).toEqual(["Tue", "Wed", "Thu"]);
+    expect(days.map(d => d.isToday)).toEqual([false, false, true]);
+    expect(days[2].status).toBe("goal");
+    expect(days[0].status).toBeNull();
+  });
+
+  test("supports the mm/dd label format", () => {
+    const days = getRecentDays(makeDaily(), 2, "2026-06-11", "mmdd");
+    expect(days.map(d => d.dayLabel)).toEqual(["06/10", "06/11"]);
+  });
+});
+
+describe("getDailyProgressPercent", () => {
+  test("uses the linked resource progress when present", () => {
+    const daily = makeDaily({
+      resource: {
+        id: "r-1",
+        name: "Course",
+        progressCurrent: 3,
+        progressTotal: 4,
+      },
+    });
+    expect(getDailyProgressPercent(daily)).toBe(0.75);
+  });
+
+  test("guards against a zero resource total", () => {
+    const daily = makeDaily({
+      resource: {
+        id: "r-1",
+        name: "Course",
+        progressCurrent: 0,
+        progressTotal: 0,
+      },
+    });
+    expect(getDailyProgressPercent(daily)).toBe(0);
+  });
+
+  test("falls back to task todo/resource progress", () => {
+    const daily = makeDaily({
+      task: {
+        id: "t-1",
+        name: "Task",
+        progress: {
+          todosTotal: 2,
+          todosComplete: 1,
+          resourcesTotal: 2,
+          resourcesUsed: 2,
+        },
+      },
+    });
+    // (1 + 2) / (2 + 2) = 0.75
+    expect(getDailyProgressPercent(daily)).toBe(0.75);
+  });
+
+  test("returns 0 when nothing is linked", () => {
+    expect(getDailyProgressPercent(makeDaily())).toBe(0);
+  });
+});
+
+describe("withCompletion", () => {
+  test("adds a status entry for a new date", () => {
+    const daily = makeDaily();
+    expect(withCompletion(daily, "2026-06-11", "goal")).toEqual([
+      {
+        date: "2026-06-11",
+        status: "goal",
+      },
+    ]);
+  });
+
+  test("replaces the existing entry for the date, preserving its note", () => {
+    const daily = makeDaily({
+      completions: [
+        {
+          date: "2026-06-11",
+          status: "touched",
+          note: "kept",
+        },
+        {
+          date: "2026-06-10",
+          status: "goal",
+        },
+      ],
+    });
+    const next = withCompletion(daily, "2026-06-11", "exceeded");
+    expect(next).toContainEqual({
+      date: "2026-06-11",
+      status: "exceeded",
+      note: "kept",
+    });
+    expect(next).toContainEqual({
+      date: "2026-06-10",
+      status: "goal",
+    });
+    expect(next).toHaveLength(2);
+  });
+
+  test("clearing a status drops the entry but keeps a note-only row", () => {
+    const withNote = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "goal",
+        note: "hi",
+      }],
+    });
+    expect(withCompletion(withNote, "2026-06-11", null)).toEqual([
+      {
+        date: "2026-06-11",
+        note: "hi",
+      },
+    ]);
+
+    const noNote = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "goal",
+      }],
+    });
+    expect(withCompletion(noNote, "2026-06-11", null)).toEqual([]);
+  });
+});
+
+describe("withCompletionNote", () => {
+  test("adds a note entry for a new date", () => {
+    expect(withCompletionNote(makeDaily(), "2026-06-11", "wrote some")).toEqual([
+      {
+        date: "2026-06-11",
+        note: "wrote some",
+      },
+    ]);
+  });
+
+  test("trims the note and preserves an existing status", () => {
+    const daily = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "goal",
+      }],
+    });
+    expect(withCompletionNote(daily, "2026-06-11", "  noted  ")).toEqual([
+      {
+        date: "2026-06-11",
+        status: "goal",
+        note: "noted",
+      },
+    ]);
+  });
+
+  test("an empty note drops the entry but keeps a status-only row", () => {
+    const withStatus = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "goal",
+        note: "old",
+      }],
+    });
+    expect(withCompletionNote(withStatus, "2026-06-11", "   ")).toEqual([
+      {
+        date: "2026-06-11",
+        status: "goal",
+      },
+    ]);
+
+    const noteOnly = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        note: "old",
+      }],
+    });
+    expect(withCompletionNote(noteOnly, "2026-06-11", null)).toEqual([]);
   });
 });

--- a/packages/client/src/utils/formatCurrency.test.ts
+++ b/packages/client/src/utils/formatCurrency.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { formatCurrency } from "./formatCurrency.ts";
+
+describe("formatCurrency", () => {
+  test("formats a whole number as USD", () => {
+    expect(formatCurrency(10)).toBe("$10.00");
+  });
+
+  test("formats zero", () => {
+    expect(formatCurrency(0)).toBe("$0.00");
+  });
+
+  test("rounds to two decimal places", () => {
+    expect(formatCurrency(9.999)).toBe("$10.00");
+    expect(formatCurrency(1.5)).toBe("$1.50");
+  });
+
+  test("groups thousands with a comma", () => {
+    expect(formatCurrency(1234567.89)).toBe("$1,234,567.89");
+  });
+
+  test("formats negative values", () => {
+    expect(formatCurrency(-42.5)).toBe("-$42.50");
+  });
+});

--- a/packages/client/src/utils/isHttpUrl.test.ts
+++ b/packages/client/src/utils/isHttpUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+
+import { isHttpUrl } from "./isHttpUrl.ts";
+
+describe("isHttpUrl", () => {
+  test("accepts http and https URLs", () => {
+    expect(isHttpUrl("http://example.com")).toBe(true);
+    expect(isHttpUrl("https://example.com/path?q=1")).toBe(true);
+  });
+
+  test("rejects non-http(s) protocols", () => {
+    expect(isHttpUrl("ftp://example.com")).toBe(false);
+    expect(isHttpUrl("mailto:someone@example.com")).toBe(false);
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  test("rejects strings that are not valid URLs", () => {
+    expect(isHttpUrl("not a url")).toBe(false);
+    expect(isHttpUrl("example.com")).toBe(false);
+    expect(isHttpUrl("")).toBe(false);
+  });
+});

--- a/packages/client/src/utils/makePercentageComplete.test.ts
+++ b/packages/client/src/utils/makePercentageComplete.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+
+import { makePercentageComplete } from "./makePercentageComplete.ts";
+
+describe("makePercentageComplete", () => {
+  test("returns the percentage fixed to two decimals", () => {
+    expect(makePercentageComplete(1, 4)).toBe("25.00");
+    expect(makePercentageComplete(1, 3)).toBe("33.33");
+    expect(makePercentageComplete(4, 4)).toBe("100.00");
+  });
+
+  test("returns undefined when current is missing or zero", () => {
+    expect(makePercentageComplete(undefined, 4)).toBeUndefined();
+    expect(makePercentageComplete(0, 4)).toBeUndefined();
+  });
+
+  test("returns undefined when total is missing or zero", () => {
+    expect(makePercentageComplete(2, undefined)).toBeUndefined();
+    expect(makePercentageComplete(2, 0)).toBeUndefined();
+  });
+});

--- a/packages/client/src/utils/parseCost.test.ts
+++ b/packages/client/src/utils/parseCost.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { parseCost } from "./parseCost.ts";
+
+describe("parseCost", () => {
+  test("parses numeric strings", () => {
+    expect(parseCost("12")).toBe(12);
+    expect(parseCost("12.50")).toBe(12.5);
+    expect(parseCost("-3")).toBe(-3);
+  });
+
+  test("defaults to 0 for null, undefined and empty string", () => {
+    expect(parseCost(null)).toBe(0);
+    expect(parseCost(undefined)).toBe(0);
+    expect(parseCost("")).toBe(0);
+  });
+
+  test("defaults to 0 for non-finite or non-numeric input", () => {
+    expect(parseCost("abc")).toBe(0);
+    expect(parseCost("Infinity")).toBe(0);
+    expect(parseCost("NaN")).toBe(0);
+  });
+});

--- a/packages/client/src/utils/queryKeys.test.ts
+++ b/packages/client/src/utils/queryKeys.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import { queryKeys } from "./queryKeys.ts";
+
+describe("queryKeys", () => {
+  test("resource keys", () => {
+    expect(queryKeys.resources.list()).toEqual(["resources"]);
+    expect(queryKeys.resources.detail("r1")).toEqual(["resource", "r1"]);
+    expect(queryKeys.resources.modules("r1")).toEqual([
+      "resource-modules",
+      "r1",
+    ]);
+    expect(queryKeys.resources.moduleGroups("r1")).toEqual([
+      "resource-module-groups",
+      "r1",
+    ]);
+    expect(queryKeys.resources.interactions("r1")).toEqual([
+      "resource-interactions",
+      "r1",
+    ]);
+  });
+
+  test("entity list/detail keys embed the id", () => {
+    expect(queryKeys.topics.list()).toEqual(["topics"]);
+    expect(queryKeys.topics.detail("t1")).toEqual(["topic", "t1"]);
+    expect(queryKeys.tasks.list()).toEqual(["tasks"]);
+    expect(queryKeys.tasks.detail("t1")).toEqual(["task", "t1"]);
+    expect(queryKeys.routines.list()).toEqual(["routines"]);
+    expect(queryKeys.routines.detail("r1")).toEqual(["routine", "r1"]);
+    expect(queryKeys.dailies.list()).toEqual(["dailies"]);
+    expect(queryKeys.dailies.detail("d1")).toEqual(["daily", "d1"]);
+    expect(queryKeys.providers.list()).toEqual(["providers"]);
+    expect(queryKeys.providers.detail("p1")).toEqual(["provider", "p1"]);
+  });
+
+  test("domain keys including radar and explore", () => {
+    expect(queryKeys.domains.list()).toEqual(["domains"]);
+    expect(queryKeys.domains.detail("d1")).toEqual(["domain", "d1"]);
+    expect(queryKeys.domains.radar("d1")).toEqual(["radar", "d1"]);
+    expect(queryKeys.domains.explore()).toEqual(["domains-explore"]);
+  });
+
+  test("singleton list keys", () => {
+    expect(queryKeys.tagGroups.list()).toEqual(["tagGroups"]);
+    expect(queryKeys.taskTypes.list()).toEqual(["taskTypes"]);
+    expect(queryKeys.modules.list()).toEqual(["modules-all"]);
+    expect(queryKeys.moduleGroups.list()).toEqual(["module-groups-all"]);
+    expect(queryKeys.routineTemplates.list()).toEqual(["routineTemplates"]);
+    expect(queryKeys.dashboardLayouts.list()).toEqual(["dashboardLayouts"]);
+    expect(queryKeys.dailyCriteriaTemplates.list()).toEqual([
+      "dailyCriteriaTemplates",
+    ]);
+    expect(queryKeys.settings.detail()).toEqual(["settings"]);
+  });
+
+  test("integration keys", () => {
+    expect(queryKeys.readwise.readingList()).toEqual([
+      "readwise",
+      "reading-list",
+    ]);
+    expect(queryKeys.todoist.tasks()).toEqual(["todoist", "tasks"]);
+    expect(queryKeys.googleCalendar.events()).toEqual([
+      "googleCalendar",
+      "events",
+    ]);
+    expect(queryKeys.googleCalendar.feeds()).toEqual([
+      "googleCalendar",
+      "feeds",
+    ]);
+  });
+});

--- a/packages/client/src/utils/selectOptions.test.ts
+++ b/packages/client/src/utils/selectOptions.test.ts
@@ -1,0 +1,99 @@
+import type { TagGroup } from "@emstack/types";
+
+import { describe, expect, test } from "vitest";
+
+import { tagGroupsToOptions, toOptions } from "./selectOptions.ts";
+
+describe("toOptions", () => {
+  test("maps {id, name} entities to {value, label}", () => {
+    expect(
+      toOptions([
+        {
+          id: "a",
+          name: "Alpha",
+        },
+        {
+          id: "b",
+          name: "Beta",
+        },
+      ]),
+    ).toEqual([
+      {
+        value: "a",
+        label: "Alpha",
+      },
+      {
+        value: "b",
+        label: "Beta",
+      },
+    ]);
+  });
+
+  test("returns an empty array for null/undefined", () => {
+    expect(toOptions(null)).toEqual([]);
+    expect(toOptions(undefined)).toEqual([]);
+  });
+});
+
+describe("tagGroupsToOptions", () => {
+  test("flattens tags across groups into options", () => {
+    const groups: TagGroup[] = [
+      {
+        id: "g1",
+        name: "Group 1",
+        tags: [
+          {
+            id: "t1",
+            groupId: "g1",
+            name: "Tag 1",
+          },
+          {
+            id: "t2",
+            groupId: "g1",
+            name: "Tag 2",
+          },
+        ],
+      },
+      {
+        id: "g2",
+        name: "Group 2",
+        tags: [
+          {
+            id: "t3",
+            groupId: "g2",
+            name: "Tag 3",
+          },
+        ],
+      },
+    ];
+    expect(tagGroupsToOptions(groups)).toEqual([
+      {
+        value: "t1",
+        label: "Tag 1",
+      },
+      {
+        value: "t2",
+        label: "Tag 2",
+      },
+      {
+        value: "t3",
+        label: "Tag 3",
+      },
+    ]);
+  });
+
+  test("handles groups with no tags", () => {
+    const groups: TagGroup[] = [
+      {
+        id: "g1",
+        name: "Group 1",
+      },
+    ];
+    expect(tagGroupsToOptions(groups)).toEqual([]);
+  });
+
+  test("returns an empty array for null/undefined", () => {
+    expect(tagGroupsToOptions(null)).toEqual([]);
+    expect(tagGroupsToOptions(undefined)).toEqual([]);
+  });
+});

--- a/packages/client/src/utils/stripCodeFence.test.ts
+++ b/packages/client/src/utils/stripCodeFence.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { stripCodeFence } from "./stripCodeFence.ts";
+
+describe("stripCodeFence", () => {
+  test("strips a fence with a language tag", () => {
+    expect(stripCodeFence("```json\n{\"a\":1}\n```")).toBe("{\"a\":1}");
+  });
+
+  test("strips a fence with no language tag", () => {
+    expect(stripCodeFence("```\nhello\n```")).toBe("hello");
+  });
+
+  test("trims surrounding whitespace before matching the fence", () => {
+    expect(stripCodeFence("  \n```\nhello\n```\n  ")).toBe("hello");
+  });
+
+  test("returns multi-line fenced content intact", () => {
+    expect(stripCodeFence("```ts\nconst a = 1;\nconst b = 2;\n```")).toBe(
+      "const a = 1;\nconst b = 2;",
+    );
+  });
+
+  test("returns the trimmed input when not fenced", () => {
+    expect(stripCodeFence("  plain text  ")).toBe("plain text");
+  });
+});

--- a/packages/client/src/utils/uuid.test.ts
+++ b/packages/client/src/utils/uuid.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { uuidv4 } from "./uuid.ts";
+
+const UUID_V4_RE
+  = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("uuidv4", () => {
+  test("produces a valid v4 UUID string", () => {
+    expect(uuidv4()).toMatch(UUID_V4_RE);
+  });
+
+  test("sets the version (4) and variant (8/9/a/b) nibbles", () => {
+    for (let i = 0; i < 50; i++) {
+      const id = uuidv4();
+      expect(id[14]).toBe("4");
+      expect(["8", "9", "a", "b"]).toContain(id[19]);
+    }
+  });
+
+  test("generates distinct values", () => {
+    const ids = new Set(Array.from({
+      length: 1000,
+    }, () => uuidv4()));
+    expect(ids.size).toBe(1000);
+  });
+});


### PR DESCRIPTION
Add Vitest unit tests for previously-untested pure functions in the client
package: the fetch layer (fetchJson/postJson/putJson/deleteJson and
createEntityClient), query-key factory, and the formatCurrency, isHttpUrl,
makePercentageComplete, parseCost, selectOptions, uuid, stripCodeFence and
copyTextToClipboard helpers. Extend the existing dailyHelpers, resourceMeta
and moduleDrafts suites to cover their remaining functions (streaks, entry
dates, recent-days projection, progress percent, completion mutations, level
labels/classes and draft builders).

Raises client function coverage from ~59% to ~83%.

https://claude.ai/code/session_011YseSmBXmwExFra7jHoJGf