### PR TITLE
refactor(client): extract resource edit form logic into hook

### DIFF
--- a/packages/client/src/hooks/useResourceEditForm.ts
+++ b/packages/client/src/hooks/useResourceEditForm.ts
@@ -1,0 +1,214 @@
+import type { Resource } from "@emstack/types";
+
+import { useMemo } from "react";
+
+import { useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { useAppForm } from "@/components/formFields";
+import {
+  buildResourcePayload,
+  formSchema,
+} from "@/routes/resources.$id.edit.-components/-buildResourcePayload";
+import {
+  createProvider,
+  createTopic,
+  fetchProviders,
+  fetchTagGroups,
+  fetchTopics,
+  formHasChanges,
+  tagGroupsToOptions,
+  toOptions,
+  upsertResource,
+  uuidv4,
+} from "@/utils";
+
+interface UseResourceEditFormOptions {
+  id: string;
+  isNew: boolean;
+  data: Resource | undefined;
+  /** `?topicId=` prefill, only honored for new resources. */
+  topicIdSearch?: string;
+  skipBlock: () => void;
+  invalidateRelated: () => Promise<void>;
+}
+
+/**
+ * Bundles the resource edit form's data layer: the topics/providers/tag-group
+ * queries and their derived combobox options, the change-tracked save form
+ * (payload assembly delegated to `buildResourcePayload`), and the provider-cost
+ * mirroring. Lives in the route component (so the form instance — and any
+ * unsaved edits — persists across tab switches) while keeping the Details tab
+ * component presentational.
+ */
+export function useResourceEditForm({
+  id,
+  isNew,
+  data,
+  topicIdSearch,
+  skipBlock,
+  invalidateRelated,
+}: UseResourceEditFormOptions) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const {
+    data: topics,
+  } = useQuery({
+    queryKey: ["topics"],
+    queryFn: () => fetchTopics(),
+  });
+
+  const {
+    data: providers,
+  } = useQuery({
+    queryKey: ["providers"],
+    queryFn: () => fetchProviders(),
+  });
+
+  const {
+    data: tagGroups,
+  } = useQuery({
+    queryKey: ["tagGroups"],
+    queryFn: () => fetchTagGroups(),
+  });
+
+  const topicOptions = useMemo(() => toOptions(topics), [topics]);
+  const providerOptions = useMemo(() => toOptions(providers), [providers]);
+  const tagOptions = useMemo(() => tagGroupsToOptions(tagGroups), [tagGroups]);
+
+  // An exhaustive field-by-field mapping of the resource onto the form's
+  // default values. Its high cyclomatic score is an artifact of per-field
+  // `?? default` coalescing, not branching logic; splitting it fights TanStack
+  // Form's value-type inference (the form keys off this object's shape), so it
+  // reads clearer kept whole.
+  const startingValues = useMemo(
+    // fallow-ignore-next-line complexity
+    () => ({
+      name: data?.name ?? "",
+      description: data?.description ?? "",
+      url: data?.url ?? "",
+      status: data?.status ?? ("active" as const),
+      progressCurrent: data?.progressCurrent ?? null,
+      progressTotal: data?.progressTotal ?? null,
+      cost: data?.cost?.cost != null ? Number(data.cost.cost) : null,
+      dateExpires: data?.dateExpires ? new Date(data.dateExpires) : null,
+      topicId:
+        (Array.isArray(data?.topics) && data.topics[0]?.id)
+        || (isNew ? (topicIdSearch ?? "") : "")
+        || "",
+      courseProviderId: data?.provider?.id ?? "",
+      providerIsSelf: data?.providerIsSelf ?? false,
+      modulesAreExhaustive: data?.modulesAreExhaustive ?? false,
+      easeOfStarting: data?.easeOfStarting ?? "",
+      timeNeeded: data?.timeNeeded ?? "",
+      interactivity: data?.interactivity ?? "",
+      tagIds: (data?.tags ?? []).map(t => t.id),
+    }),
+    [data, isNew, topicIdSearch],
+  );
+
+  const form = useAppForm({
+    defaultValues: startingValues,
+    validators: {
+      onSubmit: formSchema,
+    },
+    onSubmit: async ({
+      value,
+    }) => {
+      // `isCostFromPlatform` is the value computed below from the current
+      // provider selection; at submit time `value` mirrors `currentValues`.
+      const payload = buildResourcePayload(value, {
+        isCostFromPlatform,
+      });
+
+      try {
+        const courseId = isNew ? uuidv4() : id;
+        const previousStatus = data?.status;
+        await upsertResource(courseId, payload);
+        await invalidateRelated();
+        skipBlock();
+        toast.success(isNew ? "Resource created." : "Resource saved.");
+
+        const becameActive
+          = value.status === "active" && (isNew || previousStatus !== "active");
+        await navigate({
+          to: "/resources/$id",
+          params: {
+            id: courseId,
+          },
+          search: becameActive
+            ? {
+              promptDaily: 1,
+            }
+            : {},
+        });
+      }
+      catch (err) {
+        console.error("Failed to save resource:", err);
+        toast.error(
+          isNew
+            ? "Failed to create resource. Please try again."
+            : "Failed to save resource. Please try again.",
+        );
+      }
+    },
+  });
+
+  const currentValues = useStore(form.store, state => ({
+    ...state.values,
+  }));
+  const isSubmitting = useStore(form.store, state => state.isSubmitting);
+  const hasChanges = formHasChanges(currentValues, startingValues);
+
+  // A self-provider mirrors the resource's url, which a provider requires, so
+  // the option is only offered once the resource has a url.
+  const providerUrlMissing = !currentValues.url.trim();
+  const selectedProvider = (providers ?? []).find(
+    p => p.id === currentValues.courseProviderId,
+  );
+  const isCostFromPlatform = !!selectedProvider?.isCourseFeesShared;
+
+  if (isCostFromPlatform && selectedProvider?.cost != null) {
+    const providerCost = Number(selectedProvider.cost);
+    if (currentValues.cost !== providerCost) {
+      form.setFieldValue("cost", providerCost);
+    }
+  }
+
+  const createTopicOption = async (
+    values: Record<string, unknown>,
+  ): Promise<string> => {
+    const result = await createTopic(values);
+    await queryClient.invalidateQueries({
+      queryKey: ["topics"],
+    });
+    return result.id;
+  };
+
+  const createProviderOption = async (
+    values: Record<string, unknown>,
+  ): Promise<string> => {
+    const result = await createProvider(values);
+    await queryClient.invalidateQueries({
+      queryKey: ["providers"],
+    });
+    return result.id;
+  };
+
+  return {
+    form,
+    topicOptions,
+    providerOptions,
+    tagOptions,
+    currentValues,
+    isSubmitting,
+    hasChanges,
+    isCostFromPlatform,
+    providerUrlMissing,
+    createTopicOption,
+    createProviderOption,
+  };
+}

