### PR TITLE
fix: resolve ESLint circular fixes on JSX prop values (#517)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,33 @@ export default tseslint.config([
     },
   },
   {
+    // Wrap *every* multiline JSX context in parens-on-new-lines, including JSX
+    // that is a prop value (`settings={<Flyout … />}`) or an object-property
+    // value. The shared config leaves `prop`/`propertyValue` at "ignore", which
+    // lets a multiline multi-prop JSX prop value stay unwrapped — and there
+    // `@stylistic/jsx-closing-bracket-location` (tag-aligned) and
+    // `@stylistic/indent` fight over the closing `/>`, so `eslint --fix` cannot
+    // converge and emits `ESLintCircularFixesWarning`. Forcing the wrap
+    // (`settings={(\n  <Flyout … />\n)}`) — the form already used across the
+    // dashboard cards — removes the conflict. See #517.
+    files: ["packages/client/src/**/*.tsx"],
+    rules: {
+      "@stylistic/jsx-wrap-multilines": [
+        "error",
+        {
+          declaration: "parens-new-line",
+          assignment: "parens-new-line",
+          return: "parens-new-line",
+          arrow: "parens-new-line",
+          condition: "parens-new-line",
+          logical: "parens-new-line",
+          prop: "parens-new-line",
+          propertyValue: "parens-new-line",
+        },
+      ],
+    },
+  },
+  {
     files: ["packages/**/*.{ts,tsx}"],
     rules: {
       "no-restricted-imports": [

--- a/packages/client/src/components/ui/combobox.tsx
+++ b/packages/client/src/components/ui/combobox.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable @stylistic/indent -- vendored shadcn/base-ui file; the
-   indent fixer conflicts with JSX wrapping rules on nested render={...}
-   props (circular fixes) */
 "use client";
 
 import * as React from "react";
@@ -45,10 +42,12 @@ function ComboboxClear({
   return (
     <ComboboxPrimitive.Clear
       data-slot="combobox-clear"
-      render={<InputGroupButton
-        variant="ghost"
-        size="icon-xs"
-              />}
+      render={(
+        <InputGroupButton
+          variant="ghost"
+          size="icon-xs"
+        />
+      )}
       className={cn(className)}
       {...props}
     >
@@ -197,14 +196,14 @@ function ComboboxItem({
       {children}
       <ComboboxPrimitive.ItemIndicator
         data-slot="combobox-item-indicator"
-        render={
+        render={(
           <span
             className="
               pointer-events-none absolute right-2 flex size-4 items-center
               justify-center
             "
           />
-        }
+        )}
       >
         <CheckIcon
           className="
@@ -334,10 +333,12 @@ function ComboboxChip({
       {children}
       {showRemove && (
         <ComboboxPrimitive.ChipRemove
-          render={<Button
-            variant="ghost"
-            size="icon-xs"
-                  />}
+          render={(
+            <Button
+              variant="ghost"
+              size="icon-xs"
+            />
+          )}
           className="
             -ml-1 opacity-50
             hover:opacity-100

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/-jsxWrapMultilines.test.ts
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/-jsxWrapMultilines.test.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ESLint } from "eslint";
+import { describe, expect, test } from "vitest";
+
+// Regression guard for #517. A multiline JSX *prop value* left unwrapped
+// (`settings={<Flyout tile={…} onUpdateTile={…} />}`) makes
+// `@stylistic/jsx-closing-bracket-location` (tag-aligned `/>`) and
+// `@stylistic/indent` fight over the closing bracket: `eslint --fix` cannot
+// converge, emits `ESLintCircularFixesWarning`, and leaves a residual
+// `@stylistic/indent` error. eslint.config.js fixes this by forcing
+// jsx-wrap-multilines `prop`/`propertyValue: "parens-new-line"` so the value is
+// wrapped (`settings={(\n  <Flyout … />\n)}`) — the shape used across the
+// dashboard cards. `pnpm lint` can't catch a regression here (committed code is
+// already wrapped), so this exercises the fix transform directly.
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), "../../../../../../../..");
+const virtualFile = path.join(repoRoot, "packages/client/src/__jsx_wrap_probe__.tsx");
+
+// Prettier/format-on-save collapses these onto one line; eslint --fix must
+// re-expand each to a stable, lint-clean shape with no circular fixes.
+const collapsedSamples = [
+  // JSX prop value with multiple props (the `settings={…}` dashboard pattern).
+  "export const A = () => "
+  + "<Card settings={<Flyout tile={1} onUpdateTile={() => undefined} />} />;\n",
+  // Same, but the host element also has children.
+  "export const B = () => "
+  + "<Card settings={<Flyout tile={1} onUpdateTile={() => undefined} />}>x</Card>;\n",
+];
+
+async function fixThenLint(code: string) {
+  const fixer = new ESLint({
+    cwd: repoRoot,
+    fix: true,
+  });
+  const [fixed] = await fixer.lintText(code, {
+    filePath: virtualFile,
+  });
+  const output = fixed.output ?? code;
+
+  const linter = new ESLint({
+    cwd: repoRoot,
+  });
+  const [relinted] = await linter.lintText(output, {
+    filePath: virtualFile,
+  });
+  const stylisticErrors = relinted.messages
+    .filter(m => m.ruleId?.startsWith("@stylistic/"))
+    .map(m => `${m.ruleId} (L${m.line})`);
+
+  // Idempotency: a second fix pass must be a no-op (the circular-fix loop is gone).
+  const [refixed] = await fixer.lintText(output, {
+    filePath: virtualFile,
+  });
+  const settled = refixed.output ?? output;
+
+  return {
+    output,
+    settled,
+    stylisticErrors,
+  };
+}
+
+describe("jsx-wrap-multilines converges on JSX prop values (#517)", () => {
+  for (const [i, sample] of collapsedSamples.entries()) {
+    test(`sample ${i} re-expands with no residual @stylistic errors`, async () => {
+      const {
+        output, settled, stylisticErrors,
+      } = await fixThenLint(sample);
+      expect(stylisticErrors).toEqual([]);
+      expect(settled, "eslint --fix must be idempotent — no circular fixes").toBe(output);
+    });
+  }
+});

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardCoursesByAmortization/-DashboardCoursesByAmortization.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardCoursesByAmortization/-DashboardCoursesByAmortization.tsx
@@ -101,7 +101,7 @@ export function DashboardCoursesByAmortization({
     <DashboardCard
       autoHeight={isAutoHeight(tile)}
       title="Cost per Unit"
-      action={
+      action={(
         <Link
           to="/resources"
           className="
@@ -111,7 +111,7 @@ export function DashboardCoursesByAmortization({
         >
           View all
         </Link>
-      }
+      )}
       settings={(
         <CardSettingsFlyout
           tile={tile}

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardReadwise/-DashboardReadwise.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardReadwise/-DashboardReadwise.tsx
@@ -38,7 +38,7 @@ export function DashboardReadwise({
       tile={tile}
       onUpdateTile={onUpdateTile}
       title="Readwise"
-      action={
+      action={(
         <Button
           asChild
           size="sm"
@@ -53,14 +53,14 @@ export function DashboardReadwise({
             <ExternalLink />
           </a>
         </Button>
-      }
+      )}
       settingsLink={
         <SettingsLink className="text-sm">Set Readwise API key</SettingsLink>
       }
       configured={configured}
       isPending={isPending}
       error={error}
-      connectPrompt={
+      connectPrompt={(
         <p className="text-sm text-muted-foreground">
           Add your Readwise API key in
           {" "}
@@ -69,7 +69,7 @@ export function DashboardReadwise({
           to
           see your reading list.
         </p>
-      }
+      )}
     >
       <Tabs defaultValue="started">
         <TabsList className="h-8">

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardUnderutilizedProviders/-DashboardUnderutilizedProviders.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardUnderutilizedProviders/-DashboardUnderutilizedProviders.tsx
@@ -34,7 +34,7 @@ export function DashboardUnderutilizedProviders({
     <DashboardCard
       autoHeight={isAutoHeight(tile)}
       title="Underutilized Providers"
-      action={
+      action={(
         <Link
           to="/providers"
           className="
@@ -44,7 +44,7 @@ export function DashboardUnderutilizedProviders({
         >
           View all
         </Link>
-      }
+      )}
       settings={(
         <CardSettingsFlyout
           tile={tile}

--- a/packages/client/src/routes/routines/tracker/-components/-TrackerTables.tsx
+++ b/packages/client/src/routes/routines/tracker/-components/-TrackerTables.tsx
@@ -155,7 +155,7 @@ export function TrackerTables({
 
       {activeDailies.length > 0 && (
         <DashboardCard
-          title={
+          title={(
             <span className="inline-flex items-center gap-2">
               Active Routines
               <TooManyDailiesWarning
@@ -164,8 +164,8 @@ export function TrackerTables({
                 size="sm"
               />
             </span>
-          }
-          action={
+          )}
+          action={(
             <>
               <DailiesViewModeToggle
                 mode={mode}
@@ -173,7 +173,7 @@ export function TrackerTables({
               />
               <DailiesLimitSetting />
             </>
-          }
+          )}
         >
           {mode === "list" && (
             <DailiesActiveListView

--- a/packages/client/src/routes/settings/-components/connections/-ReadwiseSection.tsx
+++ b/packages/client/src/routes/settings/-components/connections/-ReadwiseSection.tsx
@@ -15,7 +15,7 @@ export function ReadwiseSection() {
         hint: data?.readwiseKeyHint ?? null,
       })}
       dataQueryKey={queryKeys.readwise.readingList()}
-      description={
+      description={(
         <>
           Connect your Readwise Reader account to show your reading list on the
           dashboard. Paste a token from
@@ -33,7 +33,7 @@ export function ReadwiseSection() {
           </a>
           .
         </>
-      }
+      )}
     />
   );
 }

--- a/packages/client/src/routes/settings/-components/connections/-TodoistSection.tsx
+++ b/packages/client/src/routes/settings/-components/connections/-TodoistSection.tsx
@@ -15,7 +15,7 @@ export function TodoistSection() {
         hint: data?.todoistKeyHint ?? null,
       })}
       dataQueryKey={queryKeys.todoist.tasks()}
-      description={
+      description={(
         <>
           Connect your Todoist account to show tasks due today and overdue on
           the dashboard. Copy your API token from
@@ -33,7 +33,7 @@ export function TodoistSection() {
           </a>
           .
         </>
-      }
+      )}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes an ESLint configuration issue where `@stylistic/jsx-closing-bracket-location` and `@stylistic/indent` rules were fighting over multiline JSX prop values, causing circular fixes and `ESLintCircularFixesWarning`. The fix enforces consistent wrapping of JSX in parentheses across all contexts, particularly for JSX used as prop values.

## Changes

- **eslint.config.js:** Added a new rule configuration for `packages/client/src/**/*.tsx` that sets `@stylistic/jsx-wrap-multilines` to enforce `parens-new-line` for all JSX contexts (`prop`, `propertyValue`, etc.), preventing the conflict between indent and closing-bracket-location rules.

- **Removed eslint-disable comment:** Deleted the `@stylistic/indent` disable comment from `combobox.tsx` (a vendored shadcn/ui file) since the root cause is now fixed.

- **Applied consistent JSX wrapping:** Updated JSX prop values across multiple files to use the enforced `parens-new-line` format:
  - `combobox.tsx`: Wrapped `render` prop values in parentheses
  - `DashboardReadwise.tsx`: Wrapped `action` and `connectPrompt` prop values
  - `TrackerTables.tsx`: Wrapped `title` and `action` prop values
  - `DashboardCoursesByAmortization.tsx`: Wrapped `action` prop value
  - `DashboardUnderutilizedProviders.tsx`: Wrapped `action` prop value
  - `ReadwiseSection.tsx`: Wrapped `description` prop value
  - `TodoistSection.tsx`: Wrapped `description` prop value

- **Added regression test:** Created `dashboardCards/-jsxWrapMultilines.test.ts` that verifies the fix by:
  - Testing that collapsed JSX prop values (as Prettier would format them) are correctly re-expanded by `eslint --fix`
  - Ensuring no residual `@stylistic/*` errors remain after fixing
  - Verifying that `eslint --fix` is idempotent (no circular fixes)

## Implementation Details

The root cause was that unwrapped multiline JSX prop values created a conflict: `jsx-closing-bracket-location` wants the `/>` tag-aligned, while `indent` wants it indented relative to the opening tag. By forcing all JSX to be wrapped in parentheses on new lines (`settings={(\n  <Flyout … />\n)}`), the rules no longer conflict, and `eslint --fix` converges in a single pass.

This pattern was already in use across the dashboard cards; the fix makes it mandatory via ESLint configuration.

https://claude.ai/code/session_01FtqKjXWQbUsQkaMZuMFNsr

Closes #517