### PR TITLE
refactor(client): Fixes #473: dedupe BlipDraft type across radar blips components

### DIFF
--- a/packages/client/src/routes/domains.$id.edit.-components/-BlipsPanel.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-BlipsPanel.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-interface BlipDraft {
+export interface BlipDraft {
   id?: string;
   topicId: string;
   description: string;

--- a/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-BlipsTab.tsx
@@ -1,3 +1,4 @@
+import type { BlipDraft } from "./-BlipsPanel";
 import type { Radar, RadarBlip, TopicForTopicsPage } from "@emstack/types";
 
 import { useEffect, useMemo, useState } from "react";
@@ -13,15 +14,6 @@ interface BlipsTabContainerProps {
   topics: TopicForTopicsPage[];
   domainId: string;
   onSaved: () => Promise<void>;
-}
-
-interface BlipDraft {
-  id?: string;
-  topicId: string;
-  description: string;
-  quadrantId: string;
-  ringId: string;
-  localKey: string;
 }
 
 let localKeyCounter = 0;


### PR DESCRIPTION
## ELI5
Two files that build the "radar blips" editor each had their own private copy of the exact same little data shape. This PR keeps just one copy and shares it, so the two never drift apart.

## Summary
- `BlipDraft` was declared identically in both `-BlipsTab.tsx` and its child `-BlipsPanel.tsx`.
- Export it from `-BlipsPanel.tsx` (the single source of truth) and import it type-only into `-BlipsTab.tsx`, which already imports the panel.
- Pure type-only refactor — no behavior change.

## Test plan
- [x] `pnpm typecheck` clean across the repo
- [x] `pnpm exec eslint` clean on both changed files
- [x] `vitest run` passes for `-BlipsPanel.stories.tsx` and `-BlipsTab.stories.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473