### PR TITLE
feat(client): add bulk module creation from textarea input

### DIFF
--- a/packages/client/src/components/resources/ModuleBulkAddCard.stories.tsx
+++ b/packages/client/src/components/resources/ModuleBulkAddCard.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ModuleBulkAddCard } from "./ModuleBulkAddCard";
+
+import { constrainedStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokePlay } from "@/test-utils/storyPlay";
+
+const meta: Meta<typeof ModuleBulkAddCard> = {
+  component: ModuleBulkAddCard,
+  args: {
+    moduleLabel: "Module",
+    isSaving: false,
+    onSave: fn(),
+    onCancel: fn(),
+  },
+  decorators: [constrainedStoryDecorator("max-w-xl")],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: smokePlay([
+    {
+      text: "Module names — one per line",
+    },
+    {
+      text: "No modules yet",
+    },
+  ]),
+};
+
+// Typing several lines enables the Add button and reflects the parsed count;
+// submitting fires onSave with the trimmed, blank-stripped names in order.
+export const AddsTypedNames: Story = {
+  play: async ({
+    args,
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole("textbox");
+    await userEvent.type(textarea, "Intro\n\n  Setup  \nWrap up");
+
+    const addButton = canvas.getByRole("button", {
+      name: /Add 3/,
+    });
+    await expect(addButton).toBeEnabled();
+
+    await userEvent.click(addButton);
+    await expect(args.onSave).toHaveBeenCalledWith(["Intro", "Setup", "Wrap up"]);
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+};

--- a/packages/client/src/components/resources/ModuleBulkAddCard.tsx
+++ b/packages/client/src/components/resources/ModuleBulkAddCard.tsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from "react";
+
+import { Loader2 } from "lucide-react";
+
+import { parseBulkModuleNames } from "./moduleDrafts";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+/**
+ * Inline card for adding several modules to a group at once: one module name per
+ * line. Only names are captured here — every other field takes its default and
+ * can be filled in afterwards via the edit card or the bulk-edit table. Saving
+ * is disabled until at least one non-blank line is present.
+ */
+export function ModuleBulkAddCard({
+  isSaving = false,
+  moduleLabel = "Module",
+  moduleNamePlaceholder,
+  onSave,
+  onCancel,
+}: {
+  isSaving?: boolean;
+  /** Per-resource label for a module (e.g. "Lesson"). */
+  moduleLabel?: string;
+  /** Hint (placeholder) for the name lines, from the resource's hint template. */
+  moduleNamePlaceholder?: string;
+  onSave: (names: string[]) => void;
+  onCancel: () => void;
+}) {
+  const [text, setText] = useState("");
+  const names = useMemo(() => parseBulkModuleNames(text), [text]);
+  const lowerLabel = moduleLabel.toLowerCase();
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (names.length === 0) return;
+        onSave(names);
+      }}
+      className="flex flex-col gap-2 rounded-sm border bg-muted/40 p-2"
+    >
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          {moduleLabel} names — one per line
+        </label>
+        <Textarea
+          value={text}
+          onChange={e => setText(e.target.value)}
+          rows={6}
+          autoFocus
+          placeholder={
+            moduleNamePlaceholder
+              ? `${moduleNamePlaceholder}\n…`
+              : `e.g.\nIntroduction\nGetting set up\nFirst ${lowerLabel}`
+          }
+        />
+      </div>
+      <div
+        className="flex flex-row flex-wrap items-center justify-between gap-2"
+      >
+        <p className="text-xs text-muted-foreground">
+          {names.length === 0
+            ? `No ${lowerLabel}s yet`
+            : `${names.length} ${names.length === 1 ? lowerLabel : `${lowerLabel}s`} to add`}
+        </p>
+        <div className="flex flex-row gap-2">
+          <Button
+            size="sm"
+            type="submit"
+            disabled={isSaving || names.length === 0}
+          >
+            {isSaving && <Loader2 className="animate-spin" />}
+            Add
+            {names.length > 0 ? ` ${names.length}` : ""}
+          </Button>
+          <Button
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/packages/client/src/components/resources/moduleAdminComponents.ts
+++ b/packages/client/src/components/resources/moduleAdminComponents.ts
@@ -6,6 +6,7 @@
 // there is no circular dependency.
 export { GroupEditCard, GroupMetaChips } from "./GroupEditCard";
 export { InteractionQuickLog } from "./InteractionQuickLog";
+export { ModuleBulkAddCard } from "./ModuleBulkAddCard";
 export { ModuleBulkEditTable } from "./ModuleBulkEditTable";
 export { hasModuleDetails } from "./moduleDetails";
 export { ModuleDetailsPanel } from "./ModuleDetailsPanel";

--- a/packages/client/src/components/resources/moduleDrafts.test.ts
+++ b/packages/client/src/components/resources/moduleDrafts.test.ts
@@ -11,6 +11,7 @@ import {
   levelChipClass,
   lookupTagsByIds,
   moduleToDraft,
+  parseBulkModuleNames,
   parseCount,
 } from "./moduleDrafts";
 
@@ -84,6 +85,32 @@ describe("parseCount", () => {
 
   test("a decimal is floored to an integer", () => {
     expect(parseCount("3.7")).toBe(3);
+  });
+});
+
+describe("parseBulkModuleNames", () => {
+  test("splits one name per line, preserving order", () => {
+    expect(parseBulkModuleNames("Intro\nSetup\nFirst lesson")).toEqual([
+      "Intro",
+      "Setup",
+      "First lesson",
+    ]);
+  });
+
+  test("trims each line and drops blank lines", () => {
+    expect(parseBulkModuleNames("  Intro  \n\n   \n Setup\n")).toEqual([
+      "Intro",
+      "Setup",
+    ]);
+  });
+
+  test("returns an empty array for blank input", () => {
+    expect(parseBulkModuleNames("")).toEqual([]);
+    expect(parseBulkModuleNames("   \n\n  ")).toEqual([]);
+  });
+
+  test("handles carriage-return newlines from pasted text", () => {
+    expect(parseBulkModuleNames("Intro\r\nSetup")).toEqual(["Intro", "Setup"]);
   });
 });
 

--- a/packages/client/src/components/resources/moduleDrafts.ts
+++ b/packages/client/src/components/resources/moduleDrafts.ts
@@ -176,3 +176,15 @@ export function parseCount(s: string): number | null {
   if (!Number.isFinite(n) || n < 0) return null;
   return Math.floor(n);
 }
+
+/**
+ * Split a bulk-add textarea (one module name per line) into a clean list of
+ * names: trims each line and drops blank ones. Order is preserved, so the
+ * created modules keep the order they were pasted in.
+ */
+export function parseBulkModuleNames(text: string): string[] {
+  return text
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}

--- a/packages/client/src/hooks/useModuleAdminUiState.ts
+++ b/packages/client/src/hooks/useModuleAdminUiState.ts
@@ -21,6 +21,12 @@ export function useModuleAdminUiState() {
   const [editingModuleId, setEditingModuleId] = useState<string | null>(null);
   const [creatingModuleIn, setCreatingModuleIn] = useState<string | null>(null);
 
+  // Bulk-add: which group is showing its inline "add several modules at once"
+  // card (one module name per line). Group-scoped, so it holds a groupId.
+  const [bulkAddingInGroupId, setBulkAddingInGroupId] = useState<string | null>(
+    null,
+  );
+
   // Which module has its read-only details panel expanded (only one at a time).
   // Independent of editing — expanding details must not disable other rows.
   const [expandedModuleId, setExpandedModuleId] = useState<string | null>(null);
@@ -52,6 +58,7 @@ export function useModuleAdminUiState() {
       || creatingGroup
       || editingModuleId !== null
       || creatingModuleIn !== null
+      || bulkAddingInGroupId !== null
       || loggingForGroupId !== null
       || loggingForModuleId !== null;
 
@@ -64,6 +71,8 @@ export function useModuleAdminUiState() {
     setEditingModuleId,
     creatingModuleIn,
     setCreatingModuleIn,
+    bulkAddingInGroupId,
+    setBulkAddingInGroupId,
     expandedModuleId,
     setExpandedModuleId,
     loggingForGroupId,

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -209,6 +209,37 @@ export function useResourceModules(resourceId: string) {
     onError: (e: Error) => toast.error(e.message),
   });
 
+  // Bulk add: create several name-only modules in a group (or ungrouped) in one
+  // shot from the bulk-add card's one-name-per-line input. Parallel creates
+  // mirror `bulkUpsertModulesMutation`; everything but the name takes defaults,
+  // ready to flesh out later via the edit card or bulk-edit table.
+  const bulkCreateModulesMutation = useMutation({
+    mutationFn: ({
+      names,
+      groupId,
+    }: {
+      names: string[];
+      groupId: string | null;
+    }) =>
+      Promise.all(
+        names.map(name =>
+          createModule({
+            resourceId,
+            moduleGroupId: groupId,
+            name,
+          })),
+      ),
+    onSuccess: (_data, {
+      names,
+    }) => {
+      invalidateAll();
+      toast.success(
+        `Added ${names.length} ${names.length === 1 ? "module" : "modules"}`,
+      );
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
   const upsertModuleMutation = useMutation({
     mutationFn: ({
       draft,
@@ -542,6 +573,7 @@ export function useResourceModules(resourceId: string) {
     upsertGroupMutation,
     deleteGroupMutation,
     createModuleMutation,
+    bulkCreateModulesMutation,
     upsertModuleMutation,
     bulkUpsertModulesMutation,
     setStatusMutation,

--- a/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
+++ b/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
@@ -20,6 +20,7 @@ import {
   ChevronUpIcon,
   ExternalLinkIcon,
   GripVerticalIcon,
+  ListPlusIcon,
   PencilIcon,
   PlusIcon,
 } from "lucide-react";
@@ -36,6 +37,7 @@ import {
   GroupEditCard,
   GroupMetaChips,
   InteractionQuickLog,
+  ModuleBulkAddCard,
   ModuleEditCard,
 } from "@/components/resources/moduleAdminComponents";
 import {
@@ -158,6 +160,7 @@ function GroupHeaderControls({
     isAnyEditing,
     reorderMode,
     setCreatingModuleIn,
+    setBulkAddingInGroupId,
     setLoggingForGroupId,
     setEditingGroupId,
   } = ui;
@@ -224,6 +227,16 @@ function GroupHeaderControls({
         Add
         {" "}
         {api.moduleLabel}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => setBulkAddingInGroupId(g.id)}
+        disabled={isAnyEditing}
+        title={`Add several ${api.moduleLabel.toLowerCase()}s at once`}
+      >
+        <ListPlusIcon className="size-3.5" />
+        Bulk Add
       </Button>
       <Button
         size="icon-sm"
@@ -376,12 +389,15 @@ export function ModuleGroupSection({
     upsertGroupMutation,
     deleteGroupMutation,
     createModuleMutation,
+    bulkCreateModulesMutation,
   } = api;
   const {
     editingGroupId,
     setEditingGroupId,
     creatingModuleIn,
     setCreatingModuleIn,
+    bulkAddingInGroupId,
+    setBulkAddingInGroupId,
     loggingForGroupId,
     setLoggingForGroupId,
   } = ui;
@@ -396,6 +412,7 @@ export function ModuleGroupSection({
 
   const groupModules = modulesByGroup.get(g.id) ?? [];
   const isCreatingHere = creatingModuleIn === g.id;
+  const isBulkAddingHere = bulkAddingInGroupId === g.id;
   const groupStatus = getGroupStatus(g, groupModules);
 
   if (editingGroupId === g.id) {
@@ -515,6 +532,24 @@ export function ModuleGroupSection({
               onCancel={() => setCreatingModuleIn(null)}
             />
           )}
+          {isBulkAddingHere && (
+            <ModuleBulkAddCard
+              moduleLabel={api.moduleLabel}
+              moduleNamePlaceholder={api.moduleHint}
+              isSaving={bulkCreateModulesMutation.isPending}
+              onSave={names =>
+                bulkCreateModulesMutation.mutate(
+                  {
+                    names,
+                    groupId: g.id,
+                  },
+                  {
+                    onSuccess: () => setBulkAddingInGroupId(null),
+                  },
+                )}
+              onCancel={() => setBulkAddingInGroupId(null)}
+            />
+          )}
           <GroupModuleList
             group={g}
             resourceId={resourceId}
@@ -525,7 +560,7 @@ export function ModuleGroupSection({
           <GroupProgressHint
             group={g}
             groupModules={groupModules}
-            isCreatingHere={isCreatingHere}
+            isCreatingHere={isCreatingHere || isBulkAddingHere}
           />
         </>
       )}


### PR DESCRIPTION
## Summary

Add a new bulk-add feature for creating multiple modules at once from a textarea with one module name per line. This complements the existing single-module creation flow and allows users to quickly scaffold several modules in a group before filling in other details via the edit card or bulk-edit table.

## Key Changes

- **New component `ModuleBulkAddCard`** (`ModuleBulkAddCard.tsx`): An inline card that accepts module names (one per line), parses them, and triggers bulk creation. Includes:
  - Textarea input with customizable placeholder and module label
  - Real-time count of parsed names (blank lines and whitespace trimmed)
  - Save/Cancel buttons; Save is disabled until at least one non-blank line exists
  - Loading state during mutation
  - Storybook stories with interaction tests

- **New utility `parseBulkModuleNames`** (`moduleDrafts.ts`): Splits textarea input on newlines, trims each line, filters blanks, and preserves order. Handles both `\n` and `\r\n` line endings.

- **New mutation `bulkCreateModulesMutation`** (`useResourceModules.ts`): Accepts an array of names and a groupId, creates all modules in parallel via individual `createModule` calls, and shows a success toast with the count.

- **UI state for bulk-add mode** (`useModuleAdminUiState.ts`): Added `bulkAddingInGroupId` state to track which group is showing the bulk-add card (group-scoped, similar to `creatingModuleIn`). Integrated into `isAnyEditing` check to disable other controls while bulk-adding.

- **Group header "Bulk Add" button** (`_ModuleGroupSection.tsx`): New button with `ListPlusIcon` that opens the bulk-add card for the group. Disabled when any other editing is in progress.

- **Integration in group section**: Conditionally renders `ModuleBulkAddCard` when `isBulkAddingHere` is true, wires up the mutation, and updates `GroupProgressHint` to treat bulk-add the same as single-module creation (hides the hint).

- **Export in barrel** (`moduleAdminComponents.ts`): Added `ModuleBulkAddCard` to the public exports.

## Implementation Details

- All created modules take default values for fields other than name; users can edit them afterwards via the edit card or bulk-edit table.
- The bulk-add card is inline (not a modal) and appears in the same space as the single-module creation card, so only one creation mode is active per group at a time.
- Parsing is memoized on the textarea text to avoid re-parsing on every render.
- Success toast shows the count of modules added (singular/plural aware).
- Order is preserved from the textarea input, so pasted modules maintain their sequence.

https://claude.ai/code/session_01JkuQcNRjpja8Dudm8VG9xw