### PR TITLE
ci: add fallow audit results to PR comments

### DIFF
--- a/.github/workflows/fallow-audit.yml
+++ b/.github/workflows/fallow-audit.yml
@@ -7,11 +7,20 @@ on:
   push:
     branches: [master]
 
+# This workflow now upserts a sticky PR comment, so a superseded push must not
+# let a stale run overwrite a newer one's comment — cancel in-flight runs and
+# let the last push win (mirrors the CI / PR-warnings workflows).
+concurrency:
+  group: fallow-audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fallow-audit:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to upsert the audit-findings PR comment.
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -41,3 +50,61 @@ jobs:
           set -o pipefail
           pnpm exec fallow --fail-on-issues --format markdown --quiet \
             | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Render the same findings as fallow's purpose-built GitHub PR-comment view
+      # so the failures are visible on the PR without opening the Actions log.
+      # Runs even when the gate above failed (that's the case we most want to
+      # surface) but never fails the build itself (no --fail-on-issues — the gate
+      # step owns failure). Only on PRs from this repo: push-to-master has no PR,
+      # and fork PRs get a read-only token that can't comment.
+      - name: Build fallow PR comment
+        id: comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        shell: bash
+        run: |
+          pnpm exec fallow --format pr-comment-github --quiet \
+            > "${RUNNER_TEMP}/fallow-pr-comment.md"
+
+      # Upsert by the stable marker fallow embeds, so each push updates one
+      # sticky comment instead of stacking new ones. Gated on the build step
+      # succeeding (also skips push/fork runs, where that step doesn't run).
+      - name: Upsert sticky fallow comment
+        if: ${{ steps.comment.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- fallow-id: fallow-results -->";
+            const body = fs.readFileSync(
+              `${process.env.RUNNER_TEMP}/fallow-pr-comment.md`,
+              "utf8",
+            );
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // PR comments are issue comments; find ours by its leading marker.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated fallow audit comment ${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info("Created fallow audit comment.");
+            }


### PR DESCRIPTION
## Summary

Enhance the fallow-audit workflow to surface audit findings directly on pull requests via sticky comments, improving visibility without requiring developers to open the Actions log.

## Changes

- **Concurrency control:** Added concurrency group to cancel in-flight runs when a new push supersedes an earlier one, ensuring only the latest audit comment is posted (mirrors CI/PR-warnings workflows)
- **Permissions:** Added `pull-requests: write` permission to enable PR comment creation/updates
- **PR comment rendering:** New step that runs fallow with `--format pr-comment-github` to generate a GitHub-flavored markdown comment (runs on all PRs, even when the audit gate fails — especially important when failures occur)
- **Sticky comment upsert:** New step using `actions/github-script` to find and update an existing fallow audit comment by its embedded marker (`<!-- fallow-id: fallow-results -->`), or create a new one if none exists. This prevents comment stacking on repeated pushes.
- **Conditional execution:** Comment steps only run on pull requests from the main repository (skips push-to-master and fork PRs with read-only tokens)

## Implementation Details

- The comment is only upserted if the "Build fallow PR comment" step succeeds, which ensures we only post when we have valid findings to display
- Uses a stable marker embedded in fallow's output to identify the audit comment, allowing idempotent updates across multiple pushes
- Pagination support for finding existing comments (handles repos with many comments)

https://claude.ai/code/session_012fWoLtCoBtuNL6SEdYWDCU