### PR TITLE
feat(client): add per-group progress breakdown to resource details

### DIFF
--- a/packages/client/src/hooks/useResourceModuleProgress.ts
+++ b/packages/client/src/hooks/useResourceModuleProgress.ts
@@ -1,12 +1,19 @@
-import type { ModuleProgress } from "@/utils/moduleProgress";
+import type { GroupProgress, ModuleProgress } from "@/utils/moduleProgress";
 
 import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchModuleGroups, fetchModules } from "@/utils/fetchFunctions";
-import { computeModuleProgress } from "@/utils/moduleProgress";
+import { computeGroupProgress, computeModuleProgress } from "@/utils/moduleProgress";
 import { queryKeys } from "@/utils/queryKeys";
+
+export interface ResourceModuleProgress {
+  /** Overall module-derived progress (completed/total/% across the resource). */
+  progress: ModuleProgress;
+  /** Per-group breakdown for the Details-tab progress table. */
+  groups: GroupProgress[];
+}
 
 /**
  * Read-only module progress for a resource, used by the Details tab to show
@@ -19,7 +26,7 @@ import { queryKeys } from "@/utils/queryKeys";
 export function useResourceModuleProgress(
   resourceId: string,
   enabled: boolean,
-): ModuleProgress {
+): ResourceModuleProgress {
   const groupsQuery = useQuery({
     queryKey: queryKeys.resources.moduleGroups(resourceId),
     queryFn: () => fetchModuleGroups(),
@@ -38,6 +45,9 @@ export function useResourceModuleProgress(
     const modules = (modulesQuery.data ?? []).filter(
       m => m.resourceId === resourceId,
     );
-    return computeModuleProgress(modules, groups);
+    return {
+      progress: computeModuleProgress(modules, groups),
+      groups: computeGroupProgress(modules, groups),
+    };
   }, [groupsQuery.data, modulesQuery.data, resourceId]);
 }

--- a/packages/client/src/routes/resources/$id/-components/index.ts
+++ b/packages/client/src/routes/resources/$id/-components/index.ts
@@ -1,4 +1,6 @@
-// Public API of the resource detail module-admin folder — the two tab panels the
-// resource edit route renders. Each is the public surface of its themed subfolder.
+// Public API of the resource detail module-admin folder — the tab panels the
+// resource edit route renders, plus the Details-tab group breakdown. Each is the
+// public surface of its themed subfolder.
 export { ResourceInteractionsLog } from "./interactions";
+export { ModuleGroupBreakdown } from "./progress";
 export { ResourceModulesAdmin } from "./shell";

--- a/packages/client/src/routes/resources/$id/-components/progress/-ModuleGroupBreakdown.stories.tsx
+++ b/packages/client/src/routes/resources/$id/-components/progress/-ModuleGroupBreakdown.stories.tsx
@@ -1,0 +1,78 @@
+import type { GroupProgress } from "@/utils/moduleProgress";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, within } from "storybook/test";
+
+import { ModuleGroupBreakdown } from "./-ModuleGroupBreakdown";
+
+import { smokePlay } from "@/test-utils/storyPlay";
+
+const groups: GroupProgress[] = [
+  {
+    id: "g1",
+    name: "Getting Started",
+    moduleCount: 5,
+    completedCount: 5,
+    percentComplete: 100,
+    isComplete: true,
+  },
+  {
+    id: "g2",
+    name: "Core Concepts",
+    moduleCount: 8,
+    completedCount: 3,
+    percentComplete: 38,
+    isComplete: false,
+  },
+  {
+    id: "g3",
+    name: "Appendix",
+    moduleCount: 4,
+    completedCount: 0,
+    percentComplete: 0,
+    isComplete: false,
+  },
+];
+
+const meta: Meta<typeof ModuleGroupBreakdown> = {
+  component: ModuleGroupBreakdown,
+  args: {
+    groups,
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Starts collapsed: only the toggle is visible, no table yet.
+export const Collapsed: Story = {
+  play: smokePlay([{
+    role: "button",
+    name: "Group breakdown",
+  }]),
+};
+
+// Clicking the toggle reveals the per-group table.
+export const Expanded: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Group breakdown",
+      }),
+    );
+    await expect(canvas.getByRole("table")).toBeInTheDocument();
+    await expect(canvas.getByText("Core Concepts")).toBeInTheDocument();
+    await expect(canvas.getByText("38%")).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/resources/$id/-components/progress/-ModuleGroupBreakdown.tsx
+++ b/packages/client/src/routes/resources/$id/-components/progress/-ModuleGroupBreakdown.tsx
@@ -1,0 +1,83 @@
+import type { GroupProgress } from "@/utils/moduleProgress";
+
+import { useId, useState } from "react";
+
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+/**
+ * Collapsible per-group progress table for the Details tab. Hidden entirely when
+ * the resource has no groups (ungrouped modules are reflected in the aggregate
+ * stats, not here). The repo has no Collapsible primitive, so this is a small
+ * `useState`-controlled disclosure.
+ */
+export function ModuleGroupBreakdown({
+  groups,
+}: {
+  groups: GroupProgress[];
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
+        {open
+          ? <ChevronDownIcon className="size-4" />
+          : <ChevronRightIcon className="size-4" />}
+        Group breakdown
+      </Button>
+      {open && (
+        <div
+          id={panelId}
+          className="rounded-md border bg-card"
+        >
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Group</TableHead>
+                <TableHead className="text-right">Modules</TableHead>
+                <TableHead className="text-right">% Complete</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map(g => (
+                <TableRow key={g.id}>
+                  <TableCell>{g.name}</TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {g.moduleCount}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {g.percentComplete}
+                    %
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/routes/resources/$id/-components/progress/index.ts
+++ b/packages/client/src/routes/resources/$id/-components/progress/index.ts
@@ -1,0 +1,1 @@
+export { ModuleGroupBreakdown } from "./-ModuleGroupBreakdown";

--- a/packages/client/src/routes/resources/$id/index.tsx
+++ b/packages/client/src/routes/resources/$id/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/max-dependencies */
-import type { ModuleProgress } from "@/utils/moduleProgress";
+import type { ResourceModuleProgress } from "@/hooks/useResourceModuleProgress";
+import type { GroupProgress, ModuleProgress } from "@/utils/moduleProgress";
 import type { Resource } from "@emstack/types";
 
 import { useState } from "react";
@@ -10,6 +11,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
 import {
+  ModuleGroupBreakdown,
   ResourceInteractionsLog,
   ResourceModulesAdmin,
 } from "./-components";
@@ -226,7 +228,7 @@ function ResourceDetailsTab({
 }: {
   data: Resource;
   percentComplete: string | undefined;
-  moduleProgress: ModuleProgress;
+  moduleProgress: ResourceModuleProgress;
 }) {
   const topics = data.topics ?? null;
   // Labels are no longer renamed per resource; always use the default.
@@ -288,7 +290,8 @@ function ResourceDetailsTab({
         {data.modulesAreExhaustive
           ? (
             <ModuleProgressDisplay
-              moduleProgress={moduleProgress}
+              progress={moduleProgress.progress}
+              groups={moduleProgress.groups}
               moduleLabel={moduleLabel}
             />
           )
@@ -378,34 +381,54 @@ function ResourceDetailsTab({
 
 // Module Tracking progress: completed/total/% derived from the resource's
 // modules (and count-only groups), shown instead of the manual progress fields.
+// When the resource has groups, group-level stats sit above the module stats and
+// an expandable table breaks progress down per group.
 function ModuleProgressDisplay({
-  moduleProgress,
+  progress,
+  groups,
   moduleLabel,
 }: {
-  moduleProgress: ModuleProgress;
+  progress: ModuleProgress;
+  groups: GroupProgress[];
   moduleLabel: string;
 }) {
   const {
     completedCount,
     totalCount,
     percentComplete,
-  } = moduleProgress;
+  } = progress;
 
   if (totalCount === 0) {
     return <span>No {moduleLabel.toLowerCase()}s added yet.</span>;
   }
 
+  const totalGroups = groups.length;
+  const groupsCompleted = groups.filter(g => g.isComplete).length;
+
   return (
-    <>
-      <InfoArea header={`${moduleLabel}s Completed`}>
-        <p>{completedCount}</p>
-      </InfoArea>
-      <InfoArea header={`Total ${moduleLabel}s`}>
-        <p>{totalCount}</p>
-      </InfoArea>
-      <InfoArea header="% Complete">
-        <p>{percentComplete}%</p>
-      </InfoArea>
-    </>
+    <div className="flex w-full flex-col gap-4">
+      {totalGroups > 0 && (
+        <div className="flex flex-row gap-8">
+          <InfoArea header="Groups Completed">
+            <p>{groupsCompleted}</p>
+          </InfoArea>
+          <InfoArea header="Total Groups">
+            <p>{totalGroups}</p>
+          </InfoArea>
+        </div>
+      )}
+      <div className="flex flex-row gap-8">
+        <InfoArea header={`${moduleLabel}s Completed`}>
+          <p>{completedCount}</p>
+        </InfoArea>
+        <InfoArea header={`Total ${moduleLabel}s`}>
+          <p>{totalCount}</p>
+        </InfoArea>
+        <InfoArea header="% Complete">
+          <p>{percentComplete}%</p>
+        </InfoArea>
+      </div>
+      {totalGroups > 0 && <ModuleGroupBreakdown groups={groups} />}
+    </div>
   );
 }

--- a/packages/client/src/utils/moduleProgress.test.ts
+++ b/packages/client/src/utils/moduleProgress.test.ts
@@ -2,7 +2,7 @@ import type { Module, ModuleGroup } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import { computeModuleProgress } from "./moduleProgress.ts";
+import { computeGroupProgress, computeModuleProgress } from "./moduleProgress.ts";
 
 function mod(overrides: Partial<Module>): Module {
   return {
@@ -121,5 +121,132 @@ describe("computeModuleProgress", () => {
         [],
       ).percentComplete,
     ).toBe(33);
+  });
+});
+
+describe("computeGroupProgress", () => {
+  test("measures a group by its enumerated modules", () => {
+    const result = computeGroupProgress(
+      [
+        mod({
+          moduleGroupId: "g1",
+          status: "complete",
+        }),
+        mod({
+          moduleGroupId: "g1",
+          status: "unstarted",
+        }),
+        mod({
+          moduleGroupId: "g1",
+          status: "complete",
+        }),
+      ],
+      [group({
+        id: "g1",
+        name: "Enumerated",
+        totalCount: 99,
+        completedCount: 99,
+      })],
+    );
+    expect(result).toEqual([
+      {
+        id: "g1",
+        name: "Enumerated",
+        moduleCount: 3,
+        completedCount: 2,
+        percentComplete: 67,
+        isComplete: false,
+      },
+    ]);
+  });
+
+  test("falls back to direct counts for a count-only group", () => {
+    const result = computeGroupProgress(
+      [],
+      [group({
+        id: "g1",
+        name: "Count only",
+        totalCount: 4,
+        completedCount: 4,
+      })],
+    );
+    expect(result).toEqual([
+      {
+        id: "g1",
+        name: "Count only",
+        moduleCount: 4,
+        completedCount: 4,
+        percentComplete: 100,
+        isComplete: true,
+      },
+    ]);
+  });
+
+  test("ungrouped modules do not affect group rows", () => {
+    const result = computeGroupProgress(
+      [
+        mod({
+          moduleGroupId: null,
+          status: "complete",
+        }),
+        mod({
+          moduleGroupId: "g1",
+          status: "complete",
+        }),
+      ],
+      [group({
+        id: "g1",
+        name: "Grouped",
+      })],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      moduleCount: 1,
+      completedCount: 1,
+      isComplete: true,
+    });
+  });
+
+  test("treats an empty group (no modules, no counts) as 0% and incomplete", () => {
+    const result = computeGroupProgress(
+      [],
+      [group({
+        id: "g1",
+        name: "Empty",
+      })],
+    );
+    expect(result[0]).toMatchObject({
+      moduleCount: 0,
+      completedCount: 0,
+      percentComplete: 0,
+      isComplete: false,
+    });
+  });
+
+  test("sorts by position then name", () => {
+    const result = computeGroupProgress(
+      [],
+      [
+        group({
+          id: "b",
+          name: "Bravo",
+          position: 2,
+        }),
+        group({
+          id: "a",
+          name: "Alpha",
+          position: 1,
+        }),
+        group({
+          id: "z",
+          name: "Zulu",
+        }),
+        group({
+          id: "m",
+          name: "Mike",
+        }),
+      ],
+    );
+    expect(result.map(g => g.name)).toEqual(["Alpha", "Bravo", "Mike", "Zulu"]);
   });
 });

--- a/packages/client/src/utils/moduleProgress.ts
+++ b/packages/client/src/utils/moduleProgress.ts
@@ -43,3 +43,61 @@ export function computeModuleProgress(
     percentComplete,
   };
 }
+
+export interface GroupProgress {
+  id: string;
+  name: string;
+  /** Enumerated module count, or the group's direct `totalCount` when empty. */
+  moduleCount: number;
+  /** Completed enumerated modules, or the direct `completedCount` when empty. */
+  completedCount: number;
+  /** Integer 0–100; 0 when the group has nothing to count. */
+  percentComplete: number;
+  /** True when every counted module is done (and there is something to count). */
+  isComplete: boolean;
+}
+
+/**
+ * Per-group progress breakdown for a resource. Mirrors `computeModuleProgress`'s
+ * rule at the group level: a group with enumerated modules is measured by those
+ * modules' statuses; a group without them falls back to its direct
+ * `totalCount`/`completedCount`. Sorted by `position` then name for stable display.
+ */
+export function computeGroupProgress(
+  modules: Module[],
+  groups: ModuleGroup[],
+): GroupProgress[] {
+  const modulesByGroup = new Map<string, Module[]>();
+  for (const m of modules) {
+    if (!m.moduleGroupId) continue;
+    const arr = modulesByGroup.get(m.moduleGroupId);
+    if (arr) arr.push(m);
+    else modulesByGroup.set(m.moduleGroupId, [m]);
+  }
+
+  return [...groups]
+    .sort(
+      (a, b) =>
+        (a.position ?? Infinity) - (b.position ?? Infinity)
+        || a.name.localeCompare(b.name),
+    )
+    .map((g) => {
+      const enumerated = modulesByGroup.get(g.id) ?? [];
+      const hasEnumerated = enumerated.length > 0;
+      const moduleCount = hasEnumerated ? enumerated.length : g.totalCount ?? 0;
+      const completedCount = hasEnumerated
+        ? enumerated.filter(m => isModuleComplete(m.status)).length
+        : g.completedCount ?? 0;
+      const percentComplete
+        = moduleCount > 0 ? Math.round((completedCount / moduleCount) * 100) : 0;
+
+      return {
+        id: g.id,
+        name: g.name,
+        moduleCount,
+        completedCount,
+        percentComplete,
+        isComplete: moduleCount > 0 && completedCount >= moduleCount,
+      };
+    });
+}


### PR DESCRIPTION
## Summary

Adds per-group module progress tracking to the resource Details tab. When a resource has module groups, the progress display now shows group-level completion stats and an expandable table breaking down progress by group.

## Changes

- **New `computeGroupProgress` utility** (`moduleProgress.ts`): Computes per-group progress metrics (module count, completed count, percent complete, completion status) mirroring the module-level logic. Groups with enumerated modules are measured by those modules' statuses; groups without enumerated modules fall back to their direct `totalCount`/`completedCount`. Results are sorted by position then name.

- **New `ModuleGroupBreakdown` component**: Collapsible disclosure widget showing a table of group progress. Hidden entirely when there are no groups. Uses a simple `useState` toggle since the repo lacks a Collapsible primitive.

- **Updated `ModuleProgressDisplay`**: Now displays group-level stats (groups completed / total groups) above module stats when groups exist, and includes the `ModuleGroupBreakdown` table below.

- **Refactored `useResourceModuleProgress` hook**: Returns a new `ResourceModuleProgress` interface containing both overall module progress and per-group breakdown, computed in a single `useMemo`.

- **Test coverage**: Added comprehensive test suite for `computeGroupProgress` covering enumerated modules, count-only fallback, ungrouped module filtering, empty groups, and sorting behavior.

- **Storybook stories**: Added `ModuleGroupBreakdown` stories demonstrating collapsed/expanded states and interaction.

## Implementation Details

- Groups are sorted by `position` (with `Infinity` as default for unpositioned groups) then alphabetically by name, ensuring stable and predictable display order.
- Empty groups (no modules, no counts) are treated as 0% complete and incomplete.
- Ungrouped modules (with `moduleGroupId: null`) do not affect group rows but are reflected in overall module stats.
- The component uses `aria-expanded` and `aria-controls` for accessibility on the disclosure toggle.

https://claude.ai/code/session_017HDKQ1Lp7TA2iUcEihxpgQ