### PR TITLE
refactor: consolidate UI component imports to shadcn/ui paths

### DIFF
--- a/packages/client/src/components/resources/ModuleStatusControl.tsx
+++ b/packages/client/src/components/resources/ModuleStatusControl.tsx
@@ -7,12 +7,12 @@ import {
   MODULE_STATUS_OPTIONS,
 } from "./moduleStatusMeta";
 
+import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/popover";
-import { Button } from "@/components/ui/button";
+} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 /**

--- a/packages/client/src/routes/resources.$id.-components/-ModuleConventionsEditor.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleConventionsEditor.tsx
@@ -5,13 +5,13 @@ import { useState } from "react";
 import { DEFAULT_MODULES_CONFIG } from "@emstack/types";
 import { TextCursorInputIcon } from "lucide-react";
 
-import { Input } from "@/components/input";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/popover";
-import { Button } from "@/components/ui/button";
+} from "@/components/ui/popover";
 
 /**
  * Lets the user rename what a "group" and a "module" are called for this


### PR DESCRIPTION
## Summary
Standardizes import paths for shadcn/ui components across the client package by moving all UI component imports to use the `@/components/ui/` namespace, ensuring consistency with the project's component organization.

## Changes
- **ModuleConventionsEditor.tsx**: Updated imports for `Button`, `Input`, and `Popover` components to use `@/components/ui/` paths instead of mixed import locations
- **ModuleStatusControl.tsx**: Consolidated `Button` and `Popover` component imports to use `@/components/ui/` paths
- Reordered imports alphabetically within each file for consistency

## Details
These changes ensure all shadcn/ui component imports follow a uniform pattern (`@/components/ui/<component-name>`), improving maintainability and making the codebase easier to navigate. No functional changes were made — this is purely an import path standardization refactor.

https://claude.ai/code/session_01Pfvqwhtjbhxs9muLuxR81H