### PR TITLE
ci: add PR warnings workflow with ESLint and suppression checks

### DIFF
--- a/.github/workflows/pr-warnings.yml
+++ b/.github/workflows/pr-warnings.yml
@@ -1,0 +1,89 @@
+name: PR warnings
+
+# Warn-only PR check: posts (and keeps updating) a single sticky comment that
+# summarizes ESLint warnings in the files this PR changed, plus any new
+# suppression directives it adds. It never fails the check and is purely
+# informational — annotations stay owned by the CI (eslint) and PR guards
+# (suppressions) workflows; this only adds the consolidated comment surface.
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+# A superseded push must not let a stale run overwrite the comment after a newer
+# one — cancel in-flight runs so the last push wins.
+concurrency:
+  group: warnings-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  warning-report:
+    # Fork PRs get a read-only token, so the comment post would 403 — skip them.
+    # They still get inline annotations from the CI / PR guards workflows.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so the PR base commit is reachable for the diff.
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build warning comment
+        run: node scripts/build-pr-warning-comment.mjs "${{ github.event.pull_request.base.sha }}"
+
+      - name: Upsert sticky comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- pr-warning-report -->";
+            const body = fs.readFileSync(
+              `${process.env.RUNNER_TEMP}/pr-warning-comment.md`,
+              "utf8",
+            );
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // PR comments are issue comments; find ours by its leading marker.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky warning comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info("Created sticky warning comment.");
+            }

