### PR TITLE
feat(client): add progress mode toggle and inline tag creation

### DIFF
--- a/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
+++ b/packages/client/src/components/formFields/ComboboxCreatePanel.tsx
@@ -5,13 +5,23 @@ import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export interface CreateFieldConfig {
   name: string;
   label: string;
   required?: boolean;
-  type?: "text" | "url" | "email";
+  type?: "text" | "url" | "email" | "select";
   placeholder?: string;
+  /** Choices for a `type: "select"` field. */
+  options?: { value: string;
+    label: string; }[];
   /** When true, this field is pre-filled with the user's typed input */
   isPrimary?: boolean;
 }
@@ -109,19 +119,50 @@ export function ComboboxCreatePanel({
               {f.label}
               {f.required && <span className="text-destructive"> *</span>}
             </Label>
-            <Input
-              id={`combobox-create-${f.name}`}
-              type={f.type ?? "text"}
-              value={values[f.name] ?? ""}
-              placeholder={f.placeholder}
-              onChange={e =>
-                setValues(prev => ({
-                  ...prev,
-                  [f.name]: e.target.value,
-                }))}
-              disabled={submitting}
-              autoFocus={f.name === primaryFieldName}
-            />
+            {f.type === "select"
+              ? (
+                <Select
+                  value={values[f.name] || undefined}
+                  onValueChange={val =>
+                    setValues(prev => ({
+                      ...prev,
+                      [f.name]: val,
+                    }))}
+                  disabled={submitting}
+                >
+                  <SelectTrigger
+                    id={`combobox-create-${f.name}`}
+                    className="w-full"
+                  >
+                    <SelectValue placeholder={f.placeholder ?? "Select..."} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(f.options ?? []).map(opt => (
+                      <SelectItem
+                        key={opt.value}
+                        value={opt.value}
+                      >
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )
+              : (
+                <Input
+                  id={`combobox-create-${f.name}`}
+                  type={f.type ?? "text"}
+                  value={values[f.name] ?? ""}
+                  placeholder={f.placeholder}
+                  onChange={e =>
+                    setValues(prev => ({
+                      ...prev,
+                      [f.name]: e.target.value,
+                    }))}
+                  disabled={submitting}
+                  autoFocus={f.name === primaryFieldName}
+                />
+              )}
           </div>
         ))}
         <div className="flex gap-2">

--- a/packages/client/src/hooks/useResourceEditForm.ts
+++ b/packages/client/src/hooks/useResourceEditForm.ts
@@ -7,6 +7,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
+import { useSetModulesExhaustive } from "./useSetModulesExhaustive";
+
 import { useAppForm } from "@/components/formFields";
 import {
   buildResourcePayload,
@@ -14,6 +16,7 @@ import {
 } from "@/routes/resources.$id.edit.-components/-buildResourcePayload";
 import {
   createProvider,
+  createTag,
   createTopic,
   fetchProviders,
   fetchTagGroups,
@@ -78,6 +81,9 @@ export function useResourceEditForm({
   const topicOptions = useMemo(() => toOptions(topics), [topics]);
   const providerOptions = useMemo(() => toOptions(providers), [providers]);
   const tagOptions = useMemo(() => tagGroupsToOptions(tagGroups), [tagGroups]);
+  // Tag groups themselves (not the tags within them) — used as the "Tag Group"
+  // choices when creating a new tag inline from the combobox.
+  const tagGroupOptions = useMemo(() => toOptions(tagGroups), [tagGroups]);
 
   // An exhaustive field-by-field mapping of the resource onto the form's
   // default values. Its high cyclomatic score is an artifact of per-field
@@ -198,17 +204,45 @@ export function useResourceEditForm({
     return result.id;
   };
 
+  const createTagOption = async (
+    values: Record<string, unknown>,
+  ): Promise<string> => {
+    const result = await createTag({
+      name: values.name,
+      groupId: values.groupId,
+      color: null,
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ["tagGroups"],
+    });
+    return result.id;
+  };
+
+  // Progress-mode toggle. Reuses the same optimistic mutation the Modules tab
+  // uses, so toggling here (Details tab) and the Modules-tab callout stay in
+  // sync. No-op for new resources (no id/modules yet).
+  const modulesAreExhaustive = data?.modulesAreExhaustive ?? false;
+  const setModulesExhaustiveMutation = useSetModulesExhaustive(id);
+  const setProgressMode = (mode: "manual" | "modules") => {
+    if (isNew) return;
+    setModulesExhaustiveMutation.mutate(mode === "modules");
+  };
+
   return {
     form,
     topicOptions,
     providerOptions,
     tagOptions,
+    tagGroupOptions,
     currentValues,
     isSubmitting,
     hasChanges,
     isCostFromPlatform,
     providerUrlMissing,
+    modulesAreExhaustive,
     createTopicOption,
     createProviderOption,
+    createTagOption,
+    setProgressMode,
   };
 }

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -1,11 +1,13 @@
 import type { GroupDraft, ModuleDraft } from "@/components/resources/moduleDrafts";
-import type { Module, ModuleGroup, ModulesConfig, ModuleStatus, Resource } from "@emstack/types";
+import type { Module, ModuleGroup, ModulesConfig, ModuleStatus } from "@emstack/types";
 
 import { useMemo } from "react";
 
 import { DEFAULT_MODULES_CONFIG, isModuleComplete } from "@emstack/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+
+import { useSetModulesExhaustive } from "./useSetModulesExhaustive";
 
 import { draftToLength, parseCount } from "@/components/resources/moduleDrafts";
 import {
@@ -17,7 +19,6 @@ import {
   fetchModules,
   fetchSingleResource,
   fetchTagGroups,
-  setResourceModulesExhaustive,
   updateResourceModulesConfig,
   upsertModule,
   upsertModuleGroup,
@@ -392,41 +393,9 @@ export function useResourceModules(resourceId: string) {
     = reorderModulesMutation.isPending || reorderGroupsMutation.isPending;
 
   // Toggle the resource-level "module list is exhaustive" flag. Optimistic so
-  // the checkbox responds instantly; rolls back on error.
-  const setModulesExhaustiveMutation = useMutation({
-    mutationFn: (value: boolean) =>
-      setResourceModulesExhaustive(resourceId, value),
-    onMutate: async (value: boolean) => {
-      const detailKey = queryKeys.resources.detail(resourceId);
-      await queryClient.cancelQueries({
-        queryKey: detailKey,
-      });
-      const previous = queryClient.getQueryData<Resource>(detailKey);
-      if (previous) {
-        queryClient.setQueryData<Resource>(detailKey, {
-          ...previous,
-          modulesAreExhaustive: value,
-        });
-      }
-      return {
-        previous,
-      };
-    },
-    onError: (e: Error, _value, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(
-          queryKeys.resources.detail(resourceId),
-          context.previous,
-        );
-      }
-      toast.error(e.message);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.resources.detail(resourceId),
-      });
-    },
-  });
+  // the control responds instantly; rolls back on error. Shared with the edit
+  // form's progress-mode radio so both writers stay in sync.
+  const setModulesExhaustiveMutation = useSetModulesExhaustive(resourceId);
 
   return {
     resourceQuery,

--- a/packages/client/src/hooks/useSetModulesExhaustive.ts
+++ b/packages/client/src/hooks/useSetModulesExhaustive.ts
@@ -1,0 +1,53 @@
+import type { Resource } from "@emstack/types";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { setResourceModulesExhaustive } from "@/utils/fetchFunctions";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Toggle the resource-level "modules are exhaustive" flag (whether progress is
+ * computed from finished modules instead of the manual current/total numbers).
+ * Optimistic so the control responds instantly and rolls back on error, writing
+ * to the shared `resources.detail` query so every reader — the Details-tab
+ * progress radio and the Modules-tab callout — stays in sync across tabs.
+ */
+export function useSetModulesExhaustive(resourceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (value: boolean) =>
+      setResourceModulesExhaustive(resourceId, value),
+    onMutate: async (value: boolean) => {
+      const detailKey = queryKeys.resources.detail(resourceId);
+      await queryClient.cancelQueries({
+        queryKey: detailKey,
+      });
+      const previous = queryClient.getQueryData<Resource>(detailKey);
+      if (previous) {
+        queryClient.setQueryData<Resource>(detailKey, {
+          ...previous,
+          modulesAreExhaustive: value,
+        });
+      }
+      return {
+        previous,
+      };
+    },
+    onError: (e: Error, _value, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.resources.detail(resourceId),
+          context.previous,
+        );
+      }
+      toast.error(e.message);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.resources.detail(resourceId),
+      });
+    },
+  });
+}

