### PR TITLE
refactor(middleware): Fixes #473: derive service payload types from shared shapes

### DIFF
--- a/packages/middleware/src/services/readwise.ts
+++ b/packages/middleware/src/services/readwise.ts
@@ -1,4 +1,4 @@
-import type { ReadwiseDocument } from "@emstack/types";
+import type { ReadwiseDocument, ReadwiseReadingList } from "@emstack/types";
 import { db } from "@/db";
 import { appSettings } from "@/db/schema";
 
@@ -143,10 +143,8 @@ async function fetchLocation(
   return collected;
 }
 
-export interface ReadwiseReadingListData {
-  started: ReadwiseDocument[];
-  unstarted: ReadwiseDocument[];
-}
+// The reading-list payload minus `configured`, which the route stamps on.
+export type ReadwiseReadingListData = Omit<ReadwiseReadingList, "configured">;
 
 /**
  * Fetch article documents across the active reading locations and partition

--- a/packages/middleware/src/services/todoist.ts
+++ b/packages/middleware/src/services/todoist.ts
@@ -1,4 +1,4 @@
-import type { TodoistTask } from "@emstack/types";
+import type { TodoistTask, TodoistTasks } from "@emstack/types";
 import { db } from "@/db";
 import { appSettings } from "@/db/schema";
 import { buildCloseTaskUrl } from "./todoistUrls.ts";
@@ -238,10 +238,8 @@ export async function closeTodoistTask(
   assertTodoistOk(response);
 }
 
-export interface TodoistTasksData {
-  overdue: TodoistTask[];
-  today: TodoistTask[];
-}
+// The tasks payload minus `configured`, which the route stamps on.
+export type TodoistTasksData = Omit<TodoistTasks, "configured">;
 
 /**
  * Fetch the user's active tasks due today or overdue and split them by whether


### PR DESCRIPTION
## ELI5
Two pieces of the backend each kept their own copy of a list shape that already lived in the shared types package. This swaps those copies for slices of the shared definition, so if the shared shape ever changes, the backend follows automatically instead of silently drifting out of sync.

## Summary
- Replace the locally re-declared `ReadwiseReadingListData` interface with `Omit<ReadwiseReadingList, "configured">`, derived from `@emstack/types`.
- Replace the locally re-declared `TodoistTasksData` interface with `Omit<TodoistTasks, "configured">`, derived from `@emstack/types`.
- The `configured` flag stays the route's responsibility (it's stamped on in `readwise/root.ts` / `todoist/root.ts`); the service types now carry exactly the rest.

## Test plan
- [ ] `pnpm typecheck` passes (types cross packages, so this is the real safety net)
- [ ] `pnpm exec eslint packages/middleware/src/services/readwise.ts packages/middleware/src/services/todoist.ts` is clean
- [ ] `GET /api/readwise/reading-list` still returns `{ configured, started, unstarted }`
- [ ] `GET /api/todoist/tasks` still returns `{ configured, overdue, today }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473