### PR TITLE
refactor(client): move external link to header controls

### DIFF
--- a/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.stories.tsx
+++ b/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.stories.tsx
@@ -19,14 +19,37 @@ const group: ModuleGroup = makeModuleGroup({
   name: "Section 1: Fundamentals",
 });
 
+const linkedGroup: ModuleGroup = makeModuleGroup({
+  id: "g1",
+  name: "Section 1: Fundamentals",
+  url: "https://example.com/section-1",
+});
+
+const modules = [
+  makeModule({
+    id: "m1",
+    moduleGroupId: "g1",
+    name: "Variables",
+    status: "complete",
+  }),
+  makeModule({
+    id: "m2",
+    moduleGroupId: "g1",
+    name: "Functions",
+    status: "in_progress",
+  }),
+];
+
 // One group rendered against the live controllers; its enumerated modules come
 // from the seeded modules query (matched by moduleGroupId).
-function Host() {
+function Host({
+  group: g,
+}: { group: ModuleGroup }) {
   const api = useResourceModules(RESOURCE_ID);
   const ui = useModuleAdminUiState();
   return (
     <ModuleGroupSection
-      group={group}
+      group={g}
       groupIndex={0}
       resourceId={RESOURCE_ID}
       api={api}
@@ -37,26 +60,13 @@ function Host() {
 
 const meta: Meta<typeof ModuleGroupSection> = {
   component: ModuleGroupSection,
-  render: () => <Host />,
+  render: () => <Host group={group} />,
   decorators: [
     queryStubDecorator(
       () =>
         seededModuleAdminClient({
           groups: [group],
-          modules: [
-            makeModule({
-              id: "m1",
-              moduleGroupId: "g1",
-              name: "Variables",
-              status: "complete",
-            }),
-            makeModule({
-              id: "m2",
-              moduleGroupId: "g1",
-              name: "Functions",
-              status: "in_progress",
-            }),
-          ],
+          modules,
         }),
       {
         className: "max-w-2xl",
@@ -70,3 +80,21 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+// A group carrying an http(s) url renders the external-link button beside the
+// edit (pencil) control in the header.
+export const Linked: Story = {
+  render: () => <Host group={linkedGroup} />,
+  decorators: [
+    queryStubDecorator(
+      () =>
+        seededModuleAdminClient({
+          groups: [linkedGroup],
+          modules,
+        }),
+      {
+        className: "max-w-2xl",
+      },
+    ),
+  ],
+};

--- a/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
+++ b/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
@@ -72,7 +72,10 @@ function PageRange({
   );
 }
 
-/** The group title — a link when it carries an http(s) url, plain text otherwise. */
+/**
+ * The group title — plain text (the external link, when present, is its own
+ * button in the header controls). A non-http url is surfaced as a tooltip.
+ */
 function GroupTitle({
   group: g,
 }: { group: ModuleGroup }) {
@@ -82,15 +85,7 @@ function GroupTitle({
       end={g.pageEnd}
     />
   );
-  if (!g.url) {
-    return (
-      <>
-        {g.name}
-        {pages}
-      </>
-    );
-  }
-  if (!isHttpUrl(g.url)) {
+  if (g.url && !isHttpUrl(g.url)) {
     return (
       <>
         <span title={g.url}>{g.name}</span>
@@ -100,17 +95,7 @@ function GroupTitle({
   }
   return (
     <>
-      <a
-        href={g.url}
-        target="_blank"
-        rel="noreferrer"
-        className="hover:text-blue-600"
-        onClick={e => e.stopPropagation()}
-      >
-        {g.name}
-        {" "}
-        <ExternalLinkIcon className="inline size-3.5" />
-      </a>
+      {g.name}
       {pages}
     </>
   );
@@ -128,7 +113,6 @@ function GroupStatusBadge({
       className={cn(
         `
           inline-flex size-5 shrink-0 items-center justify-center rounded-full
-          border-2
           [&_svg]:size-3.5
         `,
         option.circleClass,
@@ -259,6 +243,24 @@ function GroupHeaderControls({
       >
         <PencilIcon className="size-3.5" />
       </Button>
+      {g.url && isHttpUrl(g.url) && (
+        <Button
+          asChild
+          size="icon-sm"
+          variant="ghost"
+          aria-label={`Open link for ${g.name}`}
+          title="Open link"
+        >
+          <a
+            href={g.url}
+            target="_blank"
+            rel="noreferrer"
+            onClick={e => e.stopPropagation()}
+          >
+            <ExternalLinkIcon className="size-3.5" />
+          </a>
+        </Button>
+      )}
     </div>
   );
 }
@@ -457,10 +459,10 @@ export function ModuleGroupSection({
                   <ChevronDownIcon className="size-4" />
                 )}
             </button>
+            <GroupStatusBadge status={groupStatus} />
             <h3 className="font-medium">
               <GroupTitle group={g} />
             </h3>
-            <GroupStatusBadge status={groupStatus} />
           </div>
           {g.description && (
             <span className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Refactored the module group section UI to move the external link affordance from the group title to a dedicated button in the header controls, improving visual hierarchy and interaction patterns.

## Key Changes

- **GroupTitle component:** Removed the inline external link rendering; now displays plain text for HTTP URLs and tooltips for non-HTTP URLs
- **GroupHeaderControls component:** Added a new external link button that appears only when a group has an HTTP(s) URL, positioned alongside the edit (pencil) button
- **Header layout:** Reordered the group header to place the status badge before the title for better visual flow
- **Status badge styling:** Removed the `border-2` class from GroupStatusBadge
- **Story refactoring:** 
  - Extracted shared `modules` array to avoid duplication
  - Made the `Host` component accept a `group` prop for flexibility
  - Added a new `Linked` story to demonstrate the external link button behavior with a group that has a URL

## Implementation Details

- The external link button uses the same `Button` component with `asChild` to wrap an anchor tag, maintaining consistent styling with other header controls
- The link button only renders when `g.url && isHttpUrl(g.url)` is true, keeping non-HTTP URLs as tooltips in the title
- Event propagation is stopped on the link click to prevent unintended interactions with the collapsible group header

https://claude.ai/code/session_01MvtVmtP6SCKKkwvLaomM7U