### PR TITLE
refactor(client): split ResourceModulesAdmin into focused sections

### DIFF
--- a/packages/client/src/hooks/useModuleAdminUiState.ts
+++ b/packages/client/src/hooks/useModuleAdminUiState.ts
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+/** Sentinel group key used for the top-level (ungrouped) "Add Module" slot. */
+export const UNGROUPED_KEY = "__ungrouped__";
+
+/**
+ * Local UI state for the resource module admin: which group/module is being
+ * edited, where a new module/group is being created, and which scope is logging
+ * an interaction. Lifting it here keeps `ResourceModulesAdmin` a thin
+ * composition and lets the section components read/mutate the same state.
+ *
+ * Only one mutation slot is meant to be active at a time; `isAnyEditing`
+ * collapses every slot into the single flag the rows use to disable actions.
+ */
+export function useModuleAdminUiState() {
+  // Group state
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const [creatingGroup, setCreatingGroup] = useState(false);
+
+  // Module state — keyed by either groupId (string) or UNGROUPED_KEY for top level
+  const [editingModuleId, setEditingModuleId] = useState<string | null>(null);
+  const [creatingModuleIn, setCreatingModuleIn] = useState<string | null>(null);
+
+  // Quick-log interaction targets. Either a moduleGroupId or a moduleId is set.
+  const [loggingForGroupId, setLoggingForGroupId] = useState<string | null>(
+    null,
+  );
+  const [loggingForModuleId, setLoggingForModuleId] = useState<string | null>(
+    null,
+  );
+
+  // LLM Assist dialog
+  const [llmAssistOpen, setLlmAssistOpen] = useState(false);
+
+  const isAnyEditing
+    = editingGroupId !== null
+      || creatingGroup
+      || editingModuleId !== null
+      || creatingModuleIn !== null
+      || loggingForGroupId !== null
+      || loggingForModuleId !== null;
+
+  return {
+    editingGroupId,
+    setEditingGroupId,
+    creatingGroup,
+    setCreatingGroup,
+    editingModuleId,
+    setEditingModuleId,
+    creatingModuleIn,
+    setCreatingModuleIn,
+    loggingForGroupId,
+    setLoggingForGroupId,
+    loggingForModuleId,
+    setLoggingForModuleId,
+    llmAssistOpen,
+    setLlmAssistOpen,
+    isAnyEditing,
+  };
+}
+
+export type ModuleAdminUiState = ReturnType<typeof useModuleAdminUiState>;

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -360,3 +360,10 @@ export function useResourceModules(resourceId: string) {
     isReordering,
   };
 }
+
+/**
+ * Everything `useResourceModules` exposes. The module-admin section components
+ * accept this controller so the top-level component stays a thin composition
+ * over the hook rather than threading a dozen individual props.
+ */
+export type ResourceModulesController = ReturnType<typeof useResourceModules>;

--- a/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
@@ -1,0 +1,91 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+
+import { PlusIcon, SparklesIcon } from "lucide-react";
+
+import { ModuleAssistDialog } from "./-ModuleAssistDialog";
+
+import { Button } from "@/components/ui/button";
+import { UNGROUPED_KEY } from "@/hooks/useModuleAdminUiState";
+
+interface ModuleAdminHeaderProps {
+  resourceId: string;
+  modulesAreExhaustive?: boolean;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}
+
+/**
+ * Top bar for the module admin: the progress summary, the LLM-assist / add /
+ * new-group actions, and the (portalled) suggest dialog those actions drive.
+ */
+export function ModuleAdminHeader({
+  resourceId,
+  modulesAreExhaustive,
+  api,
+  ui,
+}: ModuleAdminHeaderProps) {
+  const {
+    completedCount, totalCount,
+  } = api;
+  const {
+    isAnyEditing,
+    setLlmAssistOpen,
+    setCreatingModuleIn,
+    setCreatingGroup,
+  } = ui;
+
+  const percentComplete
+    = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          {totalCount > 0 && (
+            <p className="text-sm text-muted-foreground">
+              {completedCount} of {totalCount} complete
+              {modulesAreExhaustive && <span> · {percentComplete}%</span>}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-row gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setLlmAssistOpen(true)}
+            disabled={isAnyEditing}
+            title="Suggest module groups and modules via Claude"
+          >
+            <SparklesIcon className="size-4" />
+            LLM Assist
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCreatingModuleIn(UNGROUPED_KEY)}
+            disabled={isAnyEditing}
+          >
+            <PlusIcon className="size-4" />
+            Add Module
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCreatingGroup(true)}
+            disabled={isAnyEditing}
+          >
+            <PlusIcon className="size-4" />
+            New Group
+          </Button>
+        </div>
+      </div>
+
+      <ModuleAssistDialog
+        resourceId={resourceId}
+        api={api}
+        ui={ui}
+      />
+    </>
+  );
+}

