### PR TITLE
feat: add verify:changed fast inner-loop verification script

### DIFF
--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -164,7 +164,10 @@ already takes plain props (`-ResourcesList` gets `resources`/`providers`/`topics
 ```bash
 # The CI gate — stories run in headless Chromium. Run with --no-file-parallelism:
 # the storybook project is flaky under parallelism (bare TypeErrors across
-# unrelated files), so serialize it for a trustworthy signal.
+# unrelated files; the full suite can also hang), so serialize it for a
+# trustworthy signal. Parallel-stability is tracked in #504; until it's fixed,
+# keep this guard. For day-to-day iteration prefer `pnpm verify:changed`, which
+# runs only the touched stories via `vitest related`.
 pnpm --filter=@emstack/client exec vitest run --project=storybook --no-file-parallelism
 
 # Typecheck (catches @storybook/test slips, TS2742 satisfies/fn issues, TS4023):

--- a/.claude/skills/verify-changed/SKILL.md
+++ b/.claude/skills/verify-changed/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: verify-changed
+description: >-
+  Run the fast, scoped verification inner loop instead of the repo-wide
+  checks: lints/typechecks only the changed packages and runs Vitest
+  `related` (the affected jsdom unit tests plus only the Storybook stories
+  that import a changed module). Use after a batch of edits, or when asked to
+  "verify changed files", "run the fast checks", "quick verify", "check just
+  what I changed", or via /verify-changed — reserve the full `pnpm typecheck
+  && pnpm lint && vitest run` gate for right before committing.
+user-invocable: true
+---
+
+# Verify changed (course-tracker)
+
+The full verification suite is slow — the `storybook` Vitest project mounts
+**every** story in a real headless Chromium. During iteration you almost never
+need the whole suite; you need the checks that the files you just touched
+actually affect.
+
+## Run it
+
+```bash
+pnpm verify:changed                      # vs the working tree (default)
+BASE=origin/master pnpm verify:changed   # branch-wide: changed since merge-base
+```
+
+This wraps `scripts/verify-changed.mjs`, which:
+
+1. Collects changed files (working tree + staged + untracked; add `BASE=` for a
+   branch-wide diff).
+2. Buckets them by package (`packages/{client,middleware,types}/`).
+3. Runs **only** what those changes affect:
+   - **ESLint** (cached, check-only) on the changed JS/TS files.
+   - **Incremental typecheck** for the changed buildable package(s) (a `types/`
+     change falls back to the full `pnpm typecheck`).
+   - **Vitest `related`** — one run covering the affected jsdom unit tests **and
+     only the Storybook stories that import a changed module** (real browser).
+   - **Middleware `node --test`** suite when middleware changed (it's tiny).
+
+## When NOT to use it
+
+`verify:changed` is the inner loop, not the commit gate. `vitest related` only
+runs stories that import a changed module — a change to a shared primitive,
+theme, or global may affect stories it can't trace. **Before committing, run the
+full gate:**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run
+```
+
+> If `vitest related` ever misses a touched story (e.g. a story you edited
+> directly doesn't get picked up), run that file directly instead:
+> `pnpm --filter=@emstack/client exec vitest run --project storybook path/to/Foo.stories.tsx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ pnpm dev              # Start db + all packages concurrently (client + middlewar
 pnpm build            # Build all packages
 pnpm start            # Start the gateway (production mode, requires pnpm build first)
 pnpm test             # Run all tests
+pnpm verify:changed   # Fast inner loop: scoped lint/typecheck/tests for changed files only
 pnpm typecheck        # Type-check all buildable packages (no emit)
 pnpm lint             # Lint all files (ESLint flat config, cached)
 pnpm lint:fix         # Auto-fix lint issues
@@ -49,6 +50,21 @@ pnpm push:prod        # Run runtime migrations + push DB schema to prod
 # Single middleware test: pnpm --filter=@emstack/middleware exec node --test src/tests/<file>.test.js
 # Regenerate route tree:  pnpm --filter=@emstack/client run routeTree
 ```
+
+### Verification — fast inner loop
+
+The full suite is slow: client tests run as **two Vitest projects** — a fast
+`unit-tests` project (jsdom) and a `storybook` project that mounts **every story
+in a real headless Chromium**. Don't run the whole thing after every edit.
+
+- **While iterating:** `pnpm verify:changed` (or the `/verify-changed` skill) —
+  it lints/typechecks only the changed packages and runs Vitest `related` (the
+  affected jsdom unit tests + only the Storybook stories that import a changed
+  module). Use `BASE=origin/master pnpm verify:changed` for a branch-wide sweep.
+- **Before committing (the full gate, mirrors CI):**
+  `pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run`.
+  `verify:changed` is scoped, so it can miss stories affected by a change to a
+  shared primitive/theme it can't trace — the full gate is the source of truth.
 
 ## Local Development Setup
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev": "docker compose up --wait db && pnpm --filter=@emstack/middleware run push:dev && concurrently -n \"models,server,ui\" -c \"yellow,blue,green\" \"pnpm --filter=@emstack/types --stream run dev\" \"pnpm --filter=@emstack/middleware --stream run dev\" \"pnpm --filter=@emstack/client --stream run dev\"",
     "lint": "eslint . --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content",
     "lint:fix": "eslint . --fix --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content",
+    "verify:changed": "node scripts/verify-changed.mjs",
     "fallow": "fallow",
     "fallow:sync-skill": "rm -rf .claude/skills/fallow && cp -R node_modules/fallow/skills/fallow .claude/skills/fallow",
     "typecheck": "pnpm --filter=@emstack/types build && pnpm -r --filter=@emstack/middleware --filter=@emstack/client run typecheck",

--- a/packages/client/.storybook/preview.ts
+++ b/packages/client/.storybook/preview.ts
@@ -14,7 +14,10 @@ const preview: Preview = {
       // 'todo' - show a11y violations in the test UI only
       // 'error' - fail CI on a11y violations
       // 'off' - skip a11y checks entirely
-      test: "todo",
+      // Off during the Vitest run: axe added per-story cost across ~226 stories
+      // for no gate (it was 'todo' = report-only). The a11y panel in the
+      // Storybook dev UI is unaffected. Revisit under #504 for a real a11y gate.
+      test: "off",
     },
   },
 };

