### PR TITLE
fix: implement partial merge for module and module group upserts

### DIFF
--- a/packages/middleware/src/routes/api/module-groups/upsertModuleGroup.ts
+++ b/packages/middleware/src/routes/api/module-groups/upsertModuleGroup.ts
@@ -83,6 +83,30 @@ export default createUpsertHandler<ModuleGroupBody>({
     interactivity: body.interactivity ?? null,
   }),
   updateableColumns,
+  // Partial merge: only write columns the request actually carries, so a save
+  // that omits a field never resets it. `position` is owned by the reorder flow
+  // — clobbering it to null sorts the group to the end of the list.
+  buildSetClause: (body, row) => {
+    const provided: Record<string, boolean> = {
+      name: body.name !== undefined,
+      resourceId: body.resourceId !== undefined,
+      description: body.description !== undefined,
+      url: body.url !== undefined,
+      position: body.position !== undefined,
+      totalCount: body.totalCount !== undefined,
+      completedCount: body.completedCount !== undefined,
+      pageStart: body.pageStart !== undefined,
+      pageEnd: body.pageEnd !== undefined,
+      easeOfStarting: body.easeOfStarting !== undefined,
+      timeNeeded: body.timeNeeded !== undefined,
+      interactivity: body.interactivity !== undefined,
+    };
+    const set: Record<string, unknown> = {};
+    for (const col of updateableColumns) {
+      if (provided[col]) set[col] = row[col];
+    }
+    return set;
+  },
   junctions: [
     {
       table: moduleGroupTags,

--- a/packages/middleware/src/routes/api/modules/upsertModule.ts
+++ b/packages/middleware/src/routes/api/modules/upsertModule.ts
@@ -92,6 +92,32 @@ export default createUpsertHandler<ModuleBody>({
     interactivity: body.interactivity ?? null,
   }),
   updateableColumns,
+  // Partial merge: only write columns the request actually carries, so a save
+  // or status toggle that omits a field never resets it. `position` is owned by
+  // the reorder flow — clobbering it to null sorts the module to the list end.
+  buildSetClause: (body, row) => {
+    const provided: Record<string, boolean> = {
+      name: body.name !== undefined,
+      resourceId: body.resourceId !== undefined,
+      moduleGroupId: body.moduleGroupId !== undefined,
+      description: body.description !== undefined,
+      url: body.url !== undefined,
+      // `length` is derived from either `length` or the deprecated `minutesLength`.
+      length: body.length !== undefined || body.minutesLength !== undefined,
+      status: body.status !== undefined,
+      position: body.position !== undefined,
+      pageStart: body.pageStart !== undefined,
+      pageEnd: body.pageEnd !== undefined,
+      easeOfStarting: body.easeOfStarting !== undefined,
+      timeNeeded: body.timeNeeded !== undefined,
+      interactivity: body.interactivity !== undefined,
+    };
+    const set: Record<string, unknown> = {};
+    for (const col of updateableColumns) {
+      if (provided[col]) set[col] = row[col];
+    }
+    return set;
+  },
   junctions: [
     {
       table: moduleTags,


### PR DESCRIPTION
## Summary

Implement partial merge semantics for module and module group upsert operations. Previously, omitted fields in update requests would be reset to null. Now, only fields explicitly provided in the request are written to the database, preserving existing values for omitted fields.

## Changes

- **`packages/middleware/src/routes/api/modules/upsertModule.ts`**: Added `buildSetClause` handler that tracks which fields are present in the request body and only includes those in the SQL SET clause. Prevents unintended nullification of fields during partial updates (e.g., status toggles, saves that omit certain fields). Special handling for `position` field, which is owned by the reorder flow and should not be clobbered by regular updates.

- **`packages/middleware/src/routes/api/module-groups/upsertModuleGroup.ts`**: Applied the same partial merge pattern to module group upserts, with identical semantics for field preservation and `position` ownership.

## Implementation Details

Both handlers now:
1. Track which fields are explicitly provided in the request body (checking for `!== undefined`)
2. Build a SET clause that only includes columns present in the request
3. Preserve the `position` field from being accidentally reset to null during non-reorder updates
4. Maintain backward compatibility with existing request patterns

https://claude.ai/code/session_01S52sjiKoUu9BwDHVBmNHv3