--- a/packages/client/src/routes/resources.$id.-components/-ModuleAssistDialog.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleAssistDialog.tsx
@@ -1,0 +1,67 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { Resource } from "@emstack/types";
+
+import { ModuleSuggestDialog } from "@/components/resources/moduleAdminComponents";
+
+interface ModuleAssistDialogProps {
+  resourceId: string;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}
+
+/** Resource detail fields the suggest dialog needs, with safe fallbacks. */
+function deriveResourceContext(resource: Resource | undefined) {
+  if (!resource) {
+    return {
+      resourceName: "this resource",
+      resourceDescription: null,
+      resourceUrl: null,
+      providerName: null,
+      topicNames: [] as string[],
+    };
+  }
+  return {
+    resourceName: resource.name,
+    resourceDescription: resource.description ?? null,
+    resourceUrl: resource.url ?? null,
+    providerName: resource.provider?.name ?? null,
+    topicNames: (resource.topics ?? []).map(t => t.name),
+  };
+}
+
+/**
+ * The LLM-assist dialog, fed from the resource detail query and the current
+ * group/module names. Kept separate from the toolbar so the resource-field
+ * coalescing stays out of the header's render path.
+ */
+export function ModuleAssistDialog({
+  resourceId,
+  api,
+  ui,
+}: ModuleAssistDialogProps) {
+  const {
+    resourceQuery, groups, ungroupedModules, invalidateAll,
+  } = api;
+  const {
+    llmAssistOpen, setLlmAssistOpen,
+  } = ui;
+
+  const context = deriveResourceContext(resourceQuery.data);
+
+  return (
+    <ModuleSuggestDialog
+      open={llmAssistOpen}
+      onOpenChange={setLlmAssistOpen}
+      resourceId={resourceId}
+      resourceName={context.resourceName}
+      resourceDescription={context.resourceDescription}
+      resourceUrl={context.resourceUrl}
+      providerName={context.providerName}
+      topicNames={context.topicNames}
+      existingGroupNames={groups.map(g => g.name)}
+      existingUngroupedModuleNames={ungroupedModules.map(m => m.name)}
+      onApplied={() => invalidateAll()}
+    />
+  );
+}