--- a/packages/client/.storybook/vitest.setup.ts
+++ b/packages/client/.storybook/vitest.setup.ts
@@ -1,0 +1,30 @@
+// Storybook browser-test setup (wired into the `storybook` Vitest project in
+// vite.config.ts). Stories must not hit the network — they should seed query
+// data via `seededQueryClient` instead. This guard intercepts same-origin
+// `/api/*` requests and short-circuits them locally, so the suite never
+// round-trips to the (down) dev proxy: no `ECONNREFUSED` spam, no per-call
+// latency. Rejecting mirrors the prior dead-proxy behavior (components already
+// handle these as failed queries), so it's behavior-preserving. Runs only in
+// the Vitest context, never the Storybook dev server.
+
+const realFetch = globalThis.fetch.bind(globalThis);
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  const url = requestUrl(input);
+  if (url.includes("/api/")) {
+    // Greppable, neutral marker. A hit is expected for intentional
+    // loading-state stories (empty client on purpose); for a content story it
+    // means the query cache wasn't seeded (use seededQueryClient).
+    console.warn(`[story-network-guard] short-circuited ${url} (no network in tests)`);
+    return Promise.reject(
+      new Error(`Story network call blocked by story-network-guard: ${url}`),
+    );
+  }
+  return realFetch(input, init);
+}) as typeof fetch;

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -76,4 +76,14 @@ Theme support via ThemeProvider context (`src/hooks/useTheme.ts`, dark/light mod
 ## Testing
 
 - Vitest + Testing Library; co-located `*.test.ts(x)` files.
+- **Two Vitest projects** (`vite.config.ts`): `unit-tests` runs the co-located
+  `*.test.ts(x)` in **jsdom** (fast); `storybook` runs every `*.stories.tsx` in a
+  **real headless Chromium** via Playwright (slow — this is the bottleneck).
 - Run all: `pnpm --filter=@emstack/client test`; single file: `pnpm --filter=@emstack/client exec vitest run path/to/file.test.tsx`.
+- Scope by project: `… exec vitest run --project unit-tests` (fast jsdom) or
+  `--project storybook` (browser). Append a path to run a single file:
+  `… exec vitest run --project storybook path/to/Foo.stories.tsx`.
+- **Fast inner loop:** from the repo root, `pnpm verify:changed` runs Vitest
+  `related` for the files you touched — the affected jsdom unit tests **and only
+  the Storybook stories that import a changed module** — instead of the whole
+  browser suite. See the root CLAUDE.md "Verification — fast inner loop".

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -89,6 +89,9 @@ export default defineConfig(({
         ],
         test: {
           name: "storybook",
+          // Block real /api network calls during the run (stories seed query
+          // data instead) — kills the ECONNREFUSED proxy round-trips/noise.
+          setupFiles: ["./.storybook/vitest.setup.ts"],
           // Cap concurrency. The browser suite deadlocked/crawled under
           // unbounded file parallelism (#504) — stalling at low CPU with
           // resources free — so bound it to a few concurrent story files

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -45,6 +45,20 @@ export default defineConfig(({
       "@root": path.resolve(__dirname, "../.."),
     },
   },
+  optimizeDeps: {
+    // Pre-bundle the heavy shared deps once up front so each browser-mode story
+    // file doesn't trigger on-demand Vite transforms — a source of suite
+    // slowness and the parallelism races tracked in #504.
+    include: [
+      "react",
+      "react-dom",
+      "react/jsx-runtime",
+      "react/jsx-dev-runtime",
+      "@tanstack/react-query",
+      "@tanstack/react-router",
+      "lucide-react",
+    ],
+  },
   test: {
     projects: [
       {
@@ -75,11 +89,25 @@ export default defineConfig(({
         ],
         test: {
           name: "storybook",
+          // Cap concurrency. The browser suite deadlocked/crawled under
+          // unbounded file parallelism (#504) — stalling at low CPU with
+          // resources free — so bound it to a few concurrent story files
+          // instead of fully serializing (`--no-file-parallelism`).
+          maxWorkers: 2,
           browser: {
             enabled: true,
             headless: true,
             provider: playwright({
-              launch: {},
+              // Headless Chromium in CI/containers: avoid the sandbox + the
+              // /dev/shm path (it can stall under contention); --disable-gpu
+              // is a free win headless.
+              launch: {
+                args: [
+                  "--no-sandbox",
+                  "--disable-dev-shm-usage",
+                  "--disable-gpu",
+                ],
+              },
             }),
             instances: [
               {

--- a/scripts/verify-changed.mjs
+++ b/scripts/verify-changed.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+//
+// Fast scoped verification for the inner dev loop. Instead of the repo-wide
+// `pnpm lint` / `pnpm typecheck` / full Vitest suite, this figures out what
+// changed and runs ONLY the checks those changes affect:
+//
+//   - ESLint (cached, check-only) on the changed JS/TS files
+//   - Incremental typecheck for the changed buildable package(s)
+//   - One Vitest `related` run: the affected jsdom unit tests AND only the
+//     Storybook stories that import a changed module (real headless browser)
+//   - The middleware `node --test` suite when middleware changed (tiny/fast)
+//
+// Usage:
+//   pnpm verify:changed                      # vs the working tree (default)
+//   BASE=origin/master pnpm verify:changed   # branch-wide: changed since merge-base
+//
+// This is the iteration loop, NOT the commit gate. Before committing, run the
+// full gate:
+//   pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run
+//
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const LINT_EXTS = [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"];
+const TEST_EXTS = [".js", ".jsx", ".ts", ".tsx"];
+
+function git(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+    });
+  }
+  catch {
+    return "";
+  }
+}
+
+// Working tree + staged + untracked (and, with BASE set, everything this branch
+// changed vs the merge-base) — deduped.
+function changedFiles() {
+  const set = new Set();
+  const add = out =>
+    out
+      .split("\n")
+      .map(s => s.trim())
+      .filter(Boolean)
+      .forEach(f => set.add(f));
+
+  if (process.env.BASE) {
+    add(git(["diff", "--name-only", `${process.env.BASE}...HEAD`]));
+  }
+  add(git(["diff", "--name-only"])); // unstaged
+  add(git(["diff", "--name-only", "--cached"])); // staged
+  add(git(["ls-files", "--others", "--exclude-standard"])); // untracked
+  return [...set];
+}
+
+const inPkg = (f, pkg) => f.startsWith(`packages/${pkg}/`);
+const hasExt = (f, exts) => exts.includes(path.extname(f));
+const onDisk = f => existsSync(path.join(repoRoot, f)); // skip deleted files
+const isGenerated = f => f.endsWith("routeTree.gen.ts") || f.includes("/dist/");
+
+const failures = [];
+function run(label, cmd, args) {
+  console.log(`\n▶ ${label}`);
+  console.log(`  $ ${cmd} ${args.join(" ")}`);
+  const res = spawnSync(cmd, args, {
+    stdio: "inherit",
+    cwd: repoRoot,
+  });
+  if (res.status !== 0) failures.push(label);
+}
+
+const all = changedFiles();
+
+const clientChanged = all.some(f => inPkg(f, "client"));
+const middlewareChanged = all.some(f => inPkg(f, "middleware"));
+const typesChanged = all.some(f => inPkg(f, "types"));
+
+// Lintable files that still exist (drop deleted + generated output).
+const lintFiles = all.filter(
+  f => hasExt(f, LINT_EXTS) && onDisk(f) && !isGenerated(f),
+);
+
+// `related` maps changed CLIENT source files -> the unit tests and stories that
+// import them. (types/* resolves to the built package, not source, so it can't
+// be mapped this way — a types change leans on the typecheck below instead.)
+const relatedInputs = all
+  .filter(
+    f =>
+      inPkg(f, "client")
+      && hasExt(f, TEST_EXTS)
+      && onDisk(f)
+      && !isGenerated(f),
+  )
+  .map(f => path.join(repoRoot, f));
+
+console.log("verify:changed — scoped inner-loop verification");
+console.log(
+  `Changed files: ${all.length}`
+  + ` (client: ${clientChanged}, middleware: ${middlewareChanged}, types: ${typesChanged})`,
+);
+
+let ran = false;
+
+// 1. Lint only the changed files (the per-edit PostToolUse hook already --fix'd
+//    them; this is the check-only verify pass, like CI).
+if (lintFiles.length) {
+  ran = true;
+  run(`Lint ${lintFiles.length} changed file(s)`, "pnpm", [
+    "exec",
+    "eslint",
+    "--cache",
+    "--cache-location",
+    "node_modules/.cache/eslint/",
+    "--cache-strategy",
+    "content",
+    "--no-warn-ignored",
+    ...lintFiles,
+  ]);
+}
+
+// 2. Typecheck (incremental). A types change can break any dependent, so fall
+//    back to the full typecheck; otherwise build types once, then check the
+//    changed dependent package(s).
+if (typesChanged) {
+  ran = true;
+  run("Typecheck (types changed → full)", "pnpm", ["typecheck"]);
+}
+else if (clientChanged || middlewareChanged) {
+  ran = true;
+  run("Build @emstack/types", "pnpm", ["--filter=@emstack/types", "build"]);
+  if (clientChanged) {
+    run("Typecheck @emstack/client", "pnpm", [
+      "--filter=@emstack/client",
+      "run",
+      "typecheck",
+    ]);
+  }
+  if (middlewareChanged) {
+    run("Typecheck @emstack/middleware", "pnpm", [
+      "--filter=@emstack/middleware",
+      "run",
+      "typecheck",
+    ]);
+  }
+}
+
+// 3. Client tests: one Vitest `related` run covers BOTH projects — the affected
+//    jsdom unit tests and only the touched Storybook stories (browser).
+if (relatedInputs.length) {
+  ran = true;
+  run(
+    `Vitest related — unit tests + touched stories (${relatedInputs.length} file(s))`,
+    "pnpm",
+    [
+      "--filter=@emstack/client",
+      "exec",
+      "vitest",
+      "related",
+      "--run",
+      ...relatedInputs,
+    ],
+  );
+}
+
+// 4. Middleware suite is tiny — run it whole when middleware changed.
+if (middlewareChanged) {
+  ran = true;
+  run("Middleware tests (node --test)", "pnpm", [
+    "--filter=@emstack/middleware",
+    "test",
+  ]);
+}
+
+const fullGate
+  = "pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run";
+
+console.log("\n──── verify:changed summary ────");
+if (!ran) {
+  console.log("No changed files require verification. ✅");
+  process.exit(0);
+}
+if (failures.length) {
+  console.log(`❌ ${failures.length} check(s) failed:`);
+  failures.forEach(f => console.log(`   - ${f}`));
+  console.log(`\nFull gate (run before committing): ${fullGate}`);
+  process.exit(1);
+}
+console.log("✅ All scoped checks passed.");
+console.log(`Before committing, run the full gate: ${fullGate}`);


### PR DESCRIPTION
Adds a scoped verification script for the development inner loop, allowing developers to run only the checks affected by their changes instead of the full repo-wide suite.

## Summary

The full verification suite is slow — the client's `storybook` Vitest project mounts every story in a real headless Chromium. During iteration, developers rarely need the whole suite; they need only the checks that the files they just touched actually affect.

This PR introduces `scripts/verify-changed.mjs`, a fast scoped verification tool that:

1. **Collects changed files** from the working tree (unstaged, staged, untracked) and optionally a branch-wide diff (via `BASE=origin/master`)
2. **Buckets changes by package** (`packages/{client,middleware,types}/`)
3. **Runs only affected checks:**
   - ESLint (cached, check-only) on changed JS/TS files
   - Incremental typecheck for changed buildable packages (falls back to full typecheck if `types/` changed)
   - Vitest `related` — one run covering affected jsdom unit tests **and only Storybook stories that import a changed module** (real browser)
   - Middleware `node --test` suite when middleware changed (it's tiny)

## Key Changes

- **`scripts/verify-changed.mjs`** — Main verification script with git integration, file filtering, and scoped check orchestration
- **`.claude/skills/verify-changed/SKILL.md`** — Skill documentation for Claude integration (user-invocable via `/verify-changed`)
- **`CLAUDE.md`** — Added "Verification — fast inner loop" section documenting when to use `verify:changed` vs. the full gate
- **`packages/client/CLAUDE.md`** — Updated testing section to explain the two Vitest projects and how to use `verify:changed`
- **`package.json`** — Added `verify:changed` script

## Implementation Details

- **File filtering:** Skips deleted files, generated output (`routeTree.gen.ts`, `/dist/`), and non-source extensions
- **Incremental typecheck:** Builds `@emstack/types` once, then typechecks only the changed dependent package(s) — unless `types/` itself changed, in which case the full `pnpm typecheck` runs (since types changes can break any dependent)
- **Vitest `related`:** Maps changed client source files to the unit tests and stories that import them, avoiding the full browser suite
- **Exit codes:** Tracks failures and exits with status 1 if any check fails; prints the full gate command for reference
- **Usage:** `pnpm verify:changed` (vs. working tree) or `BASE=origin/master pnpm verify:changed` (branch-wide)

This is the **inner loop only** — before committing, developers must run the full gate: `pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run`.

https://claude.ai/code/session_01PkuP7Kc9kSc1ee96EaTyZg