### PR TITLE
refactor(types): Fixes #473: extract shared base interfaces in @emstack/types

### DIFF
--- a/packages/types/src/Module.ts
+++ b/packages/types/src/Module.ts
@@ -1,5 +1,5 @@
 import type { Tag } from "./Tag";
-import type { TaskResourceLevel } from "./TaskResource";
+import type { ResourceLevelAttributes } from "./TaskResource";
 
 export const MODULE_DURATION_BUCKETS = [
   "extra_short",
@@ -19,7 +19,7 @@ export const MODULE_DURATION_LABELS: Record<ModuleDurationBucket, string> = {
   extra_long: "Extra Long (1h+)",
 };
 
-export interface Module {
+export interface Module extends ResourceLevelAttributes {
   id: string;
   resourceId: string;
   moduleGroupId?: string | null;
@@ -33,9 +33,6 @@ export interface Module {
   minutesLength?: number | null;
   isComplete: boolean;
   position?: number | null;
-  easeOfStarting?: TaskResourceLevel | null;
-  timeNeeded?: TaskResourceLevel | null;
-  interactivity?: TaskResourceLevel | null;
   tags?: Tag[];
 }
 

--- a/packages/types/src/ModuleGroup.ts
+++ b/packages/types/src/ModuleGroup.ts
@@ -1,8 +1,8 @@
 import type { Module } from "./Module";
 import type { Tag } from "./Tag";
-import type { TaskResourceLevel } from "./TaskResource";
+import type { ResourceLevelAttributes } from "./TaskResource";
 
-export interface ModuleGroup {
+export interface ModuleGroup extends ResourceLevelAttributes {
   id: string;
   resourceId: string;
   name: string;
@@ -16,8 +16,5 @@ export interface ModuleGroup {
   totalCount?: number | null;
   completedCount?: number | null;
   modules?: Module[];
-  easeOfStarting?: TaskResourceLevel | null;
-  timeNeeded?: TaskResourceLevel | null;
-  interactivity?: TaskResourceLevel | null;
   tags?: Tag[];
 }

--- a/packages/types/src/Resource.ts
+++ b/packages/types/src/Resource.ts
@@ -4,11 +4,11 @@ import type { MinimalTopic } from "./MinimalTopic";
 import type { Module } from "./Module";
 import type { ModuleGroup } from "./ModuleGroup";
 import type { Tag } from "./Tag";
-import type { TaskResourceLevel } from "./TaskResource";
+import type { ResourceLevelAttributes } from "./TaskResource";
 
 export type ResourceStatus = EntityStatus;
 
-export interface Resource {
+export interface Resource extends ResourceLevelAttributes {
   id: string;
   name: string;
   description?: string | null;
@@ -28,8 +28,5 @@ export interface Resource {
   providerIsSelf?: boolean;
   moduleGroups?: ModuleGroup[];
   modules?: Module[];
-  easeOfStarting?: TaskResourceLevel | null;
-  timeNeeded?: TaskResourceLevel | null;
-  interactivity?: TaskResourceLevel | null;
   tags?: Tag[];
 }

--- a/packages/types/src/ResourceLinkTarget.ts
+++ b/packages/types/src/ResourceLinkTarget.ts
@@ -1,13 +1,24 @@
-import type { TaskResourceLevel } from "./TaskResource";
+import type { ResourceLevelAttributes } from "./TaskResource";
 
 // The shared shape a Resource / ModuleGroup / Module exposes when it is the
 // target of a task or topic resource link. Ease/time/interactivity live on
 // the linked entity. Reused by TaskResource and TaskResourceLink so the
 // {id,name,ease,time,interactivity} sub-object isn't repeated per-target.
-export interface ResourceLinkTarget {
+export interface ResourceLinkTarget extends ResourceLevelAttributes {
   id: string;
   name: string;
-  easeOfStarting?: TaskResourceLevel | null;
-  timeNeeded?: TaskResourceLevel | null;
-  interactivity?: TaskResourceLevel | null;
+}
+
+// The optional sub-target narrowing shared by a resource link (TaskResourceLink)
+// and a per-task resource entry (TaskResource): which moduleGroup or module
+// within the linked Resource the row points at, plus the resolved target
+// objects. At most one of moduleGroupId / moduleId is set; both null = the
+// link targets the whole Resource. The owning `resourceId` and row `id` differ
+// in optionality between the two consumers, so they stay on each type.
+export interface ResourceLinkNarrowing {
+  resource?: ResourceLinkTarget | null;
+  moduleGroupId?: string | null;
+  moduleGroup?: ResourceLinkTarget | null;
+  moduleId?: string | null;
+  module?: ResourceLinkTarget | null;
 }

--- a/packages/types/src/TaskResource.ts
+++ b/packages/types/src/TaskResource.ts
@@ -3,11 +3,20 @@
 // (name, url, usedYet) are kept alongside for additional task-local
 // metadata. Ease/time/interactivity/tags now live on Resource, ModuleGroup,
 // and Module — when this row is linked, the linked entity supplies them.
-import type { ResourceLinkTarget } from "./ResourceLinkTarget";
+import type { ResourceLinkNarrowing } from "./ResourceLinkTarget";
 
 export type TaskResourceLevel = "low" | "medium" | "high";
 
-export interface TaskResource {
+// The ease/time/interactivity ratings shared by every learning unit a resource
+// link can target — Resource, ModuleGroup, Module — and by ResourceLinkTarget.
+// Extracted so the three-field cluster lives in one place.
+export interface ResourceLevelAttributes {
+  easeOfStarting?: TaskResourceLevel | null;
+  timeNeeded?: TaskResourceLevel | null;
+  interactivity?: TaskResourceLevel | null;
+}
+
+export interface TaskResource extends ResourceLinkNarrowing {
   id: string;
   taskId: string;
   name: string;
@@ -17,9 +26,4 @@ export interface TaskResource {
   // Optional link to a top-level Resource (= future Course rename).
   // Both null = whole-resource link; all three null = no link.
   resourceId?: string | null;
-  resource?: ResourceLinkTarget | null;
-  moduleGroupId?: string | null;
-  moduleGroup?: ResourceLinkTarget | null;
-  moduleId?: string | null;
-  module?: ResourceLinkTarget | null;
 }

--- a/packages/types/src/TaskResourceLink.ts
+++ b/packages/types/src/TaskResourceLink.ts
@@ -1,17 +1,12 @@
-import type { ResourceLinkTarget } from "./ResourceLinkTarget";
+import type { ResourceLinkNarrowing } from "./ResourceLinkTarget";
 
 // A task's (or topic's) link to a Resource, optionally narrowed to a module
 // group or a single module within that Resource. At most one of
 // moduleGroupId / moduleId is set; both null = the link targets the whole
 // Resource. A task can hold multiple links per Resource (different
 // sub-targets), so each link has a stable per-row `id`.
-export interface TaskResourceLink {
+export interface TaskResourceLink extends ResourceLinkNarrowing {
   id?: string;
   resourceId: string;
-  resource?: ResourceLinkTarget | null;
-  moduleGroupId?: string | null;
-  moduleGroup?: ResourceLinkTarget | null;
-  moduleId?: string | null;
-  module?: ResourceLinkTarget | null;
   position?: number | null;
 }

--- a/packages/types/src/TopicForTopicsPage.ts
+++ b/packages/types/src/TopicForTopicsPage.ts
@@ -1,7 +1,7 @@
-export interface TopicForTopicsPageDomain {
-  id: string;
-  title: string;
-}
+import type { TopicDomain } from "./Topic";
+
+// Same {id, title} domain reference as the full Topic view.
+export type TopicForTopicsPageDomain = TopicDomain;
 
 export interface TopicForTopicsPage {
   id: string;


### PR DESCRIPTION
## ELI5
The shared types package had several definitions that listed the same fields over and over in different places. This pulls those repeated field groups into single shared definitions that the others build on, so there's now one place to change them instead of many. Nothing about how the app behaves changes — it's purely tidying.

## Summary
- Extracted `ResourceLevelAttributes` (`easeOfStarting`/`timeNeeded`/`interactivity`) — previously repeated verbatim on `Resource`, `Module`, `ModuleGroup`, and `ResourceLinkTarget`, which now each `extends` it.
- Extracted `ResourceLinkNarrowing` (the `resource`/`moduleGroupId`/`moduleGroup`/`moduleId`/`module` sub-target cluster) shared by `TaskResource` and `TaskResourceLink`; `resourceId`/`id` stay per-type since their optionality differs.
- Aliased `TopicForTopicsPageDomain` to `TopicDomain` (it was a verbatim re-declaration of the same `{ id, title }` shape); the exported name is preserved so consumers are unaffected.

## Test plan
- [ ] `pnpm typecheck` is clean across all packages (the real safety net — `extends`/alias preserve the resolved structural shapes, so client and middleware consumers are unaffected)
- [ ] `pnpm exec eslint` clean on the changed type files
- [ ] `pnpm --filter=@emstack/client exec vitest run src/components/resources/moduleDrafts.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #473