### PR TITLE
feat(client): add per-tile column visibility toggles for daily tracker

### DIFF
--- a/packages/client/src/components/dailies/DailyTrackerRow.tsx
+++ b/packages/client/src/components/dailies/DailyTrackerRow.tsx
@@ -1,4 +1,8 @@
-import type { Daily, DailyCompletionStatus } from "@emstack/types";
+import type {
+  Daily,
+  DailyCompletionStatus,
+  DailyTrackerColumnVisibility,
+} from "@emstack/types";
 
 import { FlameIcon, LaughIcon } from "lucide-react";
 
@@ -14,6 +18,7 @@ import {
   DailyTitle,
   TodayStatusCell,
 } from "./dailyCells";
+import { resolveDailyTrackerColumns } from "./dailyTrackerColumns";
 
 import { EntityLink } from "@/components/boxElements";
 import { cn } from "@/lib/utils";
@@ -42,6 +47,8 @@ interface DailyTrackerRowProps {
   firstConnectorClassName: string;
   /** Task id used to render a task link in the location cell, when present. */
   taskId?: string | null;
+  /** Per-tile column show/hide state; omit for the all-default tracker tables. */
+  columns?: DailyTrackerColumnVisibility;
 }
 
 /** A single active-daily row shared by the dashboard card and the routine tracker tables. */
@@ -55,21 +62,27 @@ export function DailyTrackerRow({
   statusCellClassName,
   firstConnectorClassName,
   taskId,
+  columns,
 }: DailyTrackerRowProps) {
+  const vis = resolveDailyTrackerColumns(columns);
   const currentStatus = findStatusForDate(daily, todayKey);
   const chain = getCurrentChain(daily, todayKey);
   const total = getTotalCompletedDays(daily);
   const days = getRecentDays(daily, recentDaysCount + 1, todayKey, "mmdd")
     .slice(0, -1)
     .reverse();
+  // Cells emitted in the same order as buildDailyTrackerColumns' headers so the
+  // two stay aligned; toggleable cells gate on `vis`, Title and Today always show.
   return (
     <tr
       key={daily.id}
       className={rowClassName}
     >
-      <td className="p-2">
-        <DailyProgressCell daily={daily} />
-      </td>
+      {vis.progress && (
+        <td className="p-2">
+          <DailyProgressCell daily={daily} />
+        </td>
+      )}
       <td className="p-2">
         <EntityLink
           entity="routines"
@@ -82,46 +95,59 @@ export function DailyTrackerRow({
           <DailyTitle daily={daily} />
         </EntityLink>
       </td>
-      <td className="p-2">
-        <span className="inline-flex items-center gap-1.5">
-          <DailyResourceIndicator daily={daily} />
-          <DailyTaskIndicator daily={daily} />
-        </span>
-      </td>
-      <td className="p-2">
-        <DailyCadenceBadge daily={daily} />
-      </td>
-      <td className="p-2">
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 text-xs",
-            currentStatus === null || currentStatus === "incomplete"
-              ? "text-muted-foreground"
-              : chain > 0
-                ? "text-orange-600"
-                : "text-muted-foreground",
-          )}
-          title={chain > 0 ? `${chain}-day chain` : "No active chain"}
-        >
-          <FlameIcon className="size-3.5" />
-          {chain}
-        </span>
-      </td>
-      <td className="p-2">
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 text-xs",
-            total > 0 ? "text-emerald-600" : "text-muted-foreground",
-          )}
-          title={`${total} total day${total === 1 ? "" : "s"} completed`}
-        >
-          <LaughIcon className="size-3.5" />
-          {total}
-        </span>
-      </td>
-      <td className="p-2">
-        {currentStatus !== null && <DailyCommentPopover daily={daily} />}
-      </td>
+      {vis.routine && (
+        <td className="p-2 whitespace-nowrap">{daily.name}</td>
+      )}
+      {vis.type && (
+        <td className="p-2">
+          <span className="inline-flex items-center gap-1.5">
+            <DailyResourceIndicator daily={daily} />
+            <DailyTaskIndicator daily={daily} />
+          </span>
+        </td>
+      )}
+      {vis.cadence && (
+        <td className="p-2">
+          <DailyCadenceBadge daily={daily} />
+        </td>
+      )}
+      {vis.streak && (
+        <td className="p-2">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 text-xs",
+              currentStatus === null || currentStatus === "incomplete"
+                ? "text-muted-foreground"
+                : chain > 0
+                  ? "text-orange-600"
+                  : "text-muted-foreground",
+            )}
+            title={chain > 0 ? `${chain}-day chain` : "No active chain"}
+          >
+            <FlameIcon className="size-3.5" />
+            {chain}
+          </span>
+        </td>
+      )}
+      {vis.total && (
+        <td className="p-2">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 text-xs",
+              total > 0 ? "text-emerald-600" : "text-muted-foreground",
+            )}
+            title={`${total} total day${total === 1 ? "" : "s"} completed`}
+          >
+            <LaughIcon className="size-3.5" />
+            {total}
+          </span>
+        </td>
+      )}
+      {vis.comment && (
+        <td className="p-2">
+          {currentStatus !== null && <DailyCommentPopover daily={daily} />}
+        </td>
+      )}
       <td className={statusCellClassName}>
         <TodayStatusCell
           daily={daily}
