### PR TITLE
feat(client): add page-order sorting and bulk group creation

### DIFF
--- a/packages/client/src/components/resources/BulkNameAddCard.stories.tsx
+++ b/packages/client/src/components/resources/BulkNameAddCard.stories.tsx
@@ -2,15 +2,15 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, fn, userEvent, within } from "storybook/test";
 
-import { ModuleBulkAddCard } from "./ModuleBulkAddCard";
+import { BulkNameAddCard } from "./BulkNameAddCard";
 
 import { constrainedStoryDecorator } from "@/test-utils/storyDecorators";
 import { smokePlay } from "@/test-utils/storyPlay";
 
-const meta: Meta<typeof ModuleBulkAddCard> = {
-  component: ModuleBulkAddCard,
+const meta: Meta<typeof BulkNameAddCard> = {
+  component: BulkNameAddCard,
   args: {
-    moduleLabel: "Module",
+    itemLabel: "Module",
     isSaving: false,
     onSave: fn(),
     onCancel: fn(),
@@ -52,6 +52,21 @@ export const AddsTypedNames: Story = {
     await userEvent.click(addButton);
     await expect(args.onSave).toHaveBeenCalledWith(["Intro", "Setup", "Wrap up"]);
   },
+};
+
+// The same card relabelled for bulk-adding module groups.
+export const Groups: Story = {
+  args: {
+    itemLabel: "Group",
+  },
+  play: smokePlay([
+    {
+      text: "Group names — one per line",
+    },
+    {
+      text: "No groups yet",
+    },
+  ]),
 };
 
 export const Saving: Story = {

--- a/packages/client/src/components/resources/BulkNameAddCard.tsx
+++ b/packages/client/src/components/resources/BulkNameAddCard.tsx
@@ -8,29 +8,30 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
 /**
- * Inline card for adding several modules to a group at once: one module name per
- * line. Only names are captured here — every other field takes its default and
- * can be filled in afterwards via the edit card or the bulk-edit table. Saving
- * is disabled until at least one non-blank line is present.
+ * Inline card for adding several items at once: one name per line. Only names
+ * are captured here — every other field takes its default and can be filled in
+ * afterwards via the edit card. Saving is disabled until at least one non-blank
+ * line is present. Reused for both modules and module groups (the noun is set by
+ * `itemLabel`).
  */
-export function ModuleBulkAddCard({
+export function BulkNameAddCard({
   isSaving = false,
-  moduleLabel = "Module",
-  moduleNamePlaceholder,
+  itemLabel = "Module",
+  namePlaceholder,
   onSave,
   onCancel,
 }: {
   isSaving?: boolean;
-  /** Per-resource label for a module (e.g. "Lesson"). */
-  moduleLabel?: string;
+  /** Singular noun for the thing being added (e.g. "Module", "Group"). */
+  itemLabel?: string;
   /** Hint (placeholder) for the name lines, from the resource's hint template. */
-  moduleNamePlaceholder?: string;
+  namePlaceholder?: string;
   onSave: (names: string[]) => void;
   onCancel: () => void;
 }) {
   const [text, setText] = useState("");
   const names = useMemo(() => parseBulkModuleNames(text), [text]);
-  const lowerLabel = moduleLabel.toLowerCase();
+  const lowerLabel = itemLabel.toLowerCase();
 
   return (
     <form
@@ -43,7 +44,7 @@ export function ModuleBulkAddCard({
     >
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-muted-foreground">
-          {moduleLabel} names — one per line
+          {itemLabel} names — one per line
         </label>
         <Textarea
           value={text}
@@ -51,8 +52,8 @@ export function ModuleBulkAddCard({
           rows={6}
           autoFocus
           placeholder={
-            moduleNamePlaceholder
-              ? `${moduleNamePlaceholder}\n…`
+            namePlaceholder
+              ? `${namePlaceholder}\n…`
               : `e.g.\nIntroduction\nGetting set up\nFirst ${lowerLabel}`
           }
         />

--- a/packages/client/src/components/resources/moduleAdminComponents.ts
+++ b/packages/client/src/components/resources/moduleAdminComponents.ts
@@ -4,9 +4,9 @@
 // dependency. This barrel only re-exports leaf sub-components — it does not
 // import the folder, and the sub-components keep their own direct imports, so
 // there is no circular dependency.
+export { BulkNameAddCard } from "./BulkNameAddCard";
 export { GroupEditCard, GroupMetaChips } from "./GroupEditCard";
 export { InteractionQuickLog } from "./InteractionQuickLog";
-export { ModuleBulkAddCard } from "./ModuleBulkAddCard";
 export { ModuleBulkEditTable } from "./ModuleBulkEditTable";
 export { hasModuleDetails } from "./moduleDetails";
 export { ModuleDetailsPanel } from "./ModuleDetailsPanel";

--- a/packages/client/src/hooks/useModuleAdminUiState.ts
+++ b/packages/client/src/hooks/useModuleAdminUiState.ts
@@ -17,6 +17,11 @@ export function useModuleAdminUiState() {
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [creatingGroup, setCreatingGroup] = useState(false);
 
+  // Bulk-add groups: the top-level "add several groups at once" card (one group
+  // name per line). A single boolean — unlike module bulk-add it isn't scoped to
+  // a parent group.
+  const [bulkAddingGroups, setBulkAddingGroups] = useState(false);
+
   // Module state — keyed by either groupId (string) or UNGROUPED_KEY for top level
   const [editingModuleId, setEditingModuleId] = useState<string | null>(null);
   const [creatingModuleIn, setCreatingModuleIn] = useState<string | null>(null);
@@ -56,6 +61,7 @@ export function useModuleAdminUiState() {
   const isAnyEditing
     = editingGroupId !== null
       || creatingGroup
+      || bulkAddingGroups
       || editingModuleId !== null
       || creatingModuleIn !== null
       || bulkAddingInGroupId !== null
@@ -67,6 +73,8 @@ export function useModuleAdminUiState() {
     setEditingGroupId,
     creatingGroup,
     setCreatingGroup,
+    bulkAddingGroups,
+    setBulkAddingGroups,
     editingModuleId,
     setEditingModuleId,
     creatingModuleIn,

--- a/packages/client/src/hooks/useResourceModules.ts
+++ b/packages/client/src/hooks/useResourceModules.ts
@@ -14,7 +14,7 @@ import { toast } from "sonner";
 import { useSetModulesExhaustive } from "./useSetModulesExhaustive";
 
 import { draftToLength, parseCount } from "@/components/resources/moduleDrafts";
-import { fetchSettings } from "@/utils";
+import { fetchSettings, sortByPage } from "@/utils";
 import {
   createModule,
   createModuleGroup,
@@ -58,20 +58,26 @@ export function useResourceModules(resourceId: string) {
   const modulesAreExhaustive
     = resourceQuery.data?.modulesAreExhaustive ?? false;
 
-  const groups = useMemo(
-    () => (groupsQuery.data ?? []).filter(g => g.resourceId === resourceId),
-    [groupsQuery.data, resourceId],
-  );
+  // Book resources get per-module/group page ranges; the edit cards key off this,
+  // and the lists below are sorted into page (reading) order when it's set.
+  const isBook = resourceQuery.data?.type === "book";
+
+  const groups = useMemo(() => {
+    const filtered = (groupsQuery.data ?? []).filter(
+      g => g.resourceId === resourceId,
+    );
+    return isBook ? sortByPage(filtered) : filtered;
+  }, [groupsQuery.data, resourceId, isBook]);
   const allModules = useMemo(
     () =>
       (allModulesQuery.data ?? []).filter(m => m.resourceId === resourceId),
     [allModulesQuery.data, resourceId],
   );
 
-  const ungroupedModules = useMemo(
-    () => allModules.filter(m => !m.moduleGroupId),
-    [allModules],
-  );
+  const ungroupedModules = useMemo(() => {
+    const filtered = allModules.filter(m => !m.moduleGroupId);
+    return isBook ? sortByPage(filtered) : filtered;
+  }, [allModules, isBook]);
   const modulesByGroup = useMemo(() => {
     const map = new Map<string, Module[]>();
     for (const m of allModules) {
@@ -81,8 +87,13 @@ export function useResourceModules(resourceId: string) {
         else map.set(m.moduleGroupId, [m]);
       }
     }
+    if (isBook) {
+      for (const [groupId, members] of map) {
+        map.set(groupId, sortByPage(members));
+      }
+    }
     return map;
-  }, [allModules]);
+  }, [allModules, isBook]);
 
   // Aggregate progress: sum enumerated modules + groups-with-counts (only
   // groups that have NO enumerated modules contribute their direct counts;
@@ -95,8 +106,6 @@ export function useResourceModules(resourceId: string) {
     [allModules, groups],
   );
 
-  // Book resources get per-module/group page ranges; the edit cards key off this.
-  const isBook = resourceQuery.data?.type === "book";
   // The hierarchy labels are no longer renamed per resource — always the
   // defaults. Instead a resource picks a hint template whose hints surface as
   // placeholders in the group/module name fields.
@@ -175,6 +184,28 @@ export function useResourceModules(resourceId: string) {
     onSuccess: () => {
       invalidateAll();
       toast.success("Module group deleted; member modules ungrouped");
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  // Bulk add: create several name-only groups in one shot from the bulk-add
+  // card's one-name-per-line input. Mirrors `bulkCreateModulesMutation`; every
+  // field but the name takes its default, ready to flesh out via the group edit
+  // card afterwards.
+  const bulkCreateGroupsMutation = useMutation({
+    mutationFn: (names: string[]) =>
+      Promise.all(
+        names.map(name =>
+          createModuleGroup({
+            resourceId,
+            name,
+          })),
+      ),
+    onSuccess: (_data, names) => {
+      invalidateAll();
+      toast.success(
+        `Added ${names.length} ${names.length === 1 ? "group" : "groups"}`,
+      );
     },
     onError: (e: Error) => toast.error(e.message),
   });
@@ -570,6 +601,7 @@ export function useResourceModules(resourceId: string) {
     hintTemplates,
     invalidateAll,
     createGroupMutation,
+    bulkCreateGroupsMutation,
     upsertGroupMutation,
     deleteGroupMutation,
     createModuleMutation,

--- a/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
+++ b/packages/client/src/routes/resources/$id/-components/grouping/-ModuleGroupSection.tsx
@@ -34,10 +34,10 @@ import {
 import { ModuleListItem } from "../item";
 
 import {
+  BulkNameAddCard,
   GroupEditCard,
   GroupMetaChips,
   InteractionQuickLog,
-  ModuleBulkAddCard,
   ModuleEditCard,
 } from "@/components/resources/moduleAdminComponents";
 import {
@@ -533,9 +533,9 @@ export function ModuleGroupSection({
             />
           )}
           {isBulkAddingHere && (
-            <ModuleBulkAddCard
-              moduleLabel={api.moduleLabel}
-              moduleNamePlaceholder={api.moduleHint}
+            <BulkNameAddCard
+              itemLabel={api.moduleLabel}
+              namePlaceholder={api.moduleHint}
               isSaving={bulkCreateModulesMutation.isPending}
               onSave={names =>
                 bulkCreateModulesMutation.mutate(

--- a/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.tsx
+++ b/packages/client/src/routes/resources/$id/-components/header/-ModuleAdminHeader.tsx
@@ -4,6 +4,7 @@ import {
   ArrowUpDownIcon,
   CircleCheckBig,
   InfoIcon,
+  ListPlusIcon,
   PlusIcon,
   SparklesIcon,
   Table2Icon,
@@ -49,6 +50,7 @@ export function ModuleAdminHeader({
     setLlmAssistOpen,
     setCreatingModuleIn,
     setCreatingGroup,
+    setBulkAddingGroups,
     reorderMode,
     setReorderMode,
     bulkEditMode,
@@ -128,6 +130,19 @@ export function ModuleAdminHeader({
             New
             {" "}
             {groupLabel}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setBulkAddingGroups(true)}
+            disabled={otherActionsDisabled}
+            title={`Add several ${groupLabel.toLowerCase()}s at once`}
+          >
+            <ListPlusIcon className="size-4" />
+            Bulk Add
+            {" "}
+            {groupLabel}
+            s
           </Button>
         </div>
       </div>

--- a/packages/client/src/routes/resources/$id/-components/shell/-ResourceModulesAdmin.tsx
+++ b/packages/client/src/routes/resources/$id/-components/shell/-ResourceModulesAdmin.tsx
@@ -3,6 +3,7 @@ import { ModuleAdminHeader } from "../header";
 
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import {
+  BulkNameAddCard,
   GroupEditCard,
   ModuleBulkEditTable,
 } from "@/components/resources/moduleAdminComponents";
@@ -29,19 +30,26 @@ export function ResourceModulesAdmin({
     groups,
     ungroupedModules,
     createGroupMutation,
+    bulkCreateGroupsMutation,
     isBook,
     groupLabel,
     moduleLabel,
     groupHint,
   } = api;
   const {
-    creatingGroup, setCreatingGroup, creatingModuleIn, bulkEditMode,
+    creatingGroup,
+    setCreatingGroup,
+    bulkAddingGroups,
+    setBulkAddingGroups,
+    creatingModuleIn,
+    bulkEditMode,
   } = ui;
 
   const isEmpty
     = groups.length === 0
       && ungroupedModules.length === 0
       && !creatingGroup
+      && !bulkAddingGroups
       && creatingModuleIn === null;
 
   return (
@@ -83,6 +91,19 @@ export function ResourceModulesAdmin({
                     onSuccess: () => setCreatingGroup(false),
                   })}
                 onCancel={() => setCreatingGroup(false)}
+              />
+            )}
+
+            {bulkAddingGroups && (
+              <BulkNameAddCard
+                itemLabel={groupLabel}
+                namePlaceholder={groupHint}
+                isSaving={bulkCreateGroupsMutation.isPending}
+                onSave={names =>
+                  bulkCreateGroupsMutation.mutate(names, {
+                    onSuccess: () => setBulkAddingGroups(false),
+                  })}
+                onCancel={() => setBulkAddingGroups(false)}
               />
             )}
 

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from "./parseCost";
 export * from "./queryKeys";
 export * from "./routineConnections";
 export * from "./selectOptions";
+export * from "./sortByPage";
 export * from "./stripCodeFence";
 export * from "./topConnected";
 export * from "./useIsFieldInvalid";

--- a/packages/client/src/utils/sortByPage.test.ts
+++ b/packages/client/src/utils/sortByPage.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import { sortByPage } from "./sortByPage.ts";
+
+describe("sortByPage", () => {
+  test("sorts by pageStart ascending", () => {
+    const result = sortByPage([
+      {
+        id: "c",
+        pageStart: 30,
+      },
+      {
+        id: "a",
+        pageStart: 10,
+      },
+      {
+        id: "b",
+        pageStart: 20,
+      },
+    ]);
+    expect(result.map(i => i.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("tie-breaks equal pageStart by pageEnd", () => {
+    const result = sortByPage([
+      {
+        id: "wide",
+        pageStart: 10,
+        pageEnd: 20,
+      },
+      {
+        id: "narrow",
+        pageStart: 10,
+        pageEnd: 12,
+      },
+    ]);
+    expect(result.map(i => i.id)).toEqual(["narrow", "wide"]);
+  });
+
+  test("sorts items without a pageStart last, preserving their order", () => {
+    const result = sortByPage([
+      {
+        id: "none-1",
+        pageStart: null,
+      },
+      {
+        id: "paged",
+        pageStart: 5,
+      },
+      {
+        id: "none-2",
+      },
+    ]);
+    expect(result.map(i => i.id)).toEqual(["paged", "none-1", "none-2"]);
+  });
+
+  test("returns the original order when nothing has page numbers", () => {
+    const input = [
+      {
+        id: "x",
+      },
+      {
+        id: "y",
+        pageStart: null,
+      },
+      {
+        id: "z",
+      },
+    ];
+    expect(sortByPage(input).map(i => i.id)).toEqual(["x", "y", "z"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const input = [
+      {
+        id: "b",
+        pageStart: 20,
+      },
+      {
+        id: "a",
+        pageStart: 10,
+      },
+    ];
+    sortByPage(input);
+    expect(input.map(i => i.id)).toEqual(["b", "a"]);
+  });
+});

--- a/packages/client/src/utils/sortByPage.ts
+++ b/packages/client/src/utils/sortByPage.ts
@@ -1,0 +1,38 @@
+/** Anything carrying an optional page range — both `Module` and `ModuleGroup`. */
+export interface PageRanged {
+  pageStart?: number | null;
+  pageEnd?: number | null;
+}
+
+/**
+ * Stable sort by `pageStart` ascending, tie-broken by `pageEnd`, with items that
+ * have no `pageStart` (null/undefined) sorted last. Returns a new array; items
+ * with equal page keys — including a list where nothing has page numbers — keep
+ * their original relative order, so this degrades to a no-op for unpaged lists.
+ *
+ * Used to present a book resource's modules/groups in reading (page) order while
+ * leaving everything else in its existing position/name order.
+ */
+export function sortByPage<T extends PageRanged>(items: T[]): T[] {
+  return items
+    .map((item, index) => ({
+      item,
+      index,
+    }))
+    .sort((a, b) => comparePage(a.item, b.item) || a.index - b.index)
+    .map(({
+      item,
+    }) => item);
+}
+
+/** Compare two page ranges: pageStart asc, then pageEnd asc, nulls last. */
+function comparePage(a: PageRanged, b: PageRanged): number {
+  const startDiff = pageKey(a.pageStart) - pageKey(b.pageStart);
+  if (startDiff !== 0) return startDiff;
+  return pageKey(a.pageEnd) - pageKey(b.pageEnd);
+}
+
+/** Treat a missing page as +Infinity so paged items sort ahead of unpaged ones. */
+function pageKey(page: number | null | undefined): number {
+  return page == null ? Number.POSITIVE_INFINITY : page;
+}


### PR DESCRIPTION
## Summary

Adds support for sorting book resource modules and groups by page number (reading order) and introduces bulk group creation via a new "Bulk Add Groups" card in the module admin interface.

## Key Changes

- **New `sortByPage` utility** (`packages/client/src/utils/sortByPage.ts`):
  - Stable sort by `pageStart` ascending, tie-broken by `pageEnd`
  - Items without page numbers sort last while preserving their original order
  - Non-mutating; degrades gracefully for unpaged lists
  - Includes comprehensive test coverage

- **Page-order sorting in `useResourceModules`**:
  - Applies `sortByPage` to groups, ungrouped modules, and modules within groups for book resources only
  - Conditional sorting based on `isBook` resource type
  - Preserves original order for non-book resources

- **Bulk group creation**:
  - New `bulkCreateGroupsMutation` in `useResourceModules` hook
  - Mirrors existing `bulkCreateModulesMutation` pattern
  - Creates multiple name-only groups in one request; other fields default and can be edited afterwards

- **Generalized bulk-add card**:
  - Renamed `ModuleBulkAddCard` → `BulkNameAddCard` for reusability
  - Updated props: `moduleLabel` → `itemLabel`, `moduleNamePlaceholder` → `namePlaceholder`
  - Now used for both module and group bulk creation
  - Added Storybook story demonstrating group variant

- **UI updates**:
  - New "Bulk Add Groups" button in module admin header with `ListPlusIcon`
  - New bulk-add groups card in `ResourceModulesAdmin` shell
  - Added `bulkAddingGroups` state to `useModuleAdminUiState` hook
  - Updated `isAnyEditing` logic to include bulk group creation state

## Implementation Details

- Page sorting uses a stable sort with index preservation to maintain relative order of items with equal page keys
- Null/undefined page values are treated as `Number.POSITIVE_INFINITY` to sort unpaged items last
- Bulk group creation follows the same mutation pattern as bulk module creation for consistency
- All changes are scoped to book resources; other resource types are unaffected

https://claude.ai/code/session_01GzohHkMdpNPLtrVmpXZ1zg