### PR TITLE
refactor(client): unify routine footer layout and add total days icon

### DIFF
--- a/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
@@ -5,7 +5,7 @@ import type {
 } from "@emstack/types";
 
 import { Link } from "@tanstack/react-router";
-import { AlertTriangleIcon, FlameIcon } from "lucide-react";
+import { AlertTriangleIcon, FlameIcon, LaughIcon } from "lucide-react";
 
 import { Description, EntityLink } from "@/components/boxElements";
 import {
@@ -200,62 +200,58 @@ export function RoutineBox({
         <Description description={description} />
       </ContentBoxBody>
       <ContentBoxFooter>
-        {isDaily
-          ? (
-            <div className="flex flex-row items-center gap-4 text-xs">
+        <div
+          className="flex flex-row gap-1"
+          title={`${scheduledCount} day${scheduledCount === 1 ? "" : "s"} scheduled`}
+        >
+          {DAY_STRIP.map(({
+            day, letter,
+          }, index) => {
+            const scheduled = !!weekly?.[day];
+            return (
               <span
-                className="inline-flex items-center gap-1"
-                title="Current day chain"
+                key={`${day}-${index}`}
+                className={cn(
+                  "flex size-5 items-center justify-center rounded-full text-xs",
+                  scheduled
+                    ? `
+                      bg-blue-600 font-bold text-white
+                      dark:bg-blue-700
+                    `
+                    : "bg-muted text-muted-foreground",
+                )}
               >
-                <FlameIcon
-                  size={14}
-                  className={
-                    chain > 0 ? "text-orange-600" : "text-muted-foreground"
-                  }
-                />
-                <strong>{chain}</strong>
-                <span className="text-muted-foreground">chain</span>
+                {letter}
               </span>
-              <span
-                className="inline-flex items-center gap-1"
-                title="Total completed days"
-              >
-                <strong>{totalDays}</strong>
-                <span className="text-muted-foreground">total days</span>
-              </span>
-            </div>
-          )
-          : (
-            <div
-              className="flex flex-row gap-1"
-              title={`${scheduledCount} day${scheduledCount === 1 ? "" : "s"} scheduled`}
-            >
-              {DAY_STRIP.map(({
-                day, letter,
-              }, index) => {
-                const scheduled = !!weekly?.[day];
-                return (
-                  <span
-                    key={`${day}-${index}`}
-                    className={cn(
-                      `
-                        flex size-5 items-center justify-center rounded-full
-                        text-xs
-                      `,
-                      scheduled
-                        ? `
-                          bg-blue-600 font-bold text-white
-                          dark:bg-blue-700
-                        `
-                        : "bg-muted text-muted-foreground",
-                    )}
-                  >
-                    {letter}
-                  </span>
-                );
-              })}
-            </div>
-          )}
+            );
+          })}
+        </div>
+        <div className="flex flex-row items-center gap-4 text-xs">
+          <span
+            className="inline-flex items-center gap-1"
+            title="Current day chain"
+          >
+            <FlameIcon
+              size={14}
+              className={
+                chain > 0 ? "text-orange-600" : "text-muted-foreground"
+              }
+            />
+            <strong>{chain}</strong>
+          </span>
+          <span
+            className="inline-flex items-center gap-1"
+            title="Total completed days"
+          >
+            <LaughIcon
+              className={cn(
+                "size-3.5",
+                totalDays > 0 ? "text-emerald-600" : "text-muted-foreground",
+              )}
+            />
+            <strong>{totalDays}</strong>
+          </span>
+        </div>
       </ContentBoxFooter>
     </ContentBox>
   );


### PR DESCRIPTION
## Summary
Refactored the RoutineBox footer to always display the weekly schedule grid alongside chain and total days stats, removing the conditional logic that previously hid the schedule for daily routines. Added a visual icon (LaughIcon) to the total days counter for better visual hierarchy.

## Changes
- **Removed conditional rendering:** The footer now always displays the day-of-week schedule grid (previously only shown for non-daily routines)
- **Unified layout:** Chain and total days stats are now consistently displayed below the schedule grid for all routine types
- **Enhanced total days display:** Added `LaughIcon` from lucide-react to visually represent the total days counter, with color coding (emerald-600 when > 0, muted otherwise)
- **Improved text labels:** Removed redundant "chain" and "total days" text labels, relying on icons and tooltips for clarity
- **Cleaner markup:** Simplified the footer structure by removing the ternary conditional and consolidating the layout into a single, consistent structure

## Implementation Details
- The schedule grid now uses consistent styling with the previous non-daily implementation
- Chain icon (FlameIcon) retains its orange-600 color when active
- Total days icon (LaughIcon) uses emerald-600 to differentiate from the chain counter
- Both stats remain in a flex row with consistent gap spacing for visual balance

https://claude.ai/code/session_01GEJxT2PXWjfeUyuLEAeLoY