@@ -130,45 +156,48 @@ export function DailyTrackerRow({
           onChange={(status, note) => onChangeStatus(daily, status, note)}
         />
       </td>
-      {days.map((day, i) => {
-        return (
-          <td
-            key={day.dateKey}
-            className="relative px-1 py-2 align-middle"
-          >
-            {i === 0 && (
-              <DailyStatusConnector
-                left={currentStatus}
-                right={day.status}
-                className={firstConnectorClassName}
-              />
-            )}
-            {i > 0 && (
-              <DailyStatusConnector
-                left={days[i - 1].status}
-                right={day.status}
-                className="
-                  absolute top-1/2 right-[calc(50%+12px)] left-[calc(-50%+12px)]
-                  z-0 w-auto -translate-y-1/2
-                "
-              />
-            )}
-            <div className="relative z-10 flex justify-center">
-              <DailyStatusCircle
-                status={day.status}
-                size="sm"
-                title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
-              />
-            </div>
-          </td>
-        );
-      })}
-      <td className="p-2 whitespace-nowrap">
-        <DailyLocationCell
-          location={daily.location}
-          taskId={taskId}
-        />
-      </td>
+      {vis.days
+        && days.map((day, i) => {
+          return (
+            <td
+              key={day.dateKey}
+              className="relative px-1 py-2 align-middle"
+            >
+              {i === 0 && (
+                <DailyStatusConnector
+                  left={currentStatus}
+                  right={day.status}
+                  className={firstConnectorClassName}
+                />
+              )}
+              {i > 0 && (
+                <DailyStatusConnector
+                  left={days[i - 1].status}
+                  right={day.status}
+                  className="
+                    absolute top-1/2 right-[calc(50%+12px)]
+                    left-[calc(-50%+12px)] z-0 w-auto -translate-y-1/2
+                  "
+                />
+              )}
+              <div className="relative z-10 flex justify-center">
+                <DailyStatusCircle
+                  status={day.status}
+                  size="sm"
+                  title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+                />
+              </div>
+            </td>
+          );
+        })}
+      {vis.location && (
+        <td className="p-2 whitespace-nowrap">
+          <DailyLocationCell
+            location={daily.location}
+            taskId={taskId}
+          />
+        </td>
+      )}
     </tr>
   );
 }