--- a/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ModuleAdminHeader.tsx
@@ -1,12 +1,13 @@
 import type { ModuleAdminSectionProps } from "./-moduleAdminSectionProps";
 
-import { PlusIcon, SparklesIcon } from "lucide-react";
+import { CircleCheckBig, InfoIcon, PlusIcon, SparklesIcon } from "lucide-react";
 
 import { ModuleAssistDialog } from "./-ModuleAssistDialog";
 import { ModuleConventionsEditor } from "./-ModuleConventionsEditor";
 
 import { Button } from "@/components/ui/button";
 import { UNGROUPED_KEY } from "@/hooks/useModuleAdminUiState";
+import { cn } from "@/lib/utils";
 
 interface ModuleAdminHeaderProps extends ModuleAdminSectionProps {
   /** When true, render the editable "module list is exhaustive" toggle. */
@@ -29,7 +30,6 @@ export function ModuleAdminHeader({
     groupLabel,
     moduleLabel,
     modulesAreExhaustive,
-    setModulesExhaustiveMutation,
   } = api;
   const {
     isAnyEditing,
@@ -89,27 +89,48 @@ export function ModuleAdminHeader({
         </div>
       </div>
 
-      {canEditExhaustive && (
-        <label className="flex items-start gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={modulesAreExhaustive}
-            onChange={e =>
-              setModulesExhaustiveMutation.mutate(e.target.checked)}
-            className="mt-0.5 size-4"
-          />
-          <span className="flex flex-col gap-0.5">
-            <span className="font-medium">Module list is exhaustive</span>
-            <span className="text-xs text-muted-foreground">
-              Treat the modules below as the full contents of this resource. When
-              on, progress and % complete are calculated from how many modules
-              are marked done — instead of the Current Progress / Total Modules
-              numbers on the Details tab. Leave off if these modules are only a
-              partial breakdown.
-            </span>
+      <div
+        className={cn(
+          "flex items-start gap-2 rounded-md border p-3 text-sm",
+          modulesAreExhaustive
+            ? `
+              border-emerald-300 bg-emerald-50 text-emerald-900
+              dark:border-emerald-500/40 dark:bg-emerald-900/30
+              dark:text-emerald-100
+            `
+            : "border-border bg-muted/40",
+        )}
+      >
+        {modulesAreExhaustive
+          ? <CircleCheckBig className="mt-0.5 size-4 shrink-0" />
+          : (
+            <InfoIcon
+              className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+            />
+          )}
+        <span className="flex flex-col gap-0.5">
+          <span className="font-medium">
+            {modulesAreExhaustive
+              ? `These ${moduleLabel.toLowerCase()}s are used to calculate `
+              + "this resource's progress"
+              : `These ${moduleLabel.toLowerCase()}s are not used to calculate `
+                + "progress"}
           </span>
-        </label>
-      )}
+          <span
+            className={cn("text-xs", !modulesAreExhaustive && `
+              text-muted-foreground
+            `)}
+          >
+            {modulesAreExhaustive
+              ? "Progress and % complete come from how many are marked done."
+              : "Progress is tracked manually with the Current Progress / Total "
+                + "Modules numbers on the Details tab."}
+            {canEditExhaustive
+              && " Change this with \"How to calculate progress\" on the "
+              + "Details tab."}
+          </span>
+        </span>
+      </div>
 
       <ModuleAssistDialog
         resourceId={resourceId}

--- a/packages/client/src/routes/resources.$id.-components/-ResourceModulesAdmin.stories.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceModulesAdmin.stories.tsx
@@ -139,8 +139,9 @@ export const Populated: Story = {
   ]),
 };
 
-// Edit-page context: `canEditExhaustive` renders the toggle, and the exhaustive
-// flag drives the `· N%` progress summary.
+// Edit-page context: `canEditExhaustive` adds the "change this on the Details
+// tab" hint to the progress callout, and the exhaustive flag drives both the
+// "used to calculate progress" callout and the `· N%` progress summary.
 export const ExhaustiveEditable: Story = {
   args: {
     resourceId: RESOURCE_ID,
@@ -173,7 +174,7 @@ export const ExhaustiveEditable: Story = {
   ],
   play: smokePlay([
     {
-      text: "Module list is exhaustive",
+      text: /used to calculate/,
     },
     {
       text: /50%/,

--- a/packages/client/src/routes/resources.$id.edit.-components/-DetailsTab.tsx
+++ b/packages/client/src/routes/resources.$id.edit.-components/-DetailsTab.tsx
@@ -1,11 +1,12 @@
 import type { LevelValue } from "./-LevelSelectRow";
 import type { useResourceEditForm } from "@/hooks/useResourceEditForm";
-import type { AnyFieldApi } from "@tanstack/react-form";
 
 import { RESOURCE_TYPE_LABELS, RESOURCE_TYPES } from "@emstack/types";
+import { Link } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 
 import { LevelSelectRow } from "./-LevelSelectRow";
+import { ProgressModeField } from "./-ProgressModeField";
 
 import { EditForm, EditPageFooter } from "@/components/layout";
 import { Button } from "@/components/ui/button";
@@ -19,6 +20,8 @@ interface DetailsTabProps {
   onDelete: () => void | Promise<void>;
   onDuplicate: () => void | Promise<void>;
   onCancel: () => void;
+  /** Switch the edit page to the Modules tab (module-tracking mode). */
+  onGoToModules: () => void;
 }
 
 export function DetailsTab({
@@ -27,18 +30,23 @@ export function DetailsTab({
   onDelete,
   onDuplicate,
   onCancel,
+  onGoToModules,
 }: DetailsTabProps) {
   const {
     form,
     topicOptions,
     providerOptions,
     tagOptions,
+    tagGroupOptions,
     currentValues,
     isSubmitting,
     isCostFromPlatform,
     providerUrlMissing,
+    modulesAreExhaustive,
     createTopicOption,
     createProviderOption,
+    createTagOption,
+    setProgressMode,
   } = controller;
 
   return (
@@ -193,44 +201,13 @@ export function DetailsTab({
           )}
         </form.AppField>
 
-        <div className="grid grid-cols-2 gap-4">
-          <form.AppField
-            name="progressCurrent"
-            validators={{
-              onSubmit: ({
-                value,
-                fieldApi,
-              }: {
-                value: number | null;
-                fieldApi: AnyFieldApi;
-              }) => {
-                const total = fieldApi.form.getFieldValue("progressTotal");
-                if (value != null && total != null && value > total) {
-                  return {
-                    message: "Current progress cannot exceed total modules",
-                  };
-                }
-                return undefined;
-              },
-            }}
-          >
-            {field => (
-              <field.NumberField
-                label="Current Progress"
-                min={0}
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="progressTotal">
-            {field => (
-              <field.NumberField
-                label="Total Modules"
-                min={0}
-              />
-            )}
-          </form.AppField>
-        </div>
+        <ProgressModeField
+          form={form}
+          modulesAreExhaustive={modulesAreExhaustive}
+          isNew={isNew}
+          onModeChange={setProgressMode}
+          onGoToModules={onGoToModules}
+        />
 
         <form.AppField name="cost">
           {field => (
@@ -285,16 +262,51 @@ export function DetailsTab({
           </form.Field>
         </fieldset>
 
-        <form.AppField name="tagIds">
-          {field => (
-            <field.MultiComboboxField
-              label="Tags"
-              options={tagOptions}
-              placeholder="Pick tags..."
-              groupByPrefix
-            />
-          )}
-        </form.AppField>
+        <div className="flex flex-col gap-1">
+          <form.AppField name="tagIds">
+            {field => (
+              <field.MultiComboboxField
+                label="Tags"
+                options={tagOptions}
+                placeholder="Pick tags..."
+                groupByPrefix
+                create={{
+                  itemLabel: "tag",
+                  fields: [
+                    {
+                      name: "name",
+                      label: "Tag Name",
+                      required: true,
+                      isPrimary: true,
+                    },
+                    {
+                      name: "groupId",
+                      label: "Tag Group",
+                      required: true,
+                      type: "select",
+                      placeholder: "Select a group...",
+                      options: tagGroupOptions,
+                    },
+                  ],
+                  onCreate: createTagOption,
+                }}
+              />
+            )}
+          </form.AppField>
+          <Link
+            to="/settings"
+            search={{
+              tab: "tasks",
+            }}
+            className="
+              self-start text-xs text-muted-foreground underline
+              underline-offset-4
+              hover:text-foreground
+            "
+          >
+            Manage tags in settings
+          </Link>
+        </div>
 
         <EditPageFooter
           isNew={isNew}

--- a/packages/client/src/routes/resources.$id.edit.-components/-ProgressModeField.tsx
+++ b/packages/client/src/routes/resources.$id.edit.-components/-ProgressModeField.tsx
@@ -1,0 +1,138 @@
+import type { useResourceEditForm } from "@/hooks/useResourceEditForm";
+import type { AnyFieldApi } from "@tanstack/react-form";
+
+import { ListChecks } from "lucide-react";
+
+import { Field, FieldLabel } from "@/components/forms/field";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+interface ProgressModeFieldProps {
+  /** The edit form, for the manual progress number fields. */
+  form: ReturnType<typeof useResourceEditForm>["form"];
+  /** Whether progress is currently computed from finished modules. */
+  modulesAreExhaustive: boolean;
+  /** True for the new-resource form (module tracking not yet available). */
+  isNew: boolean;
+  onModeChange: (mode: "manual" | "modules") => void;
+  /** Switch the edit page to the Modules tab. */
+  onGoToModules: () => void;
+}
+
+/**
+ * "How to calculate progress" chooser: a Manual vs Module Tracking radio.
+ * Manual reveals the current/total number fields; Module Tracking drives the
+ * resource's `modulesAreExhaustive` flag (via `onModeChange`) and offers a
+ * shortcut to the Modules tab. Module Tracking is disabled for new resources,
+ * which have no modules yet.
+ */
+export function ProgressModeField({
+  form,
+  modulesAreExhaustive,
+  isNew,
+  onModeChange,
+  onGoToModules,
+}: ProgressModeFieldProps) {
+  return (
+    <Field>
+      <FieldLabel>How to calculate progress</FieldLabel>
+      <RadioGroup
+        value={modulesAreExhaustive ? "modules" : "manual"}
+        onValueChange={val => onModeChange(val as "manual" | "modules")}
+      >
+        <div className="flex items-start gap-2">
+          <RadioGroupItem
+            value="manual"
+            id="progress-mode-manual"
+            className="mt-0.5"
+          />
+          <Label
+            htmlFor="progress-mode-manual"
+            className="flex flex-col items-start gap-0.5 font-normal"
+          >
+            <span className="font-medium">Manual</span>
+            <span className="text-xs text-muted-foreground">
+              Enter your current progress and total units below.
+            </span>
+          </Label>
+        </div>
+        <div className="flex items-start gap-2">
+          <RadioGroupItem
+            value="modules"
+            id="progress-mode-modules"
+            className="mt-0.5"
+            disabled={isNew}
+          />
+          <Label
+            htmlFor="progress-mode-modules"
+            className="flex flex-col items-start gap-0.5 font-normal"
+          >
+            <span className="font-medium">Module Tracking</span>
+            <span className="text-xs text-muted-foreground">
+              {isNew
+                ? "Create the resource and add modules first, then switch to "
+                + "module tracking."
+                : "Progress and % complete are calculated from how many "
+                  + "modules are marked done."}
+            </span>
+          </Label>
+        </div>
+      </RadioGroup>
+
+      {modulesAreExhaustive
+        ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onGoToModules}
+            className="mt-2 self-start"
+          >
+            <ListChecks className="size-4" />
+            Go to Modules
+          </Button>
+        )
+        : (
+          <div className="mt-2 grid grid-cols-2 gap-4">
+            <form.AppField
+              name="progressCurrent"
+              validators={{
+                onSubmit: ({
+                  value,
+                  fieldApi,
+                }: {
+                  value: number | null;
+                  fieldApi: AnyFieldApi;
+                }) => {
+                  const total = fieldApi.form.getFieldValue("progressTotal");
+                  if (value != null && total != null && value > total) {
+                    return {
+                      message: "Current progress cannot exceed total modules",
+                    };
+                  }
+                  return undefined;
+                },
+              }}
+            >
+              {field => (
+                <field.NumberField
+                  label="Current Progress"
+                  min={0}
+                />
+              )}
+            </form.AppField>
+
+            <form.AppField name="progressTotal">
+              {field => (
+                <field.NumberField
+                  label="Total Modules"
+                  min={0}
+                />
+              )}
+            </form.AppField>
+          </div>
+        )}
+    </Field>
+  );
+}

--- a/packages/client/src/routes/resources.$id.edit.tsx
+++ b/packages/client/src/routes/resources.$id.edit.tsx
@@ -132,6 +132,7 @@ function SingleResourceEdit() {
       onDelete={handleDelete}
       onDuplicate={handleDuplicate}
       onCancel={handleCancel}
+      onGoToModules={() => changeTab("modules")}
     />
   );
 

--- a/packages/client/src/routes/resources.$id.index.tsx
+++ b/packages/client/src/routes/resources.$id.index.tsx
@@ -14,6 +14,7 @@ import { TopicList } from "@/components/boxElements";
 import { RoutineBox } from "@/components/contentBoxComponents";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InfoArea, InfoRow, PageTabs } from "@/components/layout";
+import { TagChip } from "@/components/tasks/TagChip";
 import { Button } from "@/components/ui/button";
 import { fetchRoutines, fetchSingleResource, makePercentageComplete } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
@@ -250,6 +251,19 @@ function ResourceDetailsTab({
             topics={data.topics}
             isPills={false}
           />
+        </InfoArea>
+        <InfoArea
+          header={`Tag${data.tags && data.tags.length > 1 ? "s" : ""}`}
+          condition={!!data.tags?.length}
+        >
+          <div className="flex flex-wrap gap-1">
+            {data.tags?.map(tag => (
+              <TagChip
+                key={tag.id}
+                tag={tag.name}
+              />
+            ))}
+          </div>
         </InfoArea>
       </InfoRow>
       <InfoRow header="Progress">


### PR DESCRIPTION
## Summary

Refactors progress tracking to support both manual and module-based calculation modes, with a new UI component to switch between them. Also adds inline tag creation in the resource edit form and improves the modules exhaustive callout with better visual feedback.

## Key Changes

- **New `ProgressModeField` component** (`-ProgressModeField.tsx`): Extracted progress input logic into a reusable field that displays a radio group to choose between "Manual" (current/total number inputs) and "Module Tracking" (progress calculated from finished modules). Module Tracking is disabled for new resources and includes a shortcut button to the Modules tab.

- **Shared progress-mode mutation** (`useSetModulesExhaustive.ts`): Extracted the optimistic mutation for toggling `modulesAreExhaustive` into a dedicated hook so both the Details tab (edit form) and Modules tab can write to the same state and stay in sync. Uses query client optimism with rollback on error.

- **Edit form integration** (`useResourceEditForm.ts`): Added `setProgressMode` callback and `modulesAreExhaustive` state to the edit form controller. Wired up `createTagOption` to support inline tag creation with a required tag group selection.

- **Inline tag creation** (`ComboboxCreatePanel.tsx`): Extended the create panel to support `type: "select"` fields, enabling the tag creation dialog to include a "Tag Group" dropdown alongside the tag name input.

- **Details tab refactor** (`-DetailsTab.tsx`): Replaced inline progress input fields with the new `ProgressModeField` component. Added tag group options and inline tag creation UI with a link to manage tags in settings.

- **Modules tab callout redesign** (`-ModuleAdminHeader.tsx`): Replaced the exhaustive checkbox with an informational callout that displays different messaging based on the current mode (green/success when exhaustive, neutral when manual). For editable contexts, includes a hint to change the mode on the Details tab.

- **Resource detail view** (`resources.$id.index.tsx`): Added a Tags section to display resource tags as chips.

- **Edit page routing** (`resources.$id.edit.tsx`): Added `onGoToModules` callback to switch to the Modules tab from the Details tab.

## Implementation Details

- The `useSetModulesExhaustive` mutation is reused by both `useResourceModules` (Modules tab) and `useResourceEditForm` (Details tab), ensuring the `modulesAreExhaustive` flag stays synchronized across tabs via the shared `resources.detail` query.
- The `ProgressModeField` is disabled for new resources (no modules yet) and only shows the manual input fields when in manual mode.
- Tag creation requires selecting a tag group, which is passed as a required field in the create panel configuration.
- The modules callout now provides context-aware messaging: when exhaustive, it confirms progress is calculated from modules; when manual, it explains progress is tracked manually and hints at the Details tab toggle (if editable).

https://claude.ai/code/session_01QbvfHQyZLMfHqk9P1gSbpR