### PR TITLE
fix(middleware): closes #464 url-encode Todoist task id in close request path

### DIFF
--- a/packages/middleware/src/services/todoist.ts
+++ b/packages/middleware/src/services/todoist.ts
@@ -1,6 +1,7 @@
 import type { TodoistTask } from "@emstack/types";
 import { db } from "@/db";
 import { appSettings } from "@/db/schema";
+import { buildCloseTaskUrl } from "./todoistUrls.ts";
 
 // Todoist API v1 (unified REST). The dedicated filter endpoint runs a Todoist
 // filter query server-side and returns matching active tasks, paginated.
@@ -8,9 +9,6 @@ const TODOIST_FILTER_URL = "https://api.todoist.com/api/v1/tasks/filter";
 
 // Project list, used to resolve a task's project_id to a human-readable name.
 const TODOIST_PROJECTS_URL = "https://api.todoist.com/api/v1/projects";
-
-// Base for the close-task action (marks a task complete).
-const TODOIST_TASKS_URL = "https://api.todoist.com/api/v1/tasks";
 
 // Deep-link base for the Todoist web app. Tasks don't carry a URL in the v1
 // payload, so we build one from the task id.
@@ -217,7 +215,7 @@ export async function closeTodoistTask(
 ): Promise<void> {
   let response: Response;
   try {
-    response = await fetch(`${TODOIST_TASKS_URL}/${id}/close`, {
+    response = await fetch(buildCloseTaskUrl(id), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/packages/middleware/src/services/todoistUrls.ts
+++ b/packages/middleware/src/services/todoistUrls.ts
@@ -1,0 +1,13 @@
+// Pure Todoist URL builders. No `@/` imports, so node --test can load this
+// directly (mirrors googleCalendarIcs.ts).
+
+// Base for the close-task action (marks a task complete).
+const TODOIST_TASKS_URL = "https://api.todoist.com/api/v1/tasks";
+
+/**
+ * Build the close-task action URL. The id is url-encoded so a value containing
+ * `/`, `..`, or query chars can't manipulate the request path (CWE-918).
+ */
+export function buildCloseTaskUrl(id: string): string {
+  return `${TODOIST_TASKS_URL}/${encodeURIComponent(id)}/close`;
+}

--- a/packages/middleware/src/tests/todoistUrls.test.ts
+++ b/packages/middleware/src/tests/todoistUrls.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { buildCloseTaskUrl } from "../services/todoistUrls.ts";
+
+test("buildCloseTaskUrl builds the close URL for a plain id", () => {
+  assert.strictEqual(
+    buildCloseTaskUrl("12345"),
+    "https://api.todoist.com/api/v1/tasks/12345/close",
+  );
+});
+
+test("buildCloseTaskUrl url-encodes path-manipulating chars in the id", () => {
+  // `/` would otherwise inject extra path segments / change the action target.
+  assert.strictEqual(
+    buildCloseTaskUrl("../projects/999"),
+    "https://api.todoist.com/api/v1/tasks/..%2Fprojects%2F999/close",
+  );
+  // Query chars must not leak into the path either.
+  assert.strictEqual(
+    buildCloseTaskUrl("1?x=1"),
+    "https://api.todoist.com/api/v1/tasks/1%3Fx%3D1/close",
+  );
+});


### PR DESCRIPTION
## What & why

`closeTodoistTask` interpolated the task id straight into the request path
(`packages/middleware/src/services/todoist.ts`), so an id containing `/`, `..`,
or query chars could manipulate the path sent to `api.todoist.com`
(CWE-918, `fixed-origin-dynamic-path`, flagged by `fallow security`). The origin
is fixed, so impact is limited to hitting a different Todoist API path — low
severity, but a cheap hardening.

## Change

- Extract the close-task URL builder into a new pure module
  `packages/middleware/src/services/todoistUrls.ts` (no `@/` imports, so
  `node --test` can load it directly — mirrors `googleCalendarIcs.ts`).
- Wrap the id in `encodeURIComponent` so it can only ever be a single path
  segment.
- Add unit tests (`src/tests/todoistUrls.test.ts`) asserting that
  path-manipulating chars (`/`, `..`, `?`, `=`) in the id are encoded.

Did **not** tighten the shared `idParamSchema` — it's used by every resource
route (UUID ids etc.), so a Todoist-specific pattern would wrongly constrain
them all. `encodeURIComponent` is the minimal, correct fix (as the issue notes).

## Verification

- `pnpm --filter=@emstack/middleware test` — 24 pass (2 new)
- `pnpm --filter=@emstack/middleware typecheck` — clean
- `pnpm lint` — 0 errors

https://claude.ai/code/session_01LVbrQhny7oaC5HdeTZKP6G

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVbrQhny7oaC5HdeTZKP6G)_

Closes #464