### PR TITLE
feat(client): add module progress tracking to resource details

### DIFF
--- a/packages/client/src/hooks/useResourceModuleProgress.ts
+++ b/packages/client/src/hooks/useResourceModuleProgress.ts
@@ -1,0 +1,43 @@
+import type { ModuleProgress } from "@/utils/moduleProgress";
+
+import { useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchModuleGroups, fetchModules } from "@/utils/fetchFunctions";
+import { computeModuleProgress } from "@/utils/moduleProgress";
+import { queryKeys } from "@/utils/queryKeys";
+
+/**
+ * Read-only module progress for a resource, used by the Details tab to show
+ * module-derived progress when the resource is in Module Tracking mode.
+ *
+ * Shares query keys/fetchers with `useResourceModules`, so the cache is reused
+ * when the Modules tab is also mounted. Gate fetching with `enabled` so manual
+ * progress resources don't fetch modules they never display.
+ */
+export function useResourceModuleProgress(
+  resourceId: string,
+  enabled: boolean,
+): ModuleProgress {
+  const groupsQuery = useQuery({
+    queryKey: queryKeys.resources.moduleGroups(resourceId),
+    queryFn: () => fetchModuleGroups(),
+    enabled,
+  });
+  const modulesQuery = useQuery({
+    queryKey: queryKeys.resources.modules(resourceId),
+    queryFn: () => fetchModules(),
+    enabled,
+  });
+
+  return useMemo(() => {
+    const groups = (groupsQuery.data ?? []).filter(
+      g => g.resourceId === resourceId,
+    );
+    const modules = (modulesQuery.data ?? []).filter(
+      m => m.resourceId === resourceId,
+    );
+    return computeModuleProgress(modules, groups);
+  }, [groupsQuery.data, modulesQuery.data, resourceId]);
+}

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -3,7 +3,7 @@ import type { Module, ModuleGroup, ModulesConfig, ModuleStatus } from "@emstack/
 
 import { useMemo } from "react";
 
-import { DEFAULT_MODULES_CONFIG, isModuleComplete } from "@emstack/types";
+import { DEFAULT_MODULES_CONFIG } from "@emstack/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -23,6 +23,7 @@ import {
   upsertModule,
   upsertModuleGroup,
 } from "@/utils/fetchFunctions";
