### PR TITLE
fix(client): defer cache invalidation until after navigation on delete

### DIFF
--- a/packages/client/src/hooks/useEditFormPage.ts
+++ b/packages/client/src/hooks/useEditFormPage.ts
@@ -94,12 +94,18 @@ export function useEditFormPage<TData>({
       async () => {
         try {
           await deleteFn(id);
-          await invalidateRelated();
+          // Leave the edit page before invalidating. While this route is still
+          // mounted the entity's detail query is active, so invalidating it
+          // refetches a now-deleted record -> 404 -> (under the app's default
+          // retry: 3) ~7s of retry backoff that blocks the redirect + toast.
+          // Navigating first makes that query inactive, so invalidateRelated
+          // only marks it stale.
           skipBlock();
           await navigateToList();
           toast.success(
             `${entityLabel.charAt(0).toUpperCase()}${entityLabel.slice(1)} deleted.`,
           );
+          await invalidateRelated();
         }
         catch {
           toast.error(`Failed to delete ${entityLabel}. Please try again.`);


### PR DESCRIPTION
## Summary

Fixes a performance issue where deleting an entity would trigger a 404 retry loop before the user could navigate away from the edit page.

## Key Changes

- **Reordered delete flow:** Move `invalidateRelated()` call to *after* navigation completes, rather than before
- **Root cause:** While the edit page route is still mounted, the entity's detail query remains active. Invalidating it immediately causes a refetch of the now-deleted record, which returns 404 and triggers the default retry backoff (~7 seconds across 3 retries), blocking the redirect and toast notification
- **Solution:** Navigate first to deactivate the detail query, then invalidate. This marks the query stale without refetching, eliminating the retry backoff delay

## Implementation Details

The fix preserves all existing behavior (success toast, error handling, navigation) while improving UX by removing the blocking retry delay. The comment explains the reasoning for future maintainers.

https://claude.ai/code/session_01APH4bCecCwE9rqahtwdihn