### PR TITLE
feat(client): add bulk-edit table for module spreadsheet editing

### DIFF
--- a/packages/client/src/components/resources/ModuleBulkEditRow.stories.tsx
+++ b/packages/client/src/components/resources/ModuleBulkEditRow.stories.tsx
@@ -1,0 +1,152 @@
+import type { ModuleGroupOption } from "./ModuleBulkEditRow";
+import type { Module, TagGroup } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { useState } from "react";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { ModuleBulkEditRow } from "./ModuleBulkEditRow";
+
+import { moduleToRowDraft } from "@/hooks/useModuleBulkEditDrafts";
+import {
+  makeModule,
+  makeTagGroups,
+} from "@/test-utils/resourceModulesFixtures";
+
+const groupOptions: ModuleGroupOption[] = [
+  {
+    value: "",
+    label: "Ungrouped",
+  },
+  {
+    value: "g1",
+    label: "Section 1",
+  },
+];
+
+interface RowDemoProps {
+  module: Module;
+  tagGroups: TagGroup[];
+  showPages: boolean;
+  expandedInit: boolean;
+}
+
+// A row renders `<tr>`s, so it needs a table ancestor. This wrapper also gives
+// the pure row local draft/expand state so the cells are interactive in stories.
+function RowDemo({
+  module: m,
+  tagGroups,
+  showPages,
+  expandedInit,
+}: RowDemoProps) {
+  const [rowDraft, setRowDraft] = useState(() => moduleToRowDraft(m));
+  const [expanded, setExpanded] = useState(expandedInit);
+  const colCount = showPages ? 7 : 6;
+  return (
+    <table className="w-full">
+      <tbody>
+        <ModuleBulkEditRow
+          rowDraft={rowDraft}
+          groupOptions={groupOptions}
+          tagGroups={tagGroups}
+          showPages={showPages}
+          colCount={colCount}
+          isDirty={false}
+          expanded={expanded}
+          onToggleExpand={() => setExpanded(e => !e)}
+          onPatchDraft={patch =>
+            setRowDraft(prev => ({
+              ...prev,
+              draft: {
+                ...prev.draft,
+                ...patch,
+              },
+            }))}
+          onPatchRow={patch =>
+            setRowDraft(prev => ({
+              ...prev,
+              ...patch,
+            }))}
+        />
+      </tbody>
+    </table>
+  );
+}
+
+const meta = {
+  component: RowDemo,
+  args: {
+    module: makeModule({
+      id: "m1",
+      name: "Variables",
+      moduleGroupId: "g1",
+    }),
+    tagGroups: makeTagGroups(),
+    showPages: false,
+    expandedInit: false,
+  },
+} satisfies Meta<typeof RowDemo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Website: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByDisplayValue("Variables")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", {
+      name: "Min",
+    })).toBeInTheDocument();
+    // No page inputs on a website module.
+    await expect(canvas.queryByLabelText("Start page")).not.toBeInTheDocument();
+  },
+};
+
+export const Book: Story = {
+  args: {
+    showPages: true,
+    module: makeModule({
+      id: "m1",
+      name: "Chapter 1",
+      pageStart: 1,
+      pageEnd: 20,
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText("Start page")).toBeInTheDocument();
+    await expect(canvas.getByLabelText("End page")).toBeInTheDocument();
+  },
+};
+
+export const Expanded: Story = {
+  args: {
+    expandedInit: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Ease of Starting")).toBeInTheDocument();
+    await expect(canvas.getByText("Tags")).toBeInTheDocument();
+  },
+};
+
+// Switching the length control to "Range" reveals the duration-bucket select.
+export const SwitchLengthToRange: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", {
+      name: "Range",
+    }));
+    await expect(canvas.getByLabelText("Length range")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/components/resources/ModuleBulkEditRow.tsx
+++ b/packages/client/src/components/resources/ModuleBulkEditRow.tsx
@@ -1,0 +1,311 @@
+import type { ModuleDraft } from "./moduleDrafts";
+import type { ModuleRowDraft } from "@/hooks/useModuleBulkEditDrafts";
+import type {
+  ModuleDurationBucket,
+  ModuleStatus,
+  TagGroup,
+} from "@emstack/types";
+
+import {
+  MODULE_DURATION_BUCKETS,
+  MODULE_DURATION_LABELS,
+} from "@emstack/types";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+
+import { LevelTriad } from "./LevelTriad";
+import { ModuleStatusControl } from "./ModuleStatusControl";
+
+import { TagPicker } from "@/components/tasks/TagPicker";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+const selectClass = `
+  flex h-9 w-full rounded-md border bg-background px-2 py-1 text-sm
+`;
+
+export interface ModuleGroupOption {
+  /** Empty string represents the "Ungrouped" choice (moduleGroupId === null). */
+  value: string;
+  label: string;
+}
+
+interface ModuleBulkEditRowProps {
+  rowDraft: ModuleRowDraft;
+  groupOptions: ModuleGroupOption[];
+  tagGroups: TagGroup[];
+  /** Book resources get the start/end page columns. */
+  showPages: boolean;
+  /** Total column count, for the expanded detail row's colSpan. */
+  colCount: number;
+  isDirty: boolean;
+  expanded: boolean;
+  disabled?: boolean;
+  onToggleExpand: () => void;
+  onPatchDraft: (patch: Partial<ModuleDraft>) => void;
+  onPatchRow: (patch: {
+    status?: ModuleStatus;
+    moduleGroupId?: string | null;
+  }) => void;
+}
+
+/**
+ * One editable module row of the bulk-edit table: the scannable fields as inline
+ * cells, plus a toggle that reveals a full-width sub-row for the bulkier effort
+ * levels + tags controls. Pure/controlled — all state lives in the parent's
+ * `useModuleBulkEditDrafts`.
+ */
+export function ModuleBulkEditRow({
+  rowDraft,
+  groupOptions,
+  tagGroups,
+  showPages,
+  colCount,
+  isDirty,
+  expanded,
+  disabled = false,
+  onToggleExpand,
+  onPatchDraft,
+  onPatchRow,
+}: ModuleBulkEditRowProps) {
+  const {
+    draft,
+  } = rowDraft;
+
+  return (
+    <>
+      <TableRow
+        data-dirty={isDirty || undefined}
+        className={cn(isDirty && `
+          bg-amber-50/60
+          dark:bg-amber-900/10
+        `)}
+      >
+        <TableCell className="w-8 align-top">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-expanded={expanded}
+            aria-label={expanded ? "Hide levels and tags" : "Edit levels and tags"}
+            onClick={onToggleExpand}
+          >
+            {expanded
+              ? <ChevronDownIcon className="size-4" />
+              : <ChevronRightIcon className="size-4" />}
+          </Button>
+        </TableCell>
+
+        <TableCell className="align-top">
+          <select
+            value={rowDraft.moduleGroupId ?? ""}
+            disabled={disabled}
+            aria-label="Group"
+            className={selectClass}
+            onChange={e =>
+              onPatchRow({
+                moduleGroupId: e.target.value || null,
+              })}
+          >
+            {groupOptions.map(opt => (
+              <option
+                key={opt.value || "__ungrouped__"}
+                value={opt.value}
+              >
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </TableCell>
+
+        <TableCell className="align-top">
+          <Input
+            type="text"
+            value={draft.name}
+            disabled={disabled}
+            required
+            aria-label="Module name"
+            className="min-w-40"
+            onChange={e =>
+              onPatchDraft({
+                name: e.target.value,
+              })}
+          />
+        </TableCell>
+
+        <TableCell className="align-top">
+          <ModuleStatusControl
+            status={rowDraft.status}
+            disabled={disabled}
+            onChange={status => onPatchRow({
+              status,
+            })}
+          />
+        </TableCell>
+
+        <TableCell className="align-top">
+          <div className="flex items-center gap-1">
+            <div
+              className="flex items-center rounded-md border border-input"
+              role="group"
+              aria-label="Length mode"
+            >
+              <Button
+                type="button"
+                size="sm"
+                variant={draft.durationMode === "minutes" ? "secondary" : "ghost"}
+                aria-pressed={draft.durationMode === "minutes"}
+                disabled={disabled}
+                onClick={() =>
+                  onPatchDraft({
+                    durationMode: "minutes",
+                  })}
+              >
+                Min
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={draft.durationMode === "bucket" ? "secondary" : "ghost"}
+                aria-pressed={draft.durationMode === "bucket"}
+                disabled={disabled}
+                onClick={() =>
+                  onPatchDraft({
+                    durationMode: "bucket",
+                  })}
+              >
+                Range
+              </Button>
+            </div>
+            {draft.durationMode === "minutes"
+              ? (
+                <Input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={draft.minutesValue}
+                  disabled={disabled}
+                  aria-label="Length in minutes"
+                  placeholder="min"
+                  className="w-20"
+                  onChange={e =>
+                    onPatchDraft({
+                      minutesValue: e.target.value,
+                    })}
+                />
+              )
+              : (
+                <select
+                  value={draft.bucketValue}
+                  disabled={disabled}
+                  aria-label="Length range"
+                  className={selectClass}
+                  onChange={e =>
+                    onPatchDraft({
+                      bucketValue: (e.target.value || "") as
+                      | ModuleDurationBucket
+                      | "",
+                    })}
+                >
+                  <option value="">—</option>
+                  {MODULE_DURATION_BUCKETS.map(b => (
+                    <option
+                      key={b}
+                      value={b}
+                    >
+                      {MODULE_DURATION_LABELS[b]}
+                    </option>
+                  ))}
+                </select>
+              )}
+          </div>
+        </TableCell>
+
+        {showPages && (
+          <TableCell className="align-top">
+            <div className="flex items-center gap-1">
+              <Input
+                type="number"
+                min={0}
+                step={1}
+                value={draft.pageStart}
+                disabled={disabled}
+                aria-label="Start page"
+                placeholder="start"
+                className="w-20"
+                onChange={e =>
+                  onPatchDraft({
+                    pageStart: e.target.value,
+                  })}
+              />
+              <span className="text-muted-foreground">–</span>
+              <Input
+                type="number"
+                min={0}
+                step={1}
+                value={draft.pageEnd}
+                disabled={disabled}
+                aria-label="End page"
+                placeholder="end"
+                className="w-20"
+                onChange={e =>
+                  onPatchDraft({
+                    pageEnd: e.target.value,
+                  })}
+              />
+            </div>
+          </TableCell>
+        )}
+
+        <TableCell className="align-top">
+          <Input
+            type="text"
+            value={draft.url}
+            disabled={disabled}
+            aria-label={showPages ? "URL" : "Location"}
+            className="min-w-40"
+            onChange={e =>
+              onPatchDraft({
+                url: e.target.value,
+              })}
+          />
+        </TableCell>
+      </TableRow>
+
+      {expanded && (
+        <TableRow
+          className={cn(isDirty && `
+            bg-amber-50/60
+            dark:bg-amber-900/10
+          `)}
+        >
+          <TableCell />
+          <TableCell colSpan={colCount - 1}>
+            <div className="flex flex-col gap-3 pb-2">
+              <LevelTriad
+                easeOfStarting={draft.easeOfStarting}
+                timeNeeded={draft.timeNeeded}
+                interactivity={draft.interactivity}
+                onChange={onPatchDraft}
+              />
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Tags
+                </span>
+                <TagPicker
+                  value={draft.tagIds}
+                  tagGroups={tagGroups}
+                  onChange={ids => onPatchDraft({
+                    tagIds: ids,
+                  })}
+                />
+              </div>
+            </div>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/components/resources/ModuleBulkEditTable.stories.tsx
+++ b/packages/client/src/components/resources/ModuleBulkEditTable.stories.tsx
@@ -1,0 +1,162 @@
+import type { BulkSaveRow } from "./ModuleBulkEditTable";
+import type { Module, ModuleGroup, TagGroup } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ModuleBulkEditTable } from "./ModuleBulkEditTable";
+
+import { useModuleBulkEditDrafts } from "@/hooks/useModuleBulkEditDrafts";
+import {
+  makeModule,
+  makeModuleGroup,
+  makeTagGroups,
+} from "@/test-utils/resourceModulesFixtures";
+
+interface DemoProps {
+  modules: Module[];
+  groups: ModuleGroup[];
+  tagGroups: TagGroup[];
+  isBook: boolean;
+  isSaving: boolean;
+  onSaveAll: (rows: BulkSaveRow[]) => void;
+}
+
+// The table is driven by a `useModuleBulkEditDrafts` editor; this thin wrapper
+// owns it so stories can render the table with seeded module data.
+function Demo({
+  modules,
+  groups,
+  tagGroups,
+  isBook,
+  isSaving,
+  onSaveAll,
+}: DemoProps) {
+  const editor = useModuleBulkEditDrafts(modules);
+  return (
+    <ModuleBulkEditTable
+      modules={modules}
+      groups={groups}
+      tagGroups={tagGroups}
+      isBook={isBook}
+      editor={editor}
+      isSaving={isSaving}
+      onSaveAll={onSaveAll}
+    />
+  );
+}
+
+const groups = [
+  makeModuleGroup({
+    id: "g1",
+    name: "Section 1",
+  }),
+];
+
+const websiteModules: Module[] = [
+  makeModule({
+    id: "m1",
+    moduleGroupId: "g1",
+    name: "Variables",
+    status: "complete",
+  }),
+  makeModule({
+    id: "m2",
+    moduleGroupId: "g1",
+    name: "Functions",
+    status: "in_progress",
+  }),
+  makeModule({
+    id: "m3",
+    moduleGroupId: null,
+    name: "Standalone",
+  }),
+];
+
+const meta = {
+  component: Demo,
+  args: {
+    modules: websiteModules,
+    groups,
+    tagGroups: makeTagGroups(),
+    isBook: false,
+    isSaving: false,
+    onSaveAll: fn(),
+  },
+} satisfies Meta<typeof Demo>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Group")).toBeInTheDocument();
+    await expect(canvas.getByText("Status")).toBeInTheDocument();
+    await expect(canvas.getByDisplayValue("Variables")).toBeInTheDocument();
+    // Website resources omit the page-range column.
+    await expect(canvas.queryByText("Pages")).not.toBeInTheDocument();
+  },
+};
+
+export const Book: Story = {
+  args: {
+    isBook: true,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("Pages")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    modules: [],
+    groups: [],
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByText("No modules to edit yet."),
+    ).toBeInTheDocument();
+  },
+};
+
+// Editing a single cell stages exactly one changed row; "Save all" forwards only
+// that row to the save handler.
+export const EditingARow: Story = {
+  play: async ({
+    canvasElement,
+    args,
+  }) => {
+    const canvas = within(canvasElement);
+    const input = await canvas.findByDisplayValue("Variables");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Var X");
+
+    await expect(await canvas.findByText("1 unsaved change")).toBeInTheDocument();
+
+    const saveBtn = canvas.getByRole("button", {
+      name: /save all/i,
+    });
+    await expect(saveBtn).toBeEnabled();
+    await userEvent.click(saveBtn);
+
+    await expect(args.onSaveAll).toHaveBeenCalledWith([
+      expect.objectContaining({
+        groupId: "g1",
+        status: "complete",
+        draft: expect.objectContaining({
+          name: "Var X",
+        }),
+      }),
+    ]);
+  },
+};

--- a/packages/client/src/components/resources/ModuleBulkEditTable.tsx
+++ b/packages/client/src/components/resources/ModuleBulkEditTable.tsx
@@ -1,0 +1,211 @@
+import type { ModuleGroupOption } from "./ModuleBulkEditRow";
+import type { ModuleDraft } from "./moduleDrafts";
+import type { ModuleBulkEditDrafts } from "@/hooks/useModuleBulkEditDrafts";
+import type { Module, ModuleGroup, ModuleStatus, TagGroup } from "@emstack/types";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { useMemo, useState } from "react";
+
+import { Loader2, SaveIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { ModuleBulkEditRow } from "./ModuleBulkEditRow";
+
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+import { TableCell, TableRow } from "@/components/ui/table";
+
+export interface BulkSaveRow {
+  draft: ModuleDraft;
+  groupId: string | null;
+  status: ModuleStatus;
+}
+
+interface ModuleBulkEditTableProps {
+  /** Flat, display-ordered module list — also what `editor` was seeded from. */
+  modules: Module[];
+  groups: ModuleGroup[];
+  tagGroups: TagGroup[];
+  isBook: boolean;
+  editor: ModuleBulkEditDrafts;
+  isSaving: boolean;
+  onSaveAll: (rows: BulkSaveRow[]) => void;
+}
+
+/**
+ * Spreadsheet-style editor for every module of a resource. Each row's staged
+ * edits live in `editor` (`useModuleBulkEditDrafts`); "Save all" persists only
+ * the changed rows in one batch via `onSaveAll`. The bulkier effort-level / tag
+ * controls live in a per-row expandable sub-row to keep the grid scannable.
+ */
+export function ModuleBulkEditTable({
+  modules,
+  groups,
+  tagGroups,
+  isBook,
+  editor,
+  isSaving,
+  onSaveAll,
+}: ModuleBulkEditTableProps) {
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const columns = useMemo<ColumnDef<Module>[]>(() => {
+    const cols: ColumnDef<Module>[] = [
+      {
+        id: "expand",
+        header: "",
+        meta: {
+          headClassName: "w-8",
+        },
+      },
+      {
+        id: "group",
+        header: "Group",
+      },
+      {
+        id: "name",
+        header: "Name",
+      },
+      {
+        id: "status",
+        header: "Status",
+      },
+      {
+        id: "length",
+        header: "Length",
+      },
+    ];
+    if (isBook) {
+      cols.push({
+        id: "pages",
+        header: "Pages",
+      });
+    }
+    cols.push({
+      id: "url",
+      header: isBook ? "URL" : "Location",
+    });
+    return cols;
+  }, [isBook]);
+
+  const colCount = columns.length;
+
+  const groupOptions = useMemo<ModuleGroupOption[]>(
+    () => [
+      {
+        value: "",
+        label: "Ungrouped",
+      },
+      ...groups.map(g => ({
+        value: g.id,
+        label: g.name,
+      })),
+    ],
+    [groups],
+  );
+
+  const {
+    dirtyCount,
+  } = editor;
+
+  function toggleExpand(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function handleSaveAll() {
+    const rows = editor.changedRows();
+    if (rows.length === 0) return;
+    if (rows.some(r => r.draft.name.trim() === "")) {
+      toast.error("Every module needs a name.");
+      return;
+    }
+    onSaveAll(
+      rows.map(r => ({
+        draft: r.draft,
+        groupId: r.moduleGroupId,
+        status: r.status,
+      })),
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          {dirtyCount > 0
+            ? `${dirtyCount} unsaved ${dirtyCount === 1 ? "change" : "changes"}`
+            : "No unsaved changes"}
+        </p>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={editor.reset}
+            disabled={dirtyCount === 0 || isSaving}
+          >
+            Discard
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSaveAll}
+            disabled={dirtyCount === 0 || isSaving}
+          >
+            {isSaving
+              ? <Loader2 className="size-4 animate-spin" />
+              : <SaveIcon className="size-4" />}
+            Save all
+            {dirtyCount > 0 ? ` (${dirtyCount})` : ""}
+          </Button>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={modules}
+        getRowId={m => m.id}
+        containerClassName="overflow-x-auto rounded-sm border"
+        renderRow={(row) => {
+          // During the one render between a module-list change and the hook's
+          // re-seed effect, a row's draft can be momentarily absent — skip it
+          // rather than crash; the next frame fills it in.
+          const rowDraft = editor.drafts[row.original.id];
+          if (!rowDraft) return null;
+          return (
+            <ModuleBulkEditRow
+              rowDraft={rowDraft}
+              groupOptions={groupOptions}
+              tagGroups={tagGroups}
+              showPages={isBook}
+              colCount={colCount}
+              isDirty={editor.isRowDirty(row.original.id)}
+              expanded={expandedIds.has(row.original.id)}
+              disabled={isSaving}
+              onToggleExpand={() => toggleExpand(row.original.id)}
+              onPatchDraft={patch => editor.patchDraft(row.original.id, patch)}
+              onPatchRow={patch => editor.patchRow(row.original.id, patch)}
+            />
+          );
+        }}
+        renderEmpty={() => (
+          <TableRow>
+            <TableCell
+              colSpan={colCount}
+              className="text-center text-sm text-muted-foreground"
+            >
+              No modules to edit yet.
+            </TableCell>
+          </TableRow>
+        )}
+      />
+    </div>
+  );
+}

--- a/packages/client/src/components/resources/moduleAdminComponents.ts
+++ b/packages/client/src/components/resources/moduleAdminComponents.ts
@@ -6,6 +6,7 @@
 // there is no circular dependency.
 export { GroupEditCard, GroupMetaChips } from "./GroupEditCard";
 export { InteractionQuickLog } from "./InteractionQuickLog";
+export { ModuleBulkEditTable } from "./ModuleBulkEditTable";
 export { hasModuleDetails } from "./moduleDetails";
 export { ModuleDetailsPanel } from "./ModuleDetailsPanel";
 export { ModuleDisplayRow } from "./ModuleDisplayRow";

--- a/packages/client/src/hooks/useModuleAdminUiState.ts
+++ b/packages/client/src/hooks/useModuleAdminUiState.ts
@@ -41,6 +41,12 @@ export function useModuleAdminUiState() {
   // deliberately does NOT feed into `isAnyEditing`.
   const [reorderMode, setReorderMode] = useState(false);
 
+  // Bulk edit mode: when on, the group/module cards are replaced by a single
+  // editable table of every module. Like `reorderMode` it is its own full-table
+  // mode (mutually exclusive with reorder) and is deliberately kept out of
+  // `isAnyEditing` — the table owns its own staged-edit/save lifecycle.
+  const [bulkEditMode, setBulkEditMode] = useState(false);
+
   const isAnyEditing
     = editingGroupId !== null
       || creatingGroup
@@ -68,6 +74,8 @@ export function useModuleAdminUiState() {
     setLlmAssistOpen,
     reorderMode,
     setReorderMode,
+    bulkEditMode,
+    setBulkEditMode,
     isAnyEditing,
   };
 }

--- a/packages/client/src/hooks/useModuleBulkEdit.ts
+++ b/packages/client/src/hooks/useModuleBulkEdit.ts
@@ -1,0 +1,81 @@
+import type { BulkSaveRow } from "@/components/resources/ModuleBulkEditTable";
+import type { ModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import type { ResourceModulesController } from "@/hooks/useResourceModules";
+import type { Module } from "@emstack/types";
+
+import { useMemo, useState } from "react";
+
+import { useModuleBulkEditDrafts } from "@/hooks/useModuleBulkEditDrafts";
+
+/**
+ * Controller for the module bulk-edit table. Flattens the resource's modules
+ * into display order, owns the staged-edit draft state, and centralises the
+ * mode toggle + save + discard-on-exit confirmation so `ResourceModulesAdmin`
+ * stays a thin composition. The editor lives here (not in the table) so the
+ * header's exit toggle can guard unsaved edits before the table unmounts.
+ */
+export function useModuleBulkEdit(
+  api: ResourceModulesController,
+  ui: ModuleAdminUiState,
+) {
+  const {
+    groups,
+    modulesByGroup,
+    ungroupedModules,
+    bulkUpsertModulesMutation,
+  } = api;
+  const {
+    bulkEditMode,
+    setBulkEditMode,
+    setReorderMode,
+  } = ui;
+
+  const modules = useMemo<Module[]>(() => {
+    const out: Module[] = [];
+    for (const g of groups) out.push(...(modulesByGroup.get(g.id) ?? []));
+    out.push(...ungroupedModules);
+    return out;
+  }, [groups, modulesByGroup, ungroupedModules]);
+
+  const editor = useModuleBulkEditDrafts(modules);
+  const [confirmExitOpen, setConfirmExitOpen] = useState(false);
+
+  function toggle() {
+    if (bulkEditMode) {
+      if (editor.dirtyCount > 0) {
+        setConfirmExitOpen(true);
+        return;
+      }
+      setBulkEditMode(false);
+    }
+    else {
+      setReorderMode(false);
+      setBulkEditMode(true);
+    }
+  }
+
+  function saveAll(rows: BulkSaveRow[]) {
+    bulkUpsertModulesMutation.mutate(rows);
+  }
+
+  function confirmExit() {
+    editor.reset();
+    setBulkEditMode(false);
+    setConfirmExitOpen(false);
+  }
+
+  function cancelExit() {
+    setConfirmExitOpen(false);
+  }
+
+  return {
+    modules,
+    editor,
+    isSaving: bulkUpsertModulesMutation.isPending,
+    confirmExitOpen,
+    toggle,
+    saveAll,
+    confirmExit,
+    cancelExit,
+  };
+}

--- a/packages/client/src/hooks/useModuleBulkEditDrafts.test.ts
+++ b/packages/client/src/hooks/useModuleBulkEditDrafts.test.ts
@@ -1,0 +1,184 @@
+import type { Module } from "@emstack/types";
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { useModuleBulkEditDrafts } from "./useModuleBulkEditDrafts";
+
+import { makeModule } from "@/test-utils/resourceModulesFixtures";
+
+// The hook re-seeds whenever the `modules` array reference changes (production
+// passes a `useMemo`-stabilised array). Each test therefore builds its module
+// list once and passes that stable reference to `renderHook`.
+function twoModules(): Module[] {
+  return [
+    makeModule({
+      id: "m1",
+      name: "One",
+      status: "unstarted",
+    }),
+    makeModule({
+      id: "m2",
+      name: "Two",
+      status: "in_progress",
+    }),
+  ];
+}
+
+describe("useModuleBulkEditDrafts", () => {
+  test("seeds a draft per module with no dirty rows", () => {
+    const mods = twoModules();
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(mods));
+    expect(Object.keys(result.current.drafts)).toEqual(["m1", "m2"]);
+    expect(result.current.dirtyCount).toBe(0);
+    expect(result.current.changedRows()).toEqual([]);
+    expect(result.current.drafts.m1.draft.name).toBe("One");
+    expect(result.current.drafts.m2.status).toBe("in_progress");
+  });
+
+  test("patchDraft marks only that row dirty", () => {
+    const mods = twoModules();
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(mods));
+    act(() =>
+      result.current.patchDraft("m1", {
+        name: "Changed",
+      }));
+    expect(result.current.isRowDirty("m1")).toBe(true);
+    expect(result.current.isRowDirty("m2")).toBe(false);
+    expect(result.current.dirtyCount).toBe(1);
+    expect(result.current.changedRows().map(r => r.draft.id)).toEqual(["m1"]);
+    expect(result.current.changedRows()[0].draft.name).toBe("Changed");
+  });
+
+  test("patchRow status change marks the row dirty", () => {
+    const mods = twoModules();
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(mods));
+    act(() =>
+      result.current.patchRow("m2", {
+        status: "complete",
+      }));
+    expect(result.current.isRowDirty("m2")).toBe(true);
+    expect(result.current.changedRows()[0].status).toBe("complete");
+  });
+
+  test("group reassignment marks the row dirty", () => {
+    const mods = twoModules();
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(mods));
+    act(() =>
+      result.current.patchRow("m1", {
+        moduleGroupId: "g9",
+      }));
+    expect(result.current.isRowDirty("m1")).toBe(true);
+  });
+
+  test("reordering tags is not a change", () => {
+    const tagged: Module[] = [
+      makeModule({
+        id: "m1",
+        tags: [
+          {
+            id: "t1",
+            groupId: "g",
+            name: "a",
+            color: null,
+            position: 0,
+          },
+          {
+            id: "t2",
+            groupId: "g",
+            name: "b",
+            color: null,
+            position: 1,
+          },
+        ],
+      }),
+    ];
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(tagged));
+    act(() =>
+      result.current.patchDraft("m1", {
+        tagIds: ["t2", "t1"],
+      }));
+    expect(result.current.isRowDirty("m1")).toBe(false);
+    expect(result.current.dirtyCount).toBe(0);
+  });
+
+  test("a no-op length mode toggle is not a change", () => {
+    const noLength: Module[] = [
+      makeModule({
+        id: "m1",
+        length: null,
+      }),
+    ];
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(noLength));
+    act(() =>
+      result.current.patchDraft("m1", {
+        durationMode: "bucket",
+      }));
+    expect(result.current.isRowDirty("m1")).toBe(false);
+  });
+
+  test("reset clears staged edits", () => {
+    const mods = twoModules();
+    const {
+      result,
+    } = renderHook(() => useModuleBulkEditDrafts(mods));
+    act(() =>
+      result.current.patchDraft("m1", {
+        name: "Changed",
+      }));
+    expect(result.current.dirtyCount).toBe(1);
+    act(() => result.current.reset());
+    expect(result.current.dirtyCount).toBe(0);
+    expect(result.current.drafts.m1.draft.name).toBe("One");
+  });
+
+  test("re-seeds when the source module list changes", () => {
+    const {
+      result, rerender,
+    } = renderHook(
+      ({
+        mods,
+      }: { mods: Module[] }) => useModuleBulkEditDrafts(mods),
+      {
+        initialProps: {
+          mods: twoModules(),
+        },
+      },
+    );
+    act(() =>
+      result.current.patchDraft("m1", {
+        name: "Changed",
+      }));
+    expect(result.current.dirtyCount).toBe(1);
+    // A refetch returns the saved value: dirtiness clears and the new baseline
+    // reflects the persisted name.
+    rerender({
+      mods: [
+        makeModule({
+          id: "m1",
+          name: "Changed",
+          status: "unstarted",
+        }),
+        makeModule({
+          id: "m2",
+          name: "Two",
+          status: "in_progress",
+        }),
+      ],
+    });
+    expect(result.current.dirtyCount).toBe(0);
+    expect(result.current.drafts.m1.draft.name).toBe("Changed");
+  });
+});

--- a/packages/client/src/hooks/useModuleBulkEditDrafts.ts
+++ b/packages/client/src/hooks/useModuleBulkEditDrafts.ts
@@ -1,0 +1,156 @@
+import type { ModuleDraft } from "@/components/resources/moduleDrafts";
+import type { Module, ModuleStatus } from "@emstack/types";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { draftToLength, moduleToDraft } from "@/components/resources/moduleDrafts";
+
+/**
+ * One editable row of the bulk-edit table. `ModuleDraft` carries the form-shaped
+ * scalar fields (name, url, pages, length, levels, tags); `status` and
+ * `moduleGroupId` live outside the draft because they ride alongside it into the
+ * upsert mutation, so they are tracked here rather than baked into `ModuleDraft`.
+ */
+export interface ModuleRowDraft {
+  draft: ModuleDraft;
+  status: ModuleStatus;
+  moduleGroupId: string | null;
+}
+
+export function moduleToRowDraft(m: Module): ModuleRowDraft {
+  return {
+    draft: moduleToDraft(m),
+    status: m.status,
+    moduleGroupId: m.moduleGroupId ?? null,
+  };
+}
+
+function seedDrafts(modules: Module[]): Record<string, ModuleRowDraft> {
+  const out: Record<string, ModuleRowDraft> = {};
+  for (const m of modules) out[m.id] = moduleToRowDraft(m);
+  return out;
+}
+
+function sameTagSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every(id => set.has(id));
+}
+
+/**
+ * Whether two row drafts would persist identically. Length is compared by its
+ * persisted value (via `draftToLength`) so a no-op minutes/range mode toggle
+ * doesn't read as a change, and tags are compared order-insensitively.
+ */
+export function rowDraftsEqual(a: ModuleRowDraft, b: ModuleRowDraft): boolean {
+  if (a.status !== b.status) return false;
+  if (a.moduleGroupId !== b.moduleGroupId) return false;
+  const da = a.draft;
+  const db = b.draft;
+  return (
+    da.name === db.name
+    && da.description === db.description
+    && da.url === db.url
+    && da.pageStart === db.pageStart
+    && da.pageEnd === db.pageEnd
+    && draftToLength(da) === draftToLength(db)
+    && da.easeOfStarting === db.easeOfStarting
+    && da.timeNeeded === db.timeNeeded
+    && da.interactivity === db.interactivity
+    && sameTagSet(da.tagIds, db.tagIds)
+  );
+}
+
+/**
+ * Staged per-row edit state for the module bulk-edit table. Seeds a draft for
+ * every module, exposes per-field patchers, tracks which rows differ from their
+ * original ("dirty"), and re-seeds whenever the source module list changes (e.g.
+ * after a save + refetch). A background refetch therefore discards unsaved local
+ * edits — the same trade-off the single-card editors make.
+ */
+export function useModuleBulkEditDrafts(modules: Module[]) {
+  const [drafts, setDrafts] = useState<Record<string, ModuleRowDraft>>(() =>
+    seedDrafts(modules));
+
+  useEffect(() => {
+    setDrafts(seedDrafts(modules));
+  }, [modules]);
+
+  const baselineById = useMemo(() => {
+    const map = new Map<string, ModuleRowDraft>();
+    for (const m of modules) map.set(m.id, moduleToRowDraft(m));
+    return map;
+  }, [modules]);
+
+  const patchDraft = useCallback((id: string, patch: Partial<ModuleDraft>) => {
+    setDrafts((prev) => {
+      const row = prev[id];
+      if (!row) return prev;
+      return {
+        ...prev,
+        [id]: {
+          ...row,
+          draft: {
+            ...row.draft,
+            ...patch,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const patchRow = useCallback(
+    (
+      id: string,
+      patch: { status?: ModuleStatus;
+        moduleGroupId?: string | null; },
+    ) => {
+      setDrafts((prev) => {
+        const row = prev[id];
+        if (!row) return prev;
+        return {
+          ...prev,
+          [id]: {
+            ...row,
+            ...patch,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const isRowDirty = useCallback(
+    (id: string) => {
+      const cur = drafts[id];
+      const base = baselineById.get(id);
+      if (!cur || !base) return false;
+      return !rowDraftsEqual(cur, base);
+    },
+    [drafts, baselineById],
+  );
+
+  const dirtyIds = useMemo(
+    () => Object.keys(drafts).filter(id => isRowDirty(id)),
+    [drafts, isRowDirty],
+  );
+
+  const changedRows = useCallback(
+    () => dirtyIds.map(id => drafts[id]),
+    [dirtyIds, drafts],
+  );
+
+  const reset = useCallback(() => setDrafts(seedDrafts(modules)), [modules]);
+
+  return {
+    drafts,
+    patchDraft,
+    patchRow,
+    isRowDirty,
+    dirtyCount: dirtyIds.length,
+    changedRows,
+    reset,
+  };
+}
+
+export type ModuleBulkEditDrafts = ReturnType<typeof useModuleBulkEditDrafts>;

--- a/packages/client/src/hooks/useModuleBulkEditDrafts.ts
+++ b/packages/client/src/hooks/useModuleBulkEditDrafts.ts
@@ -42,7 +42,7 @@ function sameTagSet(a: string[], b: string[]): boolean {
  * persisted value (via `draftToLength`) so a no-op minutes/range mode toggle
  * doesn't read as a change, and tags are compared order-insensitively.
  */
-export function rowDraftsEqual(a: ModuleRowDraft, b: ModuleRowDraft): boolean {
+function rowDraftsEqual(a: ModuleRowDraft, b: ModuleRowDraft): boolean {
   if (a.status !== b.status) return false;
   if (a.moduleGroupId !== b.moduleGroupId) return false;
   const da = a.draft;

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -241,6 +241,49 @@ export function useResourceModules(resourceId: string) {
     onError: (e: Error) => toast.error(e.message),
   });
 
+  // Bulk edit: persist a batch of edited module rows in one shot. Each row
+  // carries a ModuleDraft plus the status/group that live outside the draft, so
+  // the payload mirrors `upsertModuleMutation` exactly. Parallel upserts match
+  // the `reorderModulesListMutation` precedent; a single invalidate + toast.
+  const bulkUpsertModulesMutation = useMutation({
+    mutationFn: (
+      rows: {
+        draft: ModuleDraft;
+        groupId: string | null;
+        status: ModuleStatus;
+      }[],
+    ) =>
+      Promise.all(
+        rows.map(({
+          draft,
+          groupId,
+          status,
+        }) =>
+          upsertModule(draft.id, {
+            resourceId,
+            moduleGroupId: groupId,
+            name: draft.name,
+            description: draft.description || null,
+            url: draft.url || null,
+            length: draftToLength(draft),
+            pageStart: parseCount(draft.pageStart),
+            pageEnd: parseCount(draft.pageEnd),
+            status,
+            easeOfStarting: draft.easeOfStarting || null,
+            timeNeeded: draft.timeNeeded || null,
+            interactivity: draft.interactivity || null,
+            tagIds: draft.tagIds,
+          })),
+      ),
+    onSuccess: (_data, rows) => {
+      invalidateAll();
+      toast.success(
+        `Saved ${rows.length} ${rows.length === 1 ? "module" : "modules"}`,
+      );
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
   const setStatusMutation = useMutation({
     mutationFn: ({
       module: m,
@@ -500,6 +543,7 @@ export function useResourceModules(resourceId: string) {
     deleteGroupMutation,
     createModuleMutation,
     upsertModuleMutation,
+    bulkUpsertModulesMutation,
     setStatusMutation,
     deleteModuleMutation,
     setModulesExhaustiveMutation,

--- a/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupList.tsx
+++ b/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupList.tsx
@@ -1,0 +1,64 @@
+import type { ModuleAdminSectionProps } from "../-moduleAdminSectionProps";
+
+import { DndContext } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+
+import {
+  handleListDragEnd,
+  reorderCollisionDetection,
+  reorderModifiers,
+  useReorderSensors,
+} from "../-reorderDnd";
+import { ModuleGroupSection } from "./-ModuleGroupSection";
+
+/**
+ * Renders the resource's module groups, wrapping them in the drag-and-drop
+ * reorder context only while `ui.reorderMode` is on. Extracted from
+ * `ResourceModulesAdmin` so the dnd-kit wiring lives in one place and the shell
+ * stays a thin composition.
+ */
+export function ModuleGroupList({
+  resourceId,
+  api,
+  ui,
+}: ModuleAdminSectionProps) {
+  const sensors = useReorderSensors();
+  const {
+    groups, reorderGroupsList,
+  } = api;
+  const {
+    reorderMode,
+  } = ui;
+
+  const sections = groups.map((g, gIndex) => (
+    <ModuleGroupSection
+      key={g.id}
+      group={g}
+      groupIndex={gIndex}
+      resourceId={resourceId}
+      api={api}
+      ui={ui}
+    />
+  ));
+
+  if (!reorderMode) return <>{sections}</>;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={reorderCollisionDetection}
+      modifiers={reorderModifiers}
+      onDragEnd={e => handleListDragEnd(e, groups, reorderGroupsList)}
+    >
+      <SortableContext
+        items={groups.map(g => g.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        {sections}
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/packages/client/src/routes/resources/$id/-components/grouping/index.ts
+++ b/packages/client/src/routes/resources/$id/-components/grouping/index.ts
@@ -1,5 +1,5 @@
 // Public surface of the module-admin grouping family — the list sections the
-// shell renders. All compose the shared -item leaf and the root -reorderDnd util.
+// shell renders. Both compose the shared -item leaf and the root -reorderDnd
+// util; ModuleGroupList wraps the per-group sections in the reorder context.
 export { ModuleGroupList } from "./-ModuleGroupList";
-export { ModuleGroupSection } from "./-ModuleGroupSection";
 export { UngroupedModulesSection } from "./-UngroupedModulesSection";

--- a/packages/client/src/routes/resources/$id/-components/grouping/index.ts
+++ b/packages/client/src/routes/resources/$id/-components/grouping/index.ts
@@ -1,4 +1,5 @@
-// Public surface of the module-admin grouping family — the two list sections the
-// shell renders. Both compose the shared -item leaf and the root -reorderDnd util.
+// Public surface of the module-admin grouping family — the list sections the
+// shell renders. All compose the shared -item leaf and the root -reorderDnd util.
+export { ModuleGroupList } from "./-ModuleGroupList";
 export { ModuleGroupSection } from "./-ModuleGroupSection";
 export { UngroupedModulesSection } from "./-UngroupedModulesSection";

--- a/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.stories.tsx
+++ b/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { fn } from "storybook/test";
+
 import { ModuleAdminHeader } from "./-ModuleAdminHeader";
 
 import { useModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
@@ -23,6 +25,7 @@ function Host({
     <ModuleAdminHeader
       resourceId={RESOURCE_ID}
       canEditExhaustive={canEditExhaustive}
+      onToggleBulkEdit={fn()}
       api={api}
       ui={ui}
     />

--- a/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.tsx
+++ b/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.tsx
@@ -6,6 +6,7 @@ import {
   InfoIcon,
   PlusIcon,
   SparklesIcon,
+  Table2Icon,
 } from "lucide-react";
 
 import { ModuleAssistDialog } from "./-ModuleAssistDialog";
@@ -18,6 +19,11 @@ import { cn } from "@/lib/utils";
 interface ModuleAdminHeaderProps extends ModuleAdminSectionProps {
   /** When true, render the editable "module list is exhaustive" toggle. */
   canEditExhaustive?: boolean;
+  /**
+   * Toggle the bulk-edit table on/off. Owned by the parent so it can guard exit
+   * with an unsaved-changes confirmation (the staged edits live up there).
+   */
+  onToggleBulkEdit: () => void;
 }
 
 /**
@@ -27,6 +33,7 @@ interface ModuleAdminHeaderProps extends ModuleAdminSectionProps {
 export function ModuleAdminHeader({
   resourceId,
   canEditExhaustive,
+  onToggleBulkEdit,
   api,
   ui,
 }: ModuleAdminHeaderProps) {
@@ -44,7 +51,13 @@ export function ModuleAdminHeader({
     setCreatingGroup,
     reorderMode,
     setReorderMode,
+    bulkEditMode,
   } = ui;
+
+  // Bulk edit and reorder are conflicting full-table modes; the other actions
+  // are meaningless while the bulk table is open. `isAnyEditing` already covers
+  // the per-card edit/create slots.
+  const otherActionsDisabled = isAnyEditing || bulkEditMode;
 
   const percentComplete
     = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
@@ -66,17 +79,28 @@ export function ModuleAdminHeader({
             variant="outline"
             size="sm"
             onClick={() => setLlmAssistOpen(true)}
-            disabled={isAnyEditing}
+            disabled={otherActionsDisabled}
             title="Suggest module groups and modules via Claude"
           >
             <SparklesIcon className="size-4" />
             LLM Assist
           </Button>
           <Button
+            variant={bulkEditMode ? "secondary" : "outline"}
+            size="sm"
+            onClick={onToggleBulkEdit}
+            disabled={isAnyEditing || reorderMode}
+            aria-pressed={bulkEditMode}
+            title="Edit all modules in a table"
+          >
+            <Table2Icon className="size-4" />
+            Bulk Edit
+          </Button>
+          <Button
             variant={reorderMode ? "secondary" : "outline"}
             size="sm"
             onClick={() => setReorderMode(!reorderMode)}
-            disabled={isAnyEditing}
+            disabled={otherActionsDisabled}
             aria-pressed={reorderMode}
             title="Toggle reordering of groups and modules"
           >
@@ -87,7 +111,7 @@ export function ModuleAdminHeader({
             variant="outline"
             size="sm"
             onClick={() => setCreatingModuleIn(UNGROUPED_KEY)}
-            disabled={isAnyEditing}
+            disabled={otherActionsDisabled}
           >
             <PlusIcon className="size-4" />
             Add
@@ -98,7 +122,7 @@ export function ModuleAdminHeader({
             variant="outline"
             size="sm"
             onClick={() => setCreatingGroup(true)}
-            disabled={isAnyEditing}
+            disabled={otherActionsDisabled}
           >
             <PlusIcon className="size-4" />
             New

--- a/packages/client/src/routes/resources/$id/-components/shell/-ResourceModulesAdmin.tsx
+++ b/packages/client/src/routes/resources/$id/-components/shell/-ResourceModulesAdmin.tsx
@@ -1,21 +1,14 @@
-import { DndContext } from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-
-import {
-  handleListDragEnd,
-  reorderCollisionDetection,
-  reorderModifiers,
-  useReorderSensors,
-} from "../-reorderDnd";
-import { ModuleGroupSection, UngroupedModulesSection } from "../grouping";
+import { ModuleGroupList, UngroupedModulesSection } from "../grouping";
 import { ModuleAdminHeader } from "../header";
 
-import { GroupEditCard } from "@/components/resources/moduleAdminComponents";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import {
+  GroupEditCard,
+  ModuleBulkEditTable,
+} from "@/components/resources/moduleAdminComponents";
 import { emptyGroupDraft } from "@/components/resources/moduleDrafts";
 import { useModuleAdminUiState } from "@/hooks/useModuleAdminUiState";
+import { useModuleBulkEdit } from "@/hooks/useModuleBulkEdit";
 import { useResourceModules } from "@/hooks/useResourceModules";
 
 interface Props {
@@ -29,21 +22,20 @@ export function ResourceModulesAdmin({
 }: Props) {
   const api = useResourceModules(resourceId);
   const ui = useModuleAdminUiState();
-  const sensors = useReorderSensors();
+  const bulk = useModuleBulkEdit(api, ui);
 
   const {
     tagGroups,
     groups,
     ungroupedModules,
     createGroupMutation,
-    reorderGroupsList,
     isBook,
     groupLabel,
     moduleLabel,
     groupHint,
   } = api;
   const {
-    creatingGroup, setCreatingGroup, creatingModuleIn, reorderMode,
+    creatingGroup, setCreatingGroup, creatingModuleIn, bulkEditMode,
   } = ui;
 
   const isEmpty
@@ -57,78 +49,80 @@ export function ResourceModulesAdmin({
       <ModuleAdminHeader
         resourceId={resourceId}
         canEditExhaustive={canEditExhaustive}
+        onToggleBulkEdit={bulk.toggle}
         api={api}
         ui={ui}
       />
 
-      {creatingGroup && (
-        <GroupEditCard
-          draft={emptyGroupDraft()}
-          hasEnumeratedModules={false}
-          tagGroups={tagGroups}
-          showPages={isBook}
-          groupLabel={groupLabel}
-          groupNamePlaceholder={groupHint}
-          isNew
-          isSaving={createGroupMutation.isPending}
-          onSave={d =>
-            createGroupMutation.mutate(d, {
-              onSuccess: () => setCreatingGroup(false),
-            })}
-          onCancel={() => setCreatingGroup(false)}
-        />
-      )}
-
-      <UngroupedModulesSection
-        resourceId={resourceId}
-        api={api}
-        ui={ui}
-      />
-
-      {reorderMode
+      {bulkEditMode
         ? (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={reorderCollisionDetection}
-            modifiers={reorderModifiers}
-            onDragEnd={e => handleListDragEnd(e, groups, reorderGroupsList)}
-          >
-            <SortableContext
-              items={groups.map(g => g.id)}
-              strategy={verticalListSortingStrategy}
-            >
-              {groups.map((g, gIndex) => (
-                <ModuleGroupSection
-                  key={g.id}
-                  group={g}
-                  groupIndex={gIndex}
-                  resourceId={resourceId}
-                  api={api}
-                  ui={ui}
-                />
-              ))}
-            </SortableContext>
-          </DndContext>
+          <ModuleBulkEditTable
+            modules={bulk.modules}
+            groups={groups}
+            tagGroups={tagGroups}
+            isBook={isBook}
+            editor={bulk.editor}
+            isSaving={bulk.isSaving}
+            onSaveAll={bulk.saveAll}
+          />
         )
         : (
-          groups.map((g, gIndex) => (
-            <ModuleGroupSection
-              key={g.id}
-              group={g}
-              groupIndex={gIndex}
+          <>
+            {creatingGroup && (
+              <GroupEditCard
+                draft={emptyGroupDraft()}
+                hasEnumeratedModules={false}
+                tagGroups={tagGroups}
+                showPages={isBook}
+                groupLabel={groupLabel}
+                groupNamePlaceholder={groupHint}
+                isNew
+                isSaving={createGroupMutation.isPending}
+                onSave={d =>
+                  createGroupMutation.mutate(d, {
+                    onSuccess: () => setCreatingGroup(false),
+                  })}
+                onCancel={() => setCreatingGroup(false)}
+              />
+            )}
+
+            <UngroupedModulesSection
               resourceId={resourceId}
               api={api}
               ui={ui}
             />
-          ))
+
+            <ModuleGroupList
+              resourceId={resourceId}
+              api={api}
+              ui={ui}
+            />
+
+            {isEmpty && (
+              <p className="text-sm text-muted-foreground">
+                No {moduleLabel.toLowerCase()}s yet. Add a
+                {" "}
+                {moduleLabel.toLowerCase()}
+                {" "}
+                directly, or create a
+                {" "}
+                {groupLabel.toLowerCase()}
+                {" "}
+                to organize them.
+              </p>
+            )}
+          </>
         )}
 
-      {isEmpty && (
-        <p className="text-sm text-muted-foreground">
-          No {moduleLabel.toLowerCase()}s yet. Add a {moduleLabel.toLowerCase()}{" "}
-          directly, or create a {groupLabel.toLowerCase()} to organize them.
-        </p>
-      )}
+      <ConfirmDialog
+        open={bulk.confirmExitOpen}
+        title="Discard unsaved edits?"
+        description="You have unsaved changes in the bulk editor. Leaving will discard them."
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+        onConfirm={bulk.confirmExit}
+        onCancel={bulk.cancelExit}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a spreadsheet-style bulk-edit interface for modules, allowing users to edit multiple modules at once in a single table view with staged changes and batch persistence. The feature is toggled via a new button in the module admin header and includes an unsaved-changes confirmation guard.

## Key Changes

- **New `ModuleBulkEditTable` component** (`ModuleBulkEditTable.tsx`): A data-table wrapper that renders one editable row per module with inline cells for name, status, group, length, pages (books only), and URL. Includes a "Save all" button that persists only changed rows in a single batch mutation.

- **New `ModuleBulkEditRow` component** (`ModuleBulkEditRow.tsx`): A pure, controlled row component with an expand toggle that reveals a sub-row containing the bulkier effort-level controls (`LevelTriad`) and tag picker. Keeps the main grid scannable by hiding secondary fields.

- **New `useModuleBulkEditDrafts` hook** (`useModuleBulkEditDrafts.ts`): Manages staged per-row edit state, tracks which rows differ from their baseline (dirty), and re-seeds when the source module list changes (e.g., after a save + refetch). Includes smart equality checking that treats tag reordering and no-op length-mode toggles as non-changes.

- **New `useModuleBulkEdit` hook** (`useModuleBulkEdit.ts`): High-level controller that flattens the resource's modules into display order, owns the editor state, and centralizes the mode toggle + save + unsaved-changes confirmation. Allows the header to guard exit before the table unmounts.

- **Updated `ResourceModulesAdmin` shell** (`-ResourceModulesAdmin.tsx`): Conditionally renders either the bulk-edit table (when `bulkEditMode` is on) or the normal group/module card layout. Integrates the new `useModuleBulkEdit` hook and passes the toggle callback to the header.

- **Updated `ModuleAdminHeader`** (`-ModuleAdminHeader.tsx`): Adds a new "Bulk edit" button (table icon) that toggles bulk-edit mode via the `onToggleBulkEdit` callback.

- **Updated `useModuleAdminUiState`** (`useModuleAdminUiState.ts`): Adds `bulkEditMode` and `setBulkEditMode` state to track whether the bulk-edit table is visible.

- **Updated `useResourceModules`** (`useResourceModules.ts`): Adds `bulkUpsertModulesMutation` that persists a batch of edited module rows in parallel, mirroring the existing `upsertModuleMutation` payload structure.

- **New `ModuleGroupList` component** (`-ModuleGroupList.tsx`): Extracted the group-list rendering and drag-and-drop reorder context from the shell so the dnd-kit wiring lives in one place and the shell stays a thin composition.

- **Comprehensive test coverage** (`useModuleBulkEditDrafts.test.ts`): Unit tests for the draft hook covering seeding, dirty tracking, equality logic, and re-seeding on module-list changes.

- **Storybook stories** (`ModuleBulkEditTable.stories.tsx`, `ModuleBulkEditRow.stories.tsx`): Interactive stories demonstrating the table and row components in various states (website vs. book, expanded, editing, empty).

## Notable Implementation Details

- **Dirty tracking:** Rows are compared order-insensitively for tags and by persisted length value (so a minutes→range toggle with no actual change doesn't mark the row dirty).
- **Re-seeding on refetch:** When the source module list changes (e.g., after a successful save), the editor re-seeds and clears all staged edits. This matches the single-card editor trade-off.
- **Unsaved-changes guard:** The bulk-edit toggle checks `editor.dirtyCount` and shows a confirmation dialog before exiting if there are unsaved changes.
- **Batch mutation:** All changed rows are persisted in parallel via `bulkUps

https://claude.ai/code/session_019YbJppTy8wNiXqMZXYeiZk