### PR TITLE
refactor(middleware): Fixes #473: condense route request-body types toward @emstack/types

### DIFF
--- a/packages/middleware/src/routes/api/interactions/upsertInteraction.ts
+++ b/packages/middleware/src/routes/api/interactions/upsertInteraction.ts
@@ -1,23 +1,9 @@
+import type { Interaction } from "@emstack/types";
 import { interactions } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { interactionBodySchema } from "@/utils/schemas";
 
-interface InteractionBody {
-  resourceId: string;
-  moduleGroupId?: string | null;
-  moduleId?: string | null;
-  date: string;
-  progress: "incomplete" | "started" | "complete";
-  note?: string | null;
-  difficulty?: "easy" | "medium" | "hard" | null;
-  understanding?:
-    | "none"
-    | "basic"
-    | "comfortable"
-    | "proficient"
-    | "mastered"
-    | null;
-}
+type InteractionBody = Omit<Interaction, "id">;
 
 const updateableColumns = [
   "resourceId",

--- a/packages/middleware/src/routes/api/module-groups/upsertModuleGroup.ts
+++ b/packages/middleware/src/routes/api/module-groups/upsertModuleGroup.ts
@@ -1,3 +1,4 @@
+import type { TaskResourceLevel } from "@emstack/types";
 import { moduleGroups, moduleGroupTags } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import {
@@ -15,9 +16,9 @@ interface ModuleGroupBody {
   position?: number | null;
   totalCount?: number | null;
   completedCount?: number | null;
-  easeOfStarting?: "low" | "medium" | "high" | null;
-  timeNeeded?: "low" | "medium" | "high" | null;
-  interactivity?: "low" | "medium" | "high" | null;
+  easeOfStarting?: TaskResourceLevel | null;
+  timeNeeded?: TaskResourceLevel | null;
+  interactivity?: TaskResourceLevel | null;
   tagIds?: string[];
 }
 

--- a/packages/middleware/src/routes/api/modules/upsertModule.ts
+++ b/packages/middleware/src/routes/api/modules/upsertModule.ts
@@ -1,3 +1,4 @@
+import type { TaskResourceLevel } from "@emstack/types";
 import { modules, moduleTags } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { coerceModuleLength } from "@/utils/moduleLength";
@@ -19,9 +20,9 @@ interface ModuleBody {
   minutesLength?: number | null;
   isComplete?: boolean;
   position?: number | null;
-  easeOfStarting?: "low" | "medium" | "high" | null;
-  timeNeeded?: "low" | "medium" | "high" | null;
-  interactivity?: "low" | "medium" | "high" | null;
+  easeOfStarting?: TaskResourceLevel | null;
+  timeNeeded?: TaskResourceLevel | null;
+  interactivity?: TaskResourceLevel | null;
   tagIds?: string[];
 }
 

--- a/packages/middleware/src/routes/api/providers/providerRows.ts
+++ b/packages/middleware/src/routes/api/providers/providerRows.ts
@@ -1,3 +1,5 @@
+import type { RecurPeriodUnit } from "@emstack/types";
+
 import {
   nullableBoolean,
   nullableInteger,
@@ -14,7 +16,7 @@ export interface ProviderBody {
   cost?: string | null;
   isRecurring?: boolean | null;
   recurDate?: string | null;
-  recurPeriodUnit?: "days" | "months" | "years" | null;
+  recurPeriodUnit?: RecurPeriodUnit | null;
   recurPeriod?: number | null;
   isCourseFeesShared?: boolean | null;
 }

--- a/packages/middleware/src/routes/api/resources/upsertResource.ts
+++ b/packages/middleware/src/routes/api/resources/upsertResource.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
+import type { TaskResourceLevel } from "@emstack/types";
 import { db } from "@/db";
 import {
   courseProviders,
@@ -36,9 +37,9 @@ interface CourseBody {
   courseProviderId?: string | null;
   providerIsSelf?: boolean;
   modulesAreExhaustive?: boolean;
-  easeOfStarting?: "low" | "medium" | "high" | null;
-  timeNeeded?: "low" | "medium" | "high" | null;
-  interactivity?: "low" | "medium" | "high" | null;
+  easeOfStarting?: TaskResourceLevel | null;
+  timeNeeded?: TaskResourceLevel | null;
+  interactivity?: TaskResourceLevel | null;
   tagIds?: string[];
 }
 

--- a/packages/middleware/src/routes/api/routines/routineRows.ts
+++ b/packages/middleware/src/routes/api/routines/routineRows.ts
@@ -12,7 +12,12 @@ import {
 
 import type { RoutineConnectionInput } from "@/utils/routineConnectionRows";
 import type { RoutineCurated, RoutineWeekly } from "@/db/schema";
-import type { DailyCompletion, DailyCriteria } from "@emstack/types";
+import type {
+  DailyCompletion,
+  DailyCriteria,
+  EntityStatus,
+  RoutineMode,
+} from "@emstack/types";
 
 // Body schema and row builder shared by the routine create and upsert
 // handlers.
@@ -21,10 +26,10 @@ export interface RoutineBody {
   name: string;
   description?: string | null;
   connections?: RoutineConnectionInput[];
-  status?: "active" | "inactive" | "complete" | "paused" | null;
+  status?: EntityStatus | null;
   weekly?: RoutineWeekly;
   curated?: RoutineCurated;
-  mode?: "weekly" | "daily" | "curated" | null;
+  mode?: RoutineMode | null;
   completions?: DailyCompletion[];
   criteria?: DailyCriteria;
   weeklyTarget?: number | null;

--- a/packages/middleware/src/routes/api/tag-groups/upsertTagGroup.ts
+++ b/packages/middleware/src/routes/api/tag-groups/upsertTagGroup.ts
@@ -1,13 +1,9 @@
+import type { TagGroup } from "@emstack/types";
 import { tagGroups } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { nullableInteger, nullableString } from "@/utils/schemas";
 
-interface TagGroupBody {
-  name: string;
-  description?: string | null;
-  color?: string | null;
-  position?: number | null;
-}
+type TagGroupBody = Omit<TagGroup, "id" | "tags">;
 
 const updateableColumns = ["name", "description", "color", "position"] as const;
 

--- a/packages/middleware/src/routes/api/tags/upsertTag.ts
+++ b/packages/middleware/src/routes/api/tags/upsertTag.ts
@@ -1,13 +1,9 @@
+import type { Tag } from "@emstack/types";
 import { tags } from "@/db/schema";
 import { createUpsertHandler } from "@/utils/createUpsertHandler";
 import { nullableInteger, nullableString } from "@/utils/schemas";
 
-interface TagBody {
-  name: string;
-  groupId: string;
-  color?: string | null;
-  position?: number | null;
-}
+type TagBody = Omit<Tag, "id">;
 
 const updateableColumns = ["name", "groupId", "color", "position"] as const;
 

--- a/packages/middleware/src/routes/api/tasks/taskRows.ts
+++ b/packages/middleware/src/routes/api/tasks/taskRows.ts
@@ -1,5 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
+import type { TaskResourceLink } from "@emstack/types";
+
 import {
   nullableString,
   resourceLinksArraySchema,
@@ -20,11 +22,10 @@ export interface TaskBodyFields {
   taskTypeId?: string | null;
 }
 
-export interface ResourceLinkInput {
-  resourceId: string;
-  moduleGroupId?: string | null;
-  moduleId?: string | null;
-}
+export type ResourceLinkInput = Pick<
+  TaskResourceLink,
+  "resourceId" | "moduleGroupId" | "moduleId"
+>;
 
 export interface TaskResourceInput {
   id?: string | null;

--- a/packages/middleware/src/routes/api/topics/topicRows.ts
+++ b/packages/middleware/src/routes/api/topics/topicRows.ts
@@ -1,5 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
+import type { TaskResourceLink } from "@emstack/types";
+
 import {
   nullableString,
   resourceLinksArraySchema,
@@ -16,11 +18,10 @@ export interface TopicBodyFields {
   reason?: string | null;
 }
 
-export interface TopicResourceLinkInput {
-  resourceId: string;
-  moduleGroupId?: string | null;
-  moduleId?: string | null;
-}
+export type TopicResourceLinkInput = Pick<
+  TaskResourceLink,
+  "resourceId" | "moduleGroupId" | "moduleId"
+>;
 
 export interface TopicBody extends TopicBodyFields {
   domainIds?: string[];


### PR DESCRIPTION
## ELI5
The backend's API endpoints each described the exact shape of the data they accept using their own hand-written copies of shapes that already exist in one shared place. Those copies can quietly drift out of sync. This change points the copies back at the single shared definition, so there's one source of truth and less duplicated code — with no change to how anything behaves.

## Summary
- Replaced request-body interfaces that exactly re-declared a shared `@emstack/types` shape with aliases over it: `InteractionBody` → `Omit<Interaction, "id">` (also drops three inline union literals), `TagBody` → `Omit<Tag, "id">`, `TagGroupBody` → `Omit<TagGroup, "id" | "tags">`.
- Deduped the two identical resource-link inputs (`ResourceLinkInput`, `TopicResourceLinkInput`) to `Pick<TaskResourceLink, ...>` so both derive from the one shared link shape.
- Swapped inline union literals for their named shared aliases: `TaskResourceLevel` (Module/ModuleGroup/Course bodies), `RecurPeriodUnit` (Provider), `RoutineMode` / `EntityStatus` (Routine). Left `CourseBody.status` inline on purpose — it's a narrower input set than `EntityStatus` (no `paused`).

Type-only refactor; no runtime/behavior change. Write-DTO bodies that genuinely diverge from their read entities were left untouched.

## Test plan
- [x] `pnpm typecheck` — clean repo-wide
- [x] `pnpm --filter=@emstack/middleware test` — 49/49 pass
- [x] `pnpm exec eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473