### PR TITLE
fix: stabilize Vitest concurrency and changelog key generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,13 @@ jobs:
 
       # `vitest run` (not watch) keeps it non-interactive; --project storybook selects
       # the browser-mode project defined in packages/client/vite.config.ts.
+      #
+      # Failsafe timeout: the browser suite can deadlock under parallelism (#504) —
+      # a >28-min crawl at low CPU that never emits a summary. A healthy full run is
+      # ~1.5-8 min, so bound this step well under the 6h job default to fail fast on
+      # a hang instead of burning the whole runner. Scoped to the test step so the
+      # cold-cache Playwright install / Vite optimize steps above don't count against it.
       - name: Run Storybook component tests
         if: steps.changes.outputs.client == 'true'
+        timeout-minutes: 15
         run: pnpm --filter=@emstack/client exec vitest run --project storybook

--- a/packages/client/src/routes/dashboard/-components/insights/-DashboardChangelog.tsx
+++ b/packages/client/src/routes/dashboard/-components/insights/-DashboardChangelog.tsx
@@ -162,9 +162,12 @@ export function DashboardChangelog({
                         </h3>
                       )}
                       <ul className="flex list-disc flex-col gap-1 pl-4">
-                        {section.items.map(item => (
+                        {section.items.map((item, index) => (
                           <li
-                            key={item}
+                            // Changelog lines aren't unique (e.g. repeated
+                            // "Update README.md"), so pair the text with its
+                            // index for a stable per-section key.
+                            key={`${index}-${item}`}
                             className="text-sm/snug"
                           >
                             {renderInline(item)}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -92,10 +92,13 @@ export default defineConfig(({
           // Block real /api network calls during the run (stories seed query
           // data instead) — kills the ECONNREFUSED proxy round-trips/noise.
           setupFiles: ["./.storybook/vitest.setup.ts"],
-          // Cap concurrency. The browser suite deadlocked/crawled under
-          // unbounded file parallelism (#504) — stalling at low CPU with
-          // resources free — so bound it to a few concurrent story files
-          // instead of fully serializing (`--no-file-parallelism`).
+          // Cap concurrency. Unbounded file parallelism hard-deadlocked the
+          // browser suite (#504): a >28-min crawl at low CPU with resources
+          // free, no summary. This bound prevents that runaway and is what CI
+          // uses. It is not a full fix, though — on throttled/shared hosts even
+          // bounded parallelism can still crawl (reproduced under #504), so a
+          // trustworthy *full* local run still passes `--no-file-parallelism`
+          // (fully serial); day-to-day, prefer `pnpm verify:changed`.
           maxWorkers: 2,
           browser: {
             enabled: true,


### PR DESCRIPTION
## Summary
Two fixes to improve test stability and prevent React key warnings in the changelog component.

## Changes
- **Vitest concurrency:** Expanded the comment explaining why `maxWorkers: 2` is necessary. The unbounded file parallelism caused hard deadlocks in the browser suite (#504), and while the bounded setting prevents runaway, it's not a complete fix on throttled/shared hosts. Updated guidance to recommend `--no-file-parallelism` for trustworthy full local runs and `pnpm verify:changed` for day-to-day iteration.
- **Changelog keys:** Fixed React key generation for changelog items by pairing the item text with its index (`key={`${index}-${item}`}`). Changelog lines aren't unique (e.g., repeated "Update README.md"), so the index ensures stable per-section keys and eliminates console warnings.

## Implementation Details
The changelog fix acknowledges that changelog items can repeat within a section, making text-only keys unreliable. Combining the index with the item text provides a stable, unique key for each rendered list item while remaining deterministic across re-renders.

https://claude.ai/code/session_01B3h9hfbZAUqYsuoJyeJw2C