### PR TITLE
feat(client): make daily progress header label configurable

### DIFF
--- a/packages/client/src/components/dailies/dailyTrackerColumns.tsx
+++ b/packages/client/src/components/dailies/dailyTrackerColumns.tsx
@@ -9,6 +9,8 @@ interface DailyTrackerColumnsOptions {
   dayHeaders: DailyDayHeader[];
   /** Icon-only progress header (routine tracker); the dashboard shows the text. */
   progressHideLabel?: boolean;
+  /** Visible progress header text; the dashboard shortens it to keep the column narrow. */
+  progressLabel?: string;
   /** Today-status header className — the wider table adds `w-36`. */
   statusHeadClassName: string;
   /** Title header className — the dashboard uses `w-full` to absorb slack. */
@@ -25,6 +27,7 @@ interface DailyTrackerColumnsOptions {
 export function buildDailyTrackerColumns({
   dayHeaders,
   progressHideLabel = false,
+  progressLabel = "Progress",
   statusHeadClassName,
   titleHeadClassName,
 }: DailyTrackerColumnsOptions): ColumnDef<Daily>[] {
@@ -37,7 +40,7 @@ export function buildDailyTrackerColumns({
       }) => (
         <DataTableColumnHeader
           column={column}
-          label="Progress"
+          label={progressLabel}
           hideLabel={progressHideLabel}
         />
       ),

--- a/packages/client/src/routes/dashboard/-components/dailies/-DashboardDailiesBody.tsx
+++ b/packages/client/src/routes/dashboard/-components/dailies/-DashboardDailiesBody.tsx
@@ -45,6 +45,7 @@ export function DashboardDailiesBody({
     <DataTable
       columns={buildDailyTrackerColumns({
         dayHeaders,
+        progressLabel: "Prog",
         statusHeadClassName: "p-2 font-medium whitespace-nowrap",
         titleHeadClassName: "w-full",
       })}


### PR DESCRIPTION
## Summary
Make the progress column header label in the daily tracker configurable, allowing different layouts (like the dashboard) to customize it for space constraints.

## Changes
- Added `progressLabel` option to `DailyTrackerColumnsOptions` interface with a default value of `"Progress"`
- Updated `buildDailyTrackerColumns` to accept and use the `progressLabel` parameter instead of the hardcoded `"Progress"` string
- Updated the dashboard's daily tracker to pass `progressLabel: "Prog"` to keep the column narrow while maintaining readability

## Details
The dashboard previously had no way to customize the progress header text, which could be too wide for its layout. This change allows callers to provide a shorter label (e.g., `"Prog"`) while the routine tracker continues to use the full `"Progress"` label by default.

https://claude.ai/code/session_01QkYfyChuLpp97BXwoJ7qMK