--- a/scripts/build-pr-warning-comment.mjs
+++ b/scripts/build-pr-warning-comment.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+//
+// Build the body of the "PR warnings" sticky comment (posted/updated by
+// .github/workflows/pr-warnings.yml). Warn-only and informational — it never
+// fails the check; it just gives reviewers a single, always-current summary of:
+//
+//   1. ESLint *warnings* (severity 1) in the files this PR changed, and
+//   2. New suppression directives added by the PR (lint/type ignore-or-disable
+//      comments and skipped or focused tests) — reused verbatim from
+//      scripts/check-new-suppressions.sh so the two stay in lockstep.
+//
+// Scope is file-granular ("files changed by this PR"), so a warning can sit on a
+// line the PR didn't touch within a file it did — the heading says as much.
+//
+// Usage: node scripts/build-pr-warning-comment.mjs <base-sha-or-ref>
+//   Diffs <base>...HEAD (three-dot, merge-base form), matching the contract
+//   check-new-suppressions.sh already relies on. Requires the base commit to be
+//   reachable (CI checks out with fetch-depth: 0).
+//
+// Output: writes the comment body to $RUNNER_TEMP/pr-warning-comment.md (falls
+// back to the OS temp dir locally). The workflow's github-script step reads that
+// file and upserts the comment by its leading marker.
+//
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const MARKER = "<!-- pr-warning-report -->";
+const LINT_EXTS = [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"];
+const MAX_ROWS = 50; // keep well under GitHub's 65 KB comment cap
+
+const repoRoot = process.cwd();
+const tmpDir = process.env.RUNNER_TEMP || os.tmpdir();
+const outPath = path.join(tmpDir, "pr-warning-comment.md");
+
+const BASE = process.argv[2];
+if (!BASE) {
+  throw new Error("usage: build-pr-warning-comment.mjs <base-sha-or-ref>");
+}
+
+function git(args) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+    });
+  }
+  catch {
+    return "";
+  }
+}
+
+const hasExt = (f, exts) => exts.includes(path.extname(f));
+const onDisk = f => existsSync(path.join(repoRoot, f)); // skip deleted files
+const isGenerated = f =>
+  f.endsWith("routeTree.gen.ts")
+  || f.includes("/dist/")
+  || f.startsWith(".claude/")
+  || f === "pnpm-lock.yaml";
+
+// Render a value safe for a single Markdown table cell: collapse newlines and
+// neutralize the cell/markup characters (pipes and backticks) — mirrors the
+// backtick handling in check-new-suppressions.sh.
+const cell = s =>
+  String(s)
+    .replace(/\r?\n/g, " ")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "'")
+    .trim();
+
+// Files this PR changed (additions/modifications/renames — deletions excluded),
+// narrowed to lintable, non-generated sources that still exist on disk.
+const changedFiles = git([
+  "diff",
+  "--name-only",
+  "--diff-filter=d",
+  `${BASE}...HEAD`,
+])
+  .split("\n")
+  .map(s => s.trim())
+  .filter(Boolean)
+  .filter(f => hasExt(f, LINT_EXTS) && onDisk(f) && !isGenerated(f));
+
+// --- ESLint warnings in changed files --------------------------------------
+// Run eslint only when there is something to lint: eslint with no path args does
+// not no-op safely. Parse stdout regardless of exit code — a changed file may
+// carry a real error (exit 1) or eslint may crash (exit 2); we still want to
+// surface whatever warnings it did report.
+let warningRows = [];
+let eslintFailed = false;
+
+if (changedFiles.length > 0) {
+  const res = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "eslint",
+      "--format",
+      "json",
+      "--no-warn-ignored",
+      "--no-error-on-unmatched-pattern",
+      ...changedFiles,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  );
+
+  try {
+    const results = JSON.parse(res.stdout || "[]");
+    for (const file of results) {
+      const rel = path.relative(repoRoot, file.filePath) || file.filePath;
+      for (const m of file.messages) {
+        if (m.severity !== 1) continue; // warnings only
+        warningRows.push({
+          file: rel,
+          loc: `${m.line}:${m.column}`,
+          rule: m.ruleId || "(unknown)",
+          message: m.message,
+        });
+      }
+    }
+  }
+  catch {
+    // eslint produced no parseable JSON (e.g. a config crash). Don't claim a
+    // clean bill of health — flag it so the comment shows something's off.
+    eslintFailed = true;
+  }
+}
+
+function renderEslintSection() {
+  if (eslintFailed) {
+    return "_⚠️ ESLint did not produce parseable output — check the lint job._";
+  }
+  if (warningRows.length === 0) {
+    return "✅ No ESLint warnings in the files changed by this PR.";
+  }
+
+  const shown = warningRows.slice(0, MAX_ROWS);
+  const lines = [
+    "| File | Location | Rule | Message |",
+    "|---|---|---|---|",
+    ...shown.map(
+      w =>
+        `| \`${cell(w.file)}\` | ${cell(w.loc)} | \`${cell(w.rule)}\` | ${cell(w.message)} |`,
+    ),
+  ];
+  if (warningRows.length > shown.length) {
+    lines.push("");
+    lines.push(`_…and ${warningRows.length - shown.length} more warning(s)._`);
+  }
+  return lines.join("\n");
+}
+
+// --- New suppression directives --------------------------------------------
+// Reuse scripts/check-new-suppressions.sh untouched: it writes its markdown block
+// to $GITHUB_STEP_SUMMARY. Point that at a temp file and discard stdout so its
+// inline ::warning annotations don't double-fire (the pr-guards workflow already
+// owns those). Tolerate a non-zero exit (set -euo pipefail can trip if its diff
+// fails) by falling back to a neutral note.
+function renderSuppressionsSection() {
+  const supTmp = path.join(tmpDir, "pr-warning-suppressions.md");
+  const res = spawnSync("scripts/check-new-suppressions.sh", [BASE], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      GITHUB_STEP_SUMMARY: supTmp,
+    },
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+
+  if (res.status !== 0 || !existsSync(supTmp)) {
+    return {
+      markdown: "_Suppression-directive check unavailable._",
+      clean: false,
+    };
+  }
+
+  const raw = readFileSync(supTmp, "utf8").trim();
+  // Demote the script's top-level "## …" heading to "### …" so it nests under
+  // this comment's structure.
+  const markdown = raw.replace(/^##\s/, "### ");
+  return {
+    markdown,
+    clean: raw.includes("No new suppression directives"),
+  };
+}
+
+// --- Assemble & write -------------------------------------------------------
+const suppressions = renderSuppressionsSection();
+const bothClean
+  = !eslintFailed && warningRows.length === 0 && suppressions.clean;
+
+const header = [
+  MARKER,
+  "## 🔎 PR warning report",
+  "",
+  "_Warn-only — lists ESLint warnings in the files this PR changed, plus new "
+  + "suppression directives it adds. Refreshed on every push._",
+  "",
+].join("\n");
+
+let body;
+if (bothClean) {
+  body = `${header}✅ No lint warnings or new suppressions in the files changed by this PR.\n`;
+}
+else {
+  body = [
+    header,
+    "### ⚠️ ESLint warnings in files changed by this PR",
+    "",
+    renderEslintSection(),
+    "",
+    suppressions.markdown,
+    "",
+  ].join("\n");
+}
+
+writeFileSync(outPath, body);
+console.log(
+  `Wrote ${outPath} — ${warningRows.length} eslint warning(s) across `
+  + `${changedFiles.length} changed file(s); suppressions clean: ${suppressions.clean}.`,
+);


### PR DESCRIPTION
## Summary

Adds a new warn-only GitHub Actions workflow that posts a sticky comment on PRs summarizing ESLint warnings in changed files and any new suppression directives (lint ignore comments, test skips/focuses). The check never fails — it's purely informational and complements the existing CI and PR guards workflows.

## Changes

- **`scripts/build-pr-warning-comment.mjs`** — New Node.js script that:
  - Diffs the PR base against HEAD to identify changed files (additions/modifications/renames)
  - Filters to lintable sources (`.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`) that exist on disk and aren't generated
  - Runs ESLint on changed files and extracts warnings (severity 1 only) into a Markdown table
  - Reuses `scripts/check-new-suppressions.sh` to detect new suppression directives
  - Writes a consolidated comment body to `$RUNNER_TEMP/pr-warning-comment.md` with a leading marker for idempotent upserts
  - Caps output at 50 rows per section to stay well under GitHub's 65 KB comment limit

- **`.github/workflows/pr-warnings.yml`** — New workflow that:
  - Triggers on PR open, synchronize, ready_for_review, and reopen
  - Checks out with full history (`fetch-depth: 0`) so the base commit is reachable for the diff
  - Runs the build script with the PR base SHA
  - Uses `actions/github-script` to find and update an existing sticky comment by its marker, or create one if it doesn't exist
  - Skips fork PRs (which get read-only tokens and can't post comments)
  - Cancels in-flight runs on new pushes so the latest push always wins

## Implementation Details

- **File-granular scope:** Warnings can appear on lines the PR didn't touch, as long as they're in a file the PR changed — the comment heading clarifies this
- **Idempotent upserts:** The marker comment (`<!-- pr-warning-report -->`) allows the workflow to find and update the same comment across multiple pushes, avoiding comment spam
- **Markdown safety:** Cell values are sanitized (pipes escaped, backticks converted to single quotes, newlines collapsed) to prevent table corruption
- **Graceful degradation:** If ESLint crashes or produces unparseable JSON, the comment flags it rather than claiming a clean bill of health; suppression checks that fail fall back to a neutral note
- **Reuses existing logic:** The suppression directive detection is delegated to the existing `scripts/check-new-suppressions.sh` to keep the two checks in lockstep

https://claude.ai/code/session_01J7D2CaFWatBMYJpUo2HD4D