### PR TITLE
feat(resources): show routine completions in the Interactions tab

### DIFF
--- a/packages/client/src/hooks/useInteractionsLog.ts
+++ b/packages/client/src/hooks/useInteractionsLog.ts
@@ -15,6 +15,7 @@ import {
   fetchInteractions,
   fetchModuleGroups,
   fetchModules,
+  fetchResourceRoutineInteractions,
   upsertInteraction,
 } from "@/utils/fetchFunctions";
 import { queryKeys } from "@/utils/queryKeys";
@@ -48,8 +49,16 @@ export function useInteractionsLog(resourceId: string) {
     queryFn: () => fetchModules(),
   });
 
+  // Routine completions whose day-action touched this resource (derived
+  // server-side). Read-only — surfaced alongside the manually-logged interactions.
+  const routineInteractionsQuery = useQuery({
+    queryKey: queryKeys.resources.routineInteractions(resourceId),
+    queryFn: () => fetchResourceRoutineInteractions(resourceId),
+  });
+
   const allInteractions = interactionsQuery.data ?? [];
   const interactions = allInteractions.filter(i => i.resourceId === resourceId);
+  const routineInteractions = routineInteractionsQuery.data ?? [];
 
   const moduleGroups = useMemo(
     () =>
@@ -116,6 +125,7 @@ export function useInteractionsLog(resourceId: string) {
 
   return {
     interactions,
+    routineInteractions,
     moduleGroups,
     modules,
     createMutation,

--- a/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.stories.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Interaction } from "@emstack/types";
+import type { Interaction, RoutineInteraction } from "@emstack/types";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, within } from "storybook/test";
@@ -14,9 +14,13 @@ const RESOURCE_ID = "resource-1";
 
 // Build a QueryClient seeded with the data `useInteractionsLog` reads via
 // useQuery, so the log renders its loaded state without a network call.
-function seededClient(interactions: Interaction[]) {
+function seededClient(
+  interactions: Interaction[],
+  routineInteractions: RoutineInteraction[] = [],
+) {
   return seededQueryClient([
     [queryKeys.resources.interactions(RESOURCE_ID), interactions],
+    [queryKeys.resources.routineInteractions(RESOURCE_ID), routineInteractions],
     [queryKeys.resources.moduleGroups(RESOURCE_ID), []],
     [queryKeys.resources.modules(RESOURCE_ID), []],
   ]);
@@ -89,5 +93,56 @@ export const WithInteractions: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.getByText("Read chapter 1.")).toBeInTheDocument();
     await expect(canvas.getByText("Finished the intro.")).toBeInTheDocument();
+  },
+};
+
+// Routine completions that touched this resource appear in the same log as
+// manual interactions, read-only and tagged with the routine + status.
+export const WithRoutineInteractions: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededClient(
+          [
+            makeInteraction({
+              id: "i1",
+              date: "2026-06-12",
+              progress: "started",
+              note: "Read chapter 1.",
+            }),
+          ],
+          [
+            {
+              id: "rt-1:2026-06-13",
+              routineId: "rt-1",
+              routineName: "Daily Spanish",
+              date: "2026-06-13",
+              status: "goal",
+              note: "Felt good today.",
+              actionLabel: "Review Spanish flashcards",
+              via: "task",
+            },
+          ],
+        )}
+      >
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // The routine completion renders its routine, action, and note.
+    await expect(canvas.getByText("routine: Daily Spanish")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Review Spanish flashcards"),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Felt good today.")).toBeInTheDocument();
+    await expect(canvas.getByText("via task")).toBeInTheDocument();
+    // Manual interactions still show alongside it.
+    await expect(canvas.getByText("Read chapter 1.")).toBeInTheDocument();
   },
 };

--- a/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
@@ -4,12 +4,14 @@ import type {
   InteractionProgress,
   Module,
   ModuleGroup,
+  RoutineInteraction,
 } from "@emstack/types";
 
 import { useState } from "react";
 
 import { PencilIcon, PlusIcon } from "lucide-react";
 
