### PR TITLE
refactor(client): replace status badge with DailyStatusCircle in routine log

### DIFF
--- a/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.stories.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.stories.tsx
@@ -135,8 +135,10 @@ export const WithRoutineInteractions: Story = {
     canvasElement,
   }) => {
     const canvas = within(canvasElement);
-    // The routine completion renders its routine, action, and note.
-    await expect(canvas.getByText("routine: Daily Spanish")).toBeInTheDocument();
+    // The routine completion renders its routine name (plain text, far right),
+    // its status as an icon (label conveyed via title), action, and note.
+    await expect(canvas.getByText("Daily Spanish")).toBeInTheDocument();
+    await expect(canvas.getByTitle("Goal")).toBeInTheDocument();
     await expect(
       canvas.getByText("Review Spanish flashcards"),
     ).toBeInTheDocument();

--- a/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
+++ b/packages/client/src/routes/resources.$id.-components/-ResourceInteractionsLog.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 
 import { PencilIcon, PlusIcon } from "lucide-react";
 
+import { DailyStatusCircle } from "@/components/dailies/DailyStatusCircle";
 import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
 import { EditFormActions } from "@/components/layout/EditFormActions";
 import {
@@ -287,19 +288,12 @@ function RoutineInteractionRow({
   return (
     <li className="flex flex-col gap-1 p-3">
       <div className="flex flex-wrap items-center gap-2">
+        <DailyStatusCircle
+          status={item.status}
+          size="sm"
+          title={statusOption.label}
+        />
         <span className="text-sm font-medium">{item.date}</span>
-        <Badge
-          variant="outline"
-          className={statusOption.pillClass}
-        >
-          {statusOption.label}
-        </Badge>
-        <Badge
-          variant="outline"
-          className="border-blue-200 bg-blue-50 text-blue-900"
-        >
-          routine: {item.routineName}
-        </Badge>
         {item.via === "task" && (
           <Badge
             variant="outline"
@@ -308,6 +302,7 @@ function RoutineInteractionRow({
             via task
           </Badge>
         )}
+        <span className="ml-auto text-sm">{item.routineName}</span>
       </div>
       {showAction && (
         <p className="text-sm text-muted-foreground">{item.actionLabel}</p>


### PR DESCRIPTION
## Summary
Refactored the routine interaction row display to use the `DailyStatusCircle` component for status visualization instead of a custom badge, improving visual consistency with the dailies UI pattern.

## Changes
- Replaced the status `Badge` component with `DailyStatusCircle`, passing `status`, `size="sm"`, and `title` props
- Removed the routine name badge and moved the routine name to a right-aligned text label at the end of the row
- Simplified the layout by consolidating status and routine information into a cleaner, more compact display

## Implementation Details
- The `DailyStatusCircle` component now handles status styling and presentation, reducing custom badge styling in this component
- The routine name is now displayed as plain text aligned to the right (`ml-auto`) rather than as a styled badge, reducing visual clutter
- The "via task" badge remains unchanged and continues to appear conditionally

https://claude.ai/code/session_01DmcY7KNQw4HenafjkcvC1H