+import { computeModuleProgress } from "@/utils/moduleProgress";
 import { queryKeys } from "@/utils/queryKeys";
 
 export function useResourceModules(resourceId: string) {
@@ -77,25 +78,13 @@ export function useResourceModules(resourceId: string) {
   // Aggregate progress: sum enumerated modules + groups-with-counts (only
   // groups that have NO enumerated modules contribute their direct counts;
   // when a group has enumerated modules, those modules are already counted).
-  const groupsWithoutModulesCounts = useMemo(() => {
-    let total = 0;
-    let completed = 0;
-    for (const g of groups) {
-      const hasEnumerated = (modulesByGroup.get(g.id)?.length ?? 0) > 0;
-      if (hasEnumerated) continue;
-      total += g.totalCount ?? 0;
-      completed += g.completedCount ?? 0;
-    }
-    return {
-      total,
-      completed,
-    };
-  }, [groups, modulesByGroup]);
-
-  const completedCount
-    = allModules.filter(m => isModuleComplete(m.status)).length
-      + groupsWithoutModulesCounts.completed;
-  const totalCount = allModules.length + groupsWithoutModulesCounts.total;
+  const {
+    completedCount,
+    totalCount,
+  } = useMemo(
+    () => computeModuleProgress(allModules, groups),
+    [allModules, groups],
+  );
 
   // Book resources get per-module/group page ranges; the edit cards key off this.
   const isBook = resourceQuery.data?.type === "book";

--- a/packages/client/src/routes/resources.$id.index.tsx
+++ b/packages/client/src/routes/resources.$id.index.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable import/max-dependencies */
+import type { ModuleProgress } from "@/utils/moduleProgress";
 import type { Resource } from "@emstack/types";
 
 import { useState } from "react";
 
+import { DEFAULT_MODULES_CONFIG } from "@emstack/types";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
@@ -16,6 +18,7 @@ import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InfoArea, InfoRow, PageTabs } from "@/components/layout";
 import { TagChip } from "@/components/tasks/TagChip";
 import { Button } from "@/components/ui/button";
+import { useResourceModuleProgress } from "@/hooks/useResourceModuleProgress";
 import { fetchRoutines, fetchSingleResource, makePercentageComplete } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
@@ -72,6 +75,13 @@ function SingleCourse() {
     data?.progressTotal,
   );
 
+  // When Module Tracking is on, the Details tab shows progress derived from the
+  // modules instead of the manual progressCurrent/progressTotal fields.
+  const moduleProgress = useResourceModuleProgress(
+    id,
+    data?.modulesAreExhaustive ?? false,
+  );
+
   // A resource → routine link is either a weekly-grid entry or a connection.
   const linkedRoutines = (routines ?? []).filter(r =>
     Object.values(r.weekly ?? {}).some(
@@ -107,6 +117,7 @@ function SingleCourse() {
                 <ResourceDetailsTab
                   data={data}
                   percentComplete={percentComplete}
+                  moduleProgress={moduleProgress}
                 />
               )
               : null,
@@ -209,11 +220,15 @@ function SingleCourse() {
 function ResourceDetailsTab({
   data,
   percentComplete,
+  moduleProgress,
 }: {
   data: Resource;
   percentComplete: string | undefined;
+  moduleProgress: ModuleProgress;
 }) {
   const topics = data.topics ?? null;
+  const moduleLabel
+    = data.modulesConfig?.moduleLabel || DEFAULT_MODULES_CONFIG.moduleLabel;
   return (
     <div className="flex flex-col gap-12">
       <InfoArea
@@ -267,27 +282,38 @@ function ResourceDetailsTab({
         </InfoArea>
       </InfoRow>
       <InfoRow header="Progress">
-        <InfoArea
-          header="Current Progress"
-          condition={!!data.progressCurrent}
-        >
-          <p>{data.progressCurrent}</p>
-        </InfoArea>
-        <InfoArea
-          header="Total Modules"
-          condition={!!data.progressTotal}
-        >
-          <p>{data.progressTotal}</p>
-        </InfoArea>
-        <InfoArea
-          header="% Complete"
-          condition={!!data.progressTotal && !!data.progressCurrent}
-        >
-          <p>{percentComplete}%</p>
-        </InfoArea>
-        {!data.progressCurrent && !data.progressTotal && (
-          <span>No progress information given.</span>
-        )}
+        {data.modulesAreExhaustive
+          ? (
+            <ModuleProgressDisplay
+              moduleProgress={moduleProgress}
+              moduleLabel={moduleLabel}
+            />
+          )
+          : (
+            <>
+              <InfoArea
+                header="Current Progress"
+                condition={!!data.progressCurrent}
+              >
+                <p>{data.progressCurrent}</p>
+              </InfoArea>
+              <InfoArea
+                header="Total Modules"
+                condition={!!data.progressTotal}
+              >
+                <p>{data.progressTotal}</p>
+              </InfoArea>
+              <InfoArea
+                header="% Complete"
+                condition={!!data.progressTotal && !!data.progressCurrent}
+              >
+                <p>{percentComplete}%</p>
+              </InfoArea>
+              {!data.progressCurrent && !data.progressTotal && (
+                <span>No progress information given.</span>
+              )}
+            </>
+          )}
       </InfoRow>
       <InfoRow
         header="Effort & Engagement"
@@ -344,5 +370,39 @@ function ResourceDetailsTab({
         </div>
       </InfoRow>
     </div>
+  );
+}
+
+// Module Tracking progress: completed/total/% derived from the resource's
+// modules (and count-only groups), shown instead of the manual progress fields.
+function ModuleProgressDisplay({
+  moduleProgress,
+  moduleLabel,
+}: {
+  moduleProgress: ModuleProgress;
+  moduleLabel: string;
+}) {
+  const {
+    completedCount,
+    totalCount,
+    percentComplete,
+  } = moduleProgress;
+
+  if (totalCount === 0) {
+    return <span>No {moduleLabel.toLowerCase()}s added yet.</span>;
+  }
+
+  return (
+    <>
+      <InfoArea header={`${moduleLabel}s Completed`}>
+        <p>{completedCount}</p>
+      </InfoArea>
+      <InfoArea header={`Total ${moduleLabel}s`}>
+        <p>{totalCount}</p>
+      </InfoArea>
+      <InfoArea header="% Complete">
+        <p>{percentComplete}%</p>
+      </InfoArea>
+    </>
   );
 }

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from "./formatCurrency";
 export * from "./formHasChanges";
 export * from "./isHttpUrl";
 export * from "./makePercentageComplete";
+export * from "./moduleProgress";
 export * from "./parseCost";
 export * from "./queryKeys";
 export * from "./routineConnections";

--- a/packages/client/src/utils/moduleProgress.test.ts
+++ b/packages/client/src/utils/moduleProgress.test.ts
@@ -1,0 +1,125 @@
+import type { Module, ModuleGroup } from "@emstack/types";
+
+import { describe, expect, test } from "vitest";
+
+import { computeModuleProgress } from "./moduleProgress.ts";
+
+function mod(overrides: Partial<Module>): Module {
+  return {
+    id: crypto.randomUUID(),
+    resourceId: "r1",
+    name: "m",
+    status: "unstarted",
+    ...overrides,
+  } as Module;
+}
+
+function group(overrides: Partial<ModuleGroup>): ModuleGroup {
+  return {
+    id: crypto.randomUUID(),
+    resourceId: "r1",
+    name: "g",
+    ...overrides,
+  } as ModuleGroup;
+}
+
+describe("computeModuleProgress", () => {
+  test("counts enumerated modules by status", () => {
+    const result = computeModuleProgress(
+      [
+        mod({
+          status: "complete",
+        }),
+        mod({
+          status: "in_progress",
+        }),
+        mod({
+          status: "unstarted",
+        }),
+        mod({
+          status: "complete",
+        }),
+      ],
+      [],
+    );
+    expect(result).toEqual({
+      completedCount: 2,
+      totalCount: 4,
+      percentComplete: 50,
+    });
+  });
+
+  test("adds direct counts from groups without enumerated modules", () => {
+    const result = computeModuleProgress(
+      [],
+      [group({
+        totalCount: 10,
+        completedCount: 3,
+      })],
+    );
+    expect(result).toEqual({
+      completedCount: 3,
+      totalCount: 10,
+      percentComplete: 30,
+    });
+  });
+
+  test("ignores direct counts when a group has enumerated modules", () => {
+    const g = group({
+      id: "g1",
+      totalCount: 99,
+      completedCount: 99,
+    });
+    const result = computeModuleProgress(
+      [
+        mod({
+          moduleGroupId: "g1",
+          status: "complete",
+        }),
+        mod({
+          moduleGroupId: "g1",
+          status: "unstarted",
+        }),
+      ],
+      [g],
+    );
+    expect(result).toEqual({
+      completedCount: 1,
+      totalCount: 2,
+      percentComplete: 50,
+    });
+  });
+
+  test("combines enumerated modules with count-only groups", () => {
+    const result = computeModuleProgress(
+      [mod({
+        status: "complete",
+      })],
+      [group({
+        totalCount: 3,
+        completedCount: 1,
+      })],
+    );
+    expect(result).toEqual({
+      completedCount: 2,
+      totalCount: 4,
+      percentComplete: 50,
+    });
+  });
+
+  test("rounds percent and returns 0 when there is nothing to count", () => {
+    expect(computeModuleProgress([], [])).toEqual({
+      completedCount: 0,
+      totalCount: 0,
+      percentComplete: 0,
+    });
+    expect(
+      computeModuleProgress(
+        [mod({
+          status: "complete",
+        }), mod({}), mod({})],
+        [],
+      ).percentComplete,
+    ).toBe(33);
+  });
+});

--- a/packages/client/src/utils/moduleProgress.ts
+++ b/packages/client/src/utils/moduleProgress.ts
@@ -1,0 +1,45 @@
+import type { Module, ModuleGroup } from "@emstack/types";
+
+import { isModuleComplete } from "@emstack/types";
+
+export interface ModuleProgress {
+  completedCount: number;
+  totalCount: number;
+  /** Integer 0–100; 0 when there are no modules to count. */
+  percentComplete: number;
+}
+
+/**
+ * Aggregate a resource's module progress: count completed/total across
+ * enumerated modules plus groups that have NO enumerated modules (those
+ * contribute their direct `totalCount`/`completedCount`; when a group has
+ * enumerated modules, those modules are already counted).
+ */
+export function computeModuleProgress(
+  modules: Module[],
+  groups: ModuleGroup[],
+): ModuleProgress {
+  const enumeratedGroupIds = new Set(
+    modules
+      .map(m => m.moduleGroupId)
+      .filter((id): id is string => !!id),
+  );
+
+  let totalCount = modules.length;
+  let completedCount = modules.filter(m => isModuleComplete(m.status)).length;
+
+  for (const g of groups) {
+    if (enumeratedGroupIds.has(g.id)) continue;
+    totalCount += g.totalCount ?? 0;
+    completedCount += g.completedCount ?? 0;
+  }
+
+  const percentComplete
+    = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return {
+    completedCount,
+    totalCount,
+    percentComplete,
+  };
+}


### PR DESCRIPTION
## Summary

Add module-derived progress display to the resource details tab when Module Tracking is enabled (`modulesAreExhaustive`). This replaces the manual progress fields with computed progress aggregated from enumerated modules and count-only module groups.

## Key Changes

- **New utility `computeModuleProgress()`** (`packages/client/src/utils/moduleProgress.ts`): Aggregates module progress by counting completed/total modules across enumerated modules plus groups without enumerated modules (which contribute their direct counts). Returns `ModuleProgress` with `completedCount`, `totalCount`, and `percentComplete` (0–100, rounded).

- **New hook `useResourceModuleProgress()`** (`packages/client/src/hooks/useResourceModuleProgress.ts`): Fetches modules and module groups for a resource and computes progress using `computeModuleProgress()`. Shares query keys with `useResourceModules` for cache reuse; gated with `enabled` to avoid fetching when Module Tracking is off.

- **Updated resource details tab** (`packages/client/src/routes/resources.$id.index.tsx`):
  - Conditionally render `ModuleProgressDisplay` when `modulesAreExhaustive` is true
  - Fall back to manual progress fields when Module Tracking is off
  - New `ModuleProgressDisplay` component shows completed/total/% with customizable module label

- **Refactored `useResourceModules()`** (`packages/client/src/hooks/useResourceModules.ts`): Replaced inline progress aggregation logic with call to `computeModuleProgress()` for consistency.

- **Comprehensive test coverage** (`packages/client/src/utils/moduleProgress.test.ts`): 5 test cases covering enumerated modules, count-only groups, mixed scenarios, and edge cases (zero modules, rounding).

## Implementation Details

- Progress aggregation correctly handles the hybrid case: enumerated modules are counted directly, while groups without enumerated modules contribute their `totalCount`/`completedCount` fields (avoiding double-counting).
- Percentage is rounded to nearest integer; returns 0 when there are no modules to count.
- Module label is read from `modulesConfig.moduleLabel` with fallback to `DEFAULT_MODULES_CONFIG.moduleLabel`.

https://claude.ai/code/session_01GbuLAR6JRaZ9ndNNE1pUtS