### PR TITLE
ci: add warn-only PR check for newly-added suppression directives

### DIFF
--- a/.claude/skills/audit-guards/SKILL.md
+++ b/.claude/skills/audit-guards/SKILL.md
@@ -31,6 +31,12 @@ or command. Run from the repo root. If given a scope arg, limit accordingly
 (`fallow` = guards A1–A3 only, `overrides` = guard B only, a path = scope the
 fallow scans to that path; `lint` = guards C1–C3 only).
 
+> **Related, but separate:** this skill audits *existing* guards for staleness.
+> The `new-suppressions` CI job (`.github/workflows/pr-guards.yml`, backed by
+> `scripts/check-new-suppressions.sh`) flags *newly-added* inline directives
+> (C1–C3 kinds) on each PR as warn-only annotations. Use that to catch guards as
+> they land; use this skill to prune the ones that outlived their cause.
+
 ## What counts as a guard here
 
 | Guard | Where | How it goes stale |

--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -1,0 +1,30 @@
+name: PR guards
+
+# Warn-only PR check: surfaces suppression/ignore directives ADDED by this PR
+# (fallow-ignore, eslint-disable, @ts-*, skipped/focused tests) as inline
+# annotations plus a job-summary table. It never fails the check — it's
+# visibility for reviewers, not a gate. Complements the /audit-guards skill,
+# which audits *stale* directives after the fact.
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: guards-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  new-suppressions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so the PR base commit is reachable for the diff.
+          fetch-depth: 0
+
+      - name: Flag new suppression directives
+        shell: bash
+        run: scripts/check-new-suppressions.sh "${{ github.event.pull_request.base.sha }}"

--- a/scripts/check-new-suppressions.sh
+++ b/scripts/check-new-suppressions.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Flag suppression/ignore directives ADDED by the current PR. Warn-only: this
+# script emits GitHub workflow annotations (inline on the Files-changed tab) plus
+# a markdown table to $GITHUB_STEP_SUMMARY, and always exits 0 — it never fails
+# the check. Reviewers get visibility; legitimate suppressions aren't blocked.
+#
+# Detected (inline) directives:
+#   - fallow:  // fallow-ignore-file | -next-line | -line <kind>
+#   - eslint:  /* eslint-disable */, // eslint-disable-next-line, -line, etc.
+#   - TS:      // @ts-ignore | @ts-nocheck | @ts-expect-error
+#   - tests:   describe/it/test/context .skip|.only|.todo, xit/xdescribe/fit/fdescribe
+#
+# Scope: only JS/TS source files are scanned (via git pathspec), so generated
+# output (**/dist/**, routeTree.gen.ts) and docs that merely *document* these
+# patterns (.md) are never flagged.
+#
+# Usage: scripts/check-new-suppressions.sh <base-sha-or-ref>
+#   The base is the PR target; the script diffs <base>...HEAD (merge-base form,
+#   so only PR-introduced changes are considered). Requires full history
+#   (checkout with fetch-depth: 0) so the base commit is reachable.
+#
+# Known limitations:
+#   - Line-granular: moving or reindenting an existing directive reads as "added".
+#   - Renamed files may re-flag directives they carry.
+#   - Config-list growth (.fallowrc.json, pnpm.overrides, tsconfig excludes) is
+#     out of scope — this only covers inline source directives.
+#
+set -euo pipefail
+
+BASE="${1:?usage: check-new-suppressions.sh <base-sha-or-ref>}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+git diff --no-color --unified=0 "${BASE}...HEAD" -- \
+  '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' \
+  ':(exclude)**/dist/**' ':(exclude)**/routeTree.gen.ts' \
+| awk -v summary="$SUMMARY" '
+    # Track which file the current hunk belongs to.
+    /^\+\+\+ b\// { file = substr($0, 7); next }
+
+    # @@ -a,b +c,d @@  ->  new-file lines start at c.
+    /^@@ / { match($0, /\+[0-9]+/); newline = substr($0, RSTART + 1, RLENGTH - 1) + 0; next }
+
+    # Added lines (but not the +++ file header).
+    /^\+/ && !/^\+\+\+/ {
+      l = substr($0, 2); kind = ""
+      if      (l ~ /fallow-ignore-(file|next-line|line)/)            kind = "fallow-ignore"
+      else if (l ~ /eslint-disable/)                                 kind = "eslint-disable"
+      else if (l ~ /@ts-(ignore|nocheck|expect-error)/)              kind = "ts-suppression"
+      else if (l ~ /(describe|it|test|context)\.(skip|only|todo)|(xit|xdescribe|fit|fdescribe)\(/) kind = "test-skip/only"
+
+      if (kind != "") {
+        sub(/^[ \t]+/, "", l)            # trim leading whitespace for display
+        gsub(/`/, "'\''", l)             # neutralize backticks so they do not break the table cell
+        print "::warning file=" file ",line=" newline "::New " kind " directive added"
+        rows = rows "| `" file "` | " newline " | " kind " | `" l "` |\n"
+        count++
+      }
+      newline++                          # only added lines advance the counter (unified=0)
+      next
+    }
+
+    END {
+      if (count > 0)
+        printf "## \xe2\x9a\xa0\xef\xb8\x8f New suppression directives (%d)\n\nThese were added by this PR. Warn-only \xe2\x80\x94 confirm each is justified; remove if not.\n\n| File | Line | Kind | Added line |\n|---|---|---|---|\n%s", count, rows > summary
+      else
+        print "## \xe2\x9c\x85 No new suppression directives added by this PR" > summary
+    }
+  '
+
+exit 0


### PR DESCRIPTION
## ELI5
When someone writes code, they can add little notes that tell our quality tools to look the other way — handy sometimes, but easy to overuse. This adds an automatic reviewer that points out whenever a pull request introduces one of those notes, so a human can double-check it was really needed. It only flags them for visibility; it never blocks the work.

## Summary
- Add `.github/workflows/pr-guards.yml` — a warn-only `new-suppressions` PR job (no new dependencies) that posts inline annotations + a job-summary table for any suppression directive added by the PR.
- Add `scripts/check-new-suppressions.sh` — a bash + awk diff scanner that detects `fallow-ignore-*`, `eslint-disable*`, `@ts-ignore`/`@ts-nocheck`/`@ts-expect-error`, and skipped/focused tests (`.skip`/`.only`/`xit`/`fit`/`xdescribe`). Scoped to JS/TS source via git pathspec, excluding generated output (`**/dist/**`, `routeTree.gen.ts`) and docs.
- Cross-reference the new CI job from the `audit-guards` skill (which audits *stale* directives), so the catch-new and prune-stale mechanisms are discoverable together.

## Test plan
- [x] Local positive: a probe `.ts` with all four kinds → all directives flagged with correct line numbers.
- [x] Local negative: a `.md` mentioning the same patterns → not flagged (extension pathspec).
- [x] Local negative: `dist/` files excluded; `routeTree.gen.ts` uses the same verified `:(exclude)` syntax.
- [x] `bash -n` clean; baseline run against `master` reports no new directives.
- [ ] CI end-to-end: open a draft PR adding e.g. `// eslint-disable-next-line ...` → confirm the inline annotation appears on the Files-changed tab, the job summary shows the table, and the check is green (non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)