+import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
 import { EditFormActions } from "@/components/layout/EditFormActions";
 import {
   DIFFICULTY_OPTIONS,
@@ -68,11 +70,28 @@ function fromInteraction(i: Interaction): Draft {
   };
 }
 
+// One row of the merged log: a manually-logged interaction (editable) or a
+// derived routine completion that touched this resource (read-only).
+type LogRow
+  = | { source: "manual";
+    date: string;
+    manual: Interaction; }
+    | { source: "routine";
+      date: string;
+      routine: RoutineInteraction; };
+
+function touchLabel(row: LogRow): string {
+  return row.source === "manual"
+    ? PROGRESS_LABEL[row.manual.progress]
+    : getDailyStatusOption(row.routine.status).label;
+}
+
 export function ResourceInteractionsLog({
   resourceId,
 }: Props) {
   const {
     interactions,
+    routineInteractions,
     moduleGroups,
     modules,
     createMutation,
@@ -85,17 +104,36 @@ export function ResourceInteractionsLog({
 
   const isAnyEditing = creating || editingId !== null;
 
-  const lastTouch = interactions[0];
+  // Interleave manual interactions and routine completions, newest first. Both
+  // sources arrive date-desc from the server; re-sort the union to merge them.
+  const merged: LogRow[] = [
+    ...interactions.map(
+      (i): LogRow => ({
+        source: "manual",
+        date: i.date,
+        manual: i,
+      }),
+    ),
+    ...routineInteractions.map(
+      (r): LogRow => ({
+        source: "routine",
+        date: r.date,
+        routine: r,
+      }),
+    ),
+  ].sort((a, b) => b.date.localeCompare(a.date));
+
+  const lastTouch = merged[0];
 
   return (
     <section className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
           <p className="text-sm text-muted-foreground">
-            {interactions.length === 0
+            {merged.length === 0
               ? "No interactions logged yet."
               : lastTouch
-                ? `Last touch: ${lastTouch.date} · ${PROGRESS_LABEL[lastTouch.progress]}`
+                ? `Last touch: ${lastTouch.date} · ${touchLabel(lastTouch)}`
                 : null}
           </p>
         </div>
@@ -125,9 +163,18 @@ export function ResourceInteractionsLog({
         />
       )}
 
-      {interactions.length > 0 && (
+      {merged.length > 0 && (
         <ul className="flex flex-col divide-y rounded-md border bg-background">
-          {interactions.map((i) => {
+          {merged.map((row) => {
+            if (row.source === "routine") {
+              return (
+                <RoutineInteractionRow
+                  key={row.routine.id}
+                  item={row.routine}
+                />
+              );
+            }
+            const i = row.manual;
             if (i.id === editingId) {
               return (
                 <InteractionEditCard
@@ -224,6 +271,51 @@ export function ResourceInteractionsLog({
         </ul>
       )}
     </section>
+  );
+}
+
+// A read-only log row for a routine completion that touched this resource. Shows
+// the date, the routine, the completion status, and (when known) the specific
+// scheduled action and whether it touched the resource directly or via a task.
+function RoutineInteractionRow({
+  item,
+}: {
+  item: RoutineInteraction;
+}) {
+  const statusOption = getDailyStatusOption(item.status);
+  const showAction = item.actionLabel && item.actionLabel !== item.routineName;
+  return (
+    <li className="flex flex-col gap-1 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium">{item.date}</span>
+        <Badge
+          variant="outline"
+          className={statusOption.pillClass}
+        >
+          {statusOption.label}
+        </Badge>
+        <Badge
+          variant="outline"
+          className="border-blue-200 bg-blue-50 text-blue-900"
+        >
+          routine: {item.routineName}
+        </Badge>
+        {item.via === "task" && (
+          <Badge
+            variant="outline"
+            className="bg-muted/40"
+          >
+            via task
+          </Badge>
+        )}
+      </div>
+      {showAction && (
+        <p className="text-sm text-muted-foreground">{item.actionLabel}</p>
+      )}
+      {item.note && (
+        <p className="text-sm text-muted-foreground">{item.note}</p>
+      )}
+    </li>
   );
 }
 

--- a/packages/client/src/utils/api/resources.ts
+++ b/packages/client/src/utils/api/resources.ts
@@ -1,6 +1,11 @@
-import type { ModulesConfig, Resource, ResourceInResources } from "@emstack/types";
+import type {
+  ModulesConfig,
+  Resource,
+  ResourceInResources,
+  RoutineInteraction,
+} from "@emstack/types";
 
-import { createEntityClient, postJson, putJson } from "./client";
+import { createEntityClient, fetchJson, postJson, putJson } from "./client";
 
 const resourcesApi = createEntityClient<Resource, ResourceInResources[]>(
   "resources",
@@ -12,6 +17,16 @@ export const fetchSingleResource = resourcesApi.get;
 export const upsertResource = resourcesApi.upsert;
 export const deleteSingleResource = resourcesApi.delete;
 export const duplicateResource = resourcesApi.duplicate;
+
+// Routine completions whose scheduled day-action touched this resource (directly
+// or via a linked task). Derived server-side; read-only for the Interactions tab.
+export async function fetchResourceRoutineInteractions(
+  id: string,
+): Promise<RoutineInteraction[]> {
+  return fetchJson<RoutineInteraction[]>(
+    `/api/resources/${id}/routine-interactions`,
+  );
+}
 
 export async function incrementResourceProgress(
   id: string,

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -326,13 +326,15 @@ export function getDailyProgressPercent(daily: Daily): number {
 
 // Carry a completion's already-baked schedule snapshot forward across status /
 // note edits, so the frozen text survives and the server doesn't re-bake it to a
-// later schedule. Absent on first save → the server bakes it then.
-function carryEntryParts(
+// later schedule. entryParts and entryRef are baked together (coupled presence),
+// so both ride along. Absent on first save → the server bakes them then.
+function carryBakedSnapshot(
   existing: Daily["completions"][number] | undefined,
-): Pick<Daily["completions"][number], "entryParts"> | object {
+): Pick<Daily["completions"][number], "entryParts" | "entryRef"> | object {
   return existing?.entryParts !== undefined
     ? {
       entryParts: existing.entryParts,
+      entryRef: existing.entryRef,
     }
     : {};
 }
@@ -366,7 +368,7 @@ function rebakeOrCarry(
   if (todayKey !== undefined && isWithinRebakeWindow(dateKey, todayKey)) {
     return {};
   }
-  return carryEntryParts(existing);
+  return carryBakedSnapshot(existing);
 }
 
 export function withCompletion(
@@ -413,7 +415,7 @@ export function withCompletionNote(
 ): Daily["completions"] {
   const others = daily.completions.filter(c => c.date !== dateKey);
   const existing = daily.completions.find(c => c.date === dateKey);
-  const carry = carryEntryParts(existing);
+  const carry = carryBakedSnapshot(existing);
   const trimmed = note?.trim() ?? "";
   if (!trimmed) {
     if (existing?.status) {

--- a/packages/client/src/utils/queryKeys.ts
+++ b/packages/client/src/utils/queryKeys.ts
@@ -12,6 +12,8 @@ export const queryKeys = {
       ["resource-module-groups", resourceId] as const,
     interactions: (resourceId: string) =>
       ["resource-interactions", resourceId] as const,
+    routineInteractions: (resourceId: string) =>
+      ["resource-routine-interactions", resourceId] as const,
   },
   topics: {
     list: () => ["topics"] as const,

--- a/packages/middleware/src/routes/api/resources/getResourceRoutineInteractions.ts
+++ b/packages/middleware/src/routes/api/resources/getResourceRoutineInteractions.ts
@@ -1,0 +1,66 @@
+import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
+import { FastifyInstance } from "fastify";
+import { db } from "@/db";
+import { sendNotFound } from "@/utils/errors";
+import { routineInteractionsForResource } from "@/utils/routineInteractions";
+import { getTaskIdsForResource } from "@/utils/taskResourceLinks";
+import { idParamSchema } from "@/utils/schemas";
+
+import type { RoutineInteraction } from "@emstack/types";
+
+const listSchema = {
+  schema: {
+    description:
+      "Routine completions whose scheduled day-action touched this resource "
+      + "(directly, or via a task linked to it). Projection, not a stored entity.",
+    params: idParamSchema,
+  },
+} as const;
+
+export default async function (server: FastifyInstance) {
+  const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
+
+  fastify.get(
+    "/:id/routine-interactions",
+    listSchema,
+    async function (request, reply) {
+      const {
+        id,
+      } = request.params;
+
+      const resource = await db.query.resources.findFirst({
+        where: (r, {
+          eq,
+        }) => eq(r.id, id),
+        columns: {
+          id: true,
+        },
+      });
+      if (!resource) {
+        return sendNotFound(reply, "Resource");
+      }
+
+      // Tasks linked to this resource — resolved live (links are stable; only the
+      // per-day scheduled item is frozen in entryRef).
+      const taskIds = await getTaskIdsForResource(id);
+
+      const routines = await db.query.routines.findMany({
+        columns: {
+          id: true,
+          name: true,
+          mode: true,
+          weekly: true,
+          curated: true,
+          completions: true,
+        },
+      });
+
+      const results: RoutineInteraction[] = routines.flatMap(routine =>
+        routineInteractionsForResource(routine, id, taskIds));
+
+      // Newest first, matching the manual interactions list ordering.
+      results.sort((a, b) => b.date.localeCompare(a.date));
+      return results;
+    },
+  );
+}

--- a/packages/middleware/src/routes/api/resources/routes.ts
+++ b/packages/middleware/src/routes/api/resources/routes.ts
@@ -9,6 +9,7 @@ import duplicateResource from "./duplicateResource";
 import incrementResourceProgress from "./incrementResourceProgress";
 import modulesExhaustive from "./modulesExhaustive";
 import updateResourceModulesConfig from "./updateResourceModulesConfig";
+import getResourceRoutineInteractions from "./getResourceRoutineInteractions";
 
 export default async function (server: FastifyInstance) {
   const fastify = server.withTypeProvider<JsonSchemaToTsProvider>();
@@ -21,4 +22,5 @@ export default async function (server: FastifyInstance) {
   fastify.register(incrementResourceProgress);
   fastify.register(modulesExhaustive);
   fastify.register(updateResourceModulesConfig);
+  fastify.register(getResourceRoutineInteractions);
 }

--- a/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
+++ b/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
@@ -5,6 +5,7 @@ import { routines } from "@/db/schema";
 import {
   entryForCompletionDate,
   entryToCompletionParts,
+  entryToCompletionRef,
 } from "@/utils/routineWeekday";
 
 import type { RoutineBody } from "./routineRows";
@@ -118,13 +119,13 @@ export async function bakeRoutineCompletions(
     if (!(c.status && c.entryParts === undefined)) {
       return c;
     }
+    const entry = entryByDate.get(c.date) ?? null;
     return {
       ...c,
-      entryParts: entryToCompletionParts(
-        entryByDate.get(c.date) ?? null,
-        taskNames,
-        resourceNames,
-      ),
+      entryParts: entryToCompletionParts(entry, taskNames, resourceNames),
+      // Frozen alongside entryParts: the structured ref keeps the scheduled
+      // item's id so resource-side consumers can match by id later.
+      entryRef: entryToCompletionRef(entry),
     };
   });
 

--- a/packages/middleware/src/tests/routineInteractions.test.ts
+++ b/packages/middleware/src/tests/routineInteractions.test.ts
@@ -1,0 +1,180 @@
+import type {
+  DailyCompletion,
+  RoutineCurated,
+  RoutineWeekly,
+} from "@emstack/types";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+import {
+  routineInteractionsForResource,
+  type RoutineForInteractions,
+} from "../utils/routineInteractions.ts";
+
+const RESOURCE_ID = "res-1";
+
+// A weekly routine with frozen entryRef/entryParts on each completion (the path
+// taken once the bake has run). Different days point at different things.
+function weeklyRoutine(completions: DailyCompletion[]): RoutineForInteractions {
+  const weekly: RoutineWeekly = {};
+  return {
+    id: "rt-weekly",
+    name: "Daily practice",
+    mode: "weekly",
+    weekly,
+    curated: null,
+    completions,
+  };
+}
+
+test("matches a completion whose frozen ref is the resource directly", () => {
+  const routine = weeklyRoutine([
+    {
+      date: "2026-06-10",
+      status: "goal",
+      entryParts: {
+        prependText: "Read",
+        name: "Pimsleur",
+        appendText: null,
+      },
+      entryRef: {
+        type: "resource",
+        id: RESOURCE_ID,
+      },
+    },
+  ]);
+
+  const out = routineInteractionsForResource(routine, RESOURCE_ID, new Set());
+  assert.strictEqual(out.length, 1);
+  assert.deepStrictEqual(out[0], {
+    id: "rt-weekly:2026-06-10",
+    routineId: "rt-weekly",
+    routineName: "Daily practice",
+    date: "2026-06-10",
+    status: "goal",
+    note: null,
+    actionLabel: "Read Pimsleur",
+    via: "resource",
+  });
+});
+
+test("matches a completion whose frozen ref is a task linked to the resource", () => {
+  const routine = weeklyRoutine([
+    {
+      date: "2026-06-11",
+      status: "touched",
+      note: "did half",
+      entryParts: {
+        prependText: null,
+        name: "Grammar drills",
+        appendText: null,
+      },
+      entryRef: {
+        type: "task",
+        id: "task-7",
+      },
+    },
+  ]);
+
+  const out = routineInteractionsForResource(
+    routine,
+    RESOURCE_ID,
+    new Set(["task-7"]),
+  );
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].via, "task");
+  assert.strictEqual(out[0].note, "did half");
+  assert.strictEqual(out[0].actionLabel, "Grammar drills");
+});
+
+test("excludes a task ref whose task is not linked to the resource", () => {
+  const routine = weeklyRoutine([
+    {
+      date: "2026-06-11",
+      status: "goal",
+      entryRef: {
+        type: "task",
+        id: "task-other",
+      },
+    },
+  ]);
+  const out = routineInteractionsForResource(
+    routine,
+    RESOURCE_ID,
+    new Set(["task-7"]),
+  );
+  assert.deepStrictEqual(out, []);
+});
+
+test("excludes completions with no status, and a null ref (nothing scheduled)", () => {
+  const routine = weeklyRoutine([
+    // No status → not a real completion.
+    {
+      date: "2026-06-12",
+      entryRef: {
+        type: "resource",
+        id: RESOURCE_ID,
+      },
+    },
+    // Nothing was scheduled that day at bake time.
+    {
+      date: "2026-06-13",
+      status: "goal",
+      entryRef: null,
+    },
+  ]);
+  const out = routineInteractionsForResource(routine, RESOURCE_ID, new Set());
+  assert.deepStrictEqual(out, []);
+});
+
+test("counts every status, including incomplete and freeze", () => {
+  const routine = weeklyRoutine(
+    (["incomplete", "freeze"] as const).map(status => ({
+      date: status === "incomplete" ? "2026-06-14" : "2026-06-15",
+      status,
+      entryRef: {
+        type: "resource" as const,
+        id: RESOURCE_ID,
+      },
+    })),
+  );
+  const out = routineInteractionsForResource(routine, RESOURCE_ID, new Set());
+  assert.deepStrictEqual(
+    out.map(r => r.status).sort(),
+    ["freeze", "incomplete"],
+  );
+});
+
+test("falls back to live schedule resolution for unbaked (no entryRef) completions", () => {
+  // Curated mode keyed by exact date — deterministic regardless of weekday.
+  const curated: RoutineCurated = {
+    endDate: "2026-06-20",
+    entries: {
+      "2026-06-16": {
+        type: "resource",
+        id: RESOURCE_ID,
+      },
+    },
+  };
+  const routine: RoutineForInteractions = {
+    id: "rt-curated",
+    name: "Curated run",
+    mode: "curated",
+    weekly: null,
+    curated,
+    // entryRef absent → must resolve live from curated.entries.
+    completions: [
+      {
+        date: "2026-06-16",
+        status: "goal",
+      },
+    ],
+  };
+
+  const out = routineInteractionsForResource(routine, RESOURCE_ID, new Set());
+  assert.strictEqual(out.length, 1);
+  assert.strictEqual(out[0].via, "resource");
+  // No baked entryParts → actionLabel is null (UI falls back to routine name).
+  assert.strictEqual(out[0].actionLabel, null);
+});

--- a/packages/middleware/src/tests/routineProjection.test.ts
+++ b/packages/middleware/src/tests/routineProjection.test.ts
@@ -14,6 +14,7 @@ import {
   currentWeekday,
   entryForCompletionDate,
   entryToCompletionParts,
+  entryToCompletionRef,
   representativeEntry,
   weekdayForDateKey,
 } from "../utils/routineWeekday.ts";
@@ -185,4 +186,19 @@ test("entryToCompletionParts freezes resolved name + affixes (the baked snapshot
     entryToCompletionParts(null, taskNames, resourceNames),
     null,
   );
+});
+
+test("entryToCompletionRef freezes the scheduled item's kind + id", () => {
+  // Task / resource entries keep their type + id (affixes are dropped — the ref
+  // is for matching by id, not display).
+  assert.deepStrictEqual(entryToCompletionRef(mondayTask), {
+    type: "task",
+    id: "task-mon",
+  });
+  assert.deepStrictEqual(entryToCompletionRef(wednesdayResource), {
+    type: "resource",
+    id: "res-wed",
+  });
+  // Nothing scheduled → null.
+  assert.strictEqual(entryToCompletionRef(null), null);
 });

--- a/packages/middleware/src/utils/routineInteractions.ts
+++ b/packages/middleware/src/utils/routineInteractions.ts
@@ -1,0 +1,77 @@
+import { buildActionableSentence } from "@emstack/types";
+
+import { entryForCompletionDate } from "./routineWeekday.ts";
+
+import type {
+  DailyCompletion,
+  DailyCompletionEntryRef,
+  RoutineCurated,
+  RoutineInteraction,
+  RoutineMode,
+  RoutineWeekly,
+} from "@emstack/types";
+
+// The routine columns the resource-interaction projection reads.
+export interface RoutineForInteractions {
+  id: string;
+  name: string;
+  mode: RoutineMode;
+  weekly: RoutineWeekly | null;
+  curated: RoutineCurated | null;
+  completions: DailyCompletion[];
+}
+
+// Pure projection: the routine's completions whose scheduled day-action touched
+// `resourceId` — directly (the action *is* the resource) or via a task in
+// `taskIds` (tasks linked to the resource). Each completion's frozen entryRef is
+// preferred; unbaked entries (e.g. daily-mode) fall back to live schedule
+// resolution. Any completion with a status counts. Returned unsorted.
+export function routineInteractionsForResource(
+  routine: RoutineForInteractions,
+  resourceId: string,
+  taskIds: ReadonlySet<string>,
+): RoutineInteraction[] {
+  const out: RoutineInteraction[] = [];
+  for (const c of routine.completions ?? []) {
+    if (!c.status) {
+      continue;
+    }
+    const ref: DailyCompletionEntryRef | null
+      = c.entryRef !== undefined
+        ? c.entryRef
+        : entryForCompletionDate(
+          routine.mode,
+          routine.weekly,
+          routine.curated,
+          c.date,
+        );
+    if (!ref) {
+      continue;
+    }
+
+    let via: RoutineInteraction["via"] | null = null;
+    if (ref.type === "resource" && ref.id === resourceId) {
+      via = "resource";
+    }
+    else if (ref.type === "task" && taskIds.has(ref.id)) {
+      via = "task";
+    }
+    if (!via) {
+      continue;
+    }
+
+    out.push({
+      id: `${routine.id}:${c.date}`,
+      routineId: routine.id,
+      routineName: routine.name,
+      date: c.date,
+      status: c.status,
+      note: c.note ?? null,
+      actionLabel: c.entryParts
+        ? buildActionableSentence(c.entryParts)
+        : null,
+      via,
+    });
+  }
+  return out;
+}

--- a/packages/middleware/src/utils/routineWeekday.ts
+++ b/packages/middleware/src/utils/routineWeekday.ts
@@ -1,5 +1,6 @@
 import type {
   DailyCompletionEntryParts,
+  DailyCompletionEntryRef,
   RoutineCurated,
   RoutineMode,
   RoutineReferenceItem,
@@ -115,5 +116,21 @@ export function entryToCompletionParts(
     prependText: entry.prependText ?? null,
     name,
     appendText: entry.appendText ?? null,
+  };
+}
+
+// Freeze a scheduled entry's structured reference (kind + id) onto a logged
+// completion, baked alongside entryToCompletionParts. Keeping the id (not just
+// the resolved name) lets a resource's Interactions tab match completions to a
+// specific task/resource even after the schedule changes. Null entry → null.
+export function entryToCompletionRef(
+  entry: RoutineReferenceItem | null,
+): DailyCompletionEntryRef | null {
+  if (!entry) {
+    return null;
+  }
+  return {
+    type: entry.type,
+    id: entry.id,
   };
 }

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -188,6 +188,21 @@ export const completionSchema = {
         appendText: nullableString,
       },
     },
+    // Structured reference (kind + id) of the scheduled item, baked alongside
+    // entryParts. Nullable: null means nothing was scheduled that date.
+    entryRef: {
+      type: ["object", "null"],
+      required: ["type", "id"],
+      properties: {
+        type: {
+          type: "string",
+          enum: ["task", "resource", "freeform"],
+        },
+        id: {
+          type: "string",
+        },
+      },
+    },
   },
 } as const;
 

--- a/packages/middleware/src/utils/taskResourceLinks.ts
+++ b/packages/middleware/src/utils/taskResourceLinks.ts
@@ -1,0 +1,37 @@
+import { db } from "@/db";
+
+// The set of task ids that reference a given resource, across both link tables:
+// the canonical tasksToResources junction and the task-local taskResources rows
+// whose optional resourceId points at it. Used to decide whether a routine's
+// task-typed day action "involves" a resource (resource Interactions tab).
+export async function getTaskIdsForResource(
+  resourceId: string,
+): Promise<Set<string>> {
+  const [junction, local] = await Promise.all([
+    db.query.tasksToResources.findMany({
+      where: (t, {
+        eq,
+      }) => eq(t.resourceId, resourceId),
+      columns: {
+        taskId: true,
+      },
+    }),
+    db.query.taskResources.findMany({
+      where: (t, {
+        eq,
+      }) => eq(t.resourceId, resourceId),
+      columns: {
+        taskId: true,
+      },
+    }),
+  ]);
+
+  const ids = new Set<string>();
+  for (const row of junction) {
+    ids.add(row.taskId);
+  }
+  for (const row of local) {
+    ids.add(row.taskId);
+  }
+  return ids;
+}

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -1,5 +1,10 @@
 import type { EntityStatus } from "./EntityStatus";
-import type { RoutineCurated, RoutineMode, RoutineWeekly } from "./Routine";
+import type {
+  RoutineCurated,
+  RoutineMode,
+  RoutineReferenceType,
+  RoutineWeekly,
+} from "./Routine";
 
 export type DailyCompletionStatus = "incomplete" | "touched" | "goal" | "exceeded" | "freeze";
 
@@ -13,6 +18,16 @@ export interface DailyCompletionEntryParts {
   appendText?: string | null;
 }
 
+// The structured reference (kind + id) of whatever was scheduled on the entry's
+// date, frozen at save time alongside entryParts. Unlike entryParts (which holds
+// a resolved display name), this keeps the id so consumers can tell *which*
+// task/resource a completion touched even if the schedule later changes. Mirrors
+// RoutineReferenceItem's discriminator.
+export interface DailyCompletionEntryRef {
+  type: RoutineReferenceType;
+  id: string;
+}
+
 export interface DailyCompletion {
   date: string;
   status?: DailyCompletionStatus;
@@ -22,6 +37,11 @@ export interface DailyCompletion {
   // (consumers fall back to live schedule resolution). null = nothing was
   // scheduled that day at save time.
   entryParts?: DailyCompletionEntryParts | null;
+  // Structured reference (type + id) of the scheduled item, frozen together with
+  // entryParts. Lets consumers match a completion to a specific task/resource by
+  // id (e.g. a resource's Interactions tab) without re-resolving a schedule that
+  // may have changed. Same presence rules as entryParts; null = nothing scheduled.
+  entryRef?: DailyCompletionEntryRef | null;
 }
 
 export interface DailyCriteria {

--- a/packages/types/src/RoutineInteraction.ts
+++ b/packages/types/src/RoutineInteraction.ts
@@ -1,0 +1,24 @@
+import type { DailyCompletionStatus } from "./Daily";
+
+// A routine completion (a logged day-entry that carries a status) whose scheduled
+// action touched a particular resource — either because that day's action *is*
+// the resource, or because it's a task linked to the resource. Derived
+// server-side for a resource's Interactions tab; this is a projection, not a
+// stored entity.
+export interface RoutineInteraction {
+  // Synthetic but stable: `${routineId}:${date}` (a routine has at most one
+  // completion per date). Used as the React key when merged into the log.
+  id: string;
+  routineId: string;
+  routineName: string;
+  date: string; // ISO yyyy-mm-dd, matching the completion's date key
+  status: DailyCompletionStatus;
+  note?: string | null;
+  // The frozen/resolved action sentence (e.g. "Review Spanish flashcards for 10
+  // minutes"). Null when the completion has no baked snapshot (legacy entries);
+  // consumers fall back to the routine name.
+  actionLabel?: string | null;
+  // How the completion touched the resource: the day's action was the resource
+  // itself ("resource") or a task linked to it ("task").
+  via: "resource" | "task";
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -26,6 +26,7 @@ export * from "./OnboardData.js";
 export * from "./Radar.js";
 export * from "./Readwise.js";
 export * from "./Routine.js";
+export * from "./RoutineInteraction.js";
 export * from "./RoutineTemplate.js";
 export * from "./Tag.js";
 export * from "./TagGroup.js";


### PR DESCRIPTION
The resource Interactions tab previously rendered only manually-logged
Interaction rows; routine activity never appeared because the tab queries
/api/interactions and never looks at routines.

Surface a routine completion (any day-entry that carries a status) as a
read-only entry in the interaction log when that day's scheduled action
touched the resource — directly (the action is the resource) or indirectly
(the action is a task linked to the resource, even if the routine itself
isn't connected to it).

- types: add RoutineInteraction; freeze the scheduled item's {type,id} on
  each completion via DailyCompletion.entryRef (baked alongside entryParts)
  so matches stay correct after the schedule changes.
- middleware: GET /api/resources/:id/routine-interactions derives the list
  (pure routineInteractionsForResource + getTaskIdsForResource), preferring
  the frozen entryRef and falling back to live schedule resolution.
- client: fetch and interleave routine completions into the log, newest
  first, with a status badge and a "via task" tag for indirect touches.

https://claude.ai/code/session_01Erbg8LS5E2VtdmDWUXEJrz