### PR TITLE
feat(routines): autofill location from resource/module links

### DIFF
--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -5,7 +5,10 @@ import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
 import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
-import { effectiveEntryUrl } from "@/components/routines/weekly";
+import {
+  effectiveEntryUrl,
+  withLocationAutofill,
+} from "@/components/routines/weekly";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
 interface ScheduleEntryRowProps {
@@ -26,6 +29,44 @@ interface ScheduleEntryRowProps {
   onAddResource: () => void;
   // Surface the combobox's typed text so the parent can seed the add dialog.
   onInputValueChange: (val: string) => void;
+}
+
+// The resolved item name and its actionable-sentence preview for a row, pulled
+// out of the component to keep its complexity down. A resource entry's narrowing
+// (module/group) name replaces the resource name in the label (see
+// resourceEntryLabel); the preview only shows once there's prepend/append text.
+function rowPreview(
+  row: WeeklyEntry,
+  optionsMap: Map<string, string>,
+  groupOptions: SelectOption[],
+  moduleOptions: SelectOption[],
+): { showPreview: boolean;
+  preview: string; } {
+  const moduleLabel = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)?.label
+    : null;
+  const groupLabel = row.moduleGroupId
+    ? groupOptions.find(o => o.value === row.moduleGroupId)?.label
+    : null;
+  const itemName
+    = row.type === "freeform"
+      ? row.id
+      : row.type === "resource"
+        ? resourceEntryLabel({
+          resourceName: optionsMap.get(row.id) ?? "",
+          moduleName: moduleLabel,
+          groupName: groupLabel,
+        })
+        : (optionsMap.get(row.id) ?? "");
+  return {
+    showPreview:
+      !!itemName && (!!row.prependText.trim() || !!row.appendText.trim()),
+    preview: buildActionableSentence({
+      prependText: row.prependText,
+      name: itemName,
+      appendText: row.appendText,
+    }),
+  };
 }
 
 // One schedule row's editor: type select, task/resource picker (or freeform
