### PR TITLE
feat(client): re-bake recent daily entries on status update

### DIFF
--- a/packages/client/src/components/dailies/DailyTrackerRow.tsx
+++ b/packages/client/src/components/dailies/DailyTrackerRow.tsx
@@ -29,7 +29,11 @@ interface DailyTrackerRowProps {
   todayKey: string;
   recentDaysCount: number;
   mutationPending: boolean;
-  onChangeStatus: (daily: Daily, status: DailyCompletionStatus) => void;
+  onChangeStatus: (
+    daily: Daily,
+    status: DailyCompletionStatus,
+    note: string | null,
+  ) => void;
   /** `<tr>` className — the two tracker tables differ only by `align-middle`. */
   rowClassName: string;
   /** `<td>` wrapping the today-status cell — the wider table uses `w-36 p-2`. */
@@ -123,7 +127,7 @@ export function DailyTrackerRow({
           daily={daily}
           currentStatus={currentStatus}
           disabled={mutationPending}
-          onChange={status => onChangeStatus(daily, status)}
+          onChange={(status, note) => onChangeStatus(daily, status, note)}
         />
       </td>
       {days.map((day, i) => {

--- a/packages/client/src/components/dailies/NoteEditButton.tsx
+++ b/packages/client/src/components/dailies/NoteEditButton.tsx
@@ -40,8 +40,8 @@ export function NoteEditButton({
           variant="ghost"
           size="icon-sm"
           disabled={disabled}
-          title={hasNote ? "Edit note" : "Add note"}
-          aria-label={hasNote ? "Edit note" : "Add note"}
+          title={hasNote ? "Edit comment" : "Add comment"}
+          aria-label={hasNote ? "Edit comment" : "Add comment"}
           className={cn(
             !hasNote && `
               opacity-0
@@ -69,15 +69,15 @@ export function NoteEditButton({
           <Input
             value={value}
             onChange={e => setValue(e.target.value)}
-            placeholder="Add a note..."
+            placeholder="Add a comment..."
             autoFocus
             maxLength={500}
           />
           <Button
             type="submit"
             size="icon-sm"
-            aria-label="Save note"
-            title="Save note"
+            aria-label="Save comment"
+            title="Save comment"
           >
             <CheckIcon className="size-4" />
           </Button>

--- a/packages/client/src/hooks/useDailyCompletions.ts
+++ b/packages/client/src/hooks/useDailyCompletions.ts
@@ -241,7 +241,9 @@ export function useDailyCompletions(daily: Daily, readOnly = false) {
     ) => {
       const completions
         = args.kind === "status"
-          ? withCompletion(daily, args.dateKey, args.status)
+          // Recent re-updates re-bake to the current schedule; older entries
+          // (beyond REBAKE_WINDOW_DAYS) keep their frozen snapshot.
+          ? withCompletion(daily, args.dateKey, args.status, realToday)
           : withCompletionNote(daily, args.dateKey, args.note);
       return upsertDaily(daily.id, {
         name: daily.name,

--- a/packages/client/src/hooks/useDailyTracker.tsx
+++ b/packages/client/src/hooks/useDailyTracker.tsx
@@ -83,7 +83,8 @@ export function useDailyStatusMutation(todayKey: string) {
       status: DailyCompletionStatus;
       note?: string | null;
     }) => {
-      const withStatus = withCompletion(daily, todayKey, status);
+      // Re-updating today's status re-bakes the entry to the current schedule.
+      const withStatus = withCompletion(daily, todayKey, status, todayKey);
       const completions
         = note === undefined
           ? withStatus

--- a/packages/client/src/hooks/useRoutineStatusMutation.ts
+++ b/packages/client/src/hooks/useRoutineStatusMutation.ts
@@ -34,7 +34,8 @@ export function useRoutineStatusMutation(id: string) {
       status: DailyCompletionStatus;
       note?: string | null;
     }) => {
-      const withStatus = withCompletion(daily, todayDateKey, status);
+      // Re-updating today's status re-bakes the entry to the current schedule.
+      const withStatus = withCompletion(daily, todayDateKey, status, todayDateKey);
       const completions
         = note === undefined
           ? withStatus

--- a/packages/client/src/routes/dashboard.-components/-DashboardDailiesBody.tsx
+++ b/packages/client/src/routes/dashboard.-components/-DashboardDailiesBody.tsx
@@ -61,10 +61,11 @@ export function DashboardDailiesBody({
           todayKey={todayKey}
           recentDaysCount={RECENT_DAYS_COUNT}
           mutationPending={mutation.isPending}
-          onChangeStatus={(d, status) =>
+          onChangeStatus={(d, status, note) =>
             mutation.mutate({
               daily: d,
               status,
+              note,
             })}
           rowClassName="
             group border-t

--- a/packages/client/src/routes/routines.tracker.-components/-TrackerTables.tsx
+++ b/packages/client/src/routes/routines.tracker.-components/-TrackerTables.tsx
@@ -209,10 +209,11 @@ export function TrackerTables({
                   todayKey={todayKey}
                   recentDaysCount={recentDaysCount}
                   mutationPending={mutation.isPending}
-                  onChangeStatus={(d, status) =>
+                  onChangeStatus={(d, status, note) =>
                     mutation.mutate({
                       daily: d,
                       status,
+                      note,
                     })}
                   rowClassName="
                     group border-t align-middle

--- a/packages/client/src/utils/dailyHelpers.test.ts
+++ b/packages/client/src/utils/dailyHelpers.test.ts
@@ -20,6 +20,8 @@ import {
   hasTaskForDay,
   isScheduledForDay,
   isWeeklyTargetMet,
+  isWithinRebakeWindow,
+  REBAKE_WINDOW_DAYS,
   shiftDateKey,
   withCompletion,
   withCompletionNote,
@@ -759,7 +761,7 @@ describe("withCompletion", () => {
     expect(withCompletion(noNote, "2026-06-11", null)).toEqual([]);
   });
 
-  test("carries a baked entryParts snapshot forward across a status change", () => {
+  test("carries a baked entryParts snapshot forward with no recency reference", () => {
     const daily = makeDaily({
       completions: [{
         date: "2026-06-11",
@@ -771,8 +773,7 @@ describe("withCompletion", () => {
         },
       }],
     });
-    // Re-saving the status must keep the frozen snapshot so the server doesn't
-    // re-bake it to a later schedule.
+    // Without a `todayKey` reference we keep the frozen snapshot (safe default).
     expect(withCompletion(daily, "2026-06-11", "goal")).toEqual([
       {
         date: "2026-06-11",
@@ -784,6 +785,71 @@ describe("withCompletion", () => {
         },
       },
     ]);
+  });
+
+  test("drops the baked snapshot when re-updating a recent entry (re-bake)", () => {
+    const daily = makeDaily({
+      completions: [{
+        date: "2026-06-11",
+        status: "touched",
+        entryParts: {
+          prependText: "Review",
+          name: "Spanish flashcards",
+          appendText: null,
+        },
+      }],
+    });
+    // 2026-06-11 is within REBAKE_WINDOW_DAYS of 2026-06-14, so the snapshot is
+    // dropped (entryParts omitted) and the server re-bakes to the current schedule.
+    expect(withCompletion(daily, "2026-06-11", "goal", "2026-06-14")).toEqual([
+      {
+        date: "2026-06-11",
+        status: "goal",
+      },
+    ]);
+  });
+
+  test("keeps the baked snapshot when re-updating an older entry (frozen)", () => {
+    const daily = makeDaily({
+      completions: [{
+        date: "2026-06-01",
+        status: "touched",
+        entryParts: {
+          prependText: "Review",
+          name: "Spanish flashcards",
+          appendText: null,
+        },
+      }],
+    });
+    // 2026-06-01 is beyond REBAKE_WINDOW_DAYS of 2026-06-14, so it stays frozen.
+    expect(withCompletion(daily, "2026-06-01", "goal", "2026-06-14")).toEqual([
+      {
+        date: "2026-06-01",
+        status: "goal",
+        entryParts: {
+          prependText: "Review",
+          name: "Spanish flashcards",
+          appendText: null,
+        },
+      },
+    ]);
+  });
+});
+
+describe("isWithinRebakeWindow", () => {
+  test("today and future dates are within the window", () => {
+    expect(isWithinRebakeWindow("2026-06-14", "2026-06-14")).toBe(true);
+    expect(isWithinRebakeWindow("2026-06-20", "2026-06-14")).toBe(true);
+  });
+
+  test("a past date exactly at the window edge is included", () => {
+    const edge = shiftDateKey("2026-06-14", -REBAKE_WINDOW_DAYS);
+    expect(isWithinRebakeWindow(edge, "2026-06-14")).toBe(true);
+  });
+
+  test("a past date beyond the window is excluded", () => {
+    const beyond = shiftDateKey("2026-06-14", -(REBAKE_WINDOW_DAYS + 1));
+    expect(isWithinRebakeWindow(beyond, "2026-06-14")).toBe(false);
   });
 });
 

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -337,14 +337,47 @@ function carryEntryParts(
     : {};
 }
 
+// How recent a logged entry must be for a status re-update to re-snapshot its
+// scheduled task. Re-updating a recent entry re-bakes it (so a changed/renamed
+// task is reflected in the entries log); older entries stay frozen for historical
+// accuracy.
+export const REBAKE_WINDOW_DAYS = 7;
+
+// Whether `dateKey` (a "YYYY-MM-DD" key) is recent enough — today, in the future,
+// or within REBAKE_WINDOW_DAYS in the past — that re-updating its status should
+// drop the frozen snapshot and let the server re-bake to the current schedule.
+// Both keys are compared in UTC to match the rest of the daily date math.
+export function isWithinRebakeWindow(dateKey: string, todayKey: string): boolean {
+  const diffDays = Math.round(
+    (Date.parse(`${todayKey}T00:00:00Z`) - Date.parse(`${dateKey}T00:00:00Z`))
+    / 86_400_000,
+  );
+  return diffDays <= REBAKE_WINDOW_DAYS;
+}
+
+// Decide whether to keep an entry's frozen snapshot or drop it so the server
+// re-bakes. With no recency reference we keep frozen (safe default); given
+// `todayKey`, recent entries drop the snapshot (re-bake), older ones stay frozen.
+function rebakeOrCarry(
+  existing: Daily["completions"][number] | undefined,
+  dateKey: string,
+  todayKey: string | undefined,
+): Pick<Daily["completions"][number], "entryParts"> | object {
+  if (todayKey !== undefined && isWithinRebakeWindow(dateKey, todayKey)) {
+    return {};
+  }
+  return carryEntryParts(existing);
+}
+
 export function withCompletion(
   daily: Daily,
   dateKey: string,
   status: DailyCompletionStatus | null,
+  todayKey?: string,
 ): Daily["completions"] {
   const others = daily.completions.filter(c => c.date !== dateKey);
   const existing = daily.completions.find(c => c.date === dateKey);
-  const carry = carryEntryParts(existing);
+  const carry = rebakeOrCarry(existing, dateKey, todayKey);
   if (status === null) {
     if (existing?.note) {
       return [


### PR DESCRIPTION
## Summary

Adds a "rebake window" mechanism to allow recent daily entries to be re-snapshotted when their status is updated, while keeping older entries frozen for historical accuracy. This ensures that if a task is renamed or rescheduled, recent log entries reflect the current state rather than stale snapshots.

## Key Changes

- **New `isWithinRebakeWindow()` function** — determines if a dated entry is recent enough (today, future, or within `REBAKE_WINDOW_DAYS` in the past) to warrant re-baking when status changes
- **New `REBAKE_WINDOW_DAYS` constant** — set to 7 days; entries older than this keep their frozen snapshot
- **New `rebakeOrCarry()` helper** — decides whether to drop a frozen snapshot (re-bake) or preserve it based on recency and a `todayKey` reference
- **Updated `withCompletion()` signature** — now accepts optional `todayKey` parameter; when provided, recent entries drop their `entryParts` snapshot so the server re-bakes to the current schedule
- **Updated all callers** — `useDailyCompletions`, `useDailyStatusMutation`, `useRoutineStatusMutation`, and dashboard/tracker components now pass `todayKey` (or `realToday`) to enable re-baking for today's updates
- **Terminology update** — "note" → "comment" in `NoteEditButton` UI labels and placeholders for consistency
- **Updated `DailyTrackerRow.onChangeStatus` callback** — now receives `note` parameter alongside `status` to support combined status+note mutations

## Implementation Details

- The rebake window is checked in UTC to match the rest of the daily date math
- Without a `todayKey` reference, `withCompletion()` defaults to keeping the frozen snapshot (safe fallback for historical entries)
- Today's status updates always re-bake (pass `todayKey` as the date being updated); past entries within 7 days also re-bake if `todayKey` is provided; entries beyond 7 days stay frozen
- Test coverage added for both the rebake window boundary conditions and the three scenarios: no recency reference, recent re-update (re-bake), and older re-update (frozen)

https://claude.ai/code/session_01Cm6CAoF2823m2PUHTfZK7K