--- a/packages/client/src/routes/resources.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/resources.$id.edit.-components/-DetailsTab.tsx
@@ -1,0 +1,336 @@
+import type { LevelValue } from "./-LevelSelectRow";
+import type { useResourceEditForm } from "@/hooks/useResourceEditForm";
+import type { AnyFieldApi } from "@tanstack/react-form";
+
+import { Loader2 } from "lucide-react";
+
+import { LevelSelectRow } from "./-LevelSelectRow";
+
+import { EditForm, EditPageFooter } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { changedFieldClass, FieldChangeHighlightProvider } from "@/utils";
+
+interface DetailsTabProps {
+  isNew: boolean;
+  /** The form controller from `useResourceEditForm`, owned by the route. */
+  controller: ReturnType<typeof useResourceEditForm>;
+  onDelete: () => void | Promise<void>;
+  onDuplicate: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export function DetailsTab({
+  isNew,
+  controller,
+  onDelete,
+  onDuplicate,
+  onCancel,
+}: DetailsTabProps) {
+  const {
+    form,
+    topicOptions,
+    providerOptions,
+    tagOptions,
+    currentValues,
+    isSubmitting,
+    isCostFromPlatform,
+    providerUrlMissing,
+    createTopicOption,
+    createProviderOption,
+  } = controller;
+
+  return (
+    <FieldChangeHighlightProvider enabled={!isNew}>
+      <EditForm
+        onSubmit={form.handleSubmit}
+        className="flex max-w-2xl flex-col gap-8"
+      >
+        <form.AppField name="name">
+          {field => <field.InputField label="Resource Name" />}
+        </form.AppField>
+
+        <form.AppField name="description">
+          {field => (
+            <field.TextareaField
+              label="Description"
+              placeholder="What is this course about?"
+            />
+          )}
+        </form.AppField>
+
+        <form.AppField name="url">
+          {field => <field.InputField label="Resource URL" />}
+        </form.AppField>
+
+        <form.AppField name="topicId">
+          {field => (
+            <field.ComboboxField
+              label="Topic"
+              options={topicOptions}
+              placeholder="Search topics..."
+              create={{
+                itemLabel: "topic",
+                fields: [
+                  {
+                    name: "name",
+                    label: "Name",
+                    required: true,
+                    isPrimary: true,
+                  },
+                ],
+                onCreate: createTopicOption,
+              }}
+            />
+          )}
+        </form.AppField>
+
+        <form.Field name="providerIsSelf">
+          {field => (
+            <label
+              className={cn(
+                "flex items-start gap-2 text-sm",
+                !isNew && !field.state.meta.isDefaultValue && changedFieldClass,
+                providerUrlMissing && "opacity-60",
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                disabled={providerUrlMissing}
+                onChange={(e) => {
+                  field.handleChange(e.target.checked);
+                  if (e.target.checked) {
+                    form.setFieldValue("courseProviderId", "");
+                  }
+                }}
+                className="mt-0.5 size-4"
+              />
+              <span className="flex flex-col gap-0.5">
+                <span className="font-medium">
+                  This resource is its own provider
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {providerUrlMissing
+                    ? "Add a Resource URL to enable this."
+                    : "Creates a separate provider that mirrors this resource's "
+                      + "name and URL, kept in sync whenever you save."}
+                </span>
+              </span>
+            </label>
+          )}
+        </form.Field>
+
+        {currentValues.providerIsSelf
+          ? (
+            <p className="text-sm text-muted-foreground">
+              Provider mirrors this resource — its name and URL will match.
+            </p>
+          )
+          : (
+            <form.AppField name="courseProviderId">
+              {field => (
+                <field.ComboboxField
+                  label="Provider"
+                  options={providerOptions}
+                  placeholder="Search providers..."
+                  create={{
+                    itemLabel: "provider",
+                    fields: [
+                      {
+                        name: "name",
+                        label: "Name",
+                        required: true,
+                        isPrimary: true,
+                      },
+                      {
+                        name: "url",
+                        label: "URL",
+                        required: true,
+                        type: "url",
+                        placeholder: "https://...",
+                      },
+                    ],
+                    onCreate: createProviderOption,
+                  }}
+                />
+              )}
+            </form.AppField>
+          )}
+
+        <form.AppField name="status">
+          {field => (
+            <field.RadioGroupField
+              label="Status"
+              options={[
+                {
+                  value: "active",
+                  label: "active",
+                },
+                {
+                  value: "inactive",
+                  label: "inactive",
+                },
+                {
+                  value: "complete",
+                  label: "complete",
+                },
+              ]}
+            />
+          )}
+        </form.AppField>
+
+        <div className="grid grid-cols-2 gap-4">
+          <form.AppField
+            name="progressCurrent"
+            validators={{
+              onSubmit: ({
+                value,
+                fieldApi,
+              }: {
+                value: number | null;
+                fieldApi: AnyFieldApi;
+              }) => {
+                const total = fieldApi.form.getFieldValue("progressTotal");
+                if (value != null && total != null && value > total) {
+                  return {
+                    message: "Current progress cannot exceed total modules",
+                  };
+                }
+                return undefined;
+              },
+            }}
+          >
+            {field => (
+              <field.NumberField
+                label="Current Progress"
+                min={0}
+              />
+            )}
+          </form.AppField>
+
+          <form.AppField name="progressTotal">
+            {field => (
+              <field.NumberField
+                label="Total Modules"
+                min={0}
+              />
+            )}
+          </form.AppField>
+        </div>
+
+        <form.Field name="modulesAreExhaustive">
+          {field => (
+            <label
+              className={cn(
+                "flex items-start gap-2 text-sm",
+                !isNew && !field.state.meta.isDefaultValue && changedFieldClass,
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={field.state.value}
+                onChange={e => field.handleChange(e.target.checked)}
+                className="mt-0.5 size-4"
+              />
+              <span className="flex flex-col gap-0.5">
+                <span className="font-medium">Module list is exhaustive</span>
+                <span className="text-xs text-muted-foreground">
+                  When checked, course progress is computed from the count of
+                  completed modules below rather than the manual fields above.
+                </span>
+              </span>
+            </label>
+          )}
+        </form.Field>
+
+        <form.AppField name="cost">
+          {field => (
+            <field.NumberField
+              label="Cost ($)"
+              min={0}
+              step="0.01"
+              disabled={isCostFromPlatform}
+            />
+          )}
+        </form.AppField>
+
+        <form.AppField name="dateExpires">
+          {field => <field.DatePickerField label="Expiry Date" />}
+        </form.AppField>
+
+        <fieldset
+          className="flex flex-col gap-3 rounded-md border border-border/60 p-3"
+        >
+          <legend className="px-1 text-xs font-medium text-muted-foreground">
+            Effort & Engagement
+          </legend>
+          <form.Field name="easeOfStarting">
+            {field => (
+              <LevelSelectRow
+                label="Ease of Starting"
+                value={field.state.value as LevelValue}
+                onChange={v => field.handleChange(v)}
+                changed={!isNew && !field.state.meta.isDefaultValue}
+              />
+            )}
+          </form.Field>
+          <form.Field name="timeNeeded">
+            {field => (
+              <LevelSelectRow
+                label="Time Needed"
+                value={field.state.value as LevelValue}
+                onChange={v => field.handleChange(v)}
+                changed={!isNew && !field.state.meta.isDefaultValue}
+              />
+            )}
+          </form.Field>
+          <form.Field name="interactivity">
+            {field => (
+              <LevelSelectRow
+                label="Interactivity"
+                value={field.state.value as LevelValue}
+                onChange={v => field.handleChange(v)}
+                changed={!isNew && !field.state.meta.isDefaultValue}
+              />
+            )}
+          </form.Field>
+        </fieldset>
+
+        <form.AppField name="tagIds">
+          {field => (
+            <field.MultiComboboxField
+              label="Tags"
+              options={tagOptions}
+              placeholder="Pick tags..."
+              groupByPrefix
+            />
+          )}
+        </form.AppField>
+
+        <EditPageFooter
+          isNew={isNew}
+          onDelete={onDelete}
+          deleteLabel="Delete Resource"
+          onDuplicate={onDuplicate}
+          duplicateLabel="Duplicate Resource"
+        >
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting && <Loader2 className="animate-spin" />}
+            {isNew ? "Create Resource" : "Save Changes"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        </EditPageFooter>
+      </EditForm>
+    </FieldChangeHighlightProvider>
+  );
+}

--- a/packages/client/src/routes/resources.$id.edit.-components/-LevelSelectRow.tsx
+++ b/packages/client/src/routes/resources.$id.edit.-components/-LevelSelectRow.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import { changedFieldClass } from "@/utils";
+
+export type LevelValue = "" | "low" | "medium" | "high";
+
+export function LevelSelectRow({
+  label,
+  value,
+  onChange,
+  changed,
+}: {
+  label: string;
+  value: LevelValue;
+  onChange: (next: LevelValue) => void;
+  changed?: boolean;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-1", changed && changedFieldClass)}>
+      <label className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value as LevelValue)}
+        className="
+          flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm
+        "
+      >
+        <option value="">—</option>
+        <option value="low">low</option>
+        <option value="medium">medium</option>
+        <option value="high">high</option>
+      </select>
+    </div>
+  );
+}

--- a/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.test.ts
+++ b/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+
+import type { ResourceFormValues } from "./-buildResourcePayload.ts";
+
+import { buildResourcePayload } from "./-buildResourcePayload.ts";
+
+const baseValues: ResourceFormValues = {
+  name: "Intro to TypeScript",
+  description: "A course",
+  url: "https://example.com",
+  status: "active",
+  progressCurrent: 3,
+  progressTotal: 10,
+  cost: 49.99,
+  dateExpires: new Date("2026-12-31T00:00:00.000Z"),
+  topicId: "topic-1",
+  courseProviderId: "provider-1",
+  providerIsSelf: false,
+  modulesAreExhaustive: true,
+  easeOfStarting: "high",
+  timeNeeded: "medium",
+  interactivity: "low",
+  tagIds: ["tag-1", "tag-2"],
+};
+
+describe("buildResourcePayload", () => {
+  test("maps a fully-populated form onto the API payload", () => {
+    const payload = buildResourcePayload(baseValues, {
+      isCostFromPlatform: false,
+    });
+
+    expect(payload).toEqual({
+      name: "Intro to TypeScript",
+      description: "A course",
+      url: "https://example.com",
+      status: "active",
+      progressCurrent: 3,
+      progressTotal: 10,
+      cost: "49.99",
+      isCostFromPlatform: false,
+      dateExpires: "2026-12-31",
+      isExpires: true,
+      topicId: "topic-1",
+      courseProviderId: "provider-1",
+      providerIsSelf: false,
+      modulesAreExhaustive: true,
+      easeOfStarting: "high",
+      timeNeeded: "medium",
+      interactivity: "low",
+      tagIds: ["tag-1", "tag-2"],
+    });
+  });
+
+  test("coalesces empty strings and nullish numbers to null/0", () => {
+    const payload = buildResourcePayload(
+      {
+        ...baseValues,
+        description: "",
+        url: "",
+        progressCurrent: null,
+        progressTotal: null,
+        cost: null,
+        dateExpires: null,
+        topicId: "",
+        courseProviderId: "",
+        easeOfStarting: "",
+        timeNeeded: "",
+        interactivity: "",
+      },
+      {
+        isCostFromPlatform: false,
+      },
+    );
+
+    expect(payload.description).toBeNull();
+    expect(payload.url).toBeNull();
+    expect(payload.progressCurrent).toBe(0);
+    expect(payload.progressTotal).toBe(0);
+    expect(payload.cost).toBeNull();
+    expect(payload.dateExpires).toBeNull();
+    expect(payload.isExpires).toBe(false);
+    expect(payload.topicId).toBeNull();
+    expect(payload.courseProviderId).toBeNull();
+    expect(payload.easeOfStarting).toBeNull();
+    expect(payload.timeNeeded).toBeNull();
+    expect(payload.interactivity).toBeNull();
+  });
+
+  test("ignores the entered cost when it comes from the platform", () => {
+    const payload = buildResourcePayload(baseValues, {
+      isCostFromPlatform: true,
+    });
+
+    expect(payload.cost).toBeNull();
+    expect(payload.isCostFromPlatform).toBe(true);
+  });
+});

--- a/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.ts
+++ b/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.ts
@@ -1,0 +1,99 @@
+import type { EntityStatus } from "@emstack/types";
+
+import * as z from "zod";
+
+export const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(500),
+  url: z.string().max(255),
+  status: z.enum(["active", "inactive", "complete"]),
+  progressCurrent: z.number().int().min(0).nullable(),
+  progressTotal: z.number().int().min(0).nullable(),
+  cost: z.number().min(0).nullable(),
+  dateExpires: z.date().nullable(),
+  topicId: z.string(),
+  courseProviderId: z.string(),
+  providerIsSelf: z.boolean(),
+  modulesAreExhaustive: z.boolean(),
+  easeOfStarting: z.enum(["", "low", "medium", "high"]),
+  timeNeeded: z.enum(["", "low", "medium", "high"]),
+  interactivity: z.enum(["", "low", "medium", "high"]),
+  tagIds: z.array(z.string()),
+});
+
+// Mirrors the edit form's value type. It is intentionally looser than
+// `z.infer<typeof formSchema>`: TanStack Form derives the value type from the
+// default values (seeded from the fetched resource), so `status` is the full
+// `EntityStatus` and the level fields widen to `string`. The narrow schema enum
+// above is only the submit-time validator. Declared explicitly so the helper
+// stays decoupled from the form and is straightforward to unit test.
+export interface ResourceFormValues {
+  name: string;
+  description: string;
+  url: string;
+  status: EntityStatus;
+  progressCurrent: number | null;
+  progressTotal: number | null;
+  cost: number | null;
+  dateExpires: Date | null;
+  topicId: string;
+  courseProviderId: string;
+  providerIsSelf: boolean;
+  modulesAreExhaustive: boolean;
+  easeOfStarting: string;
+  timeNeeded: string;
+  interactivity: string;
+  tagIds: string[];
+}
+
+/**
+ * Assemble the resource upsert payload from the edit form's values. Kept as a
+ * pure function so the per-field `|| null` / `?? 0` coalescing and the
+ * cost/expiry branching live in one testable place instead of inflating the
+ * form's `onSubmit` handler. The return shape stays an inferred object literal
+ * so it remains assignable to the `Record<string, unknown>` that the entity
+ * client's `upsert` expects.
+ *
+ * `isCostFromPlatform` is passed in (not derived here) because it depends on the
+ * selected provider, which only the form component knows.
+ *
+ * Its cyclomatic score is an artifact of the per-field `|| null` / `?? 0`
+ * coalescing, not branching logic (same as `startingValues`), so it reads
+ * clearer kept whole.
+ */
+// fallow-ignore-next-line complexity
+export function buildResourcePayload(
+  value: ResourceFormValues,
+  {
+    isCostFromPlatform,
+  }: {
+    isCostFromPlatform: boolean;
+  },
+) {
+  return {
+    name: value.name,
+    description: value.description || null,
+    url: value.url || null,
+    status: value.status,
+    progressCurrent: value.progressCurrent ?? 0,
+    progressTotal: value.progressTotal ?? 0,
+    cost: isCostFromPlatform
+      ? null
+      : value.cost != null
+        ? String(value.cost)
+        : null,
+    isCostFromPlatform,
+    dateExpires: value.dateExpires
+      ? value.dateExpires.toISOString().split("T")[0]
+      : null,
+    isExpires: !!value.dateExpires,
+    topicId: value.topicId || null,
+    courseProviderId: value.courseProviderId || null,
+    providerIsSelf: value.providerIsSelf,
+    modulesAreExhaustive: value.modulesAreExhaustive,
+    easeOfStarting: value.easeOfStarting || null,
+    timeNeeded: value.timeNeeded || null,
+    interactivity: value.interactivity || null,
+    tagIds: value.tagIds,
+  };
+}

--- a/packages/client/src/routes/resources.$id.edit.-components/index.ts
+++ b/packages/client/src/routes/resources.$id.edit.-components/index.ts
@@ -1,0 +1,5 @@
+// Barrel for the resource-edit route's private components so the route imports
+// them from one module. These components don't import this index, so there is
+// no cycle. The `.-components/` folder is excluded from route generation, so
+// this index.ts produces no route.
+export { DetailsTab } from "./-DetailsTab";

--- a/packages/client/src/routes/resources.$id.edit.tsx
+++ b/packages/client/src/routes/resources.$id.edit.tsx
@@ -1,40 +1,17 @@
-/* eslint-disable import/max-dependencies */
-import type { AnyFieldApi } from "@tanstack/react-form";
-
-import { useMemo } from "react";
-
-import { useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
-import * as z from "zod";
 
 import { ResourceInteractionsLog } from "./resources.$id.-components/-ResourceInteractionsLog";
 import { ResourceModulesAdmin } from "./resources.$id.-components/-ResourceModulesAdmin";
+import { DetailsTab } from "./resources.$id.edit.-components";
 
-import { useAppForm } from "@/components/formFields";
-import { EditPageFooter, PageTabs } from "@/components/layout";
-import { Button } from "@/components/ui/button";
+import { PageTabs } from "@/components/layout";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
-import { cn } from "@/lib/utils";
+import { useResourceEditForm } from "@/hooks/useResourceEditForm";
 import {
-  changedFieldClass,
-  createProvider,
-  createTopic,
   deleteSingleResource,
   duplicateResource,
-  FieldChangeHighlightProvider,
-  fetchProviders,
   fetchSingleResource,
-  fetchTagGroups,
-  fetchTopics,
-  formHasChanges,
-  tagGroupsToOptions,
-  toOptions,
-  upsertResource,
-  uuidv4,
 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
@@ -61,59 +38,6 @@ export const Route = createFileRoute("/resources/$id/edit")({
   }),
 });
 
-const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
-  description: z.string().max(500),
-  url: z.string().max(255),
-  status: z.enum(["active", "inactive", "complete"]),
-  progressCurrent: z.number().int().min(0).nullable(),
-  progressTotal: z.number().int().min(0).nullable(),
-  cost: z.number().min(0).nullable(),
-  dateExpires: z.date().nullable(),
-  topicId: z.string(),
-  courseProviderId: z.string(),
-  providerIsSelf: z.boolean(),
-  modulesAreExhaustive: z.boolean(),
-  easeOfStarting: z.enum(["", "low", "medium", "high"]),
-  timeNeeded: z.enum(["", "low", "medium", "high"]),
-  interactivity: z.enum(["", "low", "medium", "high"]),
-  tagIds: z.array(z.string()),
-});
-
-type LevelValue = "" | "low" | "medium" | "high";
-
-function LevelSelectRow({
-  label,
-  value,
-  onChange,
-  changed,
-}: {
-  label: string;
-  value: LevelValue;
-  onChange: (next: LevelValue) => void;
-  changed?: boolean;
-}) {
-  return (
-    <div className={cn("flex flex-col gap-1", changed && changedFieldClass)}>
-      <label className="text-xs font-medium text-muted-foreground">
-        {label}
-      </label>
-      <select
-        value={value}
-        onChange={e => onChange(e.target.value as LevelValue)}
-        className="
-          flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm
-        "
-      >
-        <option value="">—</option>
-        <option value="low">low</option>
-        <option value="medium">medium</option>
-        <option value="high">high</option>
-      </select>
-    </div>
-  );
-}
-
 function SingleResourceEdit() {
   const {
     id,
@@ -121,7 +45,6 @@ function SingleResourceEdit() {
   const search = Route.useSearch();
   const isNew = id === "new";
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const tab: ResourceTab = search.tab ?? "details";
 
@@ -131,6 +54,7 @@ function SingleResourceEdit() {
     invalidateRelated,
     shouldBlockFn,
     makeDeleteHandler,
+    makeDuplicateHandler,
   } = useEditFormPage({
     id,
     isNew,
@@ -139,151 +63,16 @@ function SingleResourceEdit() {
     relatedQueryKeys: [queryKeys.resources.list(), queryKeys.topics.list()],
   });
 
-  const {
-    data: topics,
-  } = useQuery({
-    queryKey: ["topics"],
-    queryFn: () => fetchTopics(),
+  // The form lives here (not in DetailsTab) so its state survives tab switches,
+  // which unmount the inactive tab panels.
+  const controller = useResourceEditForm({
+    id,
+    isNew,
+    data,
+    topicIdSearch: search.topicId,
+    skipBlock,
+    invalidateRelated,
   });
-
-  const {
-    data: providers,
-  } = useQuery({
-    queryKey: ["providers"],
-    queryFn: () => fetchProviders(),
-  });
-
-  const {
-    data: tagGroups,
-  } = useQuery({
-    queryKey: ["tagGroups"],
-    queryFn: () => fetchTagGroups(),
-  });
-
-  const topicOptions = toOptions(topics);
-
-  const providerOptions = toOptions(providers);
-
-  const tagOptions = tagGroupsToOptions(tagGroups);
-
-  // An exhaustive field-by-field mapping of the resource onto the form's
-  // default values. Its high cyclomatic score is an artifact of per-field
-  // `?? default` coalescing, not branching logic; splitting it fights TanStack
-  // Form's value-type inference (the form keys off this object's shape), so it
-  // reads clearer kept whole.
-  const startingValues = useMemo(
-    // fallow-ignore-next-line complexity
-    () => ({
-      name: data?.name ?? "",
-      description: data?.description ?? "",
-      url: data?.url ?? "",
-      status: data?.status ?? ("active" as const),
-      progressCurrent: data?.progressCurrent ?? null,
-      progressTotal: data?.progressTotal ?? null,
-      cost: data?.cost?.cost != null ? Number(data.cost.cost) : null,
-      dateExpires: data?.dateExpires ? new Date(data.dateExpires) : null,
-      topicId:
-        (Array.isArray(data?.topics) && data.topics[0]?.id)
-        || (isNew ? (search.topicId ?? "") : "")
-        || "",
-      courseProviderId: data?.provider?.id ?? "",
-      providerIsSelf: data?.providerIsSelf ?? false,
-      modulesAreExhaustive: data?.modulesAreExhaustive ?? false,
-      easeOfStarting: data?.easeOfStarting ?? "",
-      timeNeeded: data?.timeNeeded ?? "",
-      interactivity: data?.interactivity ?? "",
-      tagIds: (data?.tags ?? []).map(t => t.id),
-    }),
-    [data, isNew, search.topicId],
-  );
-
-  const form = useAppForm({
-    defaultValues: startingValues,
-    validators: {
-      onSubmit: formSchema,
-    },
-    onSubmit: async ({
-      value,
-    }) => {
-      const courseData = {
-        name: value.name,
-        description: value.description || null,
-        url: value.url || null,
-        status: value.status,
-        progressCurrent: value.progressCurrent ?? 0,
-        progressTotal: value.progressTotal ?? 0,
-        cost: isCostFromPlatform
-          ? null
-          : value.cost != null
-            ? String(value.cost)
-            : null,
-        isCostFromPlatform,
-        dateExpires: value.dateExpires
-          ? value.dateExpires.toISOString().split("T")[0]
-          : null,
-        isExpires: !!value.dateExpires,
-        topicId: value.topicId || null,
-        courseProviderId: value.courseProviderId || null,
-        providerIsSelf: value.providerIsSelf,
-        modulesAreExhaustive: value.modulesAreExhaustive,
-        easeOfStarting: value.easeOfStarting || null,
-        timeNeeded: value.timeNeeded || null,
-        interactivity: value.interactivity || null,
-        tagIds: value.tagIds,
-      };
-
-      try {
-        const courseId = isNew ? uuidv4() : id;
-        const previousStatus = data?.status;
-        await upsertResource(courseId, courseData);
-        await invalidateRelated();
-        skipBlock();
-        toast.success(isNew ? "Resource created." : "Resource saved.");
-
-        const becameActive
-          = value.status === "active" && (isNew || previousStatus !== "active");
-        await navigate({
-          to: "/resources/$id",
-          params: {
-            id: courseId,
-          },
-          search: becameActive
-            ? {
-              promptDaily: 1,
-            }
-            : {},
-        });
-      }
-      catch (err) {
-        console.error("Failed to save resource:", err);
-        toast.error(
-          isNew
-            ? "Failed to create resource. Please try again."
-            : "Failed to save resource. Please try again.",
-        );
-      }
-    },
-  });
-
-  const currentValues = useStore(form.store, state => ({
-    ...state.values,
-  }));
-  const isSubmitting = useStore(form.store, state => state.isSubmitting);
-  const hasChanges = formHasChanges(currentValues, startingValues);
-  // A self-provider mirrors the resource's url, which a provider requires, so the
-  // option is only offered once the resource has a url.
-  const providerUrlMissing = !currentValues.url.trim();
-  const selectedProvider = (providers ?? []).find(
-    p => p.id === currentValues.courseProviderId,
-  );
-  const isCostFromPlatform = !!selectedProvider?.isCourseFeesShared;
-
-  if (isCostFromPlatform && selectedProvider?.cost != null) {
-    const providerCost = Number(selectedProvider.cost);
-    if (currentValues.cost !== providerCost) {
-      form.setFieldValue("cost", providerCost);
-    }
-  }
 
   const handleDelete = makeDeleteHandler({
     deleteFn: deleteSingleResource,
@@ -294,22 +83,17 @@ function SingleResourceEdit() {
       }),
   });
 
-  async function handleDuplicate() {
-    try {
-      const result = await duplicateResource(id);
-      await invalidateRelated();
-      skipBlock();
-      await navigate({
+  const handleDuplicate = makeDuplicateHandler({
+    duplicateFn: duplicateResource,
+    entityLabel: "resource",
+    navigateToEntity: newId =>
+      navigate({
         to: "/resources/$id",
         params: {
-          id: result.id,
+          id: newId,
         },
-      });
-    }
-    catch {
-      toast.error("Failed to duplicate resource. Please try again.");
-    }
-  }
+      }),
+  });
 
   function changeTab(next: ResourceTab) {
     navigate({
@@ -325,327 +109,30 @@ function SingleResourceEdit() {
     });
   }
 
+  function handleCancel() {
+    if (isNew) {
+      navigate({
+        to: "/resources",
+      });
+    }
+    else {
+      navigate({
+        to: "/resources/$id",
+        params: {
+          id,
+        },
+      });
+    }
+  }
+
   const detailsTab = (
-    <FieldChangeHighlightProvider enabled={!isNew}>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          form.handleSubmit();
-        }}
-        className="flex max-w-2xl flex-col gap-8"
-      >
-        <form.AppField name="name">
-          {field => <field.InputField label="Resource Name" />}
-        </form.AppField>
-
-        <form.AppField name="description">
-          {field => (
-            <field.TextareaField
-              label="Description"
-              placeholder="What is this course about?"
-            />
-          )}
-        </form.AppField>
-
-        <form.AppField name="url">
-          {field => <field.InputField label="Resource URL" />}
-        </form.AppField>
-
-        <form.AppField name="topicId">
-          {field => (
-            <field.ComboboxField
-              label="Topic"
-              options={topicOptions}
-              placeholder="Search topics..."
-              create={{
-                itemLabel: "topic",
-                fields: [
-                  {
-                    name: "name",
-                    label: "Name",
-                    required: true,
-                    isPrimary: true,
-                  },
-                ],
-                onCreate: async (values) => {
-                  const result = await createTopic(values);
-                  await queryClient.invalidateQueries({
-                    queryKey: ["topics"],
-                  });
-                  return result.id;
-                },
-              }}
-            />
-          )}
-        </form.AppField>
-
-        <form.Field name="providerIsSelf">
-          {field => (
-            <label
-              className={cn(
-                "flex items-start gap-2 text-sm",
-                !isNew && !field.state.meta.isDefaultValue && changedFieldClass,
-                providerUrlMissing && "opacity-60",
-              )}
-            >
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                disabled={providerUrlMissing}
-                onChange={(e) => {
-                  field.handleChange(e.target.checked);
-                  if (e.target.checked) {
-                    form.setFieldValue("courseProviderId", "");
-                  }
-                }}
-                className="mt-0.5 size-4"
-              />
-              <span className="flex flex-col gap-0.5">
-                <span className="font-medium">
-                  This resource is its own provider
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {providerUrlMissing
-                    ? "Add a Resource URL to enable this."
-                    : "Creates a separate provider that mirrors this resource's "
-                      + "name and URL, kept in sync whenever you save."}
-                </span>
-              </span>
-            </label>
-          )}
-        </form.Field>
-
-        {currentValues.providerIsSelf
-          ? (
-            <p className="text-sm text-muted-foreground">
-              Provider mirrors this resource — its name and URL will match.
-            </p>
-          )
-          : (
-            <form.AppField name="courseProviderId">
-              {field => (
-                <field.ComboboxField
-                  label="Provider"
-                  options={providerOptions}
-                  placeholder="Search providers..."
-                  create={{
-                    itemLabel: "provider",
-                    fields: [
-                      {
-                        name: "name",
-                        label: "Name",
-                        required: true,
-                        isPrimary: true,
-                      },
-                      {
-                        name: "url",
-                        label: "URL",
-                        required: true,
-                        type: "url",
-                        placeholder: "https://...",
-                      },
-                    ],
-                    onCreate: async (values) => {
-                      const result = await createProvider(values);
-                      await queryClient.invalidateQueries({
-                        queryKey: ["providers"],
-                      });
-                      return result.id;
-                    },
-                  }}
-                />
-              )}
-            </form.AppField>
-          )}
-
-        <form.AppField name="status">
-          {field => (
-            <field.RadioGroupField
-              label="Status"
-              options={[
-                {
-                  value: "active",
-                  label: "active",
-                },
-                {
-                  value: "inactive",
-                  label: "inactive",
-                },
-                {
-                  value: "complete",
-                  label: "complete",
-                },
-              ]}
-            />
-          )}
-        </form.AppField>
-
-        <div className="grid grid-cols-2 gap-4">
-          <form.AppField
-            name="progressCurrent"
-            validators={{
-              onSubmit: ({
-                value,
-                fieldApi,
-              }: {
-                value: number | null;
-                fieldApi: AnyFieldApi;
-              }) => {
-                const total = fieldApi.form.getFieldValue("progressTotal");
-                if (value != null && total != null && value > total) {
-                  return {
-                    message: "Current progress cannot exceed total modules",
-                  };
-                }
-                return undefined;
-              },
-            }}
-          >
-            {field => (
-              <field.NumberField
-                label="Current Progress"
-                min={0}
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="progressTotal">
-            {field => (
-              <field.NumberField
-                label="Total Modules"
-                min={0}
-              />
-            )}
-          </form.AppField>
-        </div>
-
-        <form.Field name="modulesAreExhaustive">
-          {field => (
-            <label
-              className={cn(
-                "flex items-start gap-2 text-sm",
-                !isNew && !field.state.meta.isDefaultValue && changedFieldClass,
-              )}
-            >
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                onChange={e => field.handleChange(e.target.checked)}
-                className="mt-0.5 size-4"
-              />
-              <span className="flex flex-col gap-0.5">
-                <span className="font-medium">Module list is exhaustive</span>
-                <span className="text-xs text-muted-foreground">
-                  When checked, course progress is computed from the count of
-                  completed modules below rather than the manual fields above.
-                </span>
-              </span>
-            </label>
-          )}
-        </form.Field>
-
-        <form.AppField name="cost">
-          {field => (
-            <field.NumberField
-              label="Cost ($)"
-              min={0}
-              step="0.01"
-              disabled={isCostFromPlatform}
-            />
-          )}
-        </form.AppField>
-
-        <form.AppField name="dateExpires">
-          {field => <field.DatePickerField label="Expiry Date" />}
-        </form.AppField>
-
-        <fieldset
-          className="flex flex-col gap-3 rounded-md border border-border/60 p-3"
-        >
-          <legend className="px-1 text-xs font-medium text-muted-foreground">
-            Effort & Engagement
-          </legend>
-          <form.Field name="easeOfStarting">
-            {field => (
-              <LevelSelectRow
-                label="Ease of Starting"
-                value={field.state.value as LevelValue}
-                onChange={v => field.handleChange(v)}
-                changed={!isNew && !field.state.meta.isDefaultValue}
-              />
-            )}
-          </form.Field>
-          <form.Field name="timeNeeded">
-            {field => (
-              <LevelSelectRow
-                label="Time Needed"
-                value={field.state.value as LevelValue}
-                onChange={v => field.handleChange(v)}
-                changed={!isNew && !field.state.meta.isDefaultValue}
-              />
-            )}
-          </form.Field>
-          <form.Field name="interactivity">
-            {field => (
-              <LevelSelectRow
-                label="Interactivity"
-                value={field.state.value as LevelValue}
-                onChange={v => field.handleChange(v)}
-                changed={!isNew && !field.state.meta.isDefaultValue}
-              />
-            )}
-          </form.Field>
-        </fieldset>
-
-        <form.AppField name="tagIds">
-          {field => (
-            <field.MultiComboboxField
-              label="Tags"
-              options={tagOptions}
-              placeholder="Pick tags..."
-              groupByPrefix
-            />
-          )}
-        </form.AppField>
-
-        <EditPageFooter
-          isNew={isNew}
-          onDelete={handleDelete}
-          deleteLabel="Delete Resource"
-          onDuplicate={handleDuplicate}
-          duplicateLabel="Duplicate Resource"
-        >
-          <Button
-            type="submit"
-            disabled={isSubmitting}
-          >
-            {isSubmitting && <Loader2 className="animate-spin" />}
-            {isNew ? "Create Resource" : "Save Changes"}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              if (isNew) {
-                navigate({
-                  to: "/resources",
-                });
-              }
-              else {
-                navigate({
-                  to: "/resources/$id",
-                  params: {
-                    id,
-                  },
-                });
-              }
-            }}
-          >
-            Cancel
-          </Button>
-        </EditPageFooter>
-      </form>
-    </FieldChangeHighlightProvider>
+    <DetailsTab
+      isNew={isNew}
+      controller={controller}
+      onDelete={handleDelete}
+      onDuplicate={handleDuplicate}
+      onCancel={handleCancel}
+    />
   );
 
   return (
@@ -685,7 +172,7 @@ function SingleResourceEdit() {
             ]}
           />
         )}
-      <UnsavedChangesDialog shouldBlockFn={shouldBlockFn(hasChanges)} />
+      <UnsavedChangesDialog shouldBlockFn={shouldBlockFn(controller.hasChanges)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Refactored the resource edit page to extract form logic and state management into a dedicated `useResourceEditForm` hook, improving separation of concerns and component reusability. The Details tab is now a presentational component that receives form state from the parent route.

## Key Changes

- **New hook `useResourceEditForm`** (`packages/client/src/hooks/useResourceEditForm.ts`): Encapsulates all form data layer logic including:
  - Topics, providers, and tag groups queries
  - Form initialization with default values
  - Form submission and validation
  - Provider cost mirroring logic
  - Topic and provider creation handlers
  - Change tracking via `formHasChanges`

- **New component `DetailsTab`** (`packages/client/src/routes/resources.$id.edit.-components/-DetailsTab.tsx`): Extracted the details form UI into a presentational component that receives:
  - Form controller from the hook
  - Callback handlers for delete, duplicate, and cancel actions
  - Maintains the same form structure and field layout

- **New utility `buildResourcePayload`** (`packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.ts`): Pure function that assembles the resource upsert payload from form values, with comprehensive unit tests (`-buildResourcePayload.test.ts`)

- **New component `LevelSelectRow`** (`packages/client/src/routes/resources.$id.edit.-components/-LevelSelectRow.tsx`): Extracted the effort/engagement level select component for reusability

- **Simplified route component** (`packages/client/src/routes/resources.$id.edit.tsx`): Now focuses on routing, tab management, and handler delegation; form state persists across tab switches via the hook instance

- **Barrel export** (`packages/client/src/routes/resources.$id.edit.-components/index.ts`): Centralizes component imports for the route

## Implementation Details

- Form instance lives in the route component (not in DetailsTab) so unsaved edits persist when switching tabs
- `buildResourcePayload` is a pure function with full test coverage, making the cost/expiry/null coalescing logic testable and decoupled from the form
- `useResourceEditForm` returns a controller object exposing form, options, computed state, and handlers — the DetailsTab is purely presentational
- Duplicate handler now uses the generic `makeDeleteHandler`/`makeDuplicateHandler` pattern from `useEditFormPage` for consistency

https://claude.ai/code/session_01Uz4166i8a8K7HGv6qcWtHM