### PR TITLE
feat(routines): let resource day entries target a module or group

### DIFF
--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -46,6 +46,8 @@ export function DailyCompletionsManager({
     toggleExpanded,
     taskNames,
     resourceNames,
+    moduleNames,
+    moduleGroupNames,
     rows,
     hasRows,
     mutationPending,
@@ -185,6 +187,8 @@ export function DailyCompletionsManager({
                               entry={scheduledEntry}
                               taskNames={taskNames}
                               resourceNames={resourceNames}
+                              moduleNames={moduleNames}
+                              moduleGroupNames={moduleGroupNames}
                               showMeta={false}
                             />
                           </span>

--- a/packages/client/src/components/routines/CuratedScheduleField.tsx
+++ b/packages/client/src/components/routines/CuratedScheduleField.tsx
@@ -12,6 +12,10 @@ interface CuratedScheduleFieldProps {
   onChange: (next: CuratedRow[]) => void;
   taskOptions: SelectOption[];
   resourceOptions: SelectOption[];
+  // Per-resource module groups / modules, keyed by resource id, for narrowing a
+  // resource entry.
+  moduleGroupsByResource: Map<string, SelectOption[]>;
+  modulesByResource: Map<string, SelectOption[]>;
 }
 
 // The curated schedule editor: one row per date from today through the chosen
@@ -21,6 +25,8 @@ export function CuratedScheduleField({
   onChange,
   taskOptions,
   resourceOptions,
+  moduleGroupsByResource,
+  modulesByResource,
 }: CuratedScheduleFieldProps) {
   // Inline "Add resource" modal — shared across dates; only one combobox dropdown
   // is open at a time, so a single typed-text value and target date are enough.
@@ -51,22 +57,31 @@ export function CuratedScheduleField({
   return (
     <div className="flex flex-col gap-2">
       <ul className="flex flex-col gap-2">
-        {value.map(row => (
-          <ScheduleEntryRow
-            key={row.date}
-            label={formatCuratedDateLabel(row.date)}
-            ariaPrefix={row.date}
-            row={row}
-            taskOptions={taskOptions}
-            resourceOptions={resourceOptions}
-            onChange={patch => update(row.date, patch)}
-            onInputValueChange={setInputValue}
-            onAddResource={() => {
-              setAddForDate(row.date);
-              setAddOpen(true);
-            }}
-          />
-        ))}
+        {value.map((row) => {
+          const isResource = row.type === "resource" && !!row.id;
+          return (
+            <ScheduleEntryRow
+              key={row.date}
+              label={formatCuratedDateLabel(row.date)}
+              ariaPrefix={row.date}
+              row={row}
+              taskOptions={taskOptions}
+              resourceOptions={resourceOptions}
+              groupOptions={
+                isResource ? (moduleGroupsByResource.get(row.id) ?? []) : []
+              }
+              moduleOptions={
+                isResource ? (modulesByResource.get(row.id) ?? []) : []
+              }
+              onChange={patch => update(row.date, patch)}
+              onInputValueChange={setInputValue}
+              onAddResource={() => {
+                setAddForDate(row.date);
+                setAddOpen(true);
+              }}
+            />
+          );
+        })}
       </ul>
 
       <QuickAddResourceDialog

--- a/packages/client/src/components/routines/RoutineEntryLabel.stories.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.stories.tsx
@@ -5,6 +5,8 @@ import { RoutineEntryLabel } from "./RoutineEntryLabel";
 import { RouterStub } from "@/test-utils/RouterStub";
 import {
   makeReferenceItem,
+  moduleGroupNames,
+  moduleNames,
   resourceNames,
   taskNames,
 } from "@/test-utils/routinesFixtures";
@@ -15,6 +17,8 @@ const meta = {
     entry: makeReferenceItem(),
     taskNames,
     resourceNames,
+    moduleNames,
+    moduleGroupNames,
   },
   // Task/resource entries render an EntityLink (<Link>), so a router is required.
   decorators: [
@@ -48,6 +52,18 @@ export const ResourceEntry: Story = {
     entry: makeReferenceItem({
       type: "resource",
       id: "resource-1",
+    }),
+  },
+};
+
+// A resource entry narrowed to a specific module shows the module name in place
+// of the resource name.
+export const ResourceModuleEntry: Story = {
+  args: {
+    entry: makeReferenceItem({
+      type: "resource",
+      id: "resource-1",
+      moduleId: "module-2",
     }),
   },
 };

--- a/packages/client/src/components/routines/RoutineEntryLabel.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.tsx
@@ -1,5 +1,6 @@
 import type { RoutineReferenceItem } from "@emstack/types";
 
+import { resourceEntryLabel } from "@emstack/types";
 import { MapPinIcon } from "lucide-react";
 
 import { EntityLink } from "@/components/boxElements";
@@ -9,6 +10,11 @@ interface RoutineEntryLabelProps {
   entry: RoutineReferenceItem;
   taskNames: Map<string, string>;
   resourceNames: Map<string, string>;
+  // A resource entry may narrow to a module or module group; these resolve that
+  // narrower name, which stands in for the resource name. Optional — omitted
+  // means "whole resource" rendering only.
+  moduleNames?: Map<string, string>;
+  moduleGroupNames?: Map<string, string>;
   // When true (default), render the full presentation: a leading TYPE badge plus
   // any notes/location. When false, render only the actionable sentence (compact
   // form used inline, e.g. inside a Day Entries row).
@@ -17,11 +23,15 @@ interface RoutineEntryLabelProps {
 
 // Renders a routine's per-day reference item (task / resource / freeform) as an
 // actionable sentence, resolving the task/resource name from the supplied maps
-// and linking task/resource entries to their detail pages.
+// and linking task/resource entries to their detail pages. A resource entry that
+// narrows to a module/group shows that narrower name (linking still targets the
+// owning resource).
 export function RoutineEntryLabel({
   entry,
   taskNames,
   resourceNames,
+  moduleNames,
+  moduleGroupNames,
   showMeta = true,
 }: RoutineEntryLabelProps) {
   // The entry's name as a clickable link (task / resource) or plain text
@@ -40,7 +50,15 @@ export function RoutineEntryLabel({
       >
         {entry.type === "task"
           ? (taskNames.get(entry.id) ?? entry.id)
-          : (resourceNames.get(entry.id) ?? entry.id)}
+          : resourceEntryLabel({
+            resourceName: resourceNames.get(entry.id) ?? entry.id,
+            moduleName: entry.moduleId
+              ? moduleNames?.get(entry.moduleId)
+              : null,
+            groupName: entry.moduleGroupId
+              ? moduleGroupNames?.get(entry.moduleGroupId)
+              : null,
+          })}
       </EntityLink>
     );
 

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -1,7 +1,7 @@
 import type { WeeklyEntry, WeeklyRowType } from "./weekly";
 import type { SelectOption } from "@/utils";
 
-import { buildActionableSentence } from "@emstack/types";
+import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
@@ -15,6 +15,10 @@ interface ScheduleEntryRowProps {
   row: WeeklyEntry;
   taskOptions: SelectOption[];
   resourceOptions: SelectOption[];
+  // Module groups / modules belonging to the row's currently-chosen resource.
+  // Empty unless the entry is a resource with a populated module hierarchy.
+  groupOptions: SelectOption[];
+  moduleOptions: SelectOption[];
   onChange: (patch: Partial<WeeklyEntry>) => void;
   // Open the "add resource" dialog targeting this row.
   onAddResource: () => void;
@@ -23,14 +27,17 @@ interface ScheduleEntryRowProps {
 }
 
 // One schedule row's editor: type select, task/resource picker (or freeform
-// input), then optional notes / location / prepend / append with a live preview.
-// Shared by WeeklyScheduleField (per weekday) and CuratedScheduleField (per date).
+// input), an optional module-group/module narrowing for resource entries, then
+// optional notes / location / prepend / append with a live preview. Shared by
+// WeeklyScheduleField (per weekday) and CuratedScheduleField (per date).
 export function ScheduleEntryRow({
   label,
   ariaPrefix,
   row,
   taskOptions,
   resourceOptions,
+  groupOptions,
+  moduleOptions,
   onChange,
   onAddResource,
   onInputValueChange,
@@ -42,8 +49,24 @@ export function ScheduleEntryRow({
         ? resourceOptions
         : [];
   const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
+  // A resource entry may narrow to a module / group; show that narrower name in
+  // the preview (matching how the entry renders everywhere else).
+  const moduleLabel = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)?.label
+    : null;
+  const groupLabel = row.moduleGroupId
+    ? groupOptions.find(o => o.value === row.moduleGroupId)?.label
+    : null;
   const itemName
-    = row.type === "freeform" ? row.id : (optionsMap.get(row.id) ?? "");
+    = row.type === "freeform"
+      ? row.id
+      : row.type === "resource"
+        ? resourceEntryLabel({
+          resourceName: optionsMap.get(row.id) ?? "",
+          moduleName: moduleLabel,
+          groupName: groupLabel,
+        })
+        : (optionsMap.get(row.id) ?? "");
   const showPreview
     = !!itemName && (!!row.prependText.trim() || !!row.appendText.trim());
   const preview = buildActionableSentence({
@@ -51,6 +74,12 @@ export function ScheduleEntryRow({
     name: itemName,
     appendText: row.appendText,
   });
+  // The module narrowing only makes sense once a resource is chosen, and only
+  // when that resource actually has modules / groups to pick from.
+  const showModulePickers
+    = row.type === "resource"
+      && !!row.id
+      && (groupOptions.length > 0 || moduleOptions.length > 0);
 
   return (
     <li
@@ -65,11 +94,13 @@ export function ScheduleEntryRow({
           aria-label={`${ariaPrefix} type`}
           value={row.type}
           onChange={(e) => {
-            // Changing the type clears the chosen item (different option set)
-            // and any note/location.
+            // Changing the type clears the chosen item (different option set),
+            // any module narrowing, and any note/location.
             onChange({
               type: e.target.value as WeeklyRowType,
               id: "",
+              moduleId: "",
+              moduleGroupId: "",
               notes: "",
               location: "",
             });
@@ -104,8 +135,12 @@ export function ScheduleEntryRow({
               items={itemOptions.map(o => o.value)}
               value={row.id || null}
               onValueChange={val =>
+                // A different resource has different modules, so clear any
+                // existing narrowing when the picked item changes.
                 onChange({
                   id: val ?? "",
+                  moduleId: "",
+                  moduleGroupId: "",
                 })}
               onInputValueChange={val => onInputValueChange(val)}
               itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
@@ -128,6 +163,70 @@ export function ScheduleEntryRow({
             </Combobox>
           )}
       </div>
+
+      {showModulePickers && (
+        <div
+          className="
+            grid grid-cols-1 gap-1.5
+            sm:grid-cols-2
+          "
+        >
+          <select
+            aria-label={`${ariaPrefix} module group`}
+            value={row.moduleGroupId}
+            onChange={e =>
+              // Group and module are mutually exclusive — picking a group clears
+              // any specific module.
+              onChange({
+                moduleGroupId: e.target.value,
+                ...(e.target.value
+                  ? {
+                    moduleId: "",
+                  }
+                  : {}),
+              })}
+            className="
+              flex h-9 w-full rounded-md border bg-background px-2 text-sm
+            "
+          >
+            <option value="">— Whole resource —</option>
+            {groupOptions.map(g => (
+              <option
+                key={g.value}
+                value={g.value}
+              >
+                {g.label}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label={`${ariaPrefix} module`}
+            value={row.moduleId}
+            onChange={e =>
+              onChange({
+                moduleId: e.target.value,
+                ...(e.target.value
+                  ? {
+                    moduleGroupId: "",
+                  }
+                  : {}),
+              })}
+            className="
+              flex h-9 w-full rounded-md border bg-background px-2 text-sm
+            "
+          >
+            <option value="">— Whole resource —</option>
+            {moduleOptions.map(m => (
+              <option
+                key={m.value}
+                value={m.value}
+              >
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {row.type !== "" && (
         <>

--- a/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
@@ -8,6 +8,8 @@ import { WeeklyScheduleField } from "./WeeklyScheduleField";
 import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
 import {
+  moduleGroupsByResource,
+  modulesByResource,
   resourceOptions,
   taskOptions,
 } from "@/test-utils/routinesFixtures";
@@ -19,6 +21,8 @@ const meta: Meta<typeof WeeklyScheduleField> = {
     onChange: fn(),
     taskOptions,
     resourceOptions,
+    moduleGroupsByResource: new Map(),
+    modulesByResource: new Map(),
   },
   // Always renders QuickAddResourceDialog (useNavigate + useQueryClient +
   // useMutation), so both a router and a query client are required.
@@ -70,5 +74,29 @@ export const Populated: Story = {
     const mondayType = await canvas.findByLabelText("Monday type");
     await expect(mondayType).toHaveValue("task");
     await expect(canvas.getByLabelText("Friday type")).toHaveValue("freeform");
+  },
+};
+
+// A resource entry on a resource that has a module hierarchy: the module-group
+// and module narrowing selects appear, with the chosen module reflected.
+export const WithModule: Story = {
+  args: {
+    value: weeklyToRows({
+      1: {
+        type: "resource",
+        id: "resource-1",
+        moduleId: "module-2",
+      },
+    }),
+    moduleGroupsByResource,
+    modulesByResource,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const moduleSelect = await canvas.findByLabelText("Monday module");
+    await expect(moduleSelect).toHaveValue("module-2");
+    await expect(canvas.getByLabelText("Monday module group")).toHaveValue("");
   },
 };

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -13,6 +13,10 @@ interface WeeklyScheduleFieldProps {
   onChange: (next: WeeklyRow[]) => void;
   taskOptions: SelectOption[];
   resourceOptions: SelectOption[];
+  // Per-resource module groups / modules, keyed by resource id, for narrowing a
+  // resource entry.
+  moduleGroupsByResource: Map<string, SelectOption[]>;
+  modulesByResource: Map<string, SelectOption[]>;
 }
 
 export function WeeklyScheduleField({
@@ -20,6 +24,8 @@ export function WeeklyScheduleField({
   onChange,
   taskOptions,
   resourceOptions,
+  moduleGroupsByResource,
+  modulesByResource,
 }: WeeklyScheduleFieldProps) {
   const rowsByDay = useMemo(
     () => new Map(value.map(r => [r.day, r])),
@@ -52,11 +58,14 @@ export function WeeklyScheduleField({
             day,
             type: "" as WeeklyRow["type"],
             id: "",
+            moduleId: "",
+            moduleGroupId: "",
             notes: "",
             location: "",
             prependText: "",
             appendText: "",
           };
+          const isResource = row.type === "resource" && !!row.id;
           return (
             <ScheduleEntryRow
               key={day}
@@ -65,6 +74,12 @@ export function WeeklyScheduleField({
               row={row}
               taskOptions={taskOptions}
               resourceOptions={resourceOptions}
+              groupOptions={
+                isResource ? (moduleGroupsByResource.get(row.id) ?? []) : []
+              }
+              moduleOptions={
+                isResource ? (modulesByResource.get(row.id) ?? []) : []
+              }
               onChange={patch => update(day, patch)}
               onInputValueChange={setInputValue}
               onAddResource={() => {

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -9,6 +9,7 @@ import {
   representativeRow,
   rowsToCurated,
   rowsToWeekly,
+  weeklyEntryName,
   weeklyToRows,
 } from "./weekly";
 
@@ -203,6 +204,8 @@ describe("representativeRow (Daily Task mode)", () => {
     expect(representativeRow(rows)).toEqual({
       type: "task",
       id: "",
+      moduleId: "",
+      moduleGroupId: "",
       notes: "",
       location: "",
       prependText: "",
@@ -222,6 +225,8 @@ describe("representativeRow (Daily Task mode)", () => {
     expect(representativeRow(rows)).toEqual({
       type: "resource",
       id: "res-1",
+      moduleId: "",
+      moduleGroupId: "",
       notes: "chapter 3",
       location: "the gym",
       prependText: "Review",
@@ -233,6 +238,8 @@ describe("representativeRow (Daily Task mode)", () => {
     expect(representativeRow(weeklyToRows(undefined))).toEqual({
       type: "",
       id: "",
+      moduleId: "",
+      moduleGroupId: "",
       notes: "",
       location: "",
       prependText: "",
@@ -279,6 +286,8 @@ describe("curated schedule helpers", () => {
       date: "2026-06-14",
       type: "",
       id: "",
+      moduleId: "",
+      moduleGroupId: "",
       notes: "",
       location: "",
       prependText: "",
@@ -337,5 +346,126 @@ describe("curated schedule helpers", () => {
       type: "freeform",
       id: "Stretch",
     });
+  });
+});
+
+describe("resource entry module narrowing", () => {
+  test("weeklyToRows surfaces a resource entry's module / group ids", () => {
+    const weekly: RoutineWeekly = {
+      1: {
+        type: "resource",
+        id: "res-1",
+        moduleId: "mod-1",
+      },
+      2: {
+        type: "resource",
+        id: "res-2",
+        moduleGroupId: "grp-1",
+      },
+    };
+    const rows = weeklyToRows(weekly);
+    expect(rows.find(r => r.day === "1")).toMatchObject({
+      moduleId: "mod-1",
+      moduleGroupId: "",
+    });
+    expect(rows.find(r => r.day === "2")).toMatchObject({
+      moduleId: "",
+      moduleGroupId: "grp-1",
+    });
+  });
+
+  test("rowsToWeekly persists a resource module but omits empty narrowing", () => {
+    const withModule = rowsToWeekly(
+      weeklyToRows({
+        1: {
+          type: "resource",
+          id: "res-1",
+          moduleId: "mod-1",
+        },
+      }),
+    );
+    expect(withModule[1]).toEqual({
+      type: "resource",
+      id: "res-1",
+      moduleId: "mod-1",
+    });
+
+    const plainResource = rowsToWeekly(
+      weeklyToRows({
+        2: {
+          type: "resource",
+          id: "res-2",
+        },
+      }),
+    );
+    expect(plainResource[2]).not.toHaveProperty("moduleId");
+    expect(plainResource[2]).not.toHaveProperty("moduleGroupId");
+  });
+
+  test("rowsToWeekly never persists module narrowing on a task entry", () => {
+    // moduleId would only ever land on a row through a resource selection, but
+    // guard the invariant that task entries stay module-free.
+    const rows = weeklyToRows({
+      3: {
+        type: "task",
+        id: "task-1",
+      },
+    });
+    const tweaked = rows.map(r =>
+      r.day === "3"
+        ? {
+          ...r,
+          moduleId: "mod-9",
+        }
+        : r);
+    expect(rowsToWeekly(tweaked)[3]).not.toHaveProperty("moduleId");
+  });
+
+  test("weeklyEntryName shows the module name in place of the resource", () => {
+    const resourceNames = new Map([["res-1", "Duolingo Spanish"]]);
+    const moduleNames = new Map([["mod-1", "Basics 1"]]);
+    const moduleGroupNames = new Map([["grp-1", "Unit 1"]]);
+
+    expect(
+      weeklyEntryName(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleId: "mod-1",
+        },
+        new Map(),
+        resourceNames,
+        moduleNames,
+        moduleGroupNames,
+      ),
+    ).toBe("Basics 1");
+
+    expect(
+      weeklyEntryName(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleGroupId: "grp-1",
+        },
+        new Map(),
+        resourceNames,
+        moduleNames,
+        moduleGroupNames,
+      ),
+    ).toBe("Unit 1");
+
+    // No narrowing → the resource name stands.
+    expect(
+      weeklyEntryName(
+        {
+          type: "resource",
+          id: "res-1",
+        },
+        new Map(),
+        resourceNames,
+        moduleNames,
+        moduleGroupNames,
+      ),
+    ).toBe("Duolingo Spanish");
   });
 });

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -6,6 +6,8 @@ import type {
   RoutineWeekly,
 } from "@emstack/types";
 
+import { resourceEntryLabel } from "@emstack/types";
+
 export type WeeklyRowType = "" | "task" | "resource" | "freeform";
 
 // Curated mode picks an end date at most this many days past today; the per-date
@@ -17,6 +19,10 @@ export interface WeeklyRow {
   // "" = no entry scheduled for this day.
   type: WeeklyRowType;
   id: string;
+  // Resource entries may narrow to a specific module or module group (mutually
+  // exclusive). "" = the whole resource. Ignored for task/freeform entries.
+  moduleId: string;
+  moduleGroupId: string;
   // Optional free-text note for this day's item. "" = no note.
   notes: string;
   // Optional place/link where this day's item happens. "" = no location.
@@ -64,6 +70,8 @@ export function weeklyToRows(
       day,
       type: entry?.type ?? "",
       id: entry?.id ?? "",
+      moduleId: entry?.moduleId ?? "",
+      moduleGroupId: entry?.moduleGroupId ?? "",
       notes: entry?.notes ?? "",
       location: entry?.location ?? "",
       prependText: entry?.prependText ?? "",
@@ -83,6 +91,16 @@ function referenceItemFromRow(
     type,
     id: row.id,
   };
+  // Module narrowing only applies to resource entries, and the two are mutually
+  // exclusive — persist at most one.
+  if (type === "resource") {
+    if (row.moduleId) {
+      item.moduleId = row.moduleId;
+    }
+    else if (row.moduleGroupId) {
+      item.moduleGroupId = row.moduleGroupId;
+    }
+  }
   if (row.notes) {
     item.notes = row.notes;
   }
@@ -123,6 +141,8 @@ export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
     ? {
       type: found.type,
       id: found.id,
+      moduleId: found.moduleId,
+      moduleGroupId: found.moduleGroupId,
       notes: found.notes,
       location: found.location,
       prependText: found.prependText,
@@ -131,6 +151,8 @@ export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
     : {
       type: "",
       id: "",
+      moduleId: "",
+      moduleGroupId: "",
       notes: "",
       location: "",
       prependText: "",
@@ -141,6 +163,8 @@ export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
 export function fillAllDays(entry: {
   type: WeeklyRowType;
   id: string;
+  moduleId?: string;
+  moduleGroupId?: string;
   notes?: string;
   location?: string;
   prependText?: string;
@@ -150,6 +174,8 @@ export function fillAllDays(entry: {
     day,
     type: entry.type,
     id: entry.id,
+    moduleId: entry.moduleId ?? "",
+    moduleGroupId: entry.moduleGroupId ?? "",
     notes: entry.notes ?? "",
     location: entry.location ?? "",
     prependText: entry.prependText ?? "",
@@ -212,6 +238,8 @@ export function curatedToRows(
       date,
       type: entry?.type ?? "",
       id: entry?.id ?? "",
+      moduleId: entry?.moduleId ?? "",
+      moduleGroupId: entry?.moduleGroupId ?? "",
       notes: entry?.notes ?? "",
       location: entry?.location ?? "",
       prependText: entry?.prependText ?? "",
@@ -242,15 +270,27 @@ export function rowsToCurated(
 
 // Display name for a weekly entry: freeform entries carry their own text in
 // `id`; task / resource entries resolve through the id → name maps and fall
-// back to the raw id when the lookup misses.
+// back to the raw id when the lookup misses. A resource entry that narrows to a
+// module or module group shows that narrower name in place of the resource name
+// (see resourceEntryLabel).
 export function weeklyEntryName(
   entry: RoutineReferenceItem,
   taskNames: Map<string, string>,
   resourceNames: Map<string, string>,
+  moduleNames = new Map<string, string>(),
+  moduleGroupNames = new Map<string, string>(),
 ): string {
   if (entry.type === "freeform") {
     return entry.id;
   }
-  const names = entry.type === "task" ? taskNames : resourceNames;
-  return names.get(entry.id) ?? entry.id;
+  if (entry.type === "task") {
+    return taskNames.get(entry.id) ?? entry.id;
+  }
+  return resourceEntryLabel({
+    resourceName: resourceNames.get(entry.id) ?? entry.id,
+    moduleName: entry.moduleId ? moduleNames.get(entry.moduleId) : null,
+    groupName: entry.moduleGroupId
+      ? moduleGroupNames.get(entry.moduleGroupId)
+      : null,
+  });
 }

--- a/packages/client/src/hooks/useDailyCompletions.ts
+++ b/packages/client/src/hooks/useDailyCompletions.ts
@@ -155,7 +155,7 @@ export function useDailyCompletions(daily: Daily, readOnly = false) {
   const curatedEntries = daily.curated?.entries ?? {};
 
   const {
-    taskNames, resourceNames,
+    taskNames, resourceNames, moduleNames, moduleGroupNames,
   } = useTaskResourceNames(isWeekly || isCurated);
 
   const completionsByDate = useMemo(() => {
@@ -305,6 +305,8 @@ export function useDailyCompletions(daily: Daily, readOnly = false) {
     isWeekly,
     taskNames,
     resourceNames,
+    moduleNames,
+    moduleGroupNames,
 
     rows,
     hasRows: visibleDateKeys.length > 0,

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -23,11 +23,14 @@ import {
   buildConnectionOptions,
   decodeConnection,
   encodeConnection,
+  fetchModuleGroups,
+  fetchModules,
   fetchResources,
   fetchTasks,
   fetchTopics,
   formHasChanges,
   getTodayKey,
+  groupOptionsByResource,
   toOptions,
   upsertRoutine,
 } from "@/utils";
@@ -38,6 +41,8 @@ const weeklyRowSchema = z
     day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
     type: z.enum(["", "task", "resource", "freeform"]),
     id: z.string(),
+    moduleId: z.string(),
+    moduleGroupId: z.string(),
     notes: z.string(),
     location: z.string(),
     prependText: z.string(),
@@ -53,6 +58,8 @@ const curatedRowSchema = z
     date: z.string(),
     type: z.enum(["", "task", "resource", "freeform"]),
     id: z.string(),
+    moduleId: z.string(),
+    moduleGroupId: z.string(),
     notes: z.string(),
     location: z.string(),
     prependText: z.string(),
@@ -124,8 +131,31 @@ export function useRoutineDetailsForm(
     queryFn: () => fetchResources(),
   });
 
+  // All modules / module groups, fetched once and bucketed by resource so a
+  // resource entry's row can offer the narrowing pickers (see ScheduleEntryRow).
+  const {
+    data: modules,
+  } = useQuery({
+    queryKey: queryKeys.modules.list(),
+    queryFn: () => fetchModules(),
+  });
+  const {
+    data: moduleGroups,
+  } = useQuery({
+    queryKey: queryKeys.moduleGroups.list(),
+    queryFn: () => fetchModuleGroups(),
+  });
+
   const taskOptions = useMemo(() => toOptions(tasks), [tasks]);
   const resourceOptions = useMemo(() => toOptions(resources), [resources]);
+  const modulesByResource = useMemo(
+    () => groupOptionsByResource(modules),
+    [modules],
+  );
+  const moduleGroupsByResource = useMemo(
+    () => groupOptionsByResource(moduleGroups),
+    [moduleGroups],
+  );
   const connectionOptions = useMemo(
     () => buildConnectionOptions(topics, tasks, resources),
     [topics, tasks, resources],
@@ -250,6 +280,8 @@ export function useRoutineDetailsForm(
             date: key,
             type: "" as const,
             id: "",
+            moduleId: "",
+            moduleGroupId: "",
             notes: "",
             location: "",
             prependText: "",
@@ -264,6 +296,8 @@ export function useRoutineDetailsForm(
     connectionOptions,
     taskOptions,
     resourceOptions,
+    modulesByResource,
+    moduleGroupsByResource,
     isDaily,
     isCurated,
     curatedWindow,

--- a/packages/client/src/hooks/useTaskResourceNames.ts
+++ b/packages/client/src/hooks/useTaskResourceNames.ts
@@ -2,13 +2,19 @@ import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
-import { fetchResources, fetchTasks } from "@/utils";
+import {
+  fetchModuleGroups,
+  fetchModules,
+  fetchResources,
+  fetchTasks,
+} from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
-// Task / resource id → display-name maps for resolving weekly schedule
-// entries. Weekly grids carry unresolved ids, so consumers look names up
-// from the (shared, cached) task/resource lists. Pass enabled=false to
-// skip the fetches when names aren't needed — the maps stay empty.
+// Task / resource / module / module-group id → display-name maps for resolving
+// weekly schedule entries. Weekly grids carry unresolved ids (a resource entry
+// may further narrow to a module or group), so consumers look names up from the
+// (shared, cached) lists. Pass enabled=false to skip the fetches when names
+// aren't needed — the maps stay empty.
 export function useTaskResourceNames(enabled = true) {
   const {
     data: tasks,
@@ -24,6 +30,20 @@ export function useTaskResourceNames(enabled = true) {
     queryFn: () => fetchResources(),
     enabled,
   });
+  const {
+    data: modules,
+  } = useQuery({
+    queryKey: queryKeys.modules.list(),
+    queryFn: () => fetchModules(),
+    enabled,
+  });
+  const {
+    data: moduleGroups,
+  } = useQuery({
+    queryKey: queryKeys.moduleGroups.list(),
+    queryFn: () => fetchModuleGroups(),
+    enabled,
+  });
 
   const taskNames = useMemo(
     () => new Map((tasks ?? []).map(t => [t.id, t.name])),
@@ -33,9 +53,19 @@ export function useTaskResourceNames(enabled = true) {
     () => new Map((resources ?? []).map(r => [r.id, r.name])),
     [resources],
   );
+  const moduleNames = useMemo(
+    () => new Map((modules ?? []).map(m => [m.id, m.name])),
+    [modules],
+  );
+  const moduleGroupNames = useMemo(
+    () => new Map((moduleGroups ?? []).map(g => [g.id, g.name])),
+    [moduleGroups],
+  );
 
   return {
     taskNames,
     resourceNames,
+    moduleNames,
+    moduleGroupNames,
   };
 }

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.stories.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.stories.tsx
@@ -30,6 +30,8 @@ const meta = {
       seededQueryClient([
         [["tasks"], [makeTask()]],
         [["resources"], makeResources()],
+        [["modules-all"], []],
+        [["module-groups-all"], []],
       ]),
     ),
   ],

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
@@ -33,6 +33,8 @@ export function RoutineDetailsContent({
   const {
     taskNames,
     resourceNames,
+    moduleNames,
+    moduleGroupNames,
   } = useTaskResourceNames();
 
   const weekly = data.weekly ?? {};
@@ -164,6 +166,8 @@ export function RoutineDetailsContent({
                         entry={entry}
                         taskNames={taskNames}
                         resourceNames={resourceNames}
+                        moduleNames={moduleNames}
+                        moduleGroupNames={moduleGroupNames}
                       />
                     )
                     : (
@@ -213,6 +217,8 @@ export function RoutineDetailsContent({
                             entry={entry}
                             taskNames={taskNames}
                             resourceNames={resourceNames}
+                            moduleNames={moduleNames}
+                            moduleGroupNames={moduleGroupNames}
                           />
                         )
                         : (

--- a/packages/client/src/routes/routines/$id/-components/-RoutineTodayCard.stories.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineTodayCard.stories.tsx
@@ -29,6 +29,8 @@ const meta = {
           client={seededQueryClient([
             [["tasks"], [makeTask()]],
             [["resources"], makeResources()],
+            [["modules-all"], []],
+            [["module-groups-all"], []],
           ])}
         >
           <Story />

--- a/packages/client/src/routes/routines/$id/-components/-RoutineTodayCard.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineTodayCard.tsx
@@ -30,7 +30,7 @@ export function RoutineTodayCard({
 }: RoutineTodayCardProps) {
   const weekTargetWindow = useWeekTargetWindow();
   const {
-    taskNames, resourceNames,
+    taskNames, resourceNames, moduleNames, moduleGroupNames,
   } = useTaskResourceNames();
   const statusMutation = useRoutineStatusMutation(data.id);
 
@@ -110,6 +110,8 @@ export function RoutineTodayCard({
                   entry={todayEntry}
                   taskNames={taskNames}
                   resourceNames={resourceNames}
+                  moduleNames={moduleNames}
+                  moduleGroupNames={moduleGroupNames}
                   showMeta={false}
                 />
               </p>

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-CuratedScheduleSection.stories.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-CuratedScheduleSection.stories.tsx
@@ -16,6 +16,8 @@ function Host() {
     curatedWindow,
     taskOptions,
     resourceOptions,
+    moduleGroupsByResource,
+    modulesByResource,
   } = useRoutineDetailsForm(makeRoutine({
     mode: "curated",
   }), () =>
@@ -27,6 +29,8 @@ function Host() {
       curatedWindow={curatedWindow}
       taskOptions={taskOptions}
       resourceOptions={resourceOptions}
+      moduleGroupsByResource={moduleGroupsByResource}
+      modulesByResource={modulesByResource}
     />
   );
 }
@@ -40,6 +44,8 @@ const meta: Meta<typeof CuratedScheduleSection> = {
         [["topics"], []],
         [["tasks"], []],
         [["resources"], []],
+        [["modules-all"], []],
+        [["module-groups-all"], []],
       ]),
     ),
   ],

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-CuratedScheduleSection.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-CuratedScheduleSection.tsx
@@ -13,6 +13,8 @@ interface CuratedScheduleSectionProps {
   curatedWindow: DetailsForm["curatedWindow"];
   taskOptions: DetailsForm["taskOptions"];
   resourceOptions: DetailsForm["resourceOptions"];
+  moduleGroupsByResource: DetailsForm["moduleGroupsByResource"];
+  modulesByResource: DetailsForm["modulesByResource"];
 }
 
 // The "Curated" schedule block: an end-date picker (capped at 14 days out) plus a
@@ -23,6 +25,8 @@ export function CuratedScheduleSection({
   curatedWindow,
   taskOptions,
   resourceOptions,
+  moduleGroupsByResource,
+  modulesByResource,
 }: CuratedScheduleSectionProps) {
   return (
     <div className="flex flex-col gap-3">
@@ -50,6 +54,8 @@ export function CuratedScheduleSection({
             onChange={next => field.handleChange(next)}
             taskOptions={taskOptions}
             resourceOptions={resourceOptions}
+            moduleGroupsByResource={moduleGroupsByResource}
+            modulesByResource={modulesByResource}
           />
         )}
       </form.Field>

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.stories.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.stories.tsx
@@ -26,6 +26,8 @@ const meta: Meta<typeof DetailsTab> = {
         [["topics"], []],
         [["tasks"], []],
         [["resources"], []],
+        [["modules-all"], []],
+        [["module-groups-all"], []],
         [["routineTemplates"], [makeRoutineTemplate()]],
       ]),
     ),

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
@@ -26,6 +26,8 @@ export function DetailsTab({
     connectionOptions,
     taskOptions,
     resourceOptions,
+    modulesByResource,
+    moduleGroupsByResource,
     isDaily,
     isCurated,
     curatedWindow,
@@ -93,6 +95,8 @@ export function DetailsTab({
             curatedWindow={curatedWindow}
             taskOptions={taskOptions}
             resourceOptions={resourceOptions}
+            moduleGroupsByResource={moduleGroupsByResource}
+            modulesByResource={modulesByResource}
           />
         )
         : (
@@ -101,6 +105,8 @@ export function DetailsTab({
             isDaily={isDaily}
             taskOptions={taskOptions}
             resourceOptions={resourceOptions}
+            moduleGroupsByResource={moduleGroupsByResource}
+            modulesByResource={modulesByResource}
           />
         )}
 

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-WeeklyScheduleSection.stories.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-WeeklyScheduleSection.stories.tsx
@@ -15,7 +15,12 @@ function Host({
   mode,
 }: { mode: RoutineMode }) {
   const {
-    form, isDaily, taskOptions, resourceOptions,
+    form,
+    isDaily,
+    taskOptions,
+    resourceOptions,
+    moduleGroupsByResource,
+    modulesByResource,
   } = useRoutineDetailsForm(
     makeRoutine({
       mode,
@@ -28,6 +33,8 @@ function Host({
       isDaily={isDaily}
       taskOptions={taskOptions}
       resourceOptions={resourceOptions}
+      moduleGroupsByResource={moduleGroupsByResource}
+      modulesByResource={modulesByResource}
     />
   );
 }
@@ -40,6 +47,8 @@ const meta: Meta<typeof WeeklyScheduleSection> = {
         [["topics"], []],
         [["tasks"], []],
         [["resources"], []],
+        [["modules-all"], []],
+        [["module-groups-all"], []],
         [["routineTemplates"], [makeRoutineTemplate()]],
       ]),
     ),

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-WeeklyScheduleSection.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-WeeklyScheduleSection.tsx
@@ -17,6 +17,8 @@ interface WeeklyScheduleSectionProps {
   isDaily: boolean;
   taskOptions: DetailsForm["taskOptions"];
   resourceOptions: DetailsForm["resourceOptions"];
+  moduleGroupsByResource: DetailsForm["moduleGroupsByResource"];
+  modulesByResource: DetailsForm["modulesByResource"];
 }
 
 // The non-curated schedule block on the `weekly` field: a single repeated entry
@@ -27,6 +29,8 @@ export function WeeklyScheduleSection({
   isDaily,
   taskOptions,
   resourceOptions,
+  moduleGroupsByResource,
+  modulesByResource,
 }: WeeklyScheduleSectionProps) {
   return (
     <form.Field name="weekly">
@@ -66,6 +70,8 @@ export function WeeklyScheduleSection({
                 onChange={next => field.handleChange(next)}
                 taskOptions={taskOptions}
                 resourceOptions={resourceOptions}
+                moduleGroupsByResource={moduleGroupsByResource}
+                modulesByResource={modulesByResource}
               />
             </div>
           )}

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
@@ -20,6 +20,10 @@ export interface WeeklyEntryEditorProps extends WeeklyEntry {
 export function useWeeklyEntryEditor({
   type,
   id,
+  // Daily mode doesn't expose the module narrowing (Curated/Weekly only), but the
+  // fields are part of WeeklyEntry, so carry them through unchanged.
+  moduleId,
+  moduleGroupId,
   notes,
   location,
   prependText,
@@ -43,6 +47,8 @@ export function useWeeklyEntryEditor({
     onChange({
       type,
       id,
+      moduleId,
+      moduleGroupId,
       notes,
       location,
       prependText,

--- a/packages/client/src/routes/routines/index.tsx
+++ b/packages/client/src/routes/routines/index.tsx
@@ -74,10 +74,11 @@ function Routines() {
     queryFn: () => fetchRoutines(),
   });
 
-  // Resolve scheduled task / resource names so a weekly routine can show today's
-  // entry in place of its name (freeform entries carry their own text in `id`).
+  // Resolve scheduled task / resource / module names so a weekly routine can show
+  // today's entry in place of its name (freeform entries carry their own text in
+  // `id`; a resource entry may narrow to a module or group).
   const {
-    taskNames, resourceNames,
+    taskNames, resourceNames, moduleNames, moduleGroupNames,
   } = useTaskResourceNames();
   const todayWeekday = String(new Date().getDay()) as RoutineWeekday;
 
@@ -93,7 +94,13 @@ function Routines() {
       return null;
     }
     return {
-      name: weeklyEntryName(entry, taskNames, resourceNames),
+      name: weeklyEntryName(
+        entry,
+        taskNames,
+        resourceNames,
+        moduleNames,
+        moduleGroupNames,
+      ),
       prependText: entry.prependText,
       appendText: entry.appendText,
     };

--- a/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplateEditModal.stories.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplateEditModal.stories.tsx
@@ -8,6 +8,8 @@ import { QueryStub } from "@/test-utils/QueryStub";
 import { RouterStub } from "@/test-utils/RouterStub";
 import {
   makeRoutineTemplate,
+  moduleGroupsByResource,
+  modulesByResource,
   resourceOptions,
   taskOptions,
 } from "@/test-utils/routinesFixtures";
@@ -22,6 +24,8 @@ const meta: Meta<typeof RoutineTemplateEditModal> = {
     onDelete: fn(),
     taskOptions,
     resourceOptions,
+    moduleGroupsByResource,
+    modulesByResource,
   },
   // The embedded WeeklyScheduleField renders QuickAddResourceDialog (router +
   // query hooks), so both stubs are required even though the dialog stays closed.

--- a/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplateEditModal.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplateEditModal.tsx
@@ -26,6 +26,8 @@ interface RoutineTemplateEditModalProps extends ControlledDialogProps {
   deleteDisabled?: boolean;
   taskOptions: SelectOption[];
   resourceOptions: SelectOption[];
+  moduleGroupsByResource: Map<string, SelectOption[]>;
+  modulesByResource: Map<string, SelectOption[]>;
 }
 
 export function RoutineTemplateEditModal({
@@ -39,6 +41,8 @@ export function RoutineTemplateEditModal({
   deleteDisabled = false,
   taskOptions,
   resourceOptions,
+  moduleGroupsByResource,
+  modulesByResource,
 }: RoutineTemplateEditModalProps) {
   const [label, setLabel] = useState(template?.label ?? "");
   const [rows, setRows] = useState<WeeklyRow[]>(weeklyToRows(template?.weekly));
@@ -107,6 +111,8 @@ export function RoutineTemplateEditModal({
               onChange={setRows}
               taskOptions={taskOptions}
               resourceOptions={resourceOptions}
+              moduleGroupsByResource={moduleGroupsByResource}
+              modulesByResource={modulesByResource}
             />
           </div>
           <EditModalFooter

--- a/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplatesSection.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplatesSection.tsx
@@ -13,9 +13,12 @@ import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createRoutineTemplate,
   deleteSingleRoutineTemplate,
+  fetchModuleGroups,
+  fetchModules,
   fetchResources,
   fetchRoutineTemplates,
   fetchTasks,
+  groupOptionsByResource,
   toOptions,
   upsertRoutineTemplate,
 } from "@/utils";
@@ -51,6 +54,16 @@ export function RoutineTemplatesSection() {
   const resourcesQuery = useQuery({
     queryKey: queryKeys.resources.list(),
     queryFn: () => fetchResources(),
+  });
+
+  const modulesQuery = useQuery({
+    queryKey: queryKeys.modules.list(),
+    queryFn: () => fetchModules(),
+  });
+
+  const moduleGroupsQuery = useQuery({
+    queryKey: queryKeys.moduleGroups.list(),
+    queryFn: () => fetchModuleGroups(),
   });
 
   const upsertRoutineTemplateMutation = useMutation({
@@ -109,6 +122,8 @@ export function RoutineTemplatesSection() {
     : null;
   const taskOptions = toOptions(tasksQuery.data);
   const resourceOptions = toOptions(resourcesQuery.data);
+  const moduleGroupsByResource = groupOptionsByResource(moduleGroupsQuery.data);
+  const modulesByResource = groupOptionsByResource(modulesQuery.data);
 
   return (
     <>
@@ -183,6 +198,8 @@ export function RoutineTemplatesSection() {
         template={editingRoutineTemplate}
         taskOptions={taskOptions}
         resourceOptions={resourceOptions}
+        moduleGroupsByResource={moduleGroupsByResource}
+        modulesByResource={modulesByResource}
         onOpenChange={(open) => {
           if (!open) setEditingRoutineTemplateId(null);
         }}
@@ -207,6 +224,8 @@ export function RoutineTemplatesSection() {
         isNew
         taskOptions={taskOptions}
         resourceOptions={resourceOptions}
+        moduleGroupsByResource={moduleGroupsByResource}
+        modulesByResource={modulesByResource}
         onOpenChange={(open) => {
           if (!open) setCreatingNewRoutineTemplate(false);
         }}

--- a/packages/client/src/test-utils/routinesFixtures.ts
+++ b/packages/client/src/test-utils/routinesFixtures.ts
@@ -31,9 +31,40 @@ export const resourceOptions: SelectOption[] = [
   },
 ];
 
+// Module groups / modules belonging to resource-1 (Duolingo Spanish), used to
+// exercise the resource-entry narrowing pickers.
+export const moduleGroupOptions: SelectOption[] = [
+  {
+    value: "group-1",
+    label: "Unit 1",
+  },
+];
+
+export const moduleOptions: SelectOption[] = [
+  {
+    value: "module-1",
+    label: "Basics 1",
+  },
+  {
+    value: "module-2",
+    label: "Basics 2",
+  },
+];
+
+// Per-resource option maps keyed by resource id (the shape the schedule fields
+// take). Only resource-1 has a module hierarchy.
+export const moduleGroupsByResource = new Map([
+  ["resource-1", moduleGroupOptions],
+]);
+export const modulesByResource = new Map([["resource-1", moduleOptions]]);
+
 // id → name maps for RoutineEntryLabel (keys align with the option values above).
 export const taskNames = new Map(taskOptions.map(o => [o.value, o.label]));
 export const resourceNames = new Map(resourceOptions.map(o => [o.value, o.label]));
+export const moduleNames = new Map(moduleOptions.map(o => [o.value, o.label]));
+export const moduleGroupNames = new Map(
+  moduleGroupOptions.map(o => [o.value, o.label]),
+);
 
 export function makeReferenceItem(
   overrides: Partial<RoutineReferenceItem> = {},

--- a/packages/client/src/utils/selectOptions.ts
+++ b/packages/client/src/utils/selectOptions.ts
@@ -19,6 +19,26 @@ export function toOptions(
   }));
 }
 
+// Bucket resource-owned entities (modules / module groups) by their resource id,
+// each mapped to combobox/select options. Used to offer a resource entry the
+// narrowing choices for its chosen resource.
+export function groupOptionsByResource(
+  items: { id: string;
+    name: string;
+    resourceId: string; }[] | null | undefined,
+): Map<string, SelectOption[]> {
+  const byResource = new Map<string, SelectOption[]>();
+  for (const item of items ?? []) {
+    const options = byResource.get(item.resourceId) ?? [];
+    options.push({
+      value: item.id,
+      label: item.name,
+    });
+    byResource.set(item.resourceId, options);
+  }
+  return byResource;
+}
+
 // Flatten tag groups into a flat list of {value, label} tag options.
 export function tagGroupsToOptions(
   tagGroups: TagGroup[] | null | undefined,

--- a/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
+++ b/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
@@ -71,11 +71,14 @@ export async function bakeRoutineCompletions(
     entries: {},
   };
 
-  // Resolve each pending date's scheduled entry; collect task/resource ids to
-  // look up names in two batched queries (avoids N+1).
+  // Resolve each pending date's scheduled entry; collect task/resource ids (plus
+  // any narrowing module/module-group ids on resource entries) to look up names
+  // in batched queries (avoids N+1).
   const entryByDate = new Map<string, RoutineReferenceItem | null>();
   const taskIds = new Set<string>();
   const resourceIds = new Set<string>();
+  const moduleIds = new Set<string>();
+  const moduleGroupIds = new Set<string>();
   for (const c of pending) {
     const entry = entryForCompletionDate(mode, weekly, curated, c.date);
     entryByDate.set(c.date, entry);
@@ -84,10 +87,16 @@ export async function bakeRoutineCompletions(
     }
     else if (entry?.type === "resource") {
       resourceIds.add(entry.id);
+      if (entry.moduleId) {
+        moduleIds.add(entry.moduleId);
+      }
+      if (entry.moduleGroupId) {
+        moduleGroupIds.add(entry.moduleGroupId);
+      }
     }
   }
 
-  const [taskRows, resourceRows] = await Promise.all([
+  const [taskRows, resourceRows, moduleRows, moduleGroupRows] = await Promise.all([
     taskIds.size
       ? db.query.tasks.findMany({
         where: (t, {
@@ -110,10 +119,34 @@ export async function bakeRoutineCompletions(
         },
       })
       : Promise.resolve([]),
+    moduleIds.size
+      ? db.query.modules.findMany({
+        where: (m, {
+          inArray,
+        }) => inArray(m.id, [...moduleIds]),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : Promise.resolve([]),
+    moduleGroupIds.size
+      ? db.query.moduleGroups.findMany({
+        where: (g, {
+          inArray,
+        }) => inArray(g.id, [...moduleGroupIds]),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : Promise.resolve([]),
   ]);
 
   const taskNames = new Map(taskRows.map(r => [r.id, r.name]));
   const resourceNames = new Map(resourceRows.map(r => [r.id, r.name]));
+  const moduleNames = new Map(moduleRows.map(r => [r.id, r.name]));
+  const moduleGroupNames = new Map(moduleGroupRows.map(r => [r.id, r.name]));
 
   const baked: DailyCompletion[] = completions.map((c) => {
     if (!(c.status && c.entryParts === undefined)) {
@@ -122,7 +155,13 @@ export async function bakeRoutineCompletions(
     const entry = entryByDate.get(c.date) ?? null;
     return {
       ...c,
-      entryParts: entryToCompletionParts(entry, taskNames, resourceNames),
+      entryParts: entryToCompletionParts(
+        entry,
+        taskNames,
+        resourceNames,
+        moduleNames,
+        moduleGroupNames,
+      ),
       // Frozen alongside entryParts: the structured ref keeps the scheduled
       // item's id so resource-side consumers can match by id later.
       entryRef: entryToCompletionRef(entry),

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -64,9 +64,13 @@ export default async function (server: FastifyInstance) {
     // routines key by date, weekly by weekday, daily by representative entry.
     const dateKey = currentDateKey();
 
-    // Batch-resolve every active task/resource id up front to avoid N+1.
+    // Batch-resolve every active task/resource id up front to avoid N+1. A
+    // resource entry may narrow to a module / group, whose name stands in for the
+    // resource name in the projected action title — collect those ids too.
     const taskIds: string[] = [];
     const resourceIds: string[] = [];
+    const moduleIds: string[] = [];
+    const moduleGroupIds: string[] = [];
     for (const routine of withConnections) {
       const entry = entryForCompletionDate(
         routine.mode,
@@ -79,6 +83,12 @@ export default async function (server: FastifyInstance) {
       }
       else if (entry?.type === "resource") {
         resourceIds.push(entry.id);
+        if (entry.moduleId) {
+          moduleIds.push(entry.moduleId);
+        }
+        if (entry.moduleGroupId) {
+          moduleGroupIds.push(entry.moduleGroupId);
+        }
       }
     }
 
@@ -122,8 +132,34 @@ export default async function (server: FastifyInstance) {
       })
       : [];
 
+    const moduleRows = moduleIds.length
+      ? await db.query.modules.findMany({
+        where: (modules, {
+          inArray,
+        }) => inArray(modules.id, moduleIds),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : [];
+
+    const moduleGroupRows = moduleGroupIds.length
+      ? await db.query.moduleGroups.findMany({
+        where: (moduleGroups, {
+          inArray,
+        }) => inArray(moduleGroups.id, moduleGroupIds),
+        columns: {
+          id: true,
+          name: true,
+        },
+      })
+      : [];
+
     const taskMap = new Map(taskRows.map(t => [t.id, t]));
     const resourceMap = new Map(resourceRows.map(r => [r.id, r]));
+    const moduleMap = new Map(moduleRows.map(m => [m.id, m]));
+    const moduleGroupMap = new Map(moduleGroupRows.map(g => [g.id, g]));
 
     return withConnections.map((routine) => {
       const entry = entryForCompletionDate(
@@ -138,9 +174,17 @@ export default async function (server: FastifyInstance) {
       const resource = entry?.type === "resource"
         ? resourceMap.get(entry.id) ?? null
         : null;
+      const module = entry?.moduleId
+        ? moduleMap.get(entry.moduleId) ?? null
+        : null;
+      const moduleGroup = entry?.moduleGroupId
+        ? moduleGroupMap.get(entry.moduleGroupId) ?? null
+        : null;
       return mapRoutineToDaily(routine as RoutineRow, {
         task,
         resource,
+        module,
+        moduleGroup,
       }, dateKey);
     });
   });

--- a/packages/middleware/src/tests/routineActionParts.test.ts
+++ b/packages/middleware/src/tests/routineActionParts.test.ts
@@ -34,6 +34,61 @@ test("resolveActionParts prefers the resolved resource name over the task name",
   );
 });
 
+test("resolveActionParts shows a resolved module / group name over the resource", () => {
+  const resourceEntry: RoutineReferenceItem = {
+    type: "resource",
+    id: "res-1",
+    moduleId: "mod-1",
+  };
+  assert.deepStrictEqual(
+    resolveActionParts(resourceEntry, {
+      resource: {
+        id: "res-1",
+        name: "Duolingo Spanish",
+        progressCurrent: 0,
+        progressTotal: 10,
+      },
+      module: {
+        id: "mod-1",
+        name: "Basics 1",
+      },
+    }),
+    {
+      prependText: null,
+      name: "Basics 1",
+      appendText: null,
+    },
+  );
+
+  // A module group narrows to the group name.
+  assert.deepStrictEqual(
+    resolveActionParts(
+      {
+        type: "resource",
+        id: "res-1",
+        moduleGroupId: "grp-1",
+      },
+      {
+        resource: {
+          id: "res-1",
+          name: "Duolingo Spanish",
+          progressCurrent: 0,
+          progressTotal: 10,
+        },
+        moduleGroup: {
+          id: "grp-1",
+          name: "Unit 1",
+        },
+      },
+    ),
+    {
+      prependText: null,
+      name: "Unit 1",
+      appendText: null,
+    },
+  );
+});
+
 test("resolveActionParts falls back to the resolved task name", () => {
   assert.deepStrictEqual(
     resolveActionParts(taskEntry, {

--- a/packages/middleware/src/tests/routineProjection.test.ts
+++ b/packages/middleware/src/tests/routineProjection.test.ts
@@ -188,6 +188,72 @@ test("entryToCompletionParts freezes resolved name + affixes (the baked snapshot
   );
 });
 
+test("entryToCompletionParts freezes the module/group name for a narrowed resource", () => {
+  const taskNames = new Map<string, string>();
+  const resourceNames = new Map([["res-1", "Duolingo Spanish"]]);
+  const moduleNames = new Map([["mod-1", "Basics 1"]]);
+  const moduleGroupNames = new Map([["grp-1", "Unit 1"]]);
+
+  // A specific module → the module name stands in for the resource name.
+  assert.deepStrictEqual(
+    entryToCompletionParts(
+      {
+        type: "resource",
+        id: "res-1",
+        moduleId: "mod-1",
+      },
+      taskNames,
+      resourceNames,
+      moduleNames,
+      moduleGroupNames,
+    ),
+    {
+      prependText: null,
+      name: "Basics 1",
+      appendText: null,
+    },
+  );
+
+  // A module group → the group name stands in.
+  assert.deepStrictEqual(
+    entryToCompletionParts(
+      {
+        type: "resource",
+        id: "res-1",
+        moduleGroupId: "grp-1",
+      },
+      taskNames,
+      resourceNames,
+      moduleNames,
+      moduleGroupNames,
+    ),
+    {
+      prependText: null,
+      name: "Unit 1",
+      appendText: null,
+    },
+  );
+
+  // No narrowing → the resource name stands.
+  assert.deepStrictEqual(
+    entryToCompletionParts(
+      {
+        type: "resource",
+        id: "res-1",
+      },
+      taskNames,
+      resourceNames,
+      moduleNames,
+      moduleGroupNames,
+    ),
+    {
+      prependText: null,
+      name: "Duolingo Spanish",
+      appendText: null,
+    },
+  );
+});
+
 test("entryToCompletionRef freezes the scheduled item's kind + id", () => {
   // Task / resource entries keep their type + id (affixes are dropped — the ref
   // is for matching by id, not display).

--- a/packages/middleware/src/utils/routineActionParts.ts
+++ b/packages/middleware/src/utils/routineActionParts.ts
@@ -1,4 +1,5 @@
 import type { Daily, RoutineReferenceItem } from "@emstack/types";
+import { resourceEntryLabel } from "@emstack/types";
 
 // Resolved task/resource rows the handler loads for an active entry. These are
 // the resource/task blocks mapDaily reads — DailyProjectionRow references them
@@ -19,23 +20,38 @@ export interface ResolvedResource {
   progressTotal: number | null;
 }
 
-// The task/resource rows a handler has already resolved for the active entry.
+// A resolved module / module-group name for a resource entry that narrows to one.
+export interface ResolvedNamed {
+  id: string;
+  name: string;
+}
+
+// The task/resource rows a handler has already resolved for the active entry,
+// plus any module/group a resource entry narrows to (used for the display name).
 export interface ResolvedConnections {
   task?: ResolvedTask | null;
   resource?: ResolvedResource | null;
+  module?: ResolvedNamed | null;
+  moduleGroup?: ResolvedNamed | null;
 }
 
-// The name the action sentence wraps: a resolved resource, then a resolved
-// task, then a freeform entry's own id (which holds the freeform text). Null
-// when nothing resolves, so the projection falls back to the routine title.
+// The name the action sentence wraps: a resolved resource (narrowed to its
+// module / group name when the entry targets one), then a resolved task, then a
+// freeform entry's own id (which holds the freeform text). Null when nothing
+// resolves, so the projection falls back to the routine title.
 function resolveBaseName(
   entry: RoutineReferenceItem | null,
   resolved: ResolvedConnections,
 ): string | null {
+  if (resolved.resource) {
+    return resourceEntryLabel({
+      resourceName: resolved.resource.name,
+      moduleName: resolved.module?.name,
+      groupName: resolved.moduleGroup?.name,
+    });
+  }
   return (
-    resolved.resource?.name
-    ?? resolved.task?.name
-    ?? (entry?.type === "freeform" ? entry.id : null)
+    resolved.task?.name ?? (entry?.type === "freeform" ? entry.id : null)
   );
 }
 

--- a/packages/middleware/src/utils/routineWeekday.ts
+++ b/packages/middleware/src/utils/routineWeekday.ts
@@ -1,3 +1,5 @@
+import { resourceEntryLabel } from "@emstack/types";
+
 import type {
   DailyCompletionEntryParts,
   DailyCompletionEntryRef,
@@ -97,11 +99,15 @@ export function entryForCompletionDate(
 // Freeze a scheduled entry into the parts stored on a logged completion. The
 // freeform name is the entry's own text; a task/resource resolves via the given
 // name maps, falling back to its id when the target was deleted (matching the
-// client's `?? entry.id` rendering). Null entry → null (nothing was scheduled).
+// client's `?? entry.id` rendering). A resource entry that narrows to a module or
+// module group freezes that narrower name in place of the resource name (see
+// resourceEntryLabel). Null entry → null (nothing was scheduled).
 export function entryToCompletionParts(
   entry: RoutineReferenceItem | null,
   taskNames: Map<string, string>,
   resourceNames: Map<string, string>,
+  moduleNames = new Map<string, string>(),
+  moduleGroupNames = new Map<string, string>(),
 ): DailyCompletionEntryParts | null {
   if (!entry) {
     return null;
@@ -111,7 +117,13 @@ export function entryToCompletionParts(
       ? entry.id
       : entry.type === "task"
         ? taskNames.get(entry.id) ?? entry.id
-        : resourceNames.get(entry.id) ?? entry.id;
+        : resourceEntryLabel({
+          resourceName: resourceNames.get(entry.id) ?? entry.id,
+          moduleName: entry.moduleId ? moduleNames.get(entry.moduleId) : null,
+          groupName: entry.moduleGroupId
+            ? moduleGroupNames.get(entry.moduleGroupId)
+            : null,
+        });
   return {
     prependText: entry.prependText ?? null,
     name,

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -62,6 +62,10 @@ const routineReferenceItemSchema = {
     id: {
       type: "string",
     },
+    // Resource entries may narrow to a specific module or module group (mutually
+    // exclusive). Absent/null = the whole resource.
+    moduleId: nullableString,
+    moduleGroupId: nullableString,
     notes: nullableString,
     location: nullableString,
     prependText: nullableString,

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -25,6 +25,12 @@ export type RoutineMode = "weekly" | "daily" | "curated";
 export interface RoutineReferenceItem {
   type: RoutineReferenceType;
   id: string;
+  // Resource entries (type === "resource") may narrow to a specific part of the
+  // resource: either a single module or a whole module group. Mutually exclusive
+  // — at most one is set; both empty/absent means the whole resource. Meaningless
+  // for task/freeform entries.
+  moduleId?: string | null;
+  moduleGroupId?: string | null;
   // Optional free-text annotation for this day's scheduled item (e.g. "focus
   // on the subjunctive"). Empty/absent means no note.
   notes?: string | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/max-dependencies */
 export * from "./actionableSentence.js";
+export * from "./resourceEntryLabel.js";
 export * from "./AppSettings.js";
 export * from "./CostData.js";
 export * from "./EntityStatus.js";

--- a/packages/types/src/resourceEntryLabel.ts
+++ b/packages/types/src/resourceEntryLabel.ts
@@ -1,0 +1,13 @@
+// The display label for a routine day entry that points at a resource. A day may
+// narrow the resource to a specific module or a whole module group; when it does,
+// that narrower name stands in for the resource name. Precedence: module name →
+// group name → resource name. Empty/missing names fall through to the next. Used
+// by both the client (live schedule rendering) and the middleware (completion
+// baking) so the two never drift.
+export function resourceEntryLabel(opts: {
+  resourceName: string;
+  moduleName?: string | null;
+  groupName?: string | null;
+}): string {
+  return opts.moduleName || opts.groupName || opts.resourceName;
+}


### PR DESCRIPTION
Curated and Weekly routine day entries that point at a resource can now
narrow to a specific module or module group (mutually exclusive), mirroring
the resource Interactions editor. The chosen module/group name stands in for
the resource name everywhere the entry renders — routine cards, the today
card, the entries log, the tracker/dashboard projection, and the frozen
completion snapshot.

- types: add optional moduleId/moduleGroupId to RoutineReferenceItem plus a
  shared resourceEntryLabel helper so client and middleware resolve the
  display name identically.
- middleware: accept the fields in the routine entry schema; resolve and
  freeze the module/group name when baking completions and projecting the
  Daily action title.
- client: add the group/module pickers to the shared ScheduleEntryRow (Weekly,
  Curated, and routine templates), thread module/group name maps through the
  display surfaces, and reset the narrowing when the resource or type changes.

https://claude.ai/code/session_01JHqJ3DPTJVhgvyFTEU4KhQ