### PR TITLE
refactor: extract action parts resolution and provider block logic

### DIFF
--- a/packages/middleware/src/tests/providerProjection.test.ts
+++ b/packages/middleware/src/tests/providerProjection.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { toProviderBlock } from "../utils/providerProjection.ts";
+
+test("toProviderBlock returns the public {name, id} block when both are present", () => {
+  assert.deepStrictEqual(
+    toProviderBlock({
+      id: "prov-1",
+      name: "Frontend Masters",
+    }),
+    {
+      name: "Frontend Masters",
+      id: "prov-1",
+    },
+  );
+});
+
+test("toProviderBlock ignores extra source columns", () => {
+  // Resource rows carry cost/isCourseFeesShared/resources we don't project.
+  assert.deepStrictEqual(
+    toProviderBlock({
+      id: "prov-2",
+      name: "Pluralsight",
+      cost: "29",
+      isCourseFeesShared: true,
+      resources: [{}, {}],
+    } as { id: string;
+      name: string | null; }),
+    {
+      name: "Pluralsight",
+      id: "prov-2",
+    },
+  );
+});
+
+test("toProviderBlock returns undefined when the name is missing", () => {
+  assert.strictEqual(toProviderBlock({
+    id: "prov-3",
+    name: null,
+  }), undefined);
+});
+
+test("toProviderBlock returns undefined when there is no provider", () => {
+  assert.strictEqual(toProviderBlock(null), undefined);
+  assert.strictEqual(toProviderBlock(undefined), undefined);
+});

--- a/packages/middleware/src/tests/routineActionParts.test.ts
+++ b/packages/middleware/src/tests/routineActionParts.test.ts
@@ -1,0 +1,100 @@
+import type { RoutineReferenceItem } from "@emstack/types";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { resolveActionParts } from "../utils/routineActionParts.ts";
+
+const taskEntry: RoutineReferenceItem = {
+  type: "task",
+  id: "task-1",
+  prependText: "Review",
+  appendText: "for 10 minutes",
+};
+
+test("resolveActionParts prefers the resolved resource name over the task name", () => {
+  assert.deepStrictEqual(
+    resolveActionParts(taskEntry, {
+      task: {
+        id: "task-1",
+        name: "Spanish drills",
+      },
+      resource: {
+        id: "res-1",
+        name: "Conjugation deck",
+        progressCurrent: 1,
+        progressTotal: 10,
+      },
+    }),
+    {
+      prependText: "Review",
+      name: "Conjugation deck",
+      appendText: "for 10 minutes",
+    },
+  );
+});
+
+test("resolveActionParts falls back to the resolved task name", () => {
+  assert.deepStrictEqual(
+    resolveActionParts(taskEntry, {
+      task: {
+        id: "task-1",
+        name: "Spanish drills",
+      },
+    }),
+    {
+      prependText: "Review",
+      name: "Spanish drills",
+      appendText: "for 10 minutes",
+    },
+  );
+});
+
+test("resolveActionParts uses a freeform entry's id as the name", () => {
+  const freeform: RoutineReferenceItem = {
+    type: "freeform",
+    id: "Stretch",
+  };
+  assert.deepStrictEqual(resolveActionParts(freeform, {}), {
+    prependText: null,
+    name: "Stretch",
+    appendText: null,
+  });
+});
+
+test("resolveActionParts defaults missing affixes to null", () => {
+  const bare: RoutineReferenceItem = {
+    type: "task",
+    id: "task-2",
+  };
+  assert.deepStrictEqual(
+    resolveActionParts(bare, {
+      task: {
+        id: "task-2",
+        name: "Read",
+      },
+    }),
+    {
+      prependText: null,
+      name: "Read",
+      appendText: null,
+    },
+  );
+});
+
+test("resolveActionParts returns null when there is no active entry", () => {
+  assert.strictEqual(
+    resolveActionParts(null, {
+      task: {
+        id: "task-1",
+        name: "Spanish drills",
+      },
+    }),
+    null,
+  );
+});
+
+test("resolveActionParts returns null when nothing resolves to a name", () => {
+  // A non-freeform entry with no resolved task/resource has no base name.
+  assert.strictEqual(resolveActionParts(taskEntry, {}), null);
+});