--- a/packages/client/src/components/dailies/dailyTrackerColumns.test.ts
+++ b/packages/client/src/components/dailies/dailyTrackerColumns.test.ts
@@ -1,0 +1,102 @@
+import type { DailyDayHeader } from "@/hooks/useDailyTracker";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDailyTrackerColumns,
+  DEFAULT_DAILY_TRACKER_COLUMNS,
+  resolveDailyTrackerColumns,
+} from "./dailyTrackerColumns";
+
+const dayHeaders: DailyDayHeader[] = [
+  {
+    dateKey: "0101",
+    label: "M",
+    isToday: false,
+  },
+  {
+    dateKey: "0102",
+    label: "T",
+    isToday: true,
+  },
+];
+
+function columnIds(columns?: Parameters<typeof buildDailyTrackerColumns>[0]["columns"]) {
+  return buildDailyTrackerColumns({
+    dayHeaders,
+    statusHeadClassName: "",
+    columns,
+  }).map(c => c.id);
+}
+
+describe("resolveDailyTrackerColumns", () => {
+  it("defaults every toggleable column on except routine", () => {
+    expect(resolveDailyTrackerColumns()).toEqual(DEFAULT_DAILY_TRACKER_COLUMNS);
+    expect(DEFAULT_DAILY_TRACKER_COLUMNS.routine).toBe(false);
+  });
+
+  it("merges a partial override over the defaults", () => {
+    const resolved = resolveDailyTrackerColumns({
+      routine: true,
+      location: false,
+    });
+    expect(resolved.routine).toBe(true);
+    expect(resolved.location).toBe(false);
+    expect(resolved.progress).toBe(true);
+  });
+});
+
+describe("buildDailyTrackerColumns", () => {
+  it("omits the routine column and keeps the rest by default", () => {
+    const ids = columnIds();
+    expect(ids).not.toContain("routine");
+    expect(ids).toEqual([
+      "progress",
+      "name",
+      "type",
+      "cadence",
+      "streak",
+      "total",
+      "comment",
+      "today",
+      "day-0101",
+      "day-0102",
+      "location",
+    ]);
+  });
+
+  it("inserts the routine column right after the title when enabled", () => {
+    const ids = columnIds({
+      routine: true,
+    });
+    expect(ids.indexOf("routine")).toBe(ids.indexOf("name") + 1);
+  });
+
+  it("drops a toggled-off column's header", () => {
+    expect(columnIds({
+      type: false,
+    })).not.toContain("type");
+  });
+
+  it("drops every recent-day column when days is off", () => {
+    const ids = columnIds({
+      days: false,
+    });
+    expect(ids).not.toContain("day-0101");
+    expect(ids).not.toContain("day-0102");
+  });
+
+  it("always keeps the always-on title and today columns", () => {
+    const ids = columnIds({
+      progress: false,
+      type: false,
+      cadence: false,
+      streak: false,
+      total: false,
+      comment: false,
+      days: false,
+      location: false,
+    });
+    expect(ids).toEqual(["name", "today"]);
+  });
+});

--- a/packages/client/src/components/dailies/dailyTrackerColumns.tsx
+++ b/packages/client/src/components/dailies/dailyTrackerColumns.tsx
@@ -1,9 +1,89 @@
 import type { DailyDayHeader } from "@/hooks/useDailyTracker";
-import type { Daily } from "@emstack/types";
+import type {
+  Daily,
+  DailyTrackerColumnKey,
+  DailyTrackerColumnVisibility,
+} from "@emstack/types";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
 import { cn } from "@/lib/utils";