@@ -51,32 +92,12 @@ export function ScheduleEntryRow({
         ? resourceOptions
         : [];
   const optionsMap = new Map(itemOptions.map(o => [o.value, o.label]));
-  // A resource entry may narrow to a module / group; show that narrower name in
-  // the preview (matching how the entry renders everywhere else). A chosen
-  // module wins over its group in the label (see resourceEntryLabel).
-  const moduleLabel = row.moduleId
-    ? moduleOptions.find(o => o.value === row.moduleId)?.label
-    : null;
-  const groupLabel = row.moduleGroupId
-    ? groupOptions.find(o => o.value === row.moduleGroupId)?.label
-    : null;
-  const itemName
-    = row.type === "freeform"
-      ? row.id
-      : row.type === "resource"
-        ? resourceEntryLabel({
-          resourceName: optionsMap.get(row.id) ?? "",
-          moduleName: moduleLabel,
-          groupName: groupLabel,
-        })
-        : (optionsMap.get(row.id) ?? "");
-  const showPreview
-    = !!itemName && (!!row.prependText.trim() || !!row.appendText.trim());
-  const preview = buildActionableSentence({
-    prependText: row.prependText,
-    name: itemName,
-    appendText: row.appendText,
-  });
+  // Item name + live preview (a resource entry's narrowing name replaces the
+  // resource name); derived in a helper to keep this component's complexity down.
+  const {
+    showPreview,
+    preview,
+  } = rowPreview(row, optionsMap, groupOptions, moduleOptions);
   // The module narrowing only makes sense once a resource is chosen, and only
   // when that resource actually has modules / groups to pick from.
   const showModulePickers
@@ -84,39 +105,30 @@ export function ScheduleEntryRow({
       && !!row.id
       && (groupOptions.length > 0 || moduleOptions.length > 0);
 
-  // The most-specific link for the current resource / module / group selection.
+  // The most-specific link for the current resource / module / group selection,
+  // and whether to offer applying it (a link exists and the location differs).
   const linkUrl = effectiveEntryUrl(
     row,
     resourceOptions,
     groupOptions,
     moduleOptions,
   );
+  const showLinkOffer = !!linkUrl && row.location !== linkUrl;
 
   // Apply a selection-changing patch, autofilling the location from the new
-  // selection's link when the field is empty or still holds the previous
-  // autofill (so it tracks a re-narrowing) — but never clobbering text the user
-  // typed. Only routed through the type-determining controls (resource picker /
-  // module narrowing); the location input itself keeps the plain onChange.
-  function applyWithAutofill(patch: Partial<WeeklyEntry>) {
-    const next = {
-      ...row,
-      ...patch,
-    };
-    const nextUrl = effectiveEntryUrl(
-      next,
-      resourceOptions,
-      groupOptions,
-      moduleOptions,
+  // selection's link (see withLocationAutofill). Only routed through the
+  // type-determining controls (resource picker / module narrowing); the location
+  // input itself keeps the plain onChange so typed text is never clobbered.
+  const applyWithAutofill = (patch: Partial<WeeklyEntry>) =>
+    onChange(
+      withLocationAutofill(
+        row,
+        patch,
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
     );
-    if (nextUrl && (row.location === "" || row.location === linkUrl)) {
-      onChange({
-        ...patch,
-        location: nextUrl,
-      });
-      return;
-    }
-    onChange(patch);
-  }
 
   return (
     <li
@@ -238,7 +250,7 @@ export function ScheduleEntryRow({
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "
           />
-          {linkUrl && row.location !== linkUrl && (
+          {showLinkOffer && (
             <button
               type="button"
               aria-label={`${ariaPrefix} use resource link`}

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -5,6 +5,7 @@ import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
 import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
+import { effectiveEntryUrl } from "@/components/routines/weekly";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
 interface ScheduleEntryRowProps {
@@ -83,6 +84,40 @@ export function ScheduleEntryRow({
       && !!row.id
       && (groupOptions.length > 0 || moduleOptions.length > 0);
 
+  // The most-specific link for the current resource / module / group selection.
+  const linkUrl = effectiveEntryUrl(
+    row,
+    resourceOptions,
+    groupOptions,
+    moduleOptions,
+  );
+
+  // Apply a selection-changing patch, autofilling the location from the new
+  // selection's link when the field is empty or still holds the previous
+  // autofill (so it tracks a re-narrowing) — but never clobbering text the user
+  // typed. Only routed through the type-determining controls (resource picker /
+  // module narrowing); the location input itself keeps the plain onChange.
+  function applyWithAutofill(patch: Partial<WeeklyEntry>) {
+    const next = {
+      ...row,
+      ...patch,
+    };
+    const nextUrl = effectiveEntryUrl(
+      next,
+      resourceOptions,
+      groupOptions,
+      moduleOptions,
+    );
+    if (nextUrl && (row.location === "" || row.location === linkUrl)) {
+      onChange({
+        ...patch,
+        location: nextUrl,
+      });
+      return;
+    }
+    onChange(patch);
+  }
+
   return (
     <li
       className="
@@ -138,8 +173,9 @@ export function ScheduleEntryRow({
               value={row.id || null}
               onValueChange={val =>
                 // A different resource has different modules, so clear any
-                // existing narrowing when the picked item changes.
-                onChange({
+                // existing narrowing when the picked item changes. Autofill the
+                // location from the newly-picked resource's link when possible.
+                applyWithAutofill({
                   id: val ?? "",
                   moduleId: "",
                   moduleGroupId: "",
@@ -172,7 +208,7 @@ export function ScheduleEntryRow({
           row={row}
           groupOptions={groupOptions}
           moduleOptions={moduleOptions}
-          onChange={onChange}
+          onChange={applyWithAutofill}
         />
       )}
 
@@ -202,6 +238,22 @@ export function ScheduleEntryRow({
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "
           />
+          {linkUrl && row.location !== linkUrl && (
+            <button
+              type="button"
+              aria-label={`${ariaPrefix} use resource link`}
+              onClick={() =>
+                onChange({
+                  location: linkUrl,
+                })}
+              className="
+                self-start text-xs text-primary underline-offset-2
+                hover:underline
+              "
+            >
+              Use link from resource
+            </button>
+          )}
           <div
             className="
               grid grid-cols-1 gap-1.5

--- a/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
@@ -1,6 +1,7 @@
+import type { SelectOption } from "@/utils";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { expect, fn, within } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { weeklyToRows } from "./weekly";
 import { WeeklyScheduleField } from "./WeeklyScheduleField";
@@ -13,6 +14,35 @@ import {
   resourceOptions,
   taskOptions,
 } from "@/test-utils/routinesFixtures";
+
+// resource-1 carries a link, so a routine entry pointing at it can offer/autofill
+// that url into its location field.
+const resourceOptionsWithLink: SelectOption[] = [
+  {
+    value: "resource-1",
+    label: "Duolingo Spanish",
+    url: "https://duolingo.com",
+  },
+  {
+    value: "resource-2",
+    label: "SICP",
+  },
+];
+
+// A module group of resource-1 that carries its own link (modules left linkless,
+// so narrowing to the group falls back to the group's url).
+const moduleGroupsByResourceWithLink = new Map([
+  [
+    "resource-1",
+    [
+      {
+        value: "group-1",
+        label: "Unit 1",
+        url: "https://example.com/unit-1",
+      },
+    ],
+  ],
+]);
 
 const meta: Meta<typeof WeeklyScheduleField> = {
   component: WeeklyScheduleField,
@@ -129,5 +159,73 @@ export const WholeGroup: Story = {
     await expect(moduleSelect).toHaveValue("");
     await expect(moduleSelect).toBeEnabled();
     await expect(within(moduleSelect).getByText("Whole Group")).toBeInTheDocument();
+  },
+};
+
+// A resource entry on a linked resource whose location already holds custom text:
+// rather than overwrite it, the row offers a one-click button to apply the link.
+export const OffersLinkWhenLocationFilled: Story = {
+  args: {
+    value: weeklyToRows({
+      1: {
+        type: "resource",
+        id: "resource-1",
+        location: "my own note",
+      },
+    }),
+    resourceOptions: resourceOptionsWithLink,
+  },
+  play: async ({
+    canvasElement,
+    args,
+  }) => {
+    const canvas = within(canvasElement);
+    // The typed location is left untouched; an offer button appears instead.
+    await expect(canvas.getByLabelText("Monday location")).toHaveValue(
+      "my own note",
+    );
+    const offer = await canvas.findByLabelText("Monday use resource link");
+    await userEvent.click(offer);
+    await expect(args.onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          day: "1",
+          location: "https://duolingo.com",
+        }),
+      ]),
+    );
+  },
+};
+
+// Narrowing a resource entry (empty location) to a linked module group autofills
+// the location from the group's link.
+export const AutofillsOnNarrowing: Story = {
+  args: {
+    value: weeklyToRows({
+      1: {
+        type: "resource",
+        id: "resource-1",
+      },
+    }),
+    resourceOptions,
+    moduleGroupsByResource: moduleGroupsByResourceWithLink,
+    modulesByResource,
+  },
+  play: async ({
+    canvasElement,
+    args,
+  }) => {
+    const canvas = within(canvasElement);
+    const groupSelect = await canvas.findByLabelText("Monday module group");
+    await userEvent.selectOptions(groupSelect, "group-1");
+    await expect(args.onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          day: "1",
+          moduleGroupId: "group-1",
+          location: "https://example.com/unit-1",
+        }),
+      ]),
+    );
   },
 };

--- a/packages/client/src/components/routines/index.ts
+++ b/packages/client/src/components/routines/index.ts
@@ -7,6 +7,7 @@ export {
   curatedToRows,
   DAY_LABELS,
   DAY_ORDER,
+  effectiveEntryUrl,
   fillAllDays,
   formatCuratedDateLabel,
   MAX_CURATED_DAYS,

--- a/packages/client/src/components/routines/index.ts
+++ b/packages/client/src/components/routines/index.ts
@@ -7,7 +7,6 @@ export {
   curatedToRows,
   DAY_LABELS,
   DAY_ORDER,
-  effectiveEntryUrl,
   fillAllDays,
   formatCuratedDateLabel,
   MAX_CURATED_DAYS,

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -2,9 +2,12 @@ import type { RoutineCurated, RoutineWeekly } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
+import type { SelectOption } from "@/utils";
+
 import {
   curatedDateRange,
   curatedToRows,
+  effectiveEntryUrl,
   fillAllDays,
   representativeRow,
   rowsToCurated,
@@ -467,5 +470,171 @@ describe("resource entry module narrowing", () => {
         moduleGroupNames,
       ),
     ).toBe("Duolingo Spanish");
+  });
+});
+
+describe("effectiveEntryUrl", () => {
+  const resourceOptions: SelectOption[] = [
+    {
+      value: "res-1",
+      label: "Duolingo",
+      url: "https://duolingo.com",
+    },
+    {
+      value: "res-2",
+      label: "Some Book",
+    },
+  ];
+  const groupOptions: SelectOption[] = [
+    {
+      value: "grp-1",
+      label: "Unit 1",
+      group: "",
+      url: "https://example.com/unit-1",
+    },
+    {
+      value: "grp-2",
+      label: "Unit 2",
+      group: "",
+    },
+  ];
+  const moduleOptions: SelectOption[] = [
+    {
+      value: "mod-1",
+      label: "Lesson 1",
+      group: "grp-1",
+      url: "https://example.com/lesson-1",
+    },
+    {
+      value: "mod-2",
+      label: "Lesson 2",
+      group: "grp-1",
+    },
+  ];
+
+  test("returns the resource's url for a whole-resource entry", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleId: "",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("https://duolingo.com");
+  });
+
+  test("a chosen module's url wins over its group and resource", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleId: "mod-1",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("https://example.com/lesson-1");
+  });
+
+  test("falls back to the module's group url when the module has none", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-1",
+          // mod-2 has no url but belongs to grp-1, which does.
+          moduleId: "mod-2",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("https://example.com/unit-1");
+  });
+
+  test("uses an explicitly chosen group's url", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleId: "",
+          moduleGroupId: "grp-1",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("https://example.com/unit-1");
+  });
+
+  test("falls back to the resource url when the chosen group has none", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-1",
+          moduleId: "",
+          moduleGroupId: "grp-2",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("https://duolingo.com");
+  });
+
+  test("returns '' when nothing in the chain has a link", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "resource",
+          id: "res-2",
+          moduleId: "",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("");
+  });
+
+  test("returns '' for task / freeform entries even if ids collide", () => {
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "task",
+          id: "res-1",
+          moduleId: "",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("");
+    expect(
+      effectiveEntryUrl(
+        {
+          type: "freeform",
+          id: "res-1",
+          moduleId: "",
+          moduleGroupId: "",
+        },
+        resourceOptions,
+        groupOptions,
+        moduleOptions,
+      ),
+    ).toBe("");
   });
 });

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -1,3 +1,4 @@
+import type { SelectOption } from "@/utils";
 import type {
   RoutineCurated,
   RoutineReferenceItem,
@@ -266,6 +267,33 @@ export function rowsToCurated(
     endDate,
     entries,
   };
+}
+
+// The most-specific link for a resource entry, used to autofill/offer its
+// location: a chosen module's url wins over its group's, which wins over the
+// resource's (mirroring resourceEntryLabel's narrowing precedence). A chosen
+// module implies its parent group, so an absent explicit group falls back to the
+// module's own `group`. Returns "" for task / freeform entries, or when nothing
+// in the chain carries a link. `groupOptions` / `moduleOptions` are the chosen
+// resource's narrowing options (empty when none, e.g. Daily mode).
+export function effectiveEntryUrl(
+  row: Pick<WeeklyEntry, "type" | "id" | "moduleId" | "moduleGroupId">,
+  resourceOptions: SelectOption[],
+  groupOptions: SelectOption[],
+  moduleOptions: SelectOption[],
+): string {
+  if (row.type !== "resource") {
+    return "";
+  }
+  const selectedModule = row.moduleId
+    ? moduleOptions.find(o => o.value === row.moduleId)
+    : undefined;
+  const effectiveGroupId = row.moduleGroupId || selectedModule?.group || "";
+  const groupUrl = effectiveGroupId
+    ? groupOptions.find(o => o.value === effectiveGroupId)?.url
+    : undefined;
+  const resourceUrl = resourceOptions.find(o => o.value === row.id)?.url;
+  return selectedModule?.url || groupUrl || resourceUrl || "";
 }
 
 // Display name for a weekly entry: freeform entries carry their own text in

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -296,6 +296,42 @@ export function effectiveEntryUrl(
   return selectedModule?.url || groupUrl || resourceUrl || "";
 }
 
+// Augment a selection-changing patch with a location autofilled from the entry's
+// link, when the field is empty or still holds the previous autofill (so it
+// tracks a re-narrowing) — never clobbering text the user typed. Returns the
+// patch unchanged when there's no link to apply. Shared by the weekly/curated
+// row editor and the daily editor so the autofill rule lives in one place.
+export function withLocationAutofill(
+  row: WeeklyEntry,
+  patch: Partial<WeeklyEntry>,
+  resourceOptions: SelectOption[],
+  groupOptions: SelectOption[],
+  moduleOptions: SelectOption[],
+): Partial<WeeklyEntry> {
+  const prevUrl = effectiveEntryUrl(
+    row,
+    resourceOptions,
+    groupOptions,
+    moduleOptions,
+  );
+  const nextUrl = effectiveEntryUrl(
+    {
+      ...row,
+      ...patch,
+    },
+    resourceOptions,
+    groupOptions,
+    moduleOptions,
+  );
+  if (nextUrl && (row.location === "" || row.location === prevUrl)) {
+    return {
+      ...patch,
+      location: nextUrl,
+    };
+  }
+  return patch;
+}
+
 // Display name for a weekly entry: freeform entries carry their own text in
 // `id`; task / resource entries resolve through the id → name maps and fall
 // back to the raw id when the lookup misses. A resource entry that narrows to a

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.stories.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.stories.tsx
@@ -1,6 +1,7 @@
+import type { SelectOption } from "@/utils";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import { WeeklyEntryEditor } from "./-WeeklyEntryEditor";
 
@@ -10,6 +11,20 @@ import {
   resourceOptions,
   taskOptions,
 } from "@/test-utils/routinesFixtures";
+
+// resource-1 carries a link, so a daily entry pointing at it can offer/autofill
+// that url into its location field.
+const resourceOptionsWithLink: SelectOption[] = [
+  {
+    value: "resource-1",
+    label: "Duolingo Spanish",
+    url: "https://duolingo.com",
+  },
+  {
+    value: "resource-2",
+    label: "SICP",
+  },
+];
 
 const meta: Meta<typeof WeeklyEntryEditor> = {
   component: WeeklyEntryEditor,
@@ -73,5 +88,33 @@ export const None: Story = {
   args: {
     type: "",
     id: "",
+  },
+};
+
+// A resource entry on a linked resource whose location already holds custom text:
+// the editor offers a one-click button to apply the resource's link rather than
+// overwriting what the user typed.
+export const OffersLinkWhenLocationFilled: Story = {
+  args: {
+    type: "resource",
+    id: "resource-1",
+    location: "my own note",
+    resourceOptions: resourceOptionsWithLink,
+  },
+  play: async ({
+    canvasElement,
+    args,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText("Daily task location")).toHaveValue(
+      "my own note",
+    );
+    const offer = await canvas.findByLabelText("Daily task use resource link");
+    await userEvent.click(offer);
+    await expect(args.onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: "https://duolingo.com",
+      }),
+    );
   },
 };

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
@@ -26,6 +26,8 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
     inputValue,
     setInputValue,
     emit,
+    emitPicked,
+    linkUrl,
     showPreview,
     preview,
   } = useWeeklyEntryEditor(props);
@@ -41,7 +43,7 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
         id={id}
         itemOptions={itemOptions}
         optionsMap={optionsMap}
-        onEmit={emit}
+        onEmit={emitPicked}
         onInputValueChange={setInputValue}
         onRequestAddResource={() => setAddOpen(true)}
       />
@@ -72,6 +74,22 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "
           />
+          {linkUrl && location !== linkUrl && (
+            <button
+              type="button"
+              aria-label="Daily task use resource link"
+              onClick={() =>
+                emit({
+                  location: linkUrl,
+                })}
+              className="
+                self-start text-xs text-primary underline-offset-2
+                hover:underline
+              "
+            >
+              Use link from resource
+            </button>
+          )}
           <div
             className="
               grid grid-cols-1 gap-1.5

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
@@ -5,7 +5,10 @@ import { useMemo, useState } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
-import { effectiveEntryUrl } from "@/components/routines/weekly";
+import {
+  effectiveEntryUrl,
+  withLocationAutofill,
+} from "@/components/routines/weekly";
 
 export interface WeeklyEntryEditorProps extends WeeklyEntry {
   onChange: (next: WeeklyEntry) => void;
@@ -73,31 +76,28 @@ export function useWeeklyEntryEditor({
     [],
   );
 
-  // Like emit, but autofills the location from the picked resource's link when
-  // the field is empty or still holds the previous autofill — never overwriting
-  // text the user typed. Used by the item picker; the location input keeps emit.
-  function emitPicked(patch: Partial<WeeklyEntry>) {
-    const nextUrl = effectiveEntryUrl(
-      {
-        type,
-        id,
-        moduleId,
-        moduleGroupId,
-        ...patch,
-      },
-      resourceOptions,
-      [],
-      [],
+  // Like emit, but autofills the location from the picked resource's link (see
+  // withLocationAutofill). Used by the item picker; the location input keeps emit
+  // so typed text is never overwritten. Daily mode has no module narrowing.
+  const emitPicked = (patch: Partial<WeeklyEntry>) =>
+    emit(
+      withLocationAutofill(
+        {
+          type,
+          id,
+          moduleId,
+          moduleGroupId,
+          notes,
+          location,
+          prependText,
+          appendText,
+        },
+        patch,
+        resourceOptions,
+        [],
+        [],
+      ),
     );
-    if (nextUrl && (location === "" || location === linkUrl)) {
-      emit({
-        ...patch,
-        location: nextUrl,
-      });
-      return;
-    }
-    emit(patch);
-  }
 
   const itemName = type === "freeform" ? id : (optionsMap.get(id) ?? "");
   const showPreview

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
@@ -5,6 +5,8 @@ import { useMemo, useState } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
+import { effectiveEntryUrl } from "@/components/routines/weekly";
+
 export interface WeeklyEntryEditorProps extends WeeklyEntry {
   onChange: (next: WeeklyEntry) => void;
   taskOptions: SelectOption[];
@@ -57,6 +59,46 @@ export function useWeeklyEntryEditor({
     });
   }
 
+  // Daily mode has no module narrowing, so the entry's link is just the chosen
+  // resource's url (empty for task / freeform).
+  const linkUrl = effectiveEntryUrl(
+    {
+      type,
+      id,
+      moduleId,
+      moduleGroupId,
+    },
+    resourceOptions,
+    [],
+    [],
+  );
+
+  // Like emit, but autofills the location from the picked resource's link when
+  // the field is empty or still holds the previous autofill — never overwriting
+  // text the user typed. Used by the item picker; the location input keeps emit.
+  function emitPicked(patch: Partial<WeeklyEntry>) {
+    const nextUrl = effectiveEntryUrl(
+      {
+        type,
+        id,
+        moduleId,
+        moduleGroupId,
+        ...patch,
+      },
+      resourceOptions,
+      [],
+      [],
+    );
+    if (nextUrl && (location === "" || location === linkUrl)) {
+      emit({
+        ...patch,
+        location: nextUrl,
+      });
+      return;
+    }
+    emit(patch);
+  }
+
   const itemName = type === "freeform" ? id : (optionsMap.get(id) ?? "");
   const showPreview
     = !!itemName && (!!prependText.trim() || !!appendText.trim());
@@ -74,6 +116,8 @@ export function useWeeklyEntryEditor({
     inputValue,
     setInputValue,
     emit,
+    emitPicked,
+    linkUrl,
     showPreview,
     preview,
   };

--- a/packages/client/src/utils/selectOptions.test.ts
+++ b/packages/client/src/utils/selectOptions.test.ts
@@ -2,7 +2,11 @@ import type { TagGroup } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
-import { tagGroupsToOptions, toOptions } from "./selectOptions.ts";
+import {
+  groupOptionsByResource,
+  tagGroupsToOptions,
+  toOptions,
+} from "./selectOptions.ts";
 
 describe("toOptions", () => {
   test("maps {id, name} entities to {value, label}", () => {
@@ -32,6 +36,50 @@ describe("toOptions", () => {
   test("returns an empty array for null/undefined", () => {
     expect(toOptions(null)).toEqual([]);
     expect(toOptions(undefined)).toEqual([]);
+  });
+
+  test("carries a url when the entity has one", () => {
+    const [option] = toOptions([
+      {
+        id: "a",
+        name: "Alpha",
+        url: "https://example.com/a",
+      },
+    ]);
+    expect(option.url).toBe("https://example.com/a");
+  });
+});
+
+describe("groupOptionsByResource", () => {
+  test("buckets by resource and carries group + url", () => {
+    const byResource = groupOptionsByResource([
+      {
+        id: "mod-1",
+        name: "Lesson 1",
+        resourceId: "res-1",
+        moduleGroupId: "grp-1",
+        url: "https://example.com/lesson-1",
+      },
+      {
+        id: "mod-2",
+        name: "Lesson 2",
+        resourceId: "res-1",
+        moduleGroupId: "grp-1",
+      },
+    ]);
+    expect(byResource.get("res-1")).toEqual([
+      {
+        value: "mod-1",
+        label: "Lesson 1",
+        group: "grp-1",
+        url: "https://example.com/lesson-1",
+      },
+      {
+        value: "mod-2",
+        label: "Lesson 2",
+        group: "grp-1",
+      },
+    ]);
   });
 });
 

--- a/packages/client/src/utils/selectOptions.ts
+++ b/packages/client/src/utils/selectOptions.ts
@@ -6,16 +6,23 @@ export interface SelectOption {
   // Optional explicit dropdown group. When set, a grouped combobox buckets the
   // option under this label instead of deriving one from the value prefix.
   group?: string;
+  // Optional link carried from the source entity (e.g. a resource / module /
+  // module-group url). Used to offer/autofill a routine entry's location; absent
+  // for entities without a link (tasks, tags).
+  url?: string;
 }
 
-// Map a list of {id, name} entities to combobox/select options.
+// Map a list of {id, name} entities to combobox/select options. A `url`, when the
+// entity carries one, rides along on the option (consumed by routine autofill).
 export function toOptions(
   items: { id: string;
-    name: string; }[] | null | undefined,
+    name: string;
+    url?: string | null; }[] | null | undefined,
 ): SelectOption[] {
   return (items ?? []).map(item => ({
     value: item.id,
     label: item.name,
+    url: item.url ?? undefined,
   }));
 }
 
@@ -26,7 +33,8 @@ export function groupOptionsByResource(
   items: { id: string;
     name: string;
     resourceId: string;
-    moduleGroupId?: string | null; }[] | null | undefined,
+    moduleGroupId?: string | null;
+    url?: string | null; }[] | null | undefined,
 ): Map<string, SelectOption[]> {
   const byResource = new Map<string, SelectOption[]>();
   for (const item of items ?? []) {
@@ -37,6 +45,9 @@ export function groupOptionsByResource(
       // Modules carry their parent group so a resource entry can scope its
       // module dropdown to the chosen group; module groups have none → "".
       group: item.moduleGroupId ?? "",
+      // A module / module-group link, when set, so a resource entry can autofill
+      // its location from the chosen narrowing.
+      url: item.url ?? undefined,
     });
     byResource.set(item.resourceId, options);
   }


### PR DESCRIPTION
## Summary

Add automatic location field population for routine entries based on linked resources, module groups, and modules. When a user selects a resource with a URL, the location field autofills with that URL (unless the user has already typed custom text). A "Use link from resource" button also offers one-click application of the link when the location field contains custom text.

## Key Changes

- **New `effectiveEntryUrl()` function** (`weekly.ts`): Determines the most-specific URL for a resource entry by checking (in precedence order): selected module's URL → module's parent group's URL → resource's URL. Returns empty string for task/freeform entries or when no link exists in the chain.

- **Autofill on resource/module selection** (`ScheduleEntryRow.tsx`, `WeeklyEntryEditor.tsx`): 
  - New `applyWithAutofill()` / `emitPicked()` helper that applies a selection change and autofills the location from the new selection's link when the field is empty or still holds the previous autofill value
  - Preserves user-typed custom text (never overwrites unless the field matches the previous autofill)
  - Wired to resource picker and module narrowing controls

- **"Use link from resource" button**: Appears when a link exists but the location field contains custom text, offering a one-click way to apply the link without losing the user's typed value

- **SelectOption type enhancement** (`selectOptions.ts`): Added optional `url` field to carry links from source entities (resources, modules, module groups). Updated `toOptions()` and `groupOptionsByResource()` to preserve URLs from input entities.

- **Test coverage**: Added comprehensive test suite for `effectiveEntryUrl()` covering all precedence cases, fallbacks, and edge cases (task/freeform entries, missing links). Added Storybook stories demonstrating autofill on narrowing and link offer when location is filled.

## Implementation Details

- The autofill logic respects the user's intent: it only autofills when the location is empty or matches the *previous* link (indicating a re-narrowing), never clobbering custom text
- Daily mode (no module narrowing) passes empty arrays for group/module options to `effectiveEntryUrl()`, correctly returning only the resource's URL
- The link precedence mirrors `resourceEntryLabel()`'s narrowing precedence, ensuring consistent UX

https://claude.ai/code/session_013KzJURRLUyifJrP6Ei2CML