--- a/packages/client/src/routes/resources.$id.-components/-ModuleGroupSection.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleGroupSection.tsx
@@ -1,0 +1,335 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { Module, ModuleGroup } from "@emstack/types";
+
+import {
+  ActivityIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ExternalLinkIcon,
+  PencilIcon,
+  PlusIcon,
+} from "lucide-react";
+
+import { ModuleListItem } from "./-ModuleListItem";
+
+import {
+  GroupEditCard,
+  GroupMetaChips,
+  InteractionQuickLog,
+  ModuleEditCard,
+} from "@/components/resources/moduleAdminComponents";
+import {
+  emptyModuleDraft,
+  groupToDraft,
+} from "@/components/resources/moduleDrafts";
+import { Button } from "@/components/ui/button";
+import { isHttpUrl } from "@/utils";
+
+interface ModuleGroupSectionProps {
+  group: ModuleGroup;
+  groupIndex: number;
+  resourceId: string;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}
+
+/** The group title — a link when it carries an http(s) url, plain text otherwise. */
+function GroupTitle({
+  group: g,
+}: { group: ModuleGroup }) {
+  if (!g.url) return <>{g.name}</>;
+  if (!isHttpUrl(g.url)) return <span title={g.url}>{g.name}</span>;
+  return (
+    <a
+      href={g.url}
+      target="_blank"
+      rel="noreferrer"
+      className="hover:text-blue-600"
+    >
+      {g.name}
+      {" "}
+      <ExternalLinkIcon className="inline size-3.5" />
+    </a>
+  );
+}
+
+/** Group meta chips, coalescing the group's optional level/tag fields. */
+function GroupMeta({
+  group: g,
+}: { group: ModuleGroup }) {
+  return (
+    <GroupMetaChips
+      easeOfStarting={g.easeOfStarting ?? null}
+      timeNeeded={g.timeNeeded ?? null}
+      interactivity={g.interactivity ?? null}
+      tags={g.tags ?? []}
+    />
+  );
+}
+
+/** Reorder / add-module / log / edit controls in the group header. */
+function GroupHeaderControls({
+  group: g,
+  groupIndex: gIndex,
+  api,
+  ui,
+}: {
+  group: ModuleGroup;
+  groupIndex: number;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}) {
+  const {
+    groups, moveGroup, isReordering,
+  } = api;
+  const {
+    isAnyEditing,
+    setCreatingModuleIn,
+    setLoggingForGroupId,
+    setEditingGroupId,
+  } = ui;
+
+  return (
+    <div className="flex flex-row items-center gap-2">
+      <div className="flex items-center gap-0.5">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={() => moveGroup(gIndex, "up")}
+          disabled={isAnyEditing || isReordering || gIndex === 0}
+          aria-label="Move group up"
+          title="Move group up"
+        >
+          <ChevronUpIcon className="size-3.5" />
+        </Button>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={() => moveGroup(gIndex, "down")}
+          disabled={
+            isAnyEditing || isReordering || gIndex === groups.length - 1
+          }
+          aria-label="Move group down"
+          title="Move group down"
+        >
+          <ChevronDownIcon className="size-3.5" />
+        </Button>
+      </div>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setCreatingModuleIn(g.id)}
+        disabled={isAnyEditing}
+      >
+        <PlusIcon className="size-3.5" />
+        Add Module
+      </Button>
+      <Button
+        size="icon-sm"
+        variant="ghost"
+        onClick={() => setLoggingForGroupId(g.id)}
+        disabled={isAnyEditing}
+        aria-label={`Log interaction for ${g.name}`}
+        title="Log interaction"
+      >
+        <ActivityIcon className="size-3.5" />
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => setEditingGroupId(g.id)}
+        disabled={isAnyEditing}
+      >
+        <PencilIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+/** The enumerated module rows for a group; renders nothing when empty. */
+function GroupModuleList({
+  group: g,
+  resourceId,
+  groupModules,
+  api,
+  ui,
+}: {
+  group: ModuleGroup;
+  resourceId: string;
+  groupModules: Module[];
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}) {
+  if (groupModules.length === 0) return null;
+  return (
+    <ul className="flex flex-col divide-y rounded-sm border">
+      {groupModules.map((m, mIndex) => (
+        <ModuleListItem
+          key={m.id}
+          module={m}
+          resourceId={resourceId}
+          groupId={g.id}
+          list={groupModules}
+          index={mIndex}
+          api={api}
+          ui={ui}
+        />
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Fallback shown when a group has no enumerated modules and none is being
+ * created: either its direct progress counts or a hint to add modules.
+ */
+function GroupProgressHint({
+  group: g,
+  groupModules,
+  isCreatingHere,
+}: {
+  group: ModuleGroup;
+  groupModules: Module[];
+  isCreatingHere: boolean;
+}) {
+  if (groupModules.length > 0 || isCreatingHere) return null;
+
+  if (g.totalCount != null || g.completedCount != null) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {g.completedCount ?? 0}
+        {" / "}
+        {g.totalCount ?? 0}
+        {" complete"}
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-xs text-muted-foreground">
+      No modules in this group yet — add modules, or edit the group to track
+      totals directly.
+    </p>
+  );
+}
+
+/**
+ * One module group: header (title, controls), meta chips, optional quick-log +
+ * create-module cards, the enumerated module list, and the fallback
+ * progress/empty hints. Swaps to an inline `GroupEditCard` while this group is
+ * being edited. Extracted from the `groups.map` body of `ResourceModulesAdmin`.
+ */
+export function ModuleGroupSection({
+  group: g,
+  groupIndex: gIndex,
+  resourceId,
+  api,
+  ui,
+}: ModuleGroupSectionProps) {
+  const {
+    tagGroups,
+    modulesByGroup,
+    upsertGroupMutation,
+    deleteGroupMutation,
+    createModuleMutation,
+  } = api;
+  const {
+    editingGroupId,
+    setEditingGroupId,
+    creatingModuleIn,
+    setCreatingModuleIn,
+    loggingForGroupId,
+    setLoggingForGroupId,
+  } = ui;
+
+  const groupModules = modulesByGroup.get(g.id) ?? [];
+  const isCreatingHere = creatingModuleIn === g.id;
+
+  if (editingGroupId === g.id) {
+    return (
+      <GroupEditCard
+        draft={groupToDraft(g)}
+        hasEnumeratedModules={groupModules.length > 0}
+        tagGroups={tagGroups}
+        isSaving={
+          upsertGroupMutation.isPending || deleteGroupMutation.isPending
+        }
+        onSave={d =>
+          upsertGroupMutation.mutate(d, {
+            onSuccess: () => setEditingGroupId(null),
+          })}
+        onCancel={() => setEditingGroupId(null)}
+        onDelete={() =>
+          deleteGroupMutation.mutate(g.id, {
+            onSuccess: () => setEditingGroupId(null),
+          })}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border bg-background p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <h3 className="font-medium">
+            <GroupTitle group={g} />
+          </h3>
+          {g.description && (
+            <span className="text-xs text-muted-foreground">
+              {g.description}
+            </span>
+          )}
+        </div>
+        <GroupHeaderControls
+          group={g}
+          groupIndex={gIndex}
+          api={api}
+          ui={ui}
+        />
+      </div>
+      <GroupMeta group={g} />
+      {loggingForGroupId === g.id && (
+        <InteractionQuickLog
+          resourceId={resourceId}
+          moduleGroupId={g.id}
+          scopeLabel={`group: ${g.name}`}
+          onCancel={() => setLoggingForGroupId(null)}
+          onSaved={() => setLoggingForGroupId(null)}
+        />
+      )}
+      {isCreatingHere && (
+        <ModuleEditCard
+          draft={emptyModuleDraft()}
+          tagGroups={tagGroups}
+          isNew
+          isComplete={false}
+          isSaving={createModuleMutation.isPending}
+          onSave={d =>
+            createModuleMutation.mutate(
+              {
+                draft: d,
+                groupId: g.id,
+              },
+              {
+                onSuccess: () => setCreatingModuleIn(null),
+              },
+            )}
+          onCancel={() => setCreatingModuleIn(null)}
+        />
+      )}
+      <GroupModuleList
+        group={g}
+        resourceId={resourceId}
+        groupModules={groupModules}
+        api={api}
+        ui={ui}
+      />
+      <GroupProgressHint
+        group={g}
+        groupModules={groupModules}
+        isCreatingHere={isCreatingHere}
+      />
+    </div>
+  );
+}

--- a/packages/client/src/routes/resources.$id.-components/-ModuleListItem.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleListItem.tsx
@@ -1,0 +1,114 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { Module } from "@emstack/types";
+
+import { Fragment } from "react";
+
+import {
+  InteractionQuickLog,
+  ModuleDisplayRow,
+  ModuleEditCard,
+} from "@/components/resources/moduleAdminComponents";
+import { moduleToDraft } from "@/components/resources/moduleDrafts";
+
+interface ModuleListItemProps {
+  module: Module;
+  resourceId: string;
+  /** Owning group id, or null for an ungrouped module. */
+  groupId: string | null;
+  /** The sibling list this module belongs to, for reorder bounds/moves. */
+  list: Module[];
+  index: number;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}
+
+/**
+ * A single module within a list (grouped or ungrouped): renders the inline edit
+ * card when it's the one being edited, otherwise the display row plus an
+ * optional quick-log panel. Shared by `UngroupedModulesSection` and
+ * `ModuleGroupSection` so the two lists stay in lockstep.
+ */
+export function ModuleListItem({
+  module: m,
+  resourceId,
+  groupId,
+  list,
+  index,
+  api,
+  ui,
+}: ModuleListItemProps) {
+  const {
+    tagGroups,
+    upsertModuleMutation,
+    deleteModuleMutation,
+    toggleCompleteMutation,
+    moveModule,
+    isReordering,
+  } = api;
+  const {
+    editingModuleId,
+    setEditingModuleId,
+    loggingForModuleId,
+    setLoggingForModuleId,
+    isAnyEditing,
+  } = ui;
+
+  if (m.id === editingModuleId) {
+    return (
+      <ModuleEditCard
+        draft={moduleToDraft(m)}
+        tagGroups={tagGroups}
+        isComplete={m.isComplete}
+        isSaving={
+          upsertModuleMutation.isPending || deleteModuleMutation.isPending
+        }
+        onSave={d =>
+          upsertModuleMutation.mutate(
+            {
+              draft: d,
+              groupId,
+              isComplete: m.isComplete,
+            },
+            {
+              onSuccess: () => setEditingModuleId(null),
+            },
+          )}
+        onCancel={() => setEditingModuleId(null)}
+        onDelete={() =>
+          deleteModuleMutation.mutate(m.id, {
+            onSuccess: () => setEditingModuleId(null),
+          })}
+      />
+    );
+  }
+
+  return (
+    <Fragment>
+      <ModuleDisplayRow
+        module={m}
+        isAnyEditing={isAnyEditing}
+        isReordering={isReordering}
+        canMoveUp={index > 0}
+        canMoveDown={index < list.length - 1}
+        onMoveUp={() => moveModule(list, index, "up")}
+        onMoveDown={() => moveModule(list, index, "down")}
+        onToggleComplete={() => toggleCompleteMutation.mutate(m)}
+        onEdit={() => setEditingModuleId(m.id)}
+        onLogInteraction={() => setLoggingForModuleId(m.id)}
+        isToggling={toggleCompleteMutation.isPending}
+      />
+      {loggingForModuleId === m.id && (
+        <li className="border-t bg-muted/30 p-3">
+          <InteractionQuickLog
+            resourceId={resourceId}
+            moduleId={m.id}
+            scopeLabel={`module: ${m.name}`}
+            onCancel={() => setLoggingForModuleId(null)}
+            onSaved={() => setLoggingForModuleId(null)}
+          />
+        </li>
+      )}
+    </Fragment>
+  );
+}

--- a/packages/client/src/routes/resources.$id.-components/-ResourceModulesAdmin.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceModulesAdmin.tsx
@@ -1,32 +1,11 @@
-import { Fragment, useState } from "react";
+import { ModuleAdminHeader } from "./-ModuleAdminHeader";
+import { ModuleGroupSection } from "./-ModuleGroupSection";
+import { UngroupedModulesSection } from "./-UngroupedModulesSection";
 
-import {
-  ActivityIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  ExternalLinkIcon,
-  PencilIcon,
-  PlusIcon,
-  SparklesIcon,
-} from "lucide-react";
-
-import {
-  GroupEditCard,
-  GroupMetaChips,
-  InteractionQuickLog,
-  ModuleDisplayRow,
-  ModuleEditCard,
-  ModuleSuggestDialog,
-} from "@/components/resources/moduleAdminComponents";
-import {
-  emptyGroupDraft,
-  emptyModuleDraft,
-  groupToDraft,
-  moduleToDraft,
-} from "@/components/resources/moduleDrafts";
-import { Button } from "@/components/ui/button";
+import { GroupEditCard } from "@/components/resources/moduleAdminComponents";
+import { emptyGroupDraft } from "@/components/resources/moduleDrafts";
+import { useModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
 import { useResourceModules } from "@/hooks/useResourceModules";
-import { isHttpUrl } from "@/utils";
 
 interface Props {
   resourceId: string;
@@ -37,114 +16,29 @@ export function ResourceModulesAdmin({
   resourceId,
   modulesAreExhaustive,
 }: Props) {
+  const api = useResourceModules(resourceId);
+  const ui = useModuleAdminUiState();
+
   const {
-    resourceQuery,
-    tagGroups,
-    groups,
-    ungroupedModules,
-    modulesByGroup,
-    completedCount,
-    totalCount,
-    invalidateAll,
-    createGroupMutation,
-    upsertGroupMutation,
-    deleteGroupMutation,
-    createModuleMutation,
-    upsertModuleMutation,
-    toggleCompleteMutation,
-    deleteModuleMutation,
-    moveModule,
-    moveGroup,
-    isReordering,
-  } = useResourceModules(resourceId);
+    tagGroups, groups, ungroupedModules, createGroupMutation,
+  } = api;
+  const {
+    creatingGroup, setCreatingGroup, creatingModuleIn,
+  } = ui;
 
-  // Group state
-  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
-  const [creatingGroup, setCreatingGroup] = useState(false);
-
-  // Module state — keyed by either groupId (string) or "__ungrouped__" for top level
-  const [editingModuleId, setEditingModuleId] = useState<string | null>(null);
-  const [creatingModuleIn, setCreatingModuleIn] = useState<string | null>(null);
-
-  // Quick-log interaction targets. Either a moduleGroupId or a moduleId is set.
-  const [loggingForGroupId, setLoggingForGroupId] = useState<string | null>(
-    null,
-  );
-  const [loggingForModuleId, setLoggingForModuleId] = useState<string | null>(
-    null,
-  );
-
-  // LLM Assist dialog
-  const [llmAssistOpen, setLlmAssistOpen] = useState(false);
-
-  const isAnyEditing
-    = editingGroupId !== null
-      || creatingGroup
-      || editingModuleId !== null
-      || creatingModuleIn !== null
-      || loggingForGroupId !== null
-      || loggingForModuleId !== null;
+  const isEmpty
+    = groups.length === 0
+      && ungroupedModules.length === 0
+      && !creatingGroup
+      && creatingModuleIn === null;
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div>
-          {totalCount > 0 && (
-            <p className="text-sm text-muted-foreground">
-              {completedCount} of {totalCount} complete
-              {modulesAreExhaustive && totalCount > 0 && (
-                <span>
-                  {" "}
-                  · {Math.round((completedCount / totalCount) * 100)}%
-                </span>
-              )}
-            </p>
-          )}
-        </div>
-        <div className="flex flex-row gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setLlmAssistOpen(true)}
-            disabled={isAnyEditing}
-            title="Suggest module groups and modules via Claude"
-          >
-            <SparklesIcon className="size-4" />
-            LLM Assist
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setCreatingModuleIn("__ungrouped__")}
-            disabled={isAnyEditing}
-          >
-            <PlusIcon className="size-4" />
-            Add Module
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setCreatingGroup(true)}
-            disabled={isAnyEditing}
-          >
-            <PlusIcon className="size-4" />
-            New Group
-          </Button>
-        </div>
-      </div>
-
-      <ModuleSuggestDialog
-        open={llmAssistOpen}
-        onOpenChange={setLlmAssistOpen}
+      <ModuleAdminHeader
         resourceId={resourceId}
-        resourceName={resourceQuery.data?.name ?? "this resource"}
-        resourceDescription={resourceQuery.data?.description ?? null}
-        resourceUrl={resourceQuery.data?.url ?? null}
-        providerName={resourceQuery.data?.provider?.name ?? null}
-        topicNames={(resourceQuery.data?.topics ?? []).map(t => t.name)}
-        existingGroupNames={groups.map(g => g.name)}
-        existingUngroupedModuleNames={ungroupedModules.map(m => m.name)}
-        onApplied={() => invalidateAll()}
+        modulesAreExhaustive={modulesAreExhaustive}
+        api={api}
+        ui={ui}
       />
 
       {creatingGroup && (
@@ -162,349 +56,24 @@ export function ResourceModulesAdmin({
         />
       )}
 
-      {/* Ungrouped modules */}
-      {(creatingModuleIn === "__ungrouped__"
-        || ungroupedModules.length > 0) && (
-        <div className="flex flex-col gap-2 rounded-md border bg-background p-3">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            Ungrouped
-          </h3>
-          {creatingModuleIn === "__ungrouped__" && (
-            <ModuleEditCard
-              draft={emptyModuleDraft()}
-              tagGroups={tagGroups}
-              isNew
-              isComplete={false}
-              isSaving={createModuleMutation.isPending}
-              onSave={d =>
-                createModuleMutation.mutate(
-                  {
-                    draft: d,
-                    groupId: null,
-                  },
-                  {
-                    onSuccess: () => setCreatingModuleIn(null),
-                  },
-                )}
-              onCancel={() => setCreatingModuleIn(null)}
-            />
-          )}
-          <ul className="flex flex-col divide-y rounded-sm border">
-            {ungroupedModules.map((m, index) =>
-              m.id === editingModuleId
-                ? (
-                  <ModuleEditCard
-                    key={m.id}
-                    draft={moduleToDraft(m)}
-                    tagGroups={tagGroups}
-                    isComplete={m.isComplete}
-                    isSaving={
-                      upsertModuleMutation.isPending
-                      || deleteModuleMutation.isPending
-                    }
-                    onSave={d =>
-                      upsertModuleMutation.mutate(
-                        {
-                          draft: d,
-                          groupId: null,
-                          // Ungrouped-module save mirrors the grouped-module branch below.
-                          // fallow-ignore-next-line code-duplication
-                          isComplete: m.isComplete,
-                        },
-                        {
-                          onSuccess: () => setEditingModuleId(null),
-                        },
-                      )}
-                    onCancel={() => setEditingModuleId(null)}
-                    onDelete={() =>
-                      deleteModuleMutation.mutate(m.id, {
-                        onSuccess: () => setEditingModuleId(null),
-                      })}
-                  />
-                )
-                : (
-                  <Fragment key={m.id}>
-                    <ModuleDisplayRow
-                      module={m}
-                      isAnyEditing={isAnyEditing}
-                      isReordering={isReordering}
-                      canMoveUp={index > 0}
-                      canMoveDown={index < ungroupedModules.length - 1}
-                      onMoveUp={() => moveModule(ungroupedModules, index, "up")}
-                      onMoveDown={() =>
-                        // Ungrouped-module display row mirrors the grouped branch below.
-                        // fallow-ignore-next-line code-duplication
-                        moveModule(ungroupedModules, index, "down")}
-                      onToggleComplete={() => toggleCompleteMutation.mutate(m)}
-                      onEdit={() => setEditingModuleId(m.id)}
-                      onLogInteraction={() => setLoggingForModuleId(m.id)}
-                      isToggling={toggleCompleteMutation.isPending}
-                    />
-                    {loggingForModuleId === m.id && (
-                      <li className="border-t bg-muted/30 p-3">
-                        <InteractionQuickLog
-                          resourceId={resourceId}
-                          moduleId={m.id}
-                          scopeLabel={`module: ${m.name}`}
-                          onCancel={() => setLoggingForModuleId(null)}
-                          onSaved={() => setLoggingForModuleId(null)}
-                        />
-                      </li>
-                    )}
-                  </Fragment>
-                ))}
-          </ul>
-        </div>
-      )}
+      <UngroupedModulesSection
+        resourceId={resourceId}
+        api={api}
+        ui={ui}
+      />
 
-      {/* Module Groups */}
-      {groups.map((g, gIndex) => {
-        const groupModules = modulesByGroup.get(g.id) ?? [];
-        const isEditing = editingGroupId === g.id;
-        const isCreatingHere = creatingModuleIn === g.id;
+      {groups.map((g, gIndex) => (
+        <ModuleGroupSection
+          key={g.id}
+          group={g}
+          groupIndex={gIndex}
+          resourceId={resourceId}
+          api={api}
+          ui={ui}
+        />
+      ))}
 
-        if (isEditing) {
-          return (
-            <GroupEditCard
-              key={g.id}
-              draft={groupToDraft(g)}
-              hasEnumeratedModules={groupModules.length > 0}
-              tagGroups={tagGroups}
-              isSaving={
-                upsertGroupMutation.isPending || deleteGroupMutation.isPending
-              }
-              onSave={d =>
-                upsertGroupMutation.mutate(d, {
-                  onSuccess: () => setEditingGroupId(null),
-                })}
-              onCancel={() => setEditingGroupId(null)}
-              onDelete={() =>
-                deleteGroupMutation.mutate(g.id, {
-                  onSuccess: () => setEditingGroupId(null),
-                })}
-            />
-          );
-        }
-
-        return (
-          <div
-            key={g.id}
-            className="flex flex-col gap-2 rounded-md border bg-background p-3"
-          >
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex flex-col gap-0.5">
-                <h3 className="font-medium">
-                  {g.url
-                    ? (
-                      isHttpUrl(g.url)
-                        ? (
-                          <a
-                            href={g.url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="hover:text-blue-600"
-                          >
-                            {g.name}
-                            {" "}
-                            <ExternalLinkIcon className="inline size-3.5" />
-                          </a>
-                        )
-                        : (
-                          <span title={g.url}>{g.name}</span>
-                        )
-                    )
-                    : (
-                      g.name
-                    )}
-                </h3>
-                {g.description && (
-                  <span className="text-xs text-muted-foreground">
-                    {g.description}
-                  </span>
-                )}
-              </div>
-              <div className="flex flex-row items-center gap-2">
-                <div className="flex items-center gap-0.5">
-                  <Button
-                    size="icon-sm"
-                    variant="ghost"
-                    onClick={() => moveGroup(gIndex, "up")}
-                    disabled={isAnyEditing || isReordering || gIndex === 0}
-                    aria-label="Move group up"
-                    title="Move group up"
-                  >
-                    <ChevronUpIcon className="size-3.5" />
-                  </Button>
-                  <Button
-                    size="icon-sm"
-                    variant="ghost"
-                    onClick={() => moveGroup(gIndex, "down")}
-                    disabled={
-                      isAnyEditing
-                      || isReordering
-                      || gIndex === groups.length - 1
-                    }
-                    aria-label="Move group down"
-                    title="Move group down"
-                  >
-                    <ChevronDownIcon className="size-3.5" />
-                  </Button>
-                </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setCreatingModuleIn(g.id)}
-                  disabled={isAnyEditing}
-                >
-                  <PlusIcon className="size-3.5" />
-                  Add Module
-                </Button>
-                <Button
-                  size="icon-sm"
-                  variant="ghost"
-                  onClick={() => setLoggingForGroupId(g.id)}
-                  disabled={isAnyEditing}
-                  aria-label={`Log interaction for ${g.name}`}
-                  title="Log interaction"
-                >
-                  <ActivityIcon className="size-3.5" />
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setEditingGroupId(g.id)}
-                  disabled={isAnyEditing}
-                >
-                  <PencilIcon className="size-3.5" />
-                </Button>
-              </div>
-            </div>
-            <GroupMetaChips
-              easeOfStarting={g.easeOfStarting ?? null}
-              timeNeeded={g.timeNeeded ?? null}
-              interactivity={g.interactivity ?? null}
-              tags={g.tags ?? []}
-            />
-            {loggingForGroupId === g.id && (
-              <InteractionQuickLog
-                resourceId={resourceId}
-                moduleGroupId={g.id}
-                scopeLabel={`group: ${g.name}`}
-                onCancel={() => setLoggingForGroupId(null)}
-                onSaved={() => setLoggingForGroupId(null)}
-              />
-            )}
-            {isCreatingHere && (
-              <ModuleEditCard
-                draft={emptyModuleDraft()}
-                tagGroups={tagGroups}
-                isNew
-                isComplete={false}
-                isSaving={createModuleMutation.isPending}
-                onSave={d =>
-                  createModuleMutation.mutate(
-                    {
-                      draft: d,
-                      groupId: g.id,
-                    },
-                    {
-                      onSuccess: () => setCreatingModuleIn(null),
-                    },
-                  )}
-                onCancel={() => setCreatingModuleIn(null)}
-              />
-            )}
-            {groupModules.length > 0 && (
-              <ul className="flex flex-col divide-y rounded-sm border">
-                {groupModules.map((m, mIndex) =>
-                  m.id === editingModuleId
-                    ? (
-                      <ModuleEditCard
-                        key={m.id}
-                        draft={moduleToDraft(m)}
-                        tagGroups={tagGroups}
-                        isComplete={m.isComplete}
-                        isSaving={
-                          upsertModuleMutation.isPending
-                          || deleteModuleMutation.isPending
-                        }
-                        onSave={d =>
-                          upsertModuleMutation.mutate(
-                            {
-                              draft: d,
-                              groupId: g.id,
-                              isComplete: m.isComplete,
-                            },
-                            {
-                              onSuccess: () => setEditingModuleId(null),
-                            },
-                          )}
-                        onCancel={() => setEditingModuleId(null)}
-                        onDelete={() =>
-                          deleteModuleMutation.mutate(m.id, {
-                            onSuccess: () => setEditingModuleId(null),
-                          })}
-                      />
-                    )
-                    : (
-                      <Fragment key={m.id}>
-                        <ModuleDisplayRow
-                          module={m}
-                          isAnyEditing={isAnyEditing}
-                          isReordering={isReordering}
-                          canMoveUp={mIndex > 0}
-                          canMoveDown={mIndex < groupModules.length - 1}
-                          onMoveUp={() => moveModule(groupModules, mIndex, "up")}
-                          onMoveDown={() =>
-                            moveModule(groupModules, mIndex, "down")}
-                          onToggleComplete={() =>
-                            toggleCompleteMutation.mutate(m)}
-                          onEdit={() => setEditingModuleId(m.id)}
-                          onLogInteraction={() => setLoggingForModuleId(m.id)}
-                          isToggling={toggleCompleteMutation.isPending}
-                        />
-                        {loggingForModuleId === m.id && (
-                          <li className="border-t bg-muted/30 p-3">
-                            <InteractionQuickLog
-                              resourceId={resourceId}
-                              moduleId={m.id}
-                              scopeLabel={`module: ${m.name}`}
-                              onCancel={() => setLoggingForModuleId(null)}
-                              onSaved={() => setLoggingForModuleId(null)}
-                            />
-                          </li>
-                        )}
-                      </Fragment>
-                    ))}
-              </ul>
-            )}
-            {groupModules.length === 0
-              && !isCreatingHere
-              && (g.totalCount != null || g.completedCount != null) && (
-              <p className="text-xs text-muted-foreground">
-                {g.completedCount ?? 0}
-                {" / "}
-                {g.totalCount ?? 0}
-                {" complete"}
-              </p>
-            )}
-            {groupModules.length === 0
-              && !isCreatingHere
-              && g.totalCount == null
-              && g.completedCount == null && (
-              <p className="text-xs text-muted-foreground">
-                No modules in this group yet — add modules, or edit the group
-                to track totals directly.
-              </p>
-            )}
-          </div>
-        );
-      })}
-
-      {groups.length === 0
-        && ungroupedModules.length === 0
-        && !creatingGroup
-        && creatingModuleIn === null && (
+      {isEmpty && (
         <p className="text-sm text-muted-foreground">
           No modules yet. Add a module directly, or create a module group to
           organize them.

--- a/packages/client/src/routes/resources.$id.-components/-UngroupedModulesSection.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-UngroupedModulesSection.tsx
@@ -1,0 +1,76 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+
+import { ModuleListItem } from "./-ModuleListItem";
+
+import { ModuleEditCard } from "@/components/resources/moduleAdminComponents";
+import { emptyModuleDraft } from "@/components/resources/moduleDrafts";
+import { UNGROUPED_KEY } from "@/hooks/useModuleAdminUiState";
+
+interface UngroupedModulesSectionProps {
+  resourceId: string;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}
+
+/**
+ * The top-level "Ungrouped" block: an optional inline create card plus the list
+ * of ungrouped modules. Renders nothing when there are no ungrouped modules and
+ * none is being created.
+ */
+export function UngroupedModulesSection({
+  resourceId,
+  api,
+  ui,
+}: UngroupedModulesSectionProps) {
+  const {
+    tagGroups, ungroupedModules, createModuleMutation,
+  } = api;
+  const {
+    creatingModuleIn, setCreatingModuleIn,
+  } = ui;
+
+  const isCreatingHere = creatingModuleIn === UNGROUPED_KEY;
+
+  if (!isCreatingHere && ungroupedModules.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border bg-background p-3">
+      <h3 className="text-sm font-medium text-muted-foreground">Ungrouped</h3>
+      {isCreatingHere && (
+        <ModuleEditCard
+          draft={emptyModuleDraft()}
+          tagGroups={tagGroups}
+          isNew
+          isComplete={false}
+          isSaving={createModuleMutation.isPending}
+          onSave={d =>
+            createModuleMutation.mutate(
+              {
+                draft: d,
+                groupId: null,
+              },
+              {
+                onSuccess: () => setCreatingModuleIn(null),
+              },
+            )}
+          onCancel={() => setCreatingModuleIn(null)}
+        />
+      )}
+      <ul className="flex flex-col divide-y rounded-sm border">
+        {ungroupedModules.map((m, index) => (
+          <ModuleListItem
+            key={m.id}
+            module={m}
+            resourceId={resourceId}
+            groupId={null}
+            list={ungroupedModules}
+            index={index}
+            api={api}
+            ui={ui}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Decompose the top complexity hotspot (issue #453). The component owned
group/module/log UI state plus a 242-line inline groups.map that branched
on edit/create states.

- Lift the UI state machine into useModuleAdminUiState
- Extract route-private section components: ModuleAdminHeader,
  ModuleAssistDialog, UngroupedModulesSection, ModuleGroupSection (with
  local GroupTitle/GroupMeta/GroupHeaderControls/GroupModuleList/
  GroupProgressHint), and a shared ModuleListItem
- Expose ResourceModulesController type so sections compose over the hook

ResourceModulesAdmin is now a thin composition; every unit is below
cyc 10 / cog 15. No behavior change.