### PR TITLE
refactor(client): extract shared constants and reduce edit-form imports

### DIFF
--- a/packages/client/src/components/dailies/DailyCommentPopover.tsx
+++ b/packages/client/src/components/dailies/DailyCommentPopover.tsx
@@ -6,20 +6,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CheckIcon, MessageSquareIcon, PencilIcon } from "lucide-react";
 import { toast } from "sonner";
 
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-} from "@/components/popover";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/popover";
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { useHoverPopover } from "@/hooks/useHoverPopover";
 import { cn } from "@/lib/utils";
-import {
-  getTodayKey,
-  upsertDaily,
-  withCompletionNote,
-} from "@/utils";
+import { getTodayKey, upsertDaily, withCompletionNote } from "@/utils";
 
 interface DailyCommentPopoverProps {
   daily: Daily;
@@ -116,9 +109,11 @@ export function DailyCommentPopover({
           type="button"
           variant="ghost"
           size="icon-sm"
-          aria-label={hasNote
-            ? `View comment for ${daily.name}`
-            : `Add comment for ${daily.name}`}
+          aria-label={
+            hasNote
+              ? `View comment for ${daily.name}`
+              : `Add comment for ${daily.name}`
+          }
           aria-haspopup="dialog"
           aria-expanded={open}
           title={hasNote ? "View comment" : "Add comment"}
@@ -134,9 +129,7 @@ export function DailyCommentPopover({
           onFocus={handleHoverOpen}
           onBlur={handleHoverClose}
           className={cn(
-            hasNote
-              ? "text-foreground"
-              : "text-muted-foreground/40",
+            hasNote ? "text-foreground" : "text-muted-foreground/40",
             buttonClassName,
           )}
         >
@@ -184,7 +177,7 @@ export function DailyCommentPopover({
                 onChange={e => setDraft(e.target.value)}
                 placeholder="Add a comment..."
                 autoFocus
-                maxLength={500}
+                maxLength={TEXT_MAX_LENGTH}
                 className="min-h-20"
               />
               <div className="flex justify-end gap-2">

--- a/packages/client/src/components/dailies/DailyStatusModal.tsx
+++ b/packages/client/src/components/dailies/DailyStatusModal.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { cn } from "@/lib/utils";
 import { getTodayKey } from "@/utils";
 
@@ -184,7 +185,7 @@ export function DailyStatusModal({
               value={comment}
               onChange={e => setComment(e.target.value)}
               placeholder="Add a comment for today..."
-              maxLength={500}
+              maxLength={TEXT_MAX_LENGTH}
               className="min-h-20"
             />
           </div>

--- a/packages/client/src/components/dailies/NoteEditButton.tsx
+++ b/packages/client/src/components/dailies/NoteEditButton.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, PencilIcon } from "lucide-react";
 import { Input } from "@/components/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/popover";
 import { Button } from "@/components/ui/button";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { cn } from "@/lib/utils";
 
 interface NoteEditButtonProps {
@@ -43,7 +44,8 @@ export function NoteEditButton({
           title={hasNote ? "Edit note" : "Add note"}
           aria-label={hasNote ? "Edit note" : "Add note"}
           className={cn(
-            !hasNote && `
+            !hasNote
+            && `
               opacity-0
               group-focus-within:opacity-100
               group-hover:opacity-100
@@ -71,7 +73,7 @@ export function NoteEditButton({
             onChange={e => setValue(e.target.value)}
             placeholder="Add a note..."
             autoFocus
-            maxLength={500}
+            maxLength={TEXT_MAX_LENGTH}
           />
           <Button
             type="submit"

--- a/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddNameDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 
 interface QuickAddNameDialogProps {
   open: boolean;
@@ -90,7 +91,7 @@ export function QuickAddNameDialog({
               value={name}
               onChange={e => setName(e.target.value)}
               placeholder={placeholder}
-              maxLength={255}
+              maxLength={NAME_MAX_LENGTH}
             />
           </div>
           <QuickAddDialogFooter

--- a/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddProviderDialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { createProvider } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
@@ -102,7 +103,7 @@ export function QuickAddProviderDialog({
               value={name}
               onChange={e => setName(e.target.value)}
               placeholder="Provider name"
-              maxLength={255}
+              maxLength={NAME_MAX_LENGTH}
             />
           </div>
           <div className="flex flex-col gap-1">
@@ -118,7 +119,7 @@ export function QuickAddProviderDialog({
               value={url}
               onChange={e => setUrl(e.target.value)}
               placeholder="https://example.com"
-              maxLength={255}
+              maxLength={NAME_MAX_LENGTH}
             />
           </div>
           <QuickAddDialogFooter

--- a/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
+++ b/packages/client/src/components/quickAdd/QuickAddRoutineDialog.tsx
@@ -13,23 +13,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 
 export function QuickAddRoutineDialog({
   open,
   onOpenChange,
 }: ControlledDialogProps) {
   const {
-    name,
-    setName,
-    mode,
-    setMode,
-    handleSubmit,
-    isPending,
-    canSubmit,
-  } = useQuickAddRoutine({
-    open,
-    onOpenChange,
-  });
+    name, setName, mode, setMode, handleSubmit, isPending, canSubmit,
+  }
+    = useQuickAddRoutine({
+      open,
+      onOpenChange,
+    });
 
   return (
     <Dialog
@@ -60,7 +56,7 @@ export function QuickAddRoutineDialog({
               value={name}
               onChange={e => setName(e.target.value)}
               placeholder="Routine name"
-              maxLength={255}
+              maxLength={NAME_MAX_LENGTH}
             />
           </div>
           <div className="flex flex-col gap-2">

--- a/packages/client/src/components/resources/InteractionQuickLog.tsx
+++ b/packages/client/src/components/resources/InteractionQuickLog.tsx
@@ -11,6 +11,12 @@ import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Input } from "@/components/input";
+import {
+  DIFFICULTY_OPTIONS,
+  PROGRESS_LABEL,
+  PROGRESS_OPTIONS,
+  UNDERSTANDING_OPTIONS,
+} from "@/components/resources/interactionMeta";
 import { OptionalSelectField } from "@/components/resources/OptionalSelectField";
 import { Textarea } from "@/components/textarea";
 import { Button } from "@/components/ui/button";
@@ -25,28 +31,6 @@ interface Props {
   onCancel: () => void;
   onSaved?: () => void;
 }
-
-const PROGRESS_OPTIONS: InteractionProgress[] = [
-  "incomplete",
-  "started",
-  "complete",
-];
-
-const DIFFICULTY_OPTIONS: InteractionDifficulty[] = ["easy", "medium", "hard"];
-
-const UNDERSTANDING_OPTIONS: InteractionUnderstanding[] = [
-  "none",
-  "basic",
-  "comfortable",
-  "proficient",
-  "mastered",
-];
-
-const PROGRESS_LABEL: Record<InteractionProgress, string> = {
-  incomplete: "Incomplete",
-  started: "Started",
-  complete: "Complete",
-};
 
 function todayIso() {
   const d = new Date();

--- a/packages/client/src/components/resources/interactionMeta.ts
+++ b/packages/client/src/components/resources/interactionMeta.ts
@@ -1,0 +1,42 @@
+import type {
+  InteractionDifficulty,
+  InteractionProgress,
+  InteractionUnderstanding,
+} from "@emstack/types";
+
+/**
+ * Shared option ordering and display metadata for interaction fields, used by
+ * both the quick-log control and the full interactions log. The base unions
+ * live in `@emstack/types`; these only add client-side ordering/labels/colors.
+ */
+export const PROGRESS_OPTIONS: InteractionProgress[] = [
+  "incomplete",
+  "started",
+  "complete",
+];
+
+export const DIFFICULTY_OPTIONS: InteractionDifficulty[] = [
+  "easy",
+  "medium",
+  "hard",
+];
+
+export const UNDERSTANDING_OPTIONS: InteractionUnderstanding[] = [
+  "none",
+  "basic",
+  "comfortable",
+  "proficient",
+  "mastered",
+];
+
+export const PROGRESS_LABEL: Record<InteractionProgress, string> = {
+  incomplete: "Incomplete",
+  started: "Started",
+  complete: "Complete",
+};
+
+export const PROGRESS_COLOR: Record<InteractionProgress, string> = {
+  incomplete: "bg-rose-100 text-rose-900 border-rose-200",
+  started: "bg-amber-100 text-amber-900 border-amber-200",
+  complete: "bg-emerald-100 text-emerald-900 border-emerald-200",
+};

--- a/packages/client/src/components/resources/moduleDrafts.test.ts
+++ b/packages/client/src/components/resources/moduleDrafts.test.ts
@@ -2,6 +2,7 @@ import type { Module, ModuleGroup, TagGroup } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
+import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   draftToLength,
   emptyGroupDraft,
@@ -89,7 +90,7 @@ describe("parseCount", () => {
 describe("emptyGroupDraft", () => {
   test("creates a blank group draft with the new-id sentinel", () => {
     const draft = emptyGroupDraft();
-    expect(draft.id).toBe("__new__");
+    expect(draft.id).toBe(NEW_ROW_ID);
     expect(draft.name).toBe("");
     expect(draft.totalCount).toBe("");
     expect(draft.completedCount).toBe("");
@@ -152,7 +153,7 @@ describe("groupToDraft", () => {
 describe("emptyModuleDraft", () => {
   test("creates a blank module draft defaulting to minutes mode", () => {
     const draft = emptyModuleDraft();
-    expect(draft.id).toBe("__new__");
+    expect(draft.id).toBe(NEW_ROW_ID);
     expect(draft.durationMode).toBe("minutes");
     expect(draft.minutesValue).toBe("");
     expect(draft.bucketValue).toBe("");
@@ -205,23 +206,29 @@ describe("lookupTagsByIds", () => {
   ];
 
   test("resolves ids to tags in request order across groups", () => {
-    expect(lookupTagsByIds(["t-3", "t-1"], tagGroups).map(t => t.name)).toEqual([
-      "Three",
-      "One",
-    ]);
+    expect(
+      lookupTagsByIds(["t-3", "t-1"], tagGroups).map(t => t.name),
+    ).toEqual(["Three", "One"]);
   });
 
   test("silently drops unknown ids", () => {
-    expect(lookupTagsByIds(["t-1", "missing"], tagGroups).map(t => t.id)).toEqual(
-      ["t-1"],
-    );
+    expect(
+      lookupTagsByIds(["t-1", "missing"], tagGroups).map(t => t.id),
+    ).toEqual(["t-1"]);
   });
 
   test("handles groups with no tags and an empty id list", () => {
     expect(lookupTagsByIds([], tagGroups)).toEqual([]);
-    expect(lookupTagsByIds(["t-1"], [{
-      id: "tg-3",
-      name: "Empty",
-    }])).toEqual([]);
+    expect(
+      lookupTagsByIds(
+        ["t-1"],
+        [
+          {
+            id: "tg-3",
+            name: "Empty",
+          },
+        ],
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/client/src/components/resources/moduleDrafts.ts
+++ b/packages/client/src/components/resources/moduleDrafts.ts
@@ -10,6 +10,8 @@ import type {
 
 import { parseModuleLength } from "@emstack/types";
 
+import { NEW_ROW_ID } from "@/constants/sentinels";
+
 // The shared "effort levels + tag picker" block rendered at the bottom of both
 // the module and module-group edit cards (see LevelAndTagsFields). Both draft
 // shapes below extend it, so the cards can pass a draft straight through.
@@ -42,11 +44,9 @@ export interface ModuleDraft extends BaseModuleEditDraft {
   bucketValue: ModuleDurationBucket | "";
 }
 
-const NEW_ID = "__new__";
-
 export function emptyGroupDraft(): GroupDraft {
   return {
-    id: NEW_ID,
+    id: NEW_ROW_ID,
     name: "",
     description: "",
     url: "",
@@ -76,7 +76,7 @@ export function groupToDraft(g: ModuleGroup): GroupDraft {
 
 export function emptyModuleDraft(): ModuleDraft {
   return {
-    id: NEW_ID,
+    id: NEW_ROW_ID,
     name: "",
     description: "",
     url: "",
@@ -133,7 +133,9 @@ export function draftToLength(d: ModuleDraft): string | null {
   return d.bucketValue || null;
 }
 
-export function levelChipClass(level: TaskResourceLevel | null | undefined): string {
+export function levelChipClass(
+  level: TaskResourceLevel | null | undefined,
+): string {
   switch (level) {
     case "low":
       return "bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-900/40 dark:text-emerald-200";

--- a/packages/client/src/constants/index.ts
+++ b/packages/client/src/constants/index.ts
@@ -1,0 +1,4 @@
+export * from "./media";
+export * from "./sentinels";
+export * from "./storageKeys";
+export * from "./stringLimits";

--- a/packages/client/src/constants/media.ts
+++ b/packages/client/src/constants/media.ts
@@ -1,0 +1,2 @@
+/** Viewport breakpoint below which the UI is treated as mobile. */
+export const MOBILE_MEDIA_QUERY = "(max-width: 767px)";

--- a/packages/client/src/constants/sentinels.ts
+++ b/packages/client/src/constants/sentinels.ts
@@ -1,0 +1,6 @@
+/**
+ * Placeholder id assigned to an unsaved "new row" draft before it is persisted.
+ * It is only ever written onto a draft's `id`; newness is read from a separate
+ * `isNew` flag, never by comparing against this value.
+ */
+export const NEW_ROW_ID = "__new__";

--- a/packages/client/src/constants/storageKeys.ts
+++ b/packages/client/src/constants/storageKeys.ts
@@ -1,0 +1,7 @@
+/** App-wide `localStorage` keys, in one place so they can't silently collide. */
+export const STORAGE_KEYS = {
+  settings: "emstack-settings",
+  theme: "vite-ui-theme",
+  dashboardLayoutId: "emstack-dashboard-layout-id",
+  exploreRing: "emstack-explore-ring",
+} as const;

--- a/packages/client/src/constants/stringLimits.ts
+++ b/packages/client/src/constants/stringLimits.ts
@@ -1,0 +1,7 @@
+/**
+ * Client-side max lengths shared by text inputs and their zod `.max(...)`
+ * validators so the two can't drift. These govern the client only — the
+ * middleware/db may enforce its own limits.
+ */
+export const NAME_MAX_LENGTH = 255; // names / urls
+export const TEXT_MAX_LENGTH = 500; // free-text notes / descriptions

--- a/packages/client/src/context/SettingsProvider.tsx
+++ b/packages/client/src/context/SettingsProvider.tsx
@@ -6,14 +6,13 @@ import type { ReactNode } from "react";
 
 import { useEffect, useState } from "react";
 
+import { STORAGE_KEYS } from "@/constants/storageKeys";
 import {
   DEFAULT_MAX_ACTIVE_DAILIES,
   DEFAULT_WEEK_TARGET_WINDOW,
   SettingsProviderContext,
   WEEK_TARGET_WINDOWS,
 } from "@/context/SettingsProviderContext";
-
-const STORAGE_KEY = "emstack-settings";
 
 interface PersistedSettings {
   maxActiveDailies?: number;
@@ -24,7 +23,7 @@ interface PersistedSettings {
 function readPersistedSettings(): PersistedSettings {
   if (typeof window === "undefined") return {};
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(STORAGE_KEYS.settings);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === "object") {
@@ -56,8 +55,10 @@ export function SettingsProvider({
   const [dailiesViewMode, setDailiesViewModeState]
     = useState<DailiesViewMode | null>(() => {
       const persisted = readPersistedSettings();
-      if (persisted.dailiesViewMode === "table"
-        || persisted.dailiesViewMode === "list") {
+      if (
+        persisted.dailiesViewMode === "table"
+        || persisted.dailiesViewMode === "list"
+      ) {
         return persisted.dailiesViewMode;
       }
       return null;
@@ -66,8 +67,10 @@ export function SettingsProvider({
   const [weekTargetWindow, setWeekTargetWindowState]
     = useState<WeekTargetWindow>(() => {
       const persisted = readPersistedSettings();
-      if (persisted.weekTargetWindow
-        && WEEK_TARGET_WINDOWS.includes(persisted.weekTargetWindow)) {
+      if (
+        persisted.weekTargetWindow
+        && WEEK_TARGET_WINDOWS.includes(persisted.weekTargetWindow)
+      ) {
         return persisted.weekTargetWindow;
       }
       return DEFAULT_WEEK_TARGET_WINDOW;
@@ -76,7 +79,7 @@ export function SettingsProvider({
   useEffect(() => {
     try {
       localStorage.setItem(
-        STORAGE_KEY,
+        STORAGE_KEYS.settings,
         JSON.stringify({
           maxActiveDailies,
           dailiesViewMode,

--- a/packages/client/src/context/ThemeProvider.tsx
+++ b/packages/client/src/context/ThemeProvider.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { useEffect, useState } from "react";
 
+import { STORAGE_KEYS } from "@/constants/storageKeys";
 import { ThemeProviderContext } from "@/context/ThemeProviderContext";
 
 interface ThemeProviderProps {
@@ -14,7 +15,7 @@ interface ThemeProviderProps {
 export function ThemeProvider({
   children,
   defaultTheme = "system",
-  storageKey = "vite-ui-theme",
+  storageKey = STORAGE_KEYS.theme,
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
@@ -24,10 +25,13 @@ export function ThemeProvider({
   useEffect(() => {
     const root = window.document.documentElement;
 
-    root.classList.remove("light", "dark"); ;
+    root.classList.remove("light", "dark");
 
     if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
 
       root.classList.add(systemTheme);
       return;

--- a/packages/client/src/hooks/useActiveDashboardLayoutId.ts
+++ b/packages/client/src/hooks/useActiveDashboardLayoutId.ts
@@ -2,7 +2,9 @@ import type { DashboardLayout } from "@emstack/types";
 
 import { useState } from "react";
 
-const STORAGE_KEY = "emstack-dashboard-layout-id";
+import { STORAGE_KEYS } from "@/constants/storageKeys";
+
+const STORAGE_KEY = STORAGE_KEYS.dashboardLayoutId;
 
 /**
  * Persists the dashboard's selected layout tab in localStorage. When the
@@ -34,7 +36,7 @@ export function useActiveDashboardLayoutId(
 
   const activeId = layouts?.some(l => l.id === storedId)
     ? storedId
-    : layouts?.[0]?.id ?? null;
+    : (layouts?.[0]?.id ?? null);
 
   return {
     activeId,

--- a/packages/client/src/hooks/useExploreRing.ts
+++ b/packages/client/src/hooks/useExploreRing.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-const STORAGE_KEY = "emstack-explore-ring";
+import { STORAGE_KEYS } from "@/constants/storageKeys";
+
+const STORAGE_KEY = STORAGE_KEYS.exploreRing;
 const DEFAULT_RING = "Trial";
 
 /**
@@ -31,11 +33,12 @@ export function useExploreRing(rings: string[] | undefined) {
 
   // While rings are still loading, surface the stored value as-is so the
   // <Select> has a stable value and doesn't flicker.
-  const ring = !rings || rings.includes(storedRing)
-    ? storedRing
-    : rings.includes(DEFAULT_RING)
-      ? DEFAULT_RING
-      : rings[0] ?? DEFAULT_RING;
+  const ring
+    = !rings || rings.includes(storedRing)
+      ? storedRing
+      : rings.includes(DEFAULT_RING)
+        ? DEFAULT_RING
+        : (rings[0] ?? DEFAULT_RING);
 
   return {
     ring,

--- a/packages/client/src/hooks/useIsMobile.ts
+++ b/packages/client/src/hooks/useIsMobile.ts
@@ -1,16 +1,16 @@
 import { useEffect, useState } from "react";
 
-const MOBILE_QUERY = "(max-width: 767px)";
+import { MOBILE_MEDIA_QUERY } from "@/constants/media";
 
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
-    return window.matchMedia(MOBILE_QUERY).matches;
+    return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
   });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const mql = window.matchMedia(MOBILE_QUERY);
+    const mql = window.matchMedia(MOBILE_MEDIA_QUERY);
     const update = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     setIsMobile(mql.matches);
     mql.addEventListener("change", update);

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -18,6 +18,7 @@ import {
   rowsToWeekly,
   weeklyToRows,
 } from "@/components/routines";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import {
   buildConnectionOptions,
   decodeConnection,
@@ -63,7 +64,7 @@ const curatedRowSchema = z
   });
 
 const detailsSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
   description: z.string().max(2000),
   connections: z.array(z.string()),
   status: z.enum(["active", "inactive", "complete", "paused"]),
@@ -132,26 +133,23 @@ export function useRoutineDetailsForm(
 
   const todayKey = getTodayKey();
 
-  const startingValues = useMemo(
-    () => {
-      const curatedEndKey = routine.curated?.endDate ?? null;
-      return {
-        name: routine.name ?? "",
-        description: routine.description ?? "",
-        connections: (routine.connections ?? []).map(encodeConnection),
-        status: routine.status ?? "active",
-        mode: routine.mode ?? "weekly",
-        weekly: weeklyToRows(routine.weekly),
-        curatedEndDate: curatedEndKey ? keyToDate(curatedEndKey) : null,
-        curated: curatedToRows(
-          routine.curated,
-          curatedDateRange(todayKey, curatedEndKey),
-        ),
-        weeklyTarget: routine.weeklyTarget ?? null,
-      };
-    },
-    [routine, todayKey],
-  );
+  const startingValues = useMemo(() => {
+    const curatedEndKey = routine.curated?.endDate ?? null;
+    return {
+      name: routine.name ?? "",
+      description: routine.description ?? "",
+      connections: (routine.connections ?? []).map(encodeConnection),
+      status: routine.status ?? "active",
+      mode: routine.mode ?? "weekly",
+      weekly: weeklyToRows(routine.weekly),
+      curatedEndDate: curatedEndKey ? keyToDate(curatedEndKey) : null,
+      curated: curatedToRows(
+        routine.curated,
+        curatedDateRange(todayKey, curatedEndKey),
+      ),
+      weeklyTarget: routine.weeklyTarget ?? null,
+    };
+  }, [routine, todayKey]);
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -189,9 +187,7 @@ export function useRoutineDetailsForm(
             value.mode === "curated"
               ? rowsToCurated(
                 value.curated,
-                value.curatedEndDate
-                  ? dateToKey(value.curatedEndDate)
-                  : null,
+                value.curatedEndDate ? dateToKey(value.curatedEndDate) : null,
               )
               : {
                 endDate: null,

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import { routeTree } from "./routeTree.gen.ts";
 
+import { STORAGE_KEYS } from "@/constants/storageKeys";
 import { SettingsProvider } from "@/context/SettingsProvider.tsx";
 import { ThemeProvider } from "@/context/ThemeProvider.tsx";
 
@@ -33,7 +34,7 @@ if (!rootElement.innerHTML) {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider
           defaultTheme="light"
-          storageKey="vite-ui-theme"
+          storageKey={STORAGE_KEYS.theme}
         >
           <SettingsProvider>
             <RouterProvider

--- a/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-DetailsTab.tsx
@@ -10,6 +10,7 @@ import * as z from "zod";
 import { useAppForm } from "@/components/formFields";
 import { EditForm } from "@/components/layout";
 import { Button } from "@/components/ui/button";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { upsertDomain, formHasChanges } from "@/utils";
 
 interface DetailsTabProps {
@@ -20,7 +21,7 @@ interface DetailsTabProps {
 }
 
 const formSchema = z.object({
-  title: z.string().min(1, "Title is required").max(255),
+  title: z.string().min(1, "Title is required").max(NAME_MAX_LENGTH),
   description: z.string().max(1000),
   topicIds: z.array(z.string()),
 });

--- a/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.tsx
+++ b/packages/client/src/routes/domains.$id.edit.-components/-NewDomainForm.tsx
@@ -13,10 +13,11 @@ import {
   PageHeader,
 } from "@/components/editPage";
 import { useAppForm } from "@/components/formFields";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { createDomain } from "@/utils";
 
 const newDomainSchema = z.object({
-  title: z.string().min(1, "Title is required").max(255),
+  title: z.string().min(1, "Title is required").max(NAME_MAX_LENGTH),
   description: z.string().max(1000),
 });
 

--- a/packages/client/src/routes/providers.$id.edit.tsx
+++ b/packages/client/src/routes/providers.$id.edit.tsx
@@ -15,6 +15,7 @@ import {
   UnsavedChangesDialog,
 } from "@/components/editPage";
 import { useAppForm } from "@/components/formFields";
+import { NAME_MAX_LENGTH, TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createProvider,
@@ -31,9 +32,9 @@ export const Route = createFileRoute("/providers/$id/edit")({
 });
 
 const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
-  description: z.string().max(500),
-  url: z.string().min(1, "URL is required").max(255),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
+  description: z.string().max(TEXT_MAX_LENGTH),
+  url: z.string().min(1, "URL is required").max(NAME_MAX_LENGTH),
   cost: z.number().min(0).nullable(),
   isRecurring: z.string(),
   recurDate: z.date().nullable(),

--- a/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
@@ -1,9 +1,7 @@
 import type { InteractionDraft } from "@/hooks/useInteractionsLog";
 import type {
   Interaction,
-  InteractionDifficulty,
   InteractionProgress,
-  InteractionUnderstanding,
   Module,
   ModuleGroup,
 } from "@emstack/types";
@@ -14,10 +12,18 @@ import { PencilIcon, PlusIcon } from "lucide-react";
 
 import { EditFormActions } from "@/components/EditFormActions";
 import { Input } from "@/components/input";
+import {
+  DIFFICULTY_OPTIONS,
+  PROGRESS_COLOR,
+  PROGRESS_LABEL,
+  PROGRESS_OPTIONS,
+  UNDERSTANDING_OPTIONS,
+} from "@/components/resources/interactionMeta";
 import { OptionalSelectField } from "@/components/resources/OptionalSelectField";
 import { Textarea } from "@/components/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { NEW_ROW_ID } from "@/constants/sentinels";
 import { useInteractionsLog } from "@/hooks/useInteractionsLog";
 
 interface Props {
@@ -25,24 +31,6 @@ interface Props {
 }
 
 type Draft = InteractionDraft;
-
-const NEW_ID = "__new__";
-
-const PROGRESS_OPTIONS: InteractionProgress[] = [
-  "incomplete",
-  "started",
-  "complete",
-];
-
-const DIFFICULTY_OPTIONS: InteractionDifficulty[] = ["easy", "medium", "hard"];
-
-const UNDERSTANDING_OPTIONS: InteractionUnderstanding[] = [
-  "none",
-  "basic",
-  "comfortable",
-  "proficient",
-  "mastered",
-];
 
 // Small local date helper; intentionally duplicated alongside InteractionQuickLog.
 // fallow-ignore-next-line code-duplication
@@ -56,7 +44,7 @@ function todayIso() {
 
 function emptyDraft(): Draft {
   return {
-    id: NEW_ID,
+    id: NEW_ROW_ID,
     date: todayIso(),
     progress: "started",
     note: "",
@@ -79,18 +67,6 @@ function fromInteraction(i: Interaction): Draft {
     moduleId: i.moduleId ?? "",
   };
 }
-
-const PROGRESS_LABEL: Record<InteractionProgress, string> = {
-  incomplete: "Incomplete",
-  started: "Started",
-  complete: "Complete",
-};
-
-const PROGRESS_COLOR: Record<InteractionProgress, string> = {
-  incomplete: "bg-rose-100 text-rose-900 border-rose-200",
-  started: "bg-amber-100 text-amber-900 border-amber-200",
-  complete: "bg-emerald-100 text-emerald-900 border-emerald-200",
-};
 
 export function ResourceInteractionsLog({
   resourceId,
@@ -201,9 +177,7 @@ export function ResourceInteractionsLog({
                         variant="outline"
                         className="border-blue-200 bg-blue-50 text-blue-900"
                       >
-                        group:
-                        {" "}
-                        {targetGroup.name}
+                        group: {targetGroup.name}
                       </Badge>
                     )}
                     {targetModule && (
@@ -211,9 +185,7 @@ export function ResourceInteractionsLog({
                         variant="outline"
                         className="border-blue-200 bg-blue-50 text-blue-900"
                       >
-                        module:
-                        {" "}
-                        {targetModule.name}
+                        module: {targetModule.name}
                       </Badge>
                     )}
                     {i.difficulty && (
@@ -221,9 +193,7 @@ export function ResourceInteractionsLog({
                         variant="outline"
                         className="bg-muted/40"
                       >
-                        difficulty:
-                        {" "}
-                        {i.difficulty}
+                        difficulty: {i.difficulty}
                       </Badge>
                     )}
                     {i.understanding && (
@@ -231,9 +201,7 @@ export function ResourceInteractionsLog({
                         variant="outline"
                         className="bg-muted/40"
                       >
-                        understanding:
-                        {" "}
-                        {i.understanding}
+                        understanding: {i.understanding}
                       </Badge>
                     )}
                   </div>
@@ -307,9 +275,10 @@ function InteractionEditCard({
           <Input
             type="date"
             value={draft.date}
-            onChange={e => update({
-              date: e.target.value,
-            })}
+            onChange={e =>
+              update({
+                date: e.target.value,
+              })}
             required
           />
         </div>
@@ -423,17 +392,19 @@ function InteractionEditCard({
           label="Difficulty (optional)"
           value={draft.difficulty}
           options={DIFFICULTY_OPTIONS}
-          onValueChange={difficulty => update({
-            difficulty,
-          })}
+          onValueChange={difficulty =>
+            update({
+              difficulty,
+            })}
         />
         <OptionalSelectField
           label="Understanding (optional)"
           value={draft.understanding}
           options={UNDERSTANDING_OPTIONS}
-          onValueChange={understanding => update({
-            understanding,
-          })}
+          onValueChange={understanding =>
+            update({
+              understanding,
+            })}
         />
       </div>
       <div className="flex flex-col gap-1">
@@ -442,9 +413,10 @@ function InteractionEditCard({
         </label>
         <Textarea
           value={draft.note}
-          onChange={e => update({
-            note: e.target.value,
-          })}
+          onChange={e =>
+            update({
+              note: e.target.value,
+            })}
           placeholder="What did you do? Anything notable?"
         />
       </div>

--- a/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.ts
+++ b/packages/client/src/routes/resources.$id.edit.-components/-buildResourcePayload.ts
@@ -2,10 +2,12 @@ import type { EntityStatus } from "@emstack/types";
 
 import * as z from "zod";
 
+import { NAME_MAX_LENGTH, TEXT_MAX_LENGTH } from "@/constants/stringLimits";
+
 export const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
-  description: z.string().max(500),
-  url: z.string().max(255),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
+  description: z.string().max(TEXT_MAX_LENGTH),
+  url: z.string().max(NAME_MAX_LENGTH),
   status: z.enum(["active", "inactive", "complete"]),
   progressCurrent: z.number().int().min(0).nullable(),
   progressTotal: z.number().int().min(0).nullable(),

--- a/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-CriteriaTab.tsx
@@ -12,14 +12,15 @@ import { QuickFillMenu } from "./-QuickFillMenu";
 import { DAILY_STATUS_OPTIONS } from "@/components/dailies";
 import { useAppForm } from "@/components/formFields";
 import { Button } from "@/components/ui/button";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { formHasChanges, upsertRoutine } from "@/utils";
 
 const criteriaSchema = z.object({
-  criteriaIncomplete: z.string().max(500),
-  criteriaTouched: z.string().max(500),
-  criteriaGoal: z.string().max(500),
-  criteriaExceeded: z.string().max(500),
-  criteriaFreeze: z.string().max(500),
+  criteriaIncomplete: z.string().max(TEXT_MAX_LENGTH),
+  criteriaTouched: z.string().max(TEXT_MAX_LENGTH),
+  criteriaGoal: z.string().max(TEXT_MAX_LENGTH),
+  criteriaExceeded: z.string().max(TEXT_MAX_LENGTH),
+  criteriaFreeze: z.string().max(TEXT_MAX_LENGTH),
 });
 
 interface CriteriaTabProps {
@@ -116,8 +117,7 @@ export function CriteriaTab({
         >
           <div className="flex flex-col gap-1">
             <p className="text-sm text-muted-foreground">
-              Optional notes describing what each status means for this
-              routine.
+              Optional notes describing what each status means for this routine.
             </p>
           </div>
           <QuickFillMenu<DailyCriteriaTemplate>
@@ -135,9 +135,10 @@ export function CriteriaTab({
           {field => (
             <field.TextareaField
               label="Incomplete"
-              placeholder="What does &quot;Incomplete&quot; mean here?"
-              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                o.value === "incomplete")?.icon}
+              placeholder='What does "Incomplete" mean here?'
+              labelIcon={
+                DAILY_STATUS_OPTIONS.find(o => o.value === "incomplete")?.icon
+              }
             />
           )}
         </form.AppField>
@@ -145,9 +146,10 @@ export function CriteriaTab({
           {field => (
             <field.TextareaField
               label="Touched"
-              placeholder="What does &quot;Touched&quot; mean here?"
-              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                o.value === "touched")?.icon}
+              placeholder='What does "Touched" mean here?'
+              labelIcon={
+                DAILY_STATUS_OPTIONS.find(o => o.value === "touched")?.icon
+              }
             />
           )}
         </form.AppField>
@@ -155,9 +157,10 @@ export function CriteriaTab({
           {field => (
             <field.TextareaField
               label="Completed (Goal)"
-              placeholder="What does &quot;Completed&quot; (goal) mean here?"
-              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                o.value === "goal")?.icon}
+              placeholder='What does "Completed" (goal) mean here?'
+              labelIcon={
+                DAILY_STATUS_OPTIONS.find(o => o.value === "goal")?.icon
+              }
             />
           )}
         </form.AppField>
@@ -165,9 +168,10 @@ export function CriteriaTab({
           {field => (
             <field.TextareaField
               label="Exceeded"
-              placeholder="What does &quot;Exceeded&quot; mean here?"
-              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                o.value === "exceeded")?.icon}
+              placeholder='What does "Exceeded" mean here?'
+              labelIcon={
+                DAILY_STATUS_OPTIONS.find(o => o.value === "exceeded")?.icon
+              }
             />
           )}
         </form.AppField>
@@ -175,9 +179,10 @@ export function CriteriaTab({
           {field => (
             <field.TextareaField
               label="Freeze"
-              placeholder="What does &quot;Freeze&quot; mean here?"
-              labelIcon={DAILY_STATUS_OPTIONS.find(o =>
-                o.value === "freeze")?.icon}
+              placeholder='What does "Freeze" mean here?'
+              labelIcon={
+                DAILY_STATUS_OPTIONS.find(o => o.value === "freeze")?.icon
+              }
             />
           )}
         </form.AppField>

--- a/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-DetailsTab.tsx
@@ -3,6 +3,7 @@ import type { Routine, RoutineTemplate } from "@emstack/types";
 import { Loader2 } from "lucide-react";
 
 import { QuickFillMenu } from "./-QuickFillMenu";
+import { MODE_OPTIONS, STATUS_OPTIONS } from "./-routineFormMeta";
 import { WeeklyEntryEditor } from "./-WeeklyEntryEditor";
 
 import { EditForm } from "@/components/layout";
@@ -16,40 +17,6 @@ import {
 } from "@/components/routines";
 import { Button } from "@/components/ui/button";
 import { useRoutineDetailsForm } from "@/hooks/useRoutineDetailsForm";
-
-const STATUS_OPTIONS = [
-  {
-    value: "active",
-    label: "Active",
-  },
-  {
-    value: "inactive",
-    label: "Inactive",
-  },
-  {
-    value: "complete",
-    label: "Complete",
-  },
-  {
-    value: "paused",
-    label: "Paused",
-  },
-];
-
-const MODE_OPTIONS = [
-  {
-    value: "weekly",
-    label: "Weekly Schedule",
-  },
-  {
-    value: "daily",
-    label: "Daily Task",
-  },
-  {
-    value: "curated",
-    label: "Curated",
-  },
-];
 
 interface DetailsTabProps {
   routine: Routine;
@@ -132,8 +99,8 @@ export function DetailsTab({
             <div className="flex flex-col gap-1">
               <span className="text-2xl">Curated</span>
               <p className="text-sm text-muted-foreground">
-                Pick an end date up to 14 days out, then set a task for each
-                day from today through then.
+                Pick an end date up to 14 days out, then set a task for each day
+                from today through then.
               </p>
             </div>
             <form.Field name="curatedEndDate">
@@ -166,14 +133,13 @@ export function DetailsTab({
                   <div className="flex flex-col gap-1">
                     <span className="text-2xl">Daily Task</span>
                     <p className="text-sm text-muted-foreground">
-                      Pick what to work on each day — the same item applies to
-                      every day of the week.
+                      Pick what to work on each day — the same item applies to every
+                      day of the week.
                     </p>
                     <div className="mt-1">
                       <WeeklyEntryEditor
                         {...representativeRow(field.state.value)}
-                        onChange={next =>
-                          field.handleChange(fillAllDays(next))}
+                        onChange={next => field.handleChange(fillAllDays(next))}
                         taskOptions={taskOptions}
                         resourceOptions={resourceOptions}
                       />

--- a/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.tsx
+++ b/packages/client/src/routes/routines.$id.edit.-components/-NewRoutineForm.tsx
@@ -7,29 +7,17 @@ import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import * as z from "zod";
 
+import { MODE_OPTIONS } from "./-routineFormMeta";
+
 import { useAppForm } from "@/components/formFields";
 import { EditForm, EditPageFooter, PageHeader } from "@/components/layout";
 import { fillAllDays, rowsToWeekly } from "@/components/routines";
 import { Button } from "@/components/ui/button";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { createRoutine } from "@/utils";
 
-const MODE_OPTIONS = [
-  {
-    value: "weekly",
-    label: "Weekly Schedule",
-  },
-  {
-    value: "daily",
-    label: "Daily Task",
-  },
-  {
-    value: "curated",
-    label: "Curated",
-  },
-];
-
 const newRoutineSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
   mode: z.enum(["weekly", "daily", "curated"]),
 });
 

--- a/packages/client/src/routes/routines.$id.edit.-components/-routineFormMeta.ts
+++ b/packages/client/src/routes/routines.$id.edit.-components/-routineFormMeta.ts
@@ -1,0 +1,39 @@
+import type { EntityStatus, RoutineMode } from "@emstack/types";
+
+/** Radio options for the routine scheduling mode, shared by the edit and create forms. */
+export const MODE_OPTIONS: { value: RoutineMode;
+  label: string; }[] = [
+  {
+    value: "weekly",
+    label: "Weekly Schedule",
+  },
+  {
+    value: "daily",
+    label: "Daily Task",
+  },
+  {
+    value: "curated",
+    label: "Curated",
+  },
+];
+
+/** Radio options for the routine status field. */
+export const STATUS_OPTIONS: { value: EntityStatus;
+  label: string; }[] = [
+  {
+    value: "active",
+    label: "Active",
+  },
+  {
+    value: "inactive",
+    label: "Inactive",
+  },
+  {
+    value: "complete",
+    label: "Complete",
+  },
+  {
+    value: "paused",
+    label: "Paused",
+  },
+];

--- a/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.tsx
+++ b/packages/client/src/routes/settings.-components/-CriteriaTemplatesSection.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { DailyCriteriaTemplateEditModal } from "./-DailyCriteriaTemplateEditModal";
 
 import { Button } from "@/components/ui/button";
+import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createDailyCriteriaTemplate,
   deleteSingleDailyCriteriaTemplate,
@@ -16,11 +17,9 @@ import {
   upsertDailyCriteriaTemplate,
 } from "@/utils";
 
-const NEW_CRITERIA_TEMPLATE_ID = "__new__";
-
 function makeEmptyCriteriaTemplate(): DailyCriteriaTemplate {
   return {
-    id: NEW_CRITERIA_TEMPLATE_ID,
+    id: NEW_ROW_ID,
     label: "",
     incomplete: "",
     touched: "",

--- a/packages/client/src/routes/settings.-components/-DailyCriteriaTemplateEditModal.tsx
+++ b/packages/client/src/routes/settings.-components/-DailyCriteriaTemplateEditModal.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 
 interface DailyCriteriaTemplateEditModalProps extends ControlledDialogProps {
   template: DailyCriteriaTemplate | null;
@@ -149,7 +150,7 @@ export function DailyCriteriaTemplateEditModal({
                     [f.key]: e.target.value,
                   })}
                 placeholder={f.placeholder}
-                maxLength={500}
+                maxLength={TEXT_MAX_LENGTH}
               />
             </div>
           ))}

--- a/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.tsx
+++ b/packages/client/src/routes/settings.-components/-RoutineTemplatesSection.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { RoutineTemplateEditModal } from "./-RoutineTemplateEditModal";
 
 import { Button } from "@/components/ui/button";
+import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createRoutineTemplate,
   deleteSingleRoutineTemplate,
@@ -20,11 +21,9 @@ import {
 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
-const NEW_ROUTINE_TEMPLATE_ID = "__new__";
-
 function makeEmptyRoutineTemplate(): RoutineTemplate {
   return {
-    id: NEW_ROUTINE_TEMPLATE_ID,
+    id: NEW_ROW_ID,
     label: "",
     weekly: {},
   };

--- a/packages/client/src/routes/settings.-components/-TaskTypesSection.tsx
+++ b/packages/client/src/routes/settings.-components/-TaskTypesSection.tsx
@@ -10,6 +10,7 @@ import { TaskTypeEditRow } from "./-TaskTypeEditRow";
 
 import { TagChip } from "@/components/tasks/TagChip";
 import { Button } from "@/components/ui/button";
+import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createTaskType,
   deleteSingleTaskType,
@@ -17,11 +18,9 @@ import {
   upsertTaskType,
 } from "@/utils";
 
-const NEW_TASK_TYPE_ID = "__new__";
-
 function makeEmptyTaskType(): TaskType {
   return {
-    id: NEW_TASK_TYPE_ID,
+    id: NEW_ROW_ID,
     name: "",
     whenToUse: "",
     tags: [],

--- a/packages/client/src/routes/tasks.$id.-components/-TodosChecklist.tsx
+++ b/packages/client/src/routes/tasks.$id.-components/-TodosChecklist.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 
 import { Input } from "@/components/input";
 import { Button } from "@/components/ui/button";
+import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { cn } from "@/lib/utils";
 import { upsertTask } from "@/utils";
 import { uuidv4 } from "@/utils/uuid";
@@ -296,7 +297,7 @@ export function TodosChecklist({
           value={draft}
           onChange={e => setDraft(e.target.value)}
           placeholder="Add a to-do..."
-          maxLength={500}
+          maxLength={TEXT_MAX_LENGTH}
           disabled={mutation.isPending}
         />
         <Button

--- a/packages/client/src/routes/tasks.$id.edit.-components/-taskFormSchema.ts
+++ b/packages/client/src/routes/tasks.$id.edit.-components/-taskFormSchema.ts
@@ -1,0 +1,12 @@
+import * as z from "zod";
+
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
+
+/** Submit-time validator for the task edit form. */
+export const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
+  description: z.string().max(2000),
+  topicId: z.string(),
+  taskTypeId: z.string(),
+  tagIds: z.array(z.string()),
+});

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -4,7 +4,8 @@ import { useStore } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
-import * as z from "zod";
+
+import { formSchema } from "./tasks.$id.edit.-components/-taskFormSchema";
 
 import {
   Button,
@@ -14,7 +15,6 @@ import {
   UnsavedChangesDialog,
 } from "@/components/editPage";
 import { useAppForm } from "@/components/formFields";
-import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createTask,
@@ -42,14 +42,6 @@ export const Route = createFileRoute("/tasks/$id/edit")({
         ? search.topicId
         : undefined,
   }),
-});
-
-const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
-  description: z.string().max(2000),
-  topicId: z.string(),
-  taskTypeId: z.string(),
-  tagIds: z.array(z.string()),
 });
 
 function SingleTaskEdit() {

--- a/packages/client/src/routes/tasks.$id.edit.tsx
+++ b/packages/client/src/routes/tasks.$id.edit.tsx
@@ -14,6 +14,7 @@ import {
   UnsavedChangesDialog,
 } from "@/components/editPage";
 import { useAppForm } from "@/components/formFields";
+import { NAME_MAX_LENGTH } from "@/constants/stringLimits";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createTask,
@@ -44,7 +45,7 @@ export const Route = createFileRoute("/tasks/$id/edit")({
 });
 
 const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
   description: z.string().max(2000),
   topicId: z.string(),
   taskTypeId: z.string(),

--- a/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.tsx
+++ b/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.tsx
@@ -15,6 +15,7 @@ import {
   UnsavedChangesDialog,
 } from "@/components/editPage";
 import { ResourceLinksPicker, useAppForm } from "@/components/formFields";
+import { NAME_MAX_LENGTH, TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createDomain,
@@ -33,9 +34,9 @@ import {
 } from "@/utils";
 
 const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255),
-  description: z.string().max(500),
-  reason: z.string().max(500),
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
+  description: z.string().max(TEXT_MAX_LENGTH),
+  reason: z.string().max(TEXT_MAX_LENGTH),
   domainIds: z.array(z.string()),
   tagIds: z.array(z.string()),
   resourceLinks: z.array(

--- a/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.tsx
+++ b/packages/client/src/routes/topics.$id.edit.-components/-TopicForm.tsx
@@ -4,7 +4,8 @@ import { useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { EyeIcon, Loader2 } from "lucide-react";
-import * as z from "zod";
+
+import { formSchema } from "./-topicFormSchema";
 
 import {
   Button,
@@ -15,7 +16,6 @@ import {
   UnsavedChangesDialog,
 } from "@/components/editPage";
 import { ResourceLinksPicker, useAppForm } from "@/components/formFields";
-import { NAME_MAX_LENGTH, TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
   createDomain,
@@ -32,22 +32,6 @@ import {
   tagGroupsToOptions,
   upsertTopic,
 } from "@/utils";
-
-const formSchema = z.object({
-  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
-  description: z.string().max(TEXT_MAX_LENGTH),
-  reason: z.string().max(TEXT_MAX_LENGTH),
-  domainIds: z.array(z.string()),
-  tagIds: z.array(z.string()),
-  resourceLinks: z.array(
-    z.object({
-      key: z.string(),
-      resourceId: z.string(),
-      moduleGroupId: z.string().nullable(),
-      moduleId: z.string().nullable(),
-    }),
-  ),
-});
 
 interface TopicFormProps {
   id: string;

--- a/packages/client/src/routes/topics.$id.edit.-components/-topicFormSchema.ts
+++ b/packages/client/src/routes/topics.$id.edit.-components/-topicFormSchema.ts
@@ -1,0 +1,20 @@
+import * as z from "zod";
+
+import { NAME_MAX_LENGTH, TEXT_MAX_LENGTH } from "@/constants/stringLimits";
+
+/** Submit-time validator for the topic edit form. */
+export const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
+  description: z.string().max(TEXT_MAX_LENGTH),
+  reason: z.string().max(TEXT_MAX_LENGTH),
+  domainIds: z.array(z.string()),
+  tagIds: z.array(z.string()),
+  resourceLinks: z.array(
+    z.object({
+      key: z.string(),
+      resourceId: z.string(),
+      moduleGroupId: z.string().nullable(),
+      moduleId: z.string().nullable(),
+    }),
+  ),
+});


### PR DESCRIPTION
## ELI5
A bunch of fixed values (like storage keys, "new item" markers, and text length limits) were copy-pasted in many places across the app, which makes them easy to get out of sync. This gathers the truly app-wide ones into a single home and tidies a few feature-specific duplicates, so each value is defined once. Nothing changes for users — it's purely a cleanup.

## Summary
- Added `packages/client/src/constants/` for genuinely app-wide values: `STORAGE_KEYS` (localStorage keys), `NEW_ROW_ID` (the unsaved "new row" sentinel, replacing 5 divergent locals), `NAME_MAX_LENGTH`/`TEXT_MAX_LENGTH` (now feed both input `maxLength` props **and** the matching zod `.max()` validators so they can't drift), and `MOBILE_MEDIA_QUERY`.
- Consolidated feature-coupled duplicates per the existing colocate convention: interaction option/label/color metadata into `components/resources/interactionMeta.ts`, and routine `MODE_OPTIONS`/`STATUS_OPTIONS` into `routes/routines.$id.edit.-components/-routineFormMeta.ts` (typed against the shared `@emstack/types` unions).
- Reduced imports in `tasks.$id.edit.tsx` and `-TopicForm.tsx` (which the new constant import had pushed over the `import/max-dependencies` threshold) by extracting each zod schema into a colocated `-*FormSchema.ts` sibling.
- Left deliberately-distinct shapes alone (the identical-but-cross-feature `getResourceLevelClass`/`levelChipClass`, already-centralized radar/dailies metadata).

## Test plan
- [x] `pnpm typecheck` — clean across the repo
- [x] `pnpm lint` — 0 errors; the 2 newly-introduced `max-dependencies` warnings resolved
- [x] `pnpm --filter=@emstack/client test` — full suite (857 tests) passing
- [x] `pnpm exec fallow dead-code` — no new circular dependencies
- [ ] Smoke-check: edit forms (resource/topic/task/routine/provider/domain) save correctly; daily note/comment + todo length caps still enforced; theme + settings persist across reload; mobile breakpoint behaves

🤖 Generated with [Claude Code](https://claude.com/claude-code)