--- a/packages/middleware/src/utils/dailyProjection.ts
+++ b/packages/middleware/src/utils/dailyProjection.ts
@@ -3,10 +3,11 @@ import type {
   DailyCompletion,
   DailyCriteria,
 } from "@emstack/types";
+import { toProviderBlock } from "./providerProjection";
 
 // The fields mapDaily reads. Both the single-daily and list daily queries
 // produce a superset of this shape, so their Drizzle rows are assignable here.
-interface DailyProjectionRow {
+export interface DailyProjectionRow {
   id: string;
   name: string;
   location: string | null;
@@ -35,23 +36,40 @@ interface DailyProjectionRow {
   } | null;
 }
 
-export function mapDaily(daily: DailyProjectionRow): Daily {
-  const taskRecord = daily.task;
-  const taskBlock = taskRecord
-    ? {
-      id: taskRecord.id,
-      name: taskRecord.name,
-      progress: {
-        todosTotal: taskRecord.todos?.length ?? 0,
-        todosComplete:
-          taskRecord.todos?.filter(t => t.isComplete).length ?? 0,
-        resourcesTotal: taskRecord.resources?.length ?? 0,
-        resourcesUsed:
-          taskRecord.resources?.filter(r => r.usedYet).length ?? 0,
-      },
-    }
-    : null;
+// Collapse the joined task row into the Daily's task progress block. Returns
+// null when no task is linked; the counts default to 0 for empty/absent arrays.
+function toTaskBlock(task: DailyProjectionRow["task"]): Daily["task"] {
+  if (!task) {
+    return null;
+  }
+  return {
+    id: task.id,
+    name: task.name,
+    progress: {
+      todosTotal: task.todos?.length ?? 0,
+      todosComplete: task.todos?.filter(t => t.isComplete).length ?? 0,
+      resourcesTotal: task.resources?.length ?? 0,
+      resourcesUsed: task.resources?.filter(r => r.usedYet).length ?? 0,
+    },
+  };
+}
 
+// Collapse the joined resource row into the Daily's resource block, present
+// only when the join resolved to a real resource (both id and name).
+function toResourceBlock(
+  resource: DailyProjectionRow["resource"],
+): Daily["resource"] {
+  return resource?.id && resource?.name
+    ? {
+      id: resource.id,
+      name: resource.name,
+      progressCurrent: resource.progressCurrent ?? 0,
+      progressTotal: resource.progressTotal ?? 0,
+    }
+    : undefined;
+}
+
+export function mapDaily(daily: DailyProjectionRow): Daily {
   return {
     id: daily.id,
     name: daily.name,
@@ -61,23 +79,9 @@ export function mapDaily(daily: DailyProjectionRow): Daily {
     status: daily.status ?? "active",
     criteria: (daily.criteria ?? {}) as DailyCriteria,
     taskId: daily.taskId ?? null,
-    task: taskBlock,
-    provider:
-      daily.courseProvider?.name && daily.courseProvider?.id
-        ? {
-          name: daily.courseProvider.name,
-          id: daily.courseProvider.id,
-        }
-        : undefined,
-    resource:
-      daily.resource?.id && daily.resource?.name
-        ? {
-          id: daily.resource.id,
-          name: daily.resource.name,
-          progressCurrent: daily.resource.progressCurrent ?? 0,
-          progressTotal: daily.resource.progressTotal ?? 0,
-        }
-        : undefined,
+    task: toTaskBlock(daily.task),
+    provider: toProviderBlock(daily.courseProvider),
+    resource: toResourceBlock(daily.resource),
     moduleGroupId: daily.moduleGroupId ?? null,
     moduleId: daily.moduleId ?? null,
   };

--- a/packages/middleware/src/utils/providerProjection.ts
+++ b/packages/middleware/src/utils/providerProjection.ts
@@ -1,0 +1,22 @@
+// Both the Daily and Resource public shapes expose the same optional
+// `provider?: { name; id }` block. The source Drizzle row's `courseProvider`
+// carries a nullable name (and, on resources, extra columns we ignore), so
+// collapse it to the public shape only when both id and name are present —
+// otherwise the provider is omitted. Shared so dailyProjection and
+// resourceProjection stay in lockstep and each keeps one fewer inline branch.
+export interface ProviderBlock {
+  name: string;
+  id: string;
+}
+
+export function toProviderBlock(
+  courseProvider: { id: string;
+    name: string | null; } | null | undefined,
+): ProviderBlock | undefined {
+  return courseProvider?.id && courseProvider?.name
+    ? {
+      name: courseProvider.name,
+      id: courseProvider.id,
+    }
+    : undefined;
+}

--- a/packages/middleware/src/utils/resourceProjection.ts
+++ b/packages/middleware/src/utils/resourceProjection.ts
@@ -1,4 +1,5 @@
 import { processCost } from "@/utils/processCost";
+import { toProviderBlock } from "@/utils/providerProjection";
 import { processResourceLinks } from "@/utils/processResourceLinks";
 import type {
   CostData,
@@ -48,13 +49,7 @@ export function mapResource(resource: ResourceProjectionRow): Resource {
     status: resource.status ?? "inactive",
     providerIsSelf: resource.providerIsSelf ?? false,
     topics: processResourceLinks(resource.topicsToResources, "topic"),
-    provider:
-      resource.courseProvider?.name && resource.courseProvider?.id
-        ? {
-          name: resource.courseProvider.name,
-          id: resource.courseProvider.id,
-        }
-        : undefined,
+    provider: toProviderBlock(resource.courseProvider),
     easeOfStarting: resource.easeOfStarting ?? null,
     timeNeeded: resource.timeNeeded ?? null,
     interactivity: resource.interactivity ?? null,

--- a/packages/middleware/src/utils/routineActionParts.ts
+++ b/packages/middleware/src/utils/routineActionParts.ts
@@ -1,0 +1,58 @@
+import type { Daily, RoutineReferenceItem } from "@emstack/types";
+
+// Resolved task/resource rows the handler loads for an active entry. They
+// mirror the column selection mapDaily expects (see dailyProjection.ts).
+export interface ResolvedTask {
+  id: string;
+  name: string;
+  todos?: { id: string;
+    isComplete: boolean; }[];
+  resources?: { id: string;
+    usedYet: boolean; }[];
+}
+
+export interface ResolvedResource {
+  id: string;
+  name: string;
+  progressCurrent: number | null;
+  progressTotal: number | null;
+}
+
+// The task/resource rows a handler has already resolved for the active entry.
+export interface ResolvedConnections {
+  task?: ResolvedTask | null;
+  resource?: ResolvedResource | null;
+}
+
+// The name the action sentence wraps: a resolved resource, then a resolved
+// task, then a freeform entry's own id (which holds the freeform text). Null
+// when nothing resolves, so the projection falls back to the routine title.
+function resolveBaseName(
+  entry: RoutineReferenceItem | null,
+  resolved: ResolvedConnections,
+): string | null {
+  return (
+    resolved.resource?.name
+    ?? resolved.task?.name
+    ?? (entry?.type === "freeform" ? entry.id : null)
+  );
+}
+
+// Derive the structured action parts (optional prepend/append affixes wrapping
+// the resolved name) for a routine's active entry. The flat actionLabel is
+// built from these by the caller, so the two never drift. Returns null when
+// there's no active entry or nothing resolves to a name.
+export function resolveActionParts(
+  entry: RoutineReferenceItem | null,
+  resolved: ResolvedConnections,
+): Daily["actionParts"] {
+  const baseName = resolveBaseName(entry, resolved);
+  if (!entry || !baseName) {
+    return null;
+  }
+  return {
+    prependText: entry.prependText ?? null,
+    name: baseName,
+    appendText: entry.appendText ?? null,
+  };
+}

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -5,38 +5,30 @@ import type {
   EntityStatus,
   RoutineConnection,
   RoutineMode,
+  RoutineReferenceItem,
   RoutineWeekday,
   RoutineWeekly,
 } from "@emstack/types";
 import { buildActionableSentence } from "@emstack/types";
+import type { DailyProjectionRow } from "./dailyProjection";
 import { mapDaily } from "./dailyProjection";
+import type {
+  ResolvedConnections,
+  ResolvedResource,
+  ResolvedTask,
+} from "./routineActionParts";
+import { resolveActionParts } from "./routineActionParts";
 import {
   activeEntry,
   currentWeekday,
   representativeEntry,
 } from "./routineWeekday";
 
-// Entry-selection helpers live in a dependency-free leaf module so they can be
-// unit-tested directly; re-export them here so callers keep a single import site.
+// Pure helpers live in dependency-free leaf modules so they can be unit-tested
+// directly; re-export them here so callers keep a single import site.
 export { activeEntry, currentWeekday, representativeEntry };
-
-// Resolved task/resource rows the handler loads for an active entry. They
-// mirror the column selection mapDaily expects (see dailyProjection.ts).
-export interface ResolvedTask {
-  id: string;
-  name: string;
-  todos?: { id: string;
-    isComplete: boolean; }[];
-  resources?: { id: string;
-    usedYet: boolean; }[];
-}
-
-export interface ResolvedResource {
-  id: string;
-  name: string;
-  progressCurrent: number | null;
-  progressTotal: number | null;
-}
+export { resolveActionParts };
+export type { ResolvedConnections, ResolvedResource, ResolvedTask };
 
 // The routine columns (plus its resolved connections) the projection reads.
 export interface RoutineRow {
@@ -62,21 +54,15 @@ export type RoutineDaily = Daily & {
   connections: RoutineConnection[];
 };
 
-// Build a Daily-compatible object from a daily-mode routine, resolving the
-// representative weekly entry's task/resource into progress blocks via mapDaily.
-// Provider/module sub-targeting is intentionally dropped in the unified model.
-export function mapRoutineToDaily(
+// Assemble the DailyProjectionRow mapDaily expects from a routine, its active
+// entry, and the resolved connections. Provider/module sub-targeting is
+// intentionally dropped in the unified routine model (always null).
+function toDailyRow(
   routine: RoutineRow,
-  resolved: { task?: ResolvedTask | null;
-    resource?: ResolvedResource | null; } = {},
-  weekday: RoutineWeekday = currentWeekday(),
-): RoutineDaily {
-  // The active entry carries the per-item location and the prepend/append text
-  // below: today's scheduled entry for weekly routines, or the representative
-  // entry (mirrored on every day) for daily ones.
-  const entry = activeEntry(routine.weekly, routine.mode, weekday);
-
-  const daily = mapDaily({
+  entry: RoutineReferenceItem | null,
+  resolved: ResolvedConnections,
+): DailyProjectionRow {
+  return {
     id: routine.id,
     name: routine.name,
     location: entry?.location ?? null,
@@ -90,29 +76,27 @@ export function mapRoutineToDaily(
     courseProvider: null,
     resource: resolved.resource ?? null,
     task: resolved.task ?? null,
-  });
+  };
+}
 
-  // Surface the representative entry's resolved name (task/resource/freeform) as
-  // the daily's action title, wrapped with any prepend/append text into a
-  // natural sentence. Set whenever the entry resolves to a name — affixes are
-  // optional and may be null — so a daily assigned to something shows that
-  // thing's name even without affixes, with the routine name rendered beneath.
-  // A daily with no representative entry still falls back to the routine name.
-  const baseName
-    = resolved.resource?.name
-      ?? resolved.task?.name
-      ?? (entry?.type === "freeform" ? entry.id : null);
-  // Structured parts (affixes + name) so consumers can render the name heavier
-  // than the surrounding text; the flat label is derived from them so the two
-  // never drift.
-  const actionParts
-    = entry && baseName
-      ? {
-        prependText: entry.prependText ?? null,
-        name: baseName,
-        appendText: entry.appendText ?? null,
-      }
-      : null;
+// Build a Daily-compatible object from a daily-mode routine, resolving the
+// representative weekly entry's task/resource into progress blocks via mapDaily.
+export function mapRoutineToDaily(
+  routine: RoutineRow,
+  resolved: ResolvedConnections = {},
+  weekday: RoutineWeekday = currentWeekday(),
+): RoutineDaily {
+  // The active entry carries the per-item location and the prepend/append text:
+  // today's scheduled entry for weekly routines, or the representative entry
+  // (mirrored on every day) for daily ones.
+  const entry = activeEntry(routine.weekly, routine.mode, weekday);
+
+  const daily = mapDaily(toDailyRow(routine, entry, resolved));
+
+  // Surface the resolved name (task/resource/freeform) as the daily's action
+  // title, wrapped with any affixes into a natural sentence. The flat label is
+  // derived from the structured parts so the two never drift.
+  const actionParts = resolveActionParts(entry, resolved);
   const actionLabel = actionParts ? buildActionableSentence(actionParts) : null;
 
   return {

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -27,7 +27,6 @@ import {
 // Pure helpers live in dependency-free leaf modules so they can be unit-tested
 // directly; re-export them here so callers keep a single import site.
 export { activeEntry, currentWeekday, representativeEntry };
-export { resolveActionParts };
 export type { ResolvedConnections, ResolvedResource, ResolvedTask };
 
 // The routine columns (plus its resolved connections) the projection reads.


### PR DESCRIPTION
## Summary

Extract two reusable pure functions from projection logic into dedicated modules to improve testability and reduce duplication across the codebase.

## Key Changes

- **New module `routineActionParts.ts`:** Extracts `resolveActionParts()` function that derives structured action parts (prepend/append affixes + resolved name) for a routine's active entry. Moves `ResolvedTask`, `ResolvedResource`, and `ResolvedConnections` types here from `routineProjection.ts`.
  - Includes comprehensive unit tests covering resource/task name resolution, freeform entries, missing affixes, and null cases.

- **New module `providerProjection.ts`:** Extracts `toProviderBlock()` function that collapses the joined `courseProvider` row into the public `{ name, id }` shape, returning `undefined` when either field is missing.
  - Shared by both `dailyProjection.ts` and `resourceProjection.ts` to keep provider block logic in lockstep.
  - Includes unit tests for presence/absence of fields and extra columns.

- **Refactored `routineProjection.ts`:**
  - Delegates action parts resolution to `resolveActionParts()`, removing inline logic.
  - Extracts `toDailyRow()` helper to prepare the row shape for `mapDaily()`.
  - Re-exports extracted types and functions for callers.

- **Refactored `dailyProjection.ts`:**
  - Extracts `toTaskBlock()` and `toResourceBlock()` helpers for clarity.
  - Uses `toProviderBlock()` instead of inline provider block logic.
  - Exports `DailyProjectionRow` interface for use in `routineProjection.ts`.

- **Refactored `resourceProjection.ts`:**
  - Uses `toProviderBlock()` instead of inline provider block logic.

## Implementation Details

- All extracted functions are pure and dependency-free, enabling direct unit testing without mocking.
- Type interfaces (`ResolvedTask`, `ResolvedResource`, `ResolvedConnections`, `ProviderBlock`) are co-located with their functions for clarity.
- The `resolveActionParts()` logic preserves the original precedence: resolved resource name → resolved task name → freeform entry id, returning `null` when nothing resolves.
- Provider block logic consistently returns `undefined` (not `null`) when the provider is absent, matching the Daily/Resource public shape.

https://claude.ai/code/session_01CZsYqGHo3xmsAf2YBDhbfy