### PR TITLE
refactor(middleware): Fixes #473: re-export DomainRadarConfig for radar_config JSONB shape

### DIFF
--- a/packages/middleware/src/db/schema/radar.ts
+++ b/packages/middleware/src/db/schema/radar.ts
@@ -1,4 +1,4 @@
-import type { RadarConfigEntry } from "@emstack/types";
+import type { DomainRadarConfig, RadarConfigEntry } from "@emstack/types";
 
 import { boolean, jsonb, pgTable, primaryKey, unique, varchar } from "drizzle-orm/pg-core";
 
@@ -7,13 +7,7 @@ import { topics } from "./topics";
 // JSONB column shape comes from the shared types package — the single source of
 // truth the client uses too (type-only re-export, erased at build time). The
 // local copy this replaces had drifted from @emstack/types.
-export type { RadarConfigEntry };
-
-export interface RadarConfig {
-  quadrants: RadarConfigEntry[];
-  rings: RadarConfigEntry[];
-  hasAdoptedSection?: boolean;
-}
+export type { DomainRadarConfig, RadarConfigEntry };
 
 export const domains = pgTable("domains", {
   id: varchar().primaryKey(),
@@ -21,7 +15,7 @@ export const domains = pgTable("domains", {
     length: 255,
   }).notNull(),
   description: varchar(),
-  radarConfig: jsonb("radar_config").$type<RadarConfig>().notNull().default({
+  radarConfig: jsonb("radar_config").$type<DomainRadarConfig>().notNull().default({
     quadrants: [],
     rings: [],
   }),

--- a/packages/middleware/src/routes/api/domains/upsertRadarConfig.ts
+++ b/packages/middleware/src/routes/api/domains/upsertRadarConfig.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "@/db";
 import { domains, radarBlips } from "@/db/schema";
-import type { RadarConfig } from "@/db/schema";
+import type { DomainRadarConfig } from "@/db/schema";
 import { sendNotFound } from "@/utils/errors";
 
 const upsertConfigSchema = {
@@ -100,7 +100,7 @@ export default async function (server: FastifyInstance) {
         return sendNotFound(reply, "Domain");
       }
 
-      const newConfig: RadarConfig = {
+      const newConfig: DomainRadarConfig = {
         quadrants: quadrants.map((q, idx) => ({
           id: q.id ?? uuidv4(),
           name: q.name,

--- a/packages/types/src/Domain.ts
+++ b/packages/types/src/Domain.ts
@@ -25,6 +25,7 @@ export interface DomainTopic {
 export interface DomainRadarConfig {
   quadrants: RadarConfigEntry[];
   rings: RadarConfigEntry[];
+  hasAdoptedSection?: boolean;
 }
 
 export interface Domain {


### PR DESCRIPTION
## ELI5
The app stores a "radar config" for each domain in the database. The code had two slightly different descriptions of what that config looks like — one in the database layer and one in the shared types — and they'd drifted apart. This PR deletes the duplicate and keeps a single shared description, fixing it so it accurately includes a setting that was actually being saved all along.

## Summary
- Deleted the local `RadarConfig` interface in `db/schema/radar.ts` that typed the `domains.radar_config` JSONB column, violating the rule that JSONB shapes must be type-only re-exports from `@emstack/types`.
- Added the missing `hasAdoptedSection?: boolean` field to the canonical `DomainRadarConfig` in `@emstack/types` — it's written by `upsertRadarConfig`, returned by `getDomain`, and read by `getRadar`, so the shared type had drifted behind the real stored shape.
- Re-exported `DomainRadarConfig` type-only from the schema and updated the consumer (`upsertRadarConfig.ts`).

## Test plan
- [x] `pnpm typecheck` clean across the repo
- [x] `pnpm exec eslint` clean on the three changed files
- [x] No remaining bare `RadarConfig` references in middleware
- [ ] Radar config upsert/read still round-trips `hasAdoptedSection` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473