### PR TITLE
refactor(client): condense resource route component types

### DIFF
--- a/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
@@ -1,5 +1,4 @@
-import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
-import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 
 import { PlusIcon, SparklesIcon } from "lucide-react";
 
@@ -8,11 +7,8 @@ import { ModuleAssistDialog } from "./-ModuleAssistDialog";
 import { Button } from "@/components/ui/button";
 import { UNGROUPED_KEY } from "@/hooks/useModuleAdminUiState";
 
-interface ModuleAdminHeaderProps {
-  resourceId: string;
+interface ModuleAdminHeaderProps extends ModuleAdminSectionProps {
   modulesAreExhaustive?: boolean;
-  api: ResourceModulesController;
-  ui: ModuleAdminUiState;
 }
 
 /**

--- a/packages/client/src/routes/resources.$id.-components/-ModuleAssistDialog.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleAssistDialog.tsx
@@ -1,14 +1,9 @@
-import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
-import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 import type { Resource } from "@emstack/types";
 
 import { ModuleSuggestDialog } from "@/components/resources/moduleAdminComponents";
 
-interface ModuleAssistDialogProps {
-  resourceId: string;
-  api: ResourceModulesController;
-  ui: ModuleAdminUiState;
-}
+type ModuleAssistDialogProps = ModuleAdminSectionProps;
 
 /** Resource detail fields the suggest dialog needs, with safe fallbacks. */
 function deriveResourceContext(resource: Resource | undefined) {

--- a/packages/client/src/routes/resources.$id.-components/-ModuleGroupSection.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleGroupSection.tsx
@@ -1,3 +1,4 @@
+import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
 import type { ResourceModulesController } from "@/hooks/useResourceModules";
 import type { Module, ModuleGroup } from "@emstack/types";
@@ -26,12 +27,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { isHttpUrl } from "@/utils";
 
-interface ModuleGroupSectionProps {
+interface ModuleGroupSectionProps extends ModuleAdminSectionProps {
   group: ModuleGroup;
   groupIndex: number;
-  resourceId: string;
-  api: ResourceModulesController;
-  ui: ModuleAdminUiState;
 }
 
 /** The group title — a link when it carries an http(s) url, plain text otherwise. */

--- a/packages/client/src/routes/resources.$id.-components/-ModuleListItem.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleListItem.tsx
@@ -1,5 +1,4 @@
-import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
-import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 import type { Module } from "@emstack/types";
 
 import { Fragment } from "react";
@@ -11,16 +10,13 @@ import {
 } from "@/components/resources/moduleAdminComponents";
 import { moduleToDraft } from "@/components/resources/moduleDrafts";
 
-interface ModuleListItemProps {
+interface ModuleListItemProps extends ModuleAdminSectionProps {
   module: Module;
-  resourceId: string;
   /** Owning group id, or null for an ungrouped module. */
   groupId: string | null;
   /** The sibling list this module belongs to, for reorder bounds/moves. */
   list: Module[];
   index: number;
-  api: ResourceModulesController;
-  ui: ModuleAdminUiState;
 }
 
 /**

--- a/packages/client/src/routes/resources.$id.-components/-UngroupedModulesSection.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-UngroupedModulesSection.tsx
@@ -1,5 +1,4 @@
-import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
-import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 
 import { ModuleListItem } from "./-ModuleListItem";
 
@@ -7,11 +6,7 @@ import { ModuleEditCard } from "@/components/resources/moduleAdminComponents";
 import { emptyModuleDraft } from "@/components/resources/moduleDrafts";
 import { UNGROUPED_KEY } from "@/hooks/useModuleAdminUiState";
 
-interface UngroupedModulesSectionProps {
-  resourceId: string;
-  api: ResourceModulesController;
-  ui: ModuleAdminUiState;
-}
+type UngroupedModulesSectionProps = ModuleAdminSectionProps;
 
 /**
  * The top-level "Ungrouped" block: an optional inline create card plus the list

--- a/packages/client/src/routes/resources.$id.-components/-moduleAdminSectionProps.ts
+++ b/packages/client/src/routes/resources.$id.-components/-moduleAdminSectionProps.ts
@@ -1,0 +1,14 @@
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+
+/**
+ * Context shared by every module-admin section: the resource being edited plus
+ * the controller/ui-state pair the sections render from and dispatch into.
+ * The header, group/ungrouped sections, list item, and assist dialog all extend
+ * this so the threaded-through props stay in lockstep.
+ */
+export interface ModuleAdminSectionProps {
+  resourceId: string;
+  api: ResourceModulesController;
+  ui: ModuleAdminUiState;
+}

--- a/packages/client/src/routes/resources.$id.edit.-components/-LevelSelectRow.tsx
+++ b/packages/client/src/routes/resources.$id.edit.-components/-LevelSelectRow.tsx
@@ -1,7 +1,9 @@
+import type { TaskResourceLevel } from "@emstack/types";
+
 import { cn } from "@/lib/utils";
 import { changedFieldClass } from "@/utils";
 
-export type LevelValue = "" | "low" | "medium" | "high";
+export type LevelValue = "" | TaskResourceLevel;
 
 export function LevelSelectRow({
   label,


### PR DESCRIPTION
## ELI5
The resource pages had the same little bundle of settings copy-pasted across several components, and one list of options written out by hand when a shared version already existed. This tidies both up so the same thing is defined in one place — no change to how anything looks or behaves.

## Summary
- Extracted a shared `ModuleAdminSectionProps` base (`resourceId` + `api` + `ui`) that the module-admin header, group/ungrouped sections, list item, and assist dialog now extend instead of each re-declaring the trio.
- Pointed the edit form's `LevelValue` at the shared `TaskResourceLevel` union (`"" | TaskResourceLevel`) rather than re-spelling `"low" | "medium" | "high"`.
- Left deliberately-distinct shapes alone (`ResourceFormValues`, `SortOption`/`ResourcesListProps`, the two non-exported local `Props`).

## Test plan
- [x] `pnpm typecheck` clean across the repo
- [x] `pnpm exec eslint` clean on all changed files
- [x] `vitest run` for the three resource route component dirs — 10/10 pass
- [ ] Smoke-check the resource detail module admin and edit-form level selects render/behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)