### PR TITLE
fix(client): fix module/group selection logic in schedule entries

### DIFF
--- a/packages/client/src/components/routines/ModuleNarrowingFields.tsx
+++ b/packages/client/src/components/routines/ModuleNarrowingFields.tsx
@@ -1,0 +1,97 @@
+import type { WeeklyEntry } from "./weekly";
+import type { SelectOption } from "@/utils";
+
+interface ModuleNarrowingFieldsProps {
+  // Prefix for the controls' aria-labels (kept stable so tests/stories can
+  // target e.g. "Monday module group").
+  ariaPrefix: string;
+  row: WeeklyEntry;
+  // Module groups / modules belonging to the row's chosen resource.
+  groupOptions: SelectOption[];
+  moduleOptions: SelectOption[];
+  onChange: (patch: Partial<WeeklyEntry>) => void;
+}
+
+// The module-narrowing controls for a resource schedule entry: a module-group
+// select plus a module select scoped to the chosen group. The two are
+// hierarchical — a chosen module implies its parent group (reflected in the
+// group select), and the module select is disabled until a group is picked.
+export function ModuleNarrowingFields({
+  ariaPrefix,
+  row,
+  groupOptions,
+  moduleOptions,
+  onChange,
+}: ModuleNarrowingFieldsProps) {
+  const selectedModule = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)
+    : undefined;
+  // A chosen module implies its parent group; otherwise use the explicitly
+  // chosen group. "" = whole resource (no narrowing).
+  const effectiveGroupId = row.moduleGroupId || selectedModule?.group || "";
+  // The module dropdown is scoped to the chosen group and disabled until one is
+  // picked — a module can only be chosen from within a group.
+  const groupModuleOptions = effectiveGroupId
+    ? moduleOptions.filter(o => (o.group ?? "") === effectiveGroupId)
+    : [];
+
+  return (
+    <div
+      className="
+        grid grid-cols-1 gap-1.5
+        sm:grid-cols-2
+      "
+    >
+      <select
+        aria-label={`${ariaPrefix} module group`}
+        value={effectiveGroupId}
+        onChange={e =>
+          // Choosing a group (or clearing to whole resource) always resets the
+          // specific module — the module list changes with the group.
+          onChange({
+            moduleGroupId: e.target.value,
+            moduleId: "",
+          })}
+        className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
+      >
+        <option value="">— Whole resource —</option>
+        {groupOptions.map(g => (
+          <option
+            key={g.value}
+            value={g.value}
+          >
+            {g.label}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label={`${ariaPrefix} module`}
+        value={row.moduleId}
+        disabled={!effectiveGroupId}
+        onChange={(e) => {
+          const moduleId = e.target.value;
+          // Picking a module: its group is implied, so drop the explicit group.
+          // Clearing back to "Whole Group": keep the group so it doesn't fall
+          // back to the whole resource.
+          onChange({
+            moduleId,
+            moduleGroupId: moduleId ? "" : effectiveGroupId,
+          });
+        }}
+        className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
+      >
+        <option value="">
+          {effectiveGroupId ? "Whole Group" : "— Select a group first —"}
+        </option>
+        {groupModuleOptions.map(m => (
+          <option
+            key={m.value}
+            value={m.value}
+          >
+            {m.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -51,12 +51,21 @@ export function ScheduleEntryRow({
   const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
   // A resource entry may narrow to a module / group; show that narrower name in
   // the preview (matching how the entry renders everywhere else).
-  const moduleLabel = row.moduleId
-    ? moduleOptions.find(o => o.value === row.moduleId)?.label
+  const selectedModule = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)
+    : undefined;
+  const moduleLabel = selectedModule?.label ?? null;
+  // A chosen module implies its parent group; otherwise use the explicitly
+  // chosen group. "" = whole resource (no narrowing).
+  const effectiveGroupId = row.moduleGroupId || selectedModule?.group || "";
+  const groupLabel = effectiveGroupId
+    ? groupOptions.find(o => o.value === effectiveGroupId)?.label
     : null;
-  const groupLabel = row.moduleGroupId
-    ? groupOptions.find(o => o.value === row.moduleGroupId)?.label
-    : null;
+  // The module dropdown is scoped to the chosen group and disabled until one is
+  // picked — a module can only be chosen from within a group.
+  const groupModuleOptions = effectiveGroupId
+    ? moduleOptions.filter(o => (o.group ?? "") === effectiveGroupId)
+    : [];
   const itemName
     = row.type === "freeform"
       ? row.id
@@ -173,17 +182,13 @@ export function ScheduleEntryRow({
         >
           <select
             aria-label={`${ariaPrefix} module group`}
-            value={row.moduleGroupId}
+            value={effectiveGroupId}
             onChange={e =>
-              // Group and module are mutually exclusive — picking a group clears
-              // any specific module.
+              // Choosing a group (or clearing to whole resource) always resets
+              // the specific module — the module list changes with the group.
               onChange({
                 moduleGroupId: e.target.value,
-                ...(e.target.value
-                  ? {
-                    moduleId: "",
-                  }
-                  : {}),
+                moduleId: "",
               })}
             className="
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
@@ -202,21 +207,25 @@ export function ScheduleEntryRow({
           <select
             aria-label={`${ariaPrefix} module`}
             value={row.moduleId}
-            onChange={e =>
+            disabled={!effectiveGroupId}
+            onChange={(e) => {
+              const moduleId = e.target.value;
+              // Picking a module: its group is implied, so drop the explicit
+              // group. Clearing back to "Whole Group": keep the group so it
+              // doesn't fall back to the whole resource.
               onChange({
-                moduleId: e.target.value,
-                ...(e.target.value
-                  ? {
-                    moduleGroupId: "",
-                  }
-                  : {}),
-              })}
+                moduleId,
+                moduleGroupId: moduleId ? "" : effectiveGroupId,
+              });
+            }}
             className="
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "
           >
-            <option value="">— Whole resource —</option>
-            {moduleOptions.map(m => (
+            <option value="">
+              {effectiveGroupId ? "Whole Group" : "— Select a group first —"}
+            </option>
+            {groupModuleOptions.map(m => (
               <option
                 key={m.value}
                 value={m.value}

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -3,6 +3,7 @@ import type { SelectOption } from "@/utils";
 
 import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
+import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
@@ -50,22 +51,14 @@ export function ScheduleEntryRow({
         : [];
   const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
   // A resource entry may narrow to a module / group; show that narrower name in
-  // the preview (matching how the entry renders everywhere else).
-  const selectedModule = row.moduleId
-    ? moduleOptions.find(o => o.value === row.moduleId)
-    : undefined;
-  const moduleLabel = selectedModule?.label ?? null;
-  // A chosen module implies its parent group; otherwise use the explicitly
-  // chosen group. "" = whole resource (no narrowing).
-  const effectiveGroupId = row.moduleGroupId || selectedModule?.group || "";
-  const groupLabel = effectiveGroupId
-    ? groupOptions.find(o => o.value === effectiveGroupId)?.label
+  // the preview (matching how the entry renders everywhere else). A chosen
+  // module wins over its group in the label (see resourceEntryLabel).
+  const moduleLabel = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)?.label
     : null;
-  // The module dropdown is scoped to the chosen group and disabled until one is
-  // picked — a module can only be chosen from within a group.
-  const groupModuleOptions = effectiveGroupId
-    ? moduleOptions.filter(o => (o.group ?? "") === effectiveGroupId)
-    : [];
+  const groupLabel = row.moduleGroupId
+    ? groupOptions.find(o => o.value === row.moduleGroupId)?.label
+    : null;
   const itemName
     = row.type === "freeform"
       ? row.id
@@ -174,67 +167,13 @@ export function ScheduleEntryRow({
       </div>
 
       {showModulePickers && (
-        <div
-          className="
-            grid grid-cols-1 gap-1.5
-            sm:grid-cols-2
-          "
-        >
-          <select
-            aria-label={`${ariaPrefix} module group`}
-            value={effectiveGroupId}
-            onChange={e =>
-              // Choosing a group (or clearing to whole resource) always resets
-              // the specific module — the module list changes with the group.
-              onChange({
-                moduleGroupId: e.target.value,
-                moduleId: "",
-              })}
-            className="
-              flex h-9 w-full rounded-md border bg-background px-2 text-sm
-            "
-          >
-            <option value="">— Whole resource —</option>
-            {groupOptions.map(g => (
-              <option
-                key={g.value}
-                value={g.value}
-              >
-                {g.label}
-              </option>
-            ))}
-          </select>
-          <select
-            aria-label={`${ariaPrefix} module`}
-            value={row.moduleId}
-            disabled={!effectiveGroupId}
-            onChange={(e) => {
-              const moduleId = e.target.value;
-              // Picking a module: its group is implied, so drop the explicit
-              // group. Clearing back to "Whole Group": keep the group so it
-              // doesn't fall back to the whole resource.
-              onChange({
-                moduleId,
-                moduleGroupId: moduleId ? "" : effectiveGroupId,
-              });
-            }}
-            className="
-              flex h-9 w-full rounded-md border bg-background px-2 text-sm
-            "
-          >
-            <option value="">
-              {effectiveGroupId ? "Whole Group" : "— Select a group first —"}
-            </option>
-            {groupModuleOptions.map(m => (
-              <option
-                key={m.value}
-                value={m.value}
-              >
-                {m.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        <ModuleNarrowingFields
+          ariaPrefix={ariaPrefix}
+          row={row}
+          groupOptions={groupOptions}
+          moduleOptions={moduleOptions}
+          onChange={onChange}
+        />
       )}
 
       {row.type !== "" && (

--- a/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
@@ -78,7 +78,8 @@ export const Populated: Story = {
 };
 
 // A resource entry on a resource that has a module hierarchy: the module-group
-// and module narrowing selects appear, with the chosen module reflected.
+// and module narrowing selects appear. A chosen module reflects its parent group
+// in the group select (the group is derived from the module).
 export const WithModule: Story = {
   args: {
     value: weeklyToRows({
@@ -97,6 +98,36 @@ export const WithModule: Story = {
     const canvas = within(canvasElement);
     const moduleSelect = await canvas.findByLabelText("Monday module");
     await expect(moduleSelect).toHaveValue("module-2");
-    await expect(canvas.getByLabelText("Monday module group")).toHaveValue("");
+    await expect(canvas.getByLabelText("Monday module group")).toHaveValue(
+      "group-1",
+    );
+  },
+};
+
+// A resource entry narrowed to a whole group (no specific module): the module
+// select is enabled and offers "Whole Group" as its empty option.
+export const WholeGroup: Story = {
+  args: {
+    value: weeklyToRows({
+      1: {
+        type: "resource",
+        id: "resource-1",
+        moduleGroupId: "group-1",
+      },
+    }),
+    moduleGroupsByResource,
+    modulesByResource,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByLabelText("Monday module group")).toHaveValue(
+      "group-1",
+    );
+    const moduleSelect = canvas.getByLabelText("Monday module");
+    await expect(moduleSelect).toHaveValue("");
+    await expect(moduleSelect).toBeEnabled();
+    await expect(within(moduleSelect).getByText("Whole Group")).toBeInTheDocument();
   },
 };

--- a/packages/client/src/test-utils/routinesFixtures.ts
+++ b/packages/client/src/test-utils/routinesFixtures.ts
@@ -45,10 +45,12 @@ const moduleOptions: SelectOption[] = [
   {
     value: "module-1",
     label: "Basics 1",
+    group: "group-1",
   },
   {
     value: "module-2",
     label: "Basics 2",
+    group: "group-1",
   },
 ];
 

--- a/packages/client/src/utils/selectOptions.ts
+++ b/packages/client/src/utils/selectOptions.ts
@@ -25,7 +25,8 @@ export function toOptions(
 export function groupOptionsByResource(
   items: { id: string;
     name: string;
-    resourceId: string; }[] | null | undefined,
+    resourceId: string;
+    moduleGroupId?: string | null; }[] | null | undefined,
 ): Map<string, SelectOption[]> {
   const byResource = new Map<string, SelectOption[]>();
   for (const item of items ?? []) {
@@ -33,6 +34,9 @@ export function groupOptionsByResource(
     options.push({
       value: item.id,
       label: item.name,
+      // Modules carry their parent group so a resource entry can scope its
+      // module dropdown to the chosen group; module groups have none → "".
+      group: item.moduleGroupId ?? "",
     });
     byResource.set(item.resourceId, options);
   }


### PR DESCRIPTION
## Summary

Fixed the module and group selection UI in schedule entry rows to properly handle the relationship between modules and their parent groups. A module now correctly implies its parent group, and the module dropdown is scoped to the selected group.

## Key Changes

- **Module-group relationship:** When a module is selected, its parent group is now automatically reflected in the group select (derived from the module's `group` property). Conversely, when a group is selected, the module selection is cleared since modules can only be chosen within a group context.

- **Module dropdown scoping:** The module dropdown is now:
  - Disabled until a group is selected
  - Filtered to show only modules belonging to the selected group
  - Shows "Whole Group" as the empty option when a group is selected, or "— Select a group first —" when no group is chosen

- **SelectOption enhancement:** Added an optional `group` property to `SelectOption` to track a module's parent group. The `groupOptionsByResource` utility now populates this field for modules (empty string for module groups themselves).

- **Test fixtures:** Updated module options in test fixtures to include the `group` property.

- **Story updates:** 
  - Updated the `WithModule` story to verify that selecting a module correctly populates the group select with the module's parent group
  - Added a new `WholeGroup` story demonstrating the behavior when a resource is narrowed to a whole group (no specific module)

## Implementation Details

The key insight is that `effectiveGroupId` represents the actual group scope: either the explicitly chosen `moduleGroupId` or the parent group of the selected module. This single source of truth drives both the group select's value and the module dropdown's filtering and enabled state.

https://claude.ai/code/session_01Shj9AeWwacV8PUgh1cSNmc