### PR TITLE
fix(middleware): closes #463 validate google calendar feed urls (ssrf)

### DIFF
--- a/packages/middleware/src/services/googleCalendar.ts
+++ b/packages/middleware/src/services/googleCalendar.ts
@@ -11,6 +11,7 @@ import {
   expandIcsToEvents,
   mergeAndSortEvents,
 } from "@/services/googleCalendarIcs";
+import { assertSafeOutboundUrl } from "@/utils/safeOutboundUrl";
 
 // How far ahead the dashboard agenda looks.
 const DAYS_AHEAD = 14;
@@ -75,6 +76,14 @@ async function saveFeeds(feeds: CalendarFeed[]): Promise<void> {
 
 /** Fetch a feed's raw ICS text, mapping failures to a GoogleCalendarError. */
 async function fetchIcsText(url: string): Promise<string> {
+  // SSRF gate: validate the destination before any network call.
+  try {
+    assertSafeOutboundUrl(url);
+  }
+  catch {
+    throw new GoogleCalendarError("Invalid or disallowed feed URL.", 400);
+  }
+
   let response: Response;
   try {
     response = await fetch(url, {

--- a/packages/middleware/src/tests/safeOutboundUrl.test.ts
+++ b/packages/middleware/src/tests/safeOutboundUrl.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import {
+  assertSafeOutboundUrl,
+  UnsafeOutboundUrlError,
+} from "../utils/safeOutboundUrl.ts";
+
+// The guard is pure and never fetches, so none of these touch the network.
+function assertBlocked(url: string): void {
+  assert.throws(
+    () => assertSafeOutboundUrl(url),
+    UnsafeOutboundUrlError,
+    `expected ${url} to be blocked`,
+  );
+}
+
+function assertAllowed(url: string): void {
+  assert.doesNotThrow(
+    () => assertSafeOutboundUrl(url),
+    `expected ${url} to be allowed`,
+  );
+}
+
+test("blocks private/loopback/link-local/metadata IPv4 literals", () => {
+  for (const host of [
+    "127.0.0.1",
+    "10.1.2.3",
+    "172.16.5.4",
+    "172.31.255.255",
+    "192.168.1.1",
+    "169.254.169.254",
+    "0.0.0.0",
+    "100.64.0.1",
+    "192.0.0.1",
+    "255.255.255.255",
+  ]) {
+    assertBlocked(`http://${host}/`);
+  }
+});
+
+test("blocks obfuscated IPv4 forms (URL normalises them to dotted-quad)", () => {
+  assertBlocked("http://2130706433/"); // 127.0.0.1
+  assertBlocked("http://0x7f000001/"); // 127.0.0.1
+  assertBlocked("http://0177.0.0.1/"); // 127.0.0.1
+  assertBlocked("http://127.1/"); // 127.0.0.1
+  assertBlocked("http://127.0.0.1./"); // trailing dot stripped for IP literals
+  assertBlocked("http://0xA9FEA9FE/"); // 169.254.169.254
+});
+
+test("blocks loopback/ULA/link-local IPv6 literals", () => {
+  for (const host of ["::1", "::", "fc00::1", "fd12:3456::1", "fe80::1", "febf::1"]) {
+    assertBlocked(`http://[${host}]/`);
+  }
+});
+
+test("blocks IPv4-mapped IPv6 addresses", () => {
+  assertBlocked("http://[::ffff:127.0.0.1]/");
+  assertBlocked("http://[::ffff:169.254.169.254]/");
+});
+
+test("blocks localhost and *.localhost (case-insensitive)", () => {
+  assertBlocked("http://localhost/");
+  assertBlocked("http://localhost:9200/");
+  assertBlocked("https://api.localhost/");
+  assertBlocked("http://LOCALHOST/");
+});
+
+test("blocks non-http(s) schemes", () => {
+  assertBlocked("file:///etc/passwd");
+  assertBlocked("ftp://example.com/");
+  assertBlocked("gopher://example.com/");
+});
+
+test("blocks malformed URLs (incl. IPv6 zone ids)", () => {
+  assertBlocked("not a url");
+  assertBlocked("");
+  assertBlocked("http://[fe80::1%eth0]/");
+});
+
+test("allows public https/http targets without touching the network", () => {
+  assertAllowed("https://calendar.google.com/calendar/ical/abc/basic.ics");
+  assertAllowed("http://8.8.8.8/");
+  assertAllowed("https://[2606:4700:4700::1111]/");
+  assertAllowed("http://example.com./");
+});
+
+test("range math is exact at block boundaries (no naive prefix matching)", () => {
+  // Just outside 172.16.0.0/12.
+  assertAllowed("http://172.15.255.255/");
+  assertAllowed("http://172.32.0.0/");
+  // Just outside 100.64.0.0/10.
+  assertAllowed("http://100.63.255.255/");
+  assertAllowed("http://100.128.0.0/");
+  // Just past fe80::/10.
+  assertAllowed("http://[fec0::1]/");
+  // A hostname that merely starts like a blocked range must not be range-checked.
+  assertAllowed("https://fed.example.org/");
+  assertAllowed("https://10.example.com/");
+});

--- a/packages/middleware/src/utils/safeOutboundUrl.ts
+++ b/packages/middleware/src/utils/safeOutboundUrl.ts
@@ -1,0 +1,133 @@
+import { isIP } from "node:net";
+
+// Guard for user-supplied fetch targets (SSRF defence). Pure + synchronous so
+// the Node test runner can load it directly — imports only `node:net`, no `@/`
+// aliases, no DNS, no I/O.
+//
+// Scope: this is a *structural/literal* guard. It rejects non-http(s) schemes,
+// `localhost`, and IP literals in private/loopback/link-local/metadata ranges
+// (IPv4, IPv6, IPv4-mapped, and obfuscated numeric forms — `new URL()`
+// canonicalises `http://2130706433/`, `http://0x7f000001/`, etc. to dotted-quad
+// for us). It does NOT resolve DNS, so a *public hostname that resolves to a
+// private IP* (DNS rebinding) is intentionally out of scope.
+//
+// Gotcha: JS `<<` is signed-32-bit, so every IPv4 int result is coerced with
+// `>>> 0` to stay unsigned (otherwise `255.255.255.255` compares as `-1`).
+
+/** Thrown when a URL targets a disallowed scheme or address. */
+export class UnsafeOutboundUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeOutboundUrlError";
+  }
+}
+
+// [networkInt, prefixBits, label] — blocked IPv4 CIDR ranges.
+const IPV4_BLOCKS: [number, number, string][] = [
+  [ipv4ToInt("0.0.0.0"), 8, "this-network 0.0.0.0/8"],
+  [ipv4ToInt("127.0.0.0"), 8, "loopback 127.0.0.0/8"],
+  [ipv4ToInt("10.0.0.0"), 8, "private 10.0.0.0/8"],
+  [ipv4ToInt("172.16.0.0"), 12, "private 172.16.0.0/12"],
+  [ipv4ToInt("192.168.0.0"), 16, "private 192.168.0.0/16"],
+  [ipv4ToInt("169.254.0.0"), 16, "link-local 169.254.0.0/16"],
+  [ipv4ToInt("100.64.0.0"), 10, "CGNAT 100.64.0.0/10"],
+  [ipv4ToInt("192.0.0.0"), 24, "IETF 192.0.0.0/24"],
+  [ipv4ToInt("255.255.255.255"), 32, "broadcast 255.255.255.255"],
+];
+
+/** Parse a canonical dotted-quad into an unsigned 32-bit int. */
+function ipv4ToInt(host: string): number {
+  const p = host.split(".");
+  return (
+    ((+p[0] << 24) | (+p[1] << 16) | (+p[2] << 8) | +p[3]) >>> 0
+  );
+}
+
+/** Reject the IPv4 literal if it falls in any blocked range. */
+function assertPublicIpv4(host: string): void {
+  const ip = ipv4ToInt(host);
+  for (const [net, bits, label] of IPV4_BLOCKS) {
+    const mask = bits === 0 ? 0 : (0xFFFFFFFF << (32 - bits)) >>> 0;
+    if (((ip & mask) >>> 0) === net) {
+      throw new UnsafeOutboundUrlError(`Blocked IPv4 range: ${label}`);
+    }
+  }
+}
+
+/**
+ * Pull the embedded IPv4 out of an IPv4-mapped IPv6 address. `URL` emits the
+ * hex form (`::ffff:7f00:1`); a raw caller could pass the dotted form
+ * (`::ffff:127.0.0.1`). Returns a dotted-quad, or null if not mapped.
+ */
+function extractMappedIpv4(host: string): string | null {
+  if (!host.startsWith("::ffff:")) return null;
+  const tail = host.slice("::ffff:".length);
+  if (tail.includes(".")) return tail;
+  const groups = tail.split(":");
+  if (groups.length !== 2) return null;
+  const hi = parseInt(groups[0], 16);
+  const lo = parseInt(groups[1], 16);
+  return [hi >> 8, hi & 0xFF, lo >> 8, lo & 0xFF].join(".");
+}
+
+/** Reject the IPv6 literal if it's loopback/unspecified/ULA/link-local/mapped. */
+function assertPublicIpv6(host: string): void {
+  const lower = host.toLowerCase();
+
+  const mapped = extractMappedIpv4(lower);
+  if (mapped) {
+    assertPublicIpv4(mapped);
+    return;
+  }
+
+  if (lower === "::" || lower === "::1") {
+    throw new UnsafeOutboundUrlError("Blocked IPv6 loopback/unspecified.");
+  }
+
+  // Leading hextet drives the prefix checks. A leading `::` (zero head) is
+  // already handled by the literal/mapped checks above.
+  const head = parseInt(lower.split(":")[0], 16) || 0;
+  if ((head & 0xFE00) === 0xFC00) {
+    throw new UnsafeOutboundUrlError("Blocked IPv6 ULA fc00::/7.");
+  }
+  if ((head & 0xFFC0) === 0xFE80) {
+    throw new UnsafeOutboundUrlError("Blocked IPv6 link-local fe80::/10.");
+  }
+}
+
+/**
+ * Throw `UnsafeOutboundUrlError` if `url` is not a safe outbound fetch target.
+ * Call this before any `fetch()` of a user-supplied URL.
+ */
+export function assertSafeOutboundUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  }
+  catch {
+    throw new UnsafeOutboundUrlError("Malformed URL.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new UnsafeOutboundUrlError(`Disallowed scheme: ${parsed.protocol}`);
+  }
+
+  // `hostname` is already lowercased by the WHATWG parser; strip IPv6 brackets.
+  let host = parsed.hostname;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new UnsafeOutboundUrlError("Loopback hostname not allowed.");
+  }
+
+  const kind = isIP(host);
+  if (kind === 4) {
+    assertPublicIpv4(host);
+  }
+  else if (kind === 6) {
+    assertPublicIpv6(host);
+  }
+  // A real hostname (kind === 0) is allowed — we never DNS-resolve it.
+}


### PR DESCRIPTION
## Problem

`POST /api/google-calendar/feeds` accepted a user-supplied `url` validated only with `minLength: 1`, which flowed straight into `fetchIcsText` → `fetch(url)` with no scheme or host validation (CWE-918, found by `fallow security`). An authenticated caller could point a feed at:

- loopback (`http://127.0.0.1/…`) — the gateway/middleware itself or other local services
- cloud instance metadata (`http://169.254.169.254/…`)
- private / link-local ranges (`10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `::1`, `fc00::/7`)
- non-HTTP schemes (`file://`, `ftp://`, `gopher://`)

The stored URL is also re-fetched on every dashboard `GET /events` (`fetchUpcomingEvents`), so a bad URL persists.

## Fix

New self-contained, **synchronous** guard `packages/middleware/src/utils/safeOutboundUrl.ts` (`assertSafeOutboundUrl`) that:

1. Parses with `new URL()` and rejects anything but `http:` / `https:`.
2. Rejects `localhost` / `*.localhost`.
3. Rejects private / loopback / link-local / metadata **IP literals** — IPv4, IPv6, IPv4-mapped IPv6, and obfuscated numeric forms (`http://2130706433/`, `http://0x7f000001/`, `http://0177.0.0.1/`, `http://127.1/`), which the WHATWG `URL` parser canonicalises to a dotted-quad for us.

It's called as the **first step** of `fetchIcsText` (before any network call), which rethrows `GoogleCalendarError("Invalid or disallowed feed URL.", 400)` so the existing route error handling surfaces a clean **400**. This covers both the feed-add and dashboard-fetch paths. No route changes needed.

The guard throws its own `UnsafeOutboundUrlError` rather than importing `GoogleCalendarError`, keeping it free of `@/` aliases so the Node test runner can load it directly (same convention as `googleCalendarIcs.ts`).

### Known limitation

This is a literal/structural guard — it does **not** resolve DNS, so a public hostname that resolves to a private IP (DNS rebinding) is out of scope. This is documented in a code comment and matches the issue's stated minimum.

## Tests

New `packages/middleware/src/tests/safeOutboundUrl.test.ts` (Node test runner, no network) covering each blocked IPv4/IPv6 range, IPv4-mapped, obfuscated numeric forms, `localhost`, bad schemes, malformed URLs, allowed public `https`/`http` targets, and exact block-boundary edge cases (e.g. `172.15.255.255` / `172.32.0.0` allowed, `fec0::1` allowed, `fed.example.org` not range-checked).

- `node --test src/tests/safeOutboundUrl.test.ts` → 9/9 pass
- Full middleware suite, `typecheck`, and `eslint` all green.

## Scope

Touches only `services/googleCalendar.ts` + the new util and its test — no overlap with the Todoist hardening ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L19oGe82wrerLC9g56Zegf)_

Closes #463