### PR TITLE
fix(client): drop unused exports flagged by fallow audit

### DIFF
--- a/packages/client/src/test-utils/routinesFixtures.ts
+++ b/packages/client/src/test-utils/routinesFixtures.ts
@@ -32,15 +32,16 @@ export const resourceOptions: SelectOption[] = [
 ];
 
 // Module groups / modules belonging to resource-1 (Duolingo Spanish), used to
-// exercise the resource-entry narrowing pickers.
-export const moduleGroupOptions: SelectOption[] = [
+// exercise the resource-entry narrowing pickers. Module-local: only the
+// per-resource maps and name lookups below are consumed by stories.
+const moduleGroupOptions: SelectOption[] = [
   {
     value: "group-1",
     label: "Unit 1",
   },
 ];
 
-export const moduleOptions: SelectOption[] = [
+const moduleOptions: SelectOption[] = [
   {
     value: "module-1",
     label: "Basics 1",


### PR DESCRIPTION
moduleGroupOptions and moduleOptions in routinesFixtures.ts were exported
but only referenced within the module (to build the per-resource maps and
name lookups). fallow's --fail-on-issues gate flagged them as unused
exports, failing the Fallow Audit job on master. Make them module-local;
the externally-consumed maps/name maps are unchanged.