+
+/**
+ * Default column visibility for the daily-tracker tables: every toggleable
+ * column on except the routine-title column, which is opt-in. Used wherever a
+ * caller doesn't supply per-tile visibility (the routine tracker), so those
+ * tables keep their existing layout.
+ */
+export const DEFAULT_DAILY_TRACKER_COLUMNS: Required<DailyTrackerColumnVisibility>
+  = {
+    progress: true,
+    routine: false,
+    type: true,
+    cadence: true,
+    streak: true,
+    total: true,
+    comment: true,
+    days: true,
+    location: true,
+  };
+
+/** Merge a partial per-tile visibility map over the defaults. */
+export function resolveDailyTrackerColumns(
+  columns?: DailyTrackerColumnVisibility,
+): Required<DailyTrackerColumnVisibility> {
+  return {
+    ...DEFAULT_DAILY_TRACKER_COLUMNS,
+    ...columns,
+  };
+}
+
+/**
+ * Toggleable columns in display order, with the labels shown in the card
+ * settings menu. The always-on Title and Today's Status columns are absent by
+ * design. Keyed off DAILY_TRACKER_TOGGLEABLE_COLUMNS in @emstack/types.
+ */
+export const DAILY_TRACKER_COLUMN_OPTIONS: {
+  key: DailyTrackerColumnKey;
+  label: string;
+}[] = [
+  {
+    key: "progress",
+    label: "Progress",
+  },
+  {
+    key: "routine",
+    label: "Routine",
+  },
+  {
+    key: "type",
+    label: "Type",
+  },
+  {
+    key: "cadence",
+    label: "Cadence",
+  },
+  {
+    key: "streak",
+    label: "Streak",
+  },
+  {
+    key: "total",
+    label: "Total",
+  },
+  {
+    key: "comment",
+    label: "Comment",
+  },
+  {
+    key: "days",
+    label: "Recent days",
+  },
+  {
+    key: "location",
+    label: "Location",
+  },
+];
 
 interface DailyTrackerColumnsOptions {
   dayHeaders: DailyDayHeader[];
@@ -15,6 +95,8 @@ interface DailyTrackerColumnsOptions {
   statusHeadClassName: string;
   /** Title header className — the dashboard uses `w-full` to absorb slack. */
   titleHeadClassName?: string;
+  /** Per-tile column show/hide state; omit for the all-default tracker tables. */
+  columns?: DailyTrackerColumnVisibility;
 }
 
 /**
@@ -30,9 +112,16 @@ export function buildDailyTrackerColumns({
   progressLabel = "Progress",
   statusHeadClassName,
   titleHeadClassName,
+  columns,
 }: DailyTrackerColumnsOptions): ColumnDef<Daily>[] {
-  return [
-    {
+  const vis = resolveDailyTrackerColumns(columns);
+  // Emitted in display order; toggleable columns gate on `vis`. `name` (Title)
+  // and `today` (Today's Status) are always present. Keep this order in lockstep
+  // with DailyTrackerRow's `<td>` order so headers and cells stay aligned.
+  const cols: ColumnDef<Daily>[] = [];
+
+  if (vis.progress) {
+    cols.push({
       id: "progress",
       sortDescFirst: true,
       header: ({
@@ -44,73 +133,103 @@ export function buildDailyTrackerColumns({
           hideLabel={progressHideLabel}
         />
       ),
+    });
+  }
+
+  cols.push({
+    id: "name",
+    sortDescFirst: false,
+    meta: {
+      headClassName: titleHeadClassName,
     },
-    {
-      id: "name",
-      sortDescFirst: false,
-      meta: {
-        headClassName: titleHeadClassName,
-      },
-      header: ({
-        column,
-      }) => (
-        <DataTableColumnHeader
-          column={column}
-          label="Title"
-        />
-      ),
-    },
-    {
+    header: ({
+      column,
+    }) => (
+      <DataTableColumnHeader
+        column={column}
+        label="Title"
+      />
+    ),
+  });
+
+  if (vis.routine) {
+    cols.push({
+      id: "routine",
+      enableSorting: false,
+      header: "Routine",
+    });
+  }
+  if (vis.type) {
+    cols.push({
       id: "type",
       enableSorting: false,
       header: "Type",
-    },
-    {
+    });
+  }
+  if (vis.cadence) {
+    cols.push({
       id: "cadence",
       enableSorting: false,
       header: "Cadence",
-    },
-    {
+    });
+  }
+  if (vis.streak) {
+    cols.push({
       id: "streak",
       enableSorting: false,
       header: "Streak",
-    },
-    {
+    });
+  }
+  if (vis.total) {
+    cols.push({
       id: "total",
       enableSorting: false,
       header: "Total",
-    },
-    {
+    });
+  }
+  if (vis.comment) {
+    cols.push({
       id: "comment",
       enableSorting: false,
       header: () => null,
+    });
+  }
+
+  cols.push({
+    id: "today",
+    enableSorting: false,
+    meta: {
+      headClassName: statusHeadClassName,
     },
-    {
-      id: "today",
-      enableSorting: false,
-      meta: {
-        headClassName: statusHeadClassName,
-      },
-      header: "Today's Status",
-    },
-    ...dayHeaders.map((d): ColumnDef<Daily> => ({
-      id: `day-${d.dateKey}`,
-      enableSorting: false,
-      meta: {
-        headClassName: cn(
-          "px-1 py-2 text-center font-medium",
-          d.isToday && "text-foreground",
-        ),
-      },
-      header: d.label,
-    })),
-    {
+    header: "Today's Status",
+  });
+
+  if (vis.days) {
+    cols.push(
+      ...dayHeaders.map((d): ColumnDef<Daily> => ({
+        id: `day-${d.dateKey}`,
+        enableSorting: false,
+        meta: {
+          headClassName: cn(
+            "px-1 py-2 text-center font-medium",
+            d.isToday && "text-foreground",
+          ),
+        },
+        header: d.label,
+      })),
+    );
+  }
+
+  if (vis.location) {
+    cols.push({
       id: "location",
       enableSorting: false,
       meta: {
         headClassName: "whitespace-nowrap",
       },
       header: "Location",
-    },
-  ];
+    });
+  }
+
+  return cols;
 }

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -11,7 +11,6 @@ export { DailyTrackerRow } from "./DailyTrackerRow";
 export {
   buildDailyTrackerColumns,
   DAILY_TRACKER_COLUMN_OPTIONS,
-  DEFAULT_DAILY_TRACKER_COLUMNS,
   resolveDailyTrackerColumns,
 } from "./dailyTrackerColumns";
 export {

--- a/packages/client/src/components/dailies/index.ts
+++ b/packages/client/src/components/dailies/index.ts
@@ -8,7 +8,12 @@ export { TodayStatusCell } from "./TodayStatusCell";
 export { TooManyDailiesWarning } from "./TooManyDailiesWarning";
 export { DailiesLimitSetting } from "./DailiesLimitSetting";
 export { DailyTrackerRow } from "./DailyTrackerRow";
-export { buildDailyTrackerColumns } from "./dailyTrackerColumns";
+export {
+  buildDailyTrackerColumns,
+  DAILY_TRACKER_COLUMN_OPTIONS,
+  DEFAULT_DAILY_TRACKER_COLUMNS,
+  resolveDailyTrackerColumns,
+} from "./dailyTrackerColumns";
 export {
   DAILY_DETAIL_TABS,
   DAILY_STATUS_OPTIONS,

--- a/packages/client/src/lib/dashboardTiles.ts
+++ b/packages/client/src/lib/dashboardTiles.ts
@@ -1,4 +1,5 @@
 import type {
+  DailyTrackerColumnVisibility,
   DashboardLayout,
   DashboardLayoutTile,
   DashboardTileId,
@@ -331,6 +332,7 @@ interface GridItemSettings {
   showLabels?: boolean;
   showDescription?: boolean;
   showOverdue?: boolean;
+  columns?: DailyTrackerColumnVisibility;
 }
 
 export interface GridLayoutItem extends GridItemSettings {
@@ -354,6 +356,7 @@ function pickSettings(source: GridItemSettings): GridItemSettings {
     out.showDescription = source.showDescription;
   }
   if (source.showOverdue !== undefined) out.showOverdue = source.showOverdue;
+  if (source.columns !== undefined) out.columns = source.columns;
   return out;
 }
 

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DailiesColumnSettings.stories.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DailiesColumnSettings.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { DailiesColumnSettings } from "./-DailiesColumnSettings";
+
+import { makeTile } from "@/test-utils/dashboardFixtures";
+
+const meta: Meta<typeof DailiesColumnSettings> = {
+  component: DailiesColumnSettings,
+  args: {
+    tile: makeTile("doNow"),
+    onUpdateTile: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// The per-card column show/hide toggles. The routine column defaults off, so
+// clicking it asks to enable that column for this tile.
+export const Columns: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const routine = canvas.getByRole("switch", {
+      name: /routine/i,
+    });
+    await expect(routine).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(routine);
+    await expect(args.onUpdateTile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: expect.objectContaining({
+          routine: true,
+        }),
+      }),
+    );
+  },
+};

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DailiesColumnSettings.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DailiesColumnSettings.tsx
@@ -1,0 +1,48 @@
+import type { DashboardTileProps } from "@/lib/dashboardTiles";
+
+import { SettingToggle } from "../DashboardCard/-cardKit";
+
+import {
+  DAILY_TRACKER_COLUMN_OPTIONS,
+  resolveDailyTrackerColumns,
+} from "@/components/dailies";
+
+/**
+ * The "Columns" section of the Do Now / Done for the Day settings flyout: one
+ * toggle per show/hide-able tracker column. Visibility is stored per tile (so
+ * it's per dashboard tab and independent for each card) via `onUpdateTile`.
+ * Title and Today's Status are always shown and have no toggle.
+ */
+export function DailiesColumnSettings({
+  tile,
+  onUpdateTile,
+}: DashboardTileProps) {
+  const columns = resolveDailyTrackerColumns(tile.columns);
+  return (
+    <div className="flex flex-col gap-2 border-t pt-3">
+      <span
+        className="
+          text-xs font-semibold tracking-wide text-muted-foreground uppercase
+        "
+      >
+        Columns
+      </span>
+      {DAILY_TRACKER_COLUMN_OPTIONS.map(({
+        key, label,
+      }) => (
+        <SettingToggle
+          key={key}
+          label={label}
+          checked={columns[key]}
+          onChange={checked =>
+            onUpdateTile({
+              columns: {
+                ...columns,
+                [key]: checked,
+              },
+            })}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailies.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailies.tsx
@@ -2,6 +2,7 @@ import type { DashboardTileProps } from "@/lib/dashboardTiles";
 
 import { Link } from "@tanstack/react-router";
 
+import { DailiesColumnSettings } from "./-DailiesColumnSettings";
 import { DashboardDailiesBody } from "./-DashboardDailiesBody";
 import { useDashboardDailies } from "./-useDashboardDailies";
 import {
@@ -60,7 +61,12 @@ export function DashboardDoNow({
         <CardSettingsFlyout
           tile={tile}
           onUpdateTile={onUpdateTile}
-        />
+        >
+          <DailiesColumnSettings
+            tile={tile}
+            onUpdateTile={onUpdateTile}
+          />
+        </CardSettingsFlyout>
       )}
     >
       <DashboardSectionStatus
@@ -73,6 +79,7 @@ export function DashboardDoNow({
       <DashboardDailiesBody
         list={doNow}
         data={data}
+        columns={tile.columns}
       />
     </DashboardCard>
   );
@@ -96,7 +103,12 @@ export function DashboardDoneForDay({
         <CardSettingsFlyout
           tile={tile}
           onUpdateTile={onUpdateTile}
-        />
+        >
+          <DailiesColumnSettings
+            tile={tile}
+            onUpdateTile={onUpdateTile}
+          />
+        </CardSettingsFlyout>
       )}
     >
       <DashboardSectionStatus
@@ -107,6 +119,7 @@ export function DashboardDoneForDay({
       <DashboardDailiesBody
         list={doneForDay}
         data={data}
+        columns={tile.columns}
       />
     </DashboardCard>
   );

--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailiesBody.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailiesBody.tsx
@@ -1,5 +1,5 @@
 import type { DashboardDailiesData } from "./-useDashboardDailies";
-import type { Daily } from "@emstack/types";
+import type { Daily, DailyTrackerColumnVisibility } from "@emstack/types";
 
 import { RECENT_DAYS_COUNT } from "./-useDashboardDailies";
 
@@ -14,9 +14,12 @@ import { DataTable } from "@/components/ui/data-table";
 export function DashboardDailiesBody({
   list,
   data,
+  columns,
 }: {
   list: Daily[];
   data: DashboardDailiesData;
+  /** Per-tile column show/hide state from the card's settings menu. */
+  columns?: DailyTrackerColumnVisibility;
 }) {
   const {
     mode, mutation, dayHeaders, todayKey, sorting, onSortingChange,
@@ -48,6 +51,7 @@ export function DashboardDailiesBody({
         progressLabel: "Prog",
         statusHeadClassName: "p-2 font-medium whitespace-nowrap",
         titleHeadClassName: "w-full",
+        columns,
       })}
       data={list}
       getRowId={daily => daily.id}
@@ -78,6 +82,7 @@ export function DashboardDailiesBody({
             z-0 -translate-y-1/2
           "
           taskId={null}
+          columns={columns}
         />
       )}
     />

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -274,6 +274,41 @@ const dashboardLayoutTileSchema = {
     showOverdue: {
       type: "boolean",
     },
+    // Do Now / Done for the Day tiles only — per-column show/hide state. Keys
+    // mirror DAILY_TRACKER_TOGGLEABLE_COLUMNS in @emstack/types.
+    columns: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        progress: {
+          type: "boolean",
+        },
+        routine: {
+          type: "boolean",
+        },
+        type: {
+          type: "boolean",
+        },
+        cadence: {
+          type: "boolean",
+        },
+        streak: {
+          type: "boolean",
+        },
+        total: {
+          type: "boolean",
+        },
+        comment: {
+          type: "boolean",
+        },
+        days: {
+          type: "boolean",
+        },
+        location: {
+          type: "boolean",
+        },
+      },
+    },
   },
 } as const;
 

--- a/packages/types/src/DashboardLayout.ts
+++ b/packages/types/src/DashboardLayout.ts
@@ -22,6 +22,32 @@ export type DashboardTileId = (typeof DASHBOARD_TILE_IDS)[number];
 // An undefined `heightMode` is treated as "auto" (the default).
 export type TileHeightMode = "auto" | "fixed";
 
+// The daily-tracker table columns the user can show/hide from the Do Now /
+// Done for the Day card settings. Lives here (a runtime const) so the client
+// table builder and the middleware JSON schema derive from the same list — the
+// always-on Title and Today's Status columns are deliberately not toggleable.
+// "days" toggles the recent-day columns as a group.
+export const DAILY_TRACKER_TOGGLEABLE_COLUMNS = [
+  "progress",
+  "routine",
+  "type",
+  "cadence",
+  "streak",
+  "total",
+  "comment",
+  "days",
+  "location",
+] as const;
+
+export type DailyTrackerColumnKey
+  = (typeof DAILY_TRACKER_TOGGLEABLE_COLUMNS)[number];
+
+// Per-tile show/hide state for the toggleable columns. Partial: a missing key
+// means "use the default" (all on except the routine column).
+export type DailyTrackerColumnVisibility = Partial<
+  Record<DailyTrackerColumnKey, boolean>
+>;
+
 // Position/size of one enabled tile in the 4-column dashboard grid. A tile
 // that is disabled is simply absent from the layout's `tiles` array. The grid
 // `h` unit is 4em per row (see the client grid config).
@@ -40,6 +66,8 @@ export interface DashboardLayoutTile {
   showLabels?: boolean;
   showDescription?: boolean;
   showOverdue?: boolean;
+  // Do Now / Done for the Day tiles only — which tracker-table columns to show.
+  columns?: DailyTrackerColumnVisibility;
 }
 
 export interface DashboardLayout {


### PR DESCRIPTION
## Summary

Add per-dashboard-tile column show/hide controls for the daily tracker tables (Do Now / Done for the Day cards). Users can now customize which columns appear in each card independently via a new "Columns" settings section, with visibility state persisted to the dashboard layout.

## Key Changes

- **New types in `@emstack/types`:**
  - `DAILY_TRACKER_TOGGLEABLE_COLUMNS` constant listing the 9 user-configurable columns
  - `DailyTrackerColumnKey` and `DailyTrackerColumnVisibility` types for per-tile column state
  - `DashboardLayoutTile.columns` field to store visibility preferences

- **Daily tracker column builder refactor (`dailyTrackerColumns.tsx`):**
  - `DEFAULT_DAILY_TRACKER_COLUMNS` constant: all columns on except `routine` (opt-in)
  - `resolveDailyTrackerColumns()` helper: merges partial per-tile overrides with defaults
  - `DAILY_TRACKER_COLUMN_OPTIONS` array: metadata for the settings UI (column keys + labels)
  - `buildDailyTrackerColumns()` now accepts optional `columns` param and conditionally includes headers based on visibility state
  - Refactored from a single array return to building columns incrementally with visibility gates

- **Daily tracker row updates (`DailyTrackerRow.tsx`):**
  - Accepts optional `columns` prop and resolves visibility the same way as headers
  - Wraps each toggleable cell (`<td>`) in a conditional render matching the header visibility
  - Maintains strict alignment between header and cell order via comments

- **New settings UI:**
  - `DailiesColumnSettings` component: renders toggles for all 9 columns, updates tile via `onUpdateTile`
  - Integrated into both Do Now and Done for the Day card settings flyouts
  - Storybook story demonstrating the routine column toggle

- **Dashboard integration:**
  - `DashboardDailiesBody` accepts and passes `columns` prop to the row builder
  - Both card variants (Do Now / Done for the Day) wire up column visibility from `tile.columns`

- **Middleware schema (`packages/middleware/src/utils/schemas.ts`):**
  - Added `columns` object schema with 9 boolean properties, matching the toggleable columns list

- **Tests:**
  - `dailyTrackerColumns.test.ts`: comprehensive coverage of default behavior, merging logic, column ordering, and conditional inclusion

## Implementation Details

- The routine column defaults to **off** (unlike other columns) to preserve the existing default layout for tables that don't specify per-tile visibility
- Column order is maintained in lockstep between `buildDailyTrackerColumns()` and `DailyTrackerRow` via explicit comments
- The "days" toggle controls all recent-day columns as a group (not individually)
- Title and Today's Status columns are always shown and have no toggle
- Visibility state is optional on the tile; missing keys use the default (all on except routine)

https://claude.ai/code/session_01QFNYUaowsN1mKiwXL6JvRn