### PR TITLE
refactor(middleware): Fixes #473: condense utils types onto shared shapes

### DIFF
--- a/packages/middleware/src/utils/dailyProjection.ts
+++ b/packages/middleware/src/utils/dailyProjection.ts
@@ -4,6 +4,7 @@ import type {
   DailyCriteria,
 } from "@emstack/types";
 import { toProviderBlock } from "./providerProjection";
+import type { ResolvedResource, ResolvedTask } from "./routineActionParts";
 
 // The fields mapDaily reads. Both the single-daily and list daily queries
 // produce a superset of this shape, so their Drizzle rows are assignable here.
@@ -20,20 +21,8 @@ export interface DailyProjectionRow {
   moduleId: string | null;
   courseProvider: { id: string;
     name: string | null; } | null;
-  resource: {
-    id: string;
-    name: string;
-    progressCurrent: number | null;
-    progressTotal: number | null;
-  } | null;
-  task: {
-    id: string;
-    name: string;
-    todos?: { id: string;
-      isComplete: boolean; }[];
-    resources?: { id: string;
-      usedYet: boolean; }[];
-  } | null;
+  resource: ResolvedResource | null;
+  task: ResolvedTask | null;
 }
 
 // Collapse the joined task row into the Daily's task progress block. Returns

--- a/packages/middleware/src/utils/resolveRoutineConnections.ts
+++ b/packages/middleware/src/utils/resolveRoutineConnections.ts
@@ -1,16 +1,16 @@
 import { db } from "@/db";
 import type { RoutineConnectionType } from "@/db/schema";
 
+import type { RoutineConnection } from "@emstack/types";
+
 export interface RawRoutineConnection {
   connectedType: RoutineConnectionType;
   connectedId: string;
 }
 
-export interface ResolvedRoutineConnection {
-  type: RoutineConnectionType;
-  id: string;
-  name: string;
-}
+// A shared RoutineConnection with its display name resolved on read (always
+// present here, unlike the optional `name` on the wire/persisted shape).
+export type ResolvedRoutineConnection = RoutineConnection & { name: string };
 
 // Batch-resolve display names for the polymorphic connections across a set of
 // routines, querying each target table at most once (avoids N+1). Connections

--- a/packages/middleware/src/utils/routineActionParts.ts
+++ b/packages/middleware/src/utils/routineActionParts.ts
@@ -1,7 +1,8 @@
 import type { Daily, RoutineReferenceItem } from "@emstack/types";
 
-// Resolved task/resource rows the handler loads for an active entry. They
-// mirror the column selection mapDaily expects (see dailyProjection.ts).
+// Resolved task/resource rows the handler loads for an active entry. These are
+// the resource/task blocks mapDaily reads — DailyProjectionRow references them
+// directly (see dailyProjection.ts) so the two can't drift.
 export interface ResolvedTask {
   id: string;
   name: string;

--- a/packages/middleware/src/utils/routineConnectionRows.ts
+++ b/packages/middleware/src/utils/routineConnectionRows.ts
@@ -1,11 +1,11 @@
 import { v4 as uuidv4 } from "uuid";
 
 import type { RoutineConnectionType } from "@/db/schema";
+import type { RoutineConnection } from "@emstack/types";
 
-export interface RoutineConnectionInput {
-  type: RoutineConnectionType;
-  id: string;
-}
+// The write-side slice of a RoutineConnection: the client sends only type + id;
+// the display `name` is resolved on read (see resolveRoutineConnections).
+export type RoutineConnectionInput = Pick<RoutineConnection, "type" | "id">;
 
 // Dedupe by (type, id) and produce routine_connections rows with stable
 // positions, matching the junction-build pattern used for topics/tasks links.


### PR DESCRIPTION
## ELI5
The backend had a few type definitions that were really just copies of shapes already defined elsewhere. This swaps those copies out for the originals, so there's now one source of truth and they can't quietly drift apart over time. Nothing about how the app behaves changes.

## Summary
- `DailyProjectionRow`'s inline `resource`/`task` blocks now reference the existing `ResolvedResource`/`ResolvedTask` types (they already described the exact column selection `mapDaily` reads).
- `ResolvedRoutineConnection` is now `RoutineConnection & { name: string }` — the shared connection shape with the read-resolved name guaranteed present.
- `RoutineConnectionInput` is now `Pick<RoutineConnection, "type" | "id">`, the write-side slice of the shared connection type.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `eslint` on the 4 changed files — clean
- [x] `routineActionParts` / `routineProjection` / `providerProjection` middleware tests — 20/20 pass
- [ ] No behavior change expected; type-only refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473