### PR TITLE
feat(client): add curated routine mode display and scheduling

### DIFF
--- a/packages/client/src/components/routines/CuratedScheduleField.tsx
+++ b/packages/client/src/components/routines/CuratedScheduleField.tsx
@@ -5,16 +5,7 @@ import { useState } from "react";
 
 import { QuickAddResourceDialog } from "@/components/quickAdd/QuickAddResourceDialog";
 import { ScheduleEntryRow } from "@/components/routines/ScheduleEntryRow";
-
-// "Mon, Jun 15" — read in UTC to match the curated date keys.
-function formatDateLabel(dateKey: string): string {
-  return new Date(`${dateKey}T00:00:00Z`).toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
+import { formatCuratedDateLabel } from "@/components/routines/weekly";
 
 interface CuratedScheduleFieldProps {
   value: CuratedRow[];
@@ -63,7 +54,7 @@ export function CuratedScheduleField({
         {value.map(row => (
           <ScheduleEntryRow
             key={row.date}
-            label={formatDateLabel(row.date)}
+            label={formatCuratedDateLabel(row.date)}
             ariaPrefix={row.date}
             row={row}
             taskOptions={taskOptions}

--- a/packages/client/src/components/routines/index.ts
+++ b/packages/client/src/components/routines/index.ts
@@ -8,6 +8,7 @@ export {
   DAY_LABELS,
   DAY_ORDER,
   fillAllDays,
+  formatCuratedDateLabel,
   MAX_CURATED_DAYS,
   representativeRow,
   rowsToCurated,

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -189,6 +189,17 @@ export function curatedDateRange(
   return keys;
 }
 
+// Human label for a curated date key ("YYYY-MM-DD"), e.g. "Mon, Jun 15". Read in
+// UTC to match the curated date keys (which curatedDateRange also builds in UTC).
+export function formatCuratedDateLabel(dateKey: string): string {
+  return new Date(`${dateKey}T00:00:00Z`).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 // Build the curated editor rows for a set of date keys, defaulting each from the
 // routine's stored entries (empty dates become blank rows).
 export function curatedToRows(

--- a/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.stories.tsx
@@ -8,6 +8,15 @@ import { makeRoutine, makeResources, makeTask } from "@/test-utils/boxFixtures";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
 import { queryStoryDecorator } from "@/test-utils/storyDecorators";
 import { smokePlay } from "@/test-utils/storyPlay";
+import { getTodayKey } from "@/utils";
+
+// A "YYYY-MM-DD" key `days` after today, built in UTC to match the curated date
+// keys (curatedDateRange resolves them the same way).
+function dateKeyOffset(days: number): string {
+  const d = new Date(`${getTodayKey()}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
 
 const meta = {
   component: RoutineDetailsContent,
@@ -61,4 +70,35 @@ export const Weekly: Story = {
     const headings = await canvas.findAllByText("Weekly Schedule");
     await expect(headings.length).toBeGreaterThanOrEqual(2);
   },
+};
+
+// Curated routine: the Type tile reads "Curated" and the schedule renders one
+// row per date from today through the end date (date-keyed, not by weekday).
+export const Curated: Story = {
+  args: {
+    data: makeRoutine({
+      mode: "curated",
+      weekly: {},
+      curated: {
+        endDate: dateKeyOffset(2),
+        entries: {
+          [getTodayKey()]: {
+            type: "resource",
+            id: "resource-1",
+          },
+        },
+      },
+    }),
+  },
+  play: smokePlay([
+    {
+      text: "Curated",
+    },
+    {
+      text: "Curated Schedule",
+    },
+    {
+      text: "Course 1",
+    },
+  ]),
 };

--- a/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineDetailsContent.tsx
@@ -4,11 +4,18 @@ import { FlameIcon, LaughIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements";
 import { InfoArea } from "@/components/layout";
-import { DAY_LABELS, DAY_ORDER, RoutineEntryLabel } from "@/components/routines";
+import {
+  curatedDateRange,
+  DAY_LABELS,
+  DAY_ORDER,
+  formatCuratedDateLabel,
+  RoutineEntryLabel,
+} from "@/components/routines";
 import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
 import {
   connectionEntityKind,
   getCurrentChain,
+  getTodayKey,
   getTotalCompletedDays,
 } from "@/utils";
 
@@ -30,6 +37,12 @@ export function RoutineDetailsContent({
 
   const weekly = data.weekly ?? {};
   const isDaily = data.mode === "daily";
+  const isCurated = data.mode === "curated";
+  // Full window of dates this curated run spans (today → end date); empty for the
+  // other modes, or when no end date is set / it has already passed.
+  const curatedDates = isCurated
+    ? curatedDateRange(getTodayKey(), data.curated?.endDate)
+    : [];
   const completions = data.completions ?? [];
   const chain = getCurrentChain({
     completions,
@@ -56,7 +69,11 @@ export function RoutineDetailsContent({
               font-medium
             "
           >
-            {isDaily ? "Daily Task" : "Weekly Schedule"}
+            {isCurated
+              ? "Curated"
+              : isDaily
+                ? "Daily Task"
+                : "Weekly Schedule"}
           </span>
         </InfoArea>
         <InfoArea
@@ -122,7 +139,7 @@ export function RoutineDetailsContent({
           ))}
         </ul>
       </InfoArea>
-      {!isDaily && (
+      {!isDaily && !isCurated && (
         <InfoArea
           header="Weekly Schedule"
           condition={true}
@@ -160,6 +177,61 @@ export function RoutineDetailsContent({
               );
             })}
           </ul>
+        </InfoArea>
+      )}
+      {isCurated && (
+        <InfoArea
+          header="Curated Schedule"
+          condition={true}
+        >
+          {data.curated?.endDate && (
+            <p className="mb-2 text-sm text-muted-foreground">
+              Ends
+              {" "}
+              {formatCuratedDateLabel(data.curated.endDate)}
+            </p>
+          )}
+          {curatedDates.length > 0
+            ? (
+              <ul className="flex flex-col gap-1">
+                {curatedDates.map((dateKey) => {
+                  const entry = data.curated?.entries?.[dateKey];
+                  return (
+                    <li
+                      key={dateKey}
+                      className="
+                        grid grid-cols-[150px_1fr] items-center gap-2 border-b
+                        border-border/60 py-1
+                      "
+                    >
+                      <span className="text-sm font-medium">
+                        {formatCuratedDateLabel(dateKey)}
+                      </span>
+                      {entry
+                        ? (
+                          <RoutineEntryLabel
+                            entry={entry}
+                            taskNames={taskNames}
+                            resourceNames={resourceNames}
+                          />
+                        )
+                        : (
+                          <span
+                            className="text-sm text-muted-foreground italic"
+                          >
+                            Nothing scheduled
+                          </span>
+                        )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )
+            : (
+              <span className="text-sm text-muted-foreground italic">
+                No curated schedule set.
+              </span>
+            )}
         </InfoArea>
       )}
     </div>

--- a/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.stories.tsx
@@ -8,6 +8,15 @@ import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
 import { seededQueryClient } from "@/test-utils/seededQueryClient";
 import { smokePlay } from "@/test-utils/storyPlay";
+import { getTodayKey } from "@/utils";
+
+// A "YYYY-MM-DD" key `days` after today, built in UTC to match the curated date
+// keys (curatedDateRange resolves them the same way).
+function dateKeyOffset(days: number): string {
+  const d = new Date(`${getTodayKey()}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
 
 const meta = {
   component: RoutineTodayCard,
@@ -53,5 +62,28 @@ export const NothingToday: Story = {
   },
   play: smokePlay([{
     text: /nothing, take a break/i,
+  }]),
+};
+
+// Curated routine: today's entry is keyed by absolute date (weekly is empty), so
+// the card resolves it from curated.entries rather than the weekday grid.
+export const Curated: Story = {
+  args: {
+    data: makeRoutine({
+      mode: "curated",
+      weekly: {},
+      curated: {
+        endDate: dateKeyOffset(2),
+        entries: {
+          [getTodayKey()]: {
+            type: "resource",
+            id: "resource-1",
+          },
+        },
+      },
+    }),
+  },
+  play: smokePlay([{
+    text: "Course 1",
   }]),
 };

--- a/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.tsx
+++ b/packages/client/src/routes/routines.$id.-components/-RoutineTodayCard.tsx
@@ -35,16 +35,21 @@ export function RoutineTodayCard({
   const todayDateKey = getTodayKey();
   const weekly = data.weekly ?? {};
   const isDaily = data.mode === "daily";
+  const isCurated = data.mode === "curated";
   const dailyEntry = isDaily
     ? Object.values(weekly).find(Boolean) ?? null
     : null;
   // The same day of the week as today (JS getDay: "0" = Sunday … "6" = Saturday).
   // Daily routines mirror their entry onto every day, so this resolves to the
   // single daily item; weekly routines resolve to today's scheduled entry (if any).
+  // Curated routines key by the absolute date instead, so they look today up in
+  // the date-keyed `curated.entries` map (weekly is empty for them).
   const todayKey = String(new Date().getDay());
-  const todayEntry = isDaily
-    ? dailyEntry
-    : (weekly[todayKey as keyof typeof weekly] ?? null);
+  const todayEntry = isCurated
+    ? (data.curated?.entries?.[todayDateKey] ?? null)
+    : isDaily
+      ? dailyEntry
+      : (weekly[todayKey as keyof typeof weekly] ?? null);
   // When today's item has a URL location, surface a "Go" button beside the
   // task text so it can be opened in a new tab (non-URL locations show no button).
   const todayLocation = todayEntry?.location ?? null;


### PR DESCRIPTION
## Summary

Add UI support for the "curated" routine mode, which schedules tasks by absolute date rather than by weekday. This includes displaying curated schedules in routine details, rendering today's curated entry in the routine card, and extracting date formatting logic into a shared utility.

## Key Changes

- **RoutineDetailsContent:** Display "Curated" type label and render a date-keyed schedule view (one row per date from today through the end date) when `mode === "curated"`. Hide the weekly schedule section for curated routines.
- **RoutineTodayCard:** Resolve today's entry from `curated.entries[todayDateKey]` instead of the weekday grid for curated routines.
- **CuratedScheduleField:** Extract the date label formatter (`formatCuratedDateLabel`) into a shared utility in `weekly.ts` to avoid duplication.
- **weekly.ts:** Export `formatCuratedDateLabel()` — formats a "YYYY-MM-DD" key as "Mon, Jun 15" in UTC (matching how `curatedDateRange` builds date keys).
- **Storybook stories:** Add `Curated` story variants to both `RoutineDetailsContent.stories.tsx` and `RoutineTodayCard.stories.tsx` with a helper `dateKeyOffset()` to generate future date keys in UTC.

## Implementation Details

- Curated date keys are built and read in UTC (via `curatedDateRange` and `formatCuratedDateLabel`) to ensure consistent date boundaries across timezones.
- The curated schedule section displays an end-date label and iterates through `curatedDates` (computed from `curatedDateRange(getTodayKey(), data.curated?.endDate)`), showing each date's entry or "Nothing scheduled" if empty.
- Weekly schedule section is now conditionally rendered only when `!isDaily && !isCurated`.

https://claude.ai/code/session_01KABfAUdARqK9xk3NAYmKY2