### PR TITLE
refactor: persist resource links as location defaults on save

### DIFF
--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -5,10 +5,7 @@ import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
 import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
-import {
-  effectiveEntryUrl,
-  withLocationAutofill,
-} from "@/components/routines/weekly";
+import { effectiveEntryUrl } from "@/components/routines/weekly";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
 interface ScheduleEntryRowProps {
@@ -105,30 +102,18 @@ export function ScheduleEntryRow({
       && !!row.id
       && (groupOptions.length > 0 || moduleOptions.length > 0);
 
-  // The most-specific link for the current resource / module / group selection,
-  // and whether to offer applying it (a link exists and the location differs).
+  // The most-specific link for the current resource / module / group selection.
+  // Shown as the location input's placeholder (and persisted on save when the
+  // field is left blank). The "use link" button is only offered once the user has
+  // typed a value that differs from the link.
   const linkUrl = effectiveEntryUrl(
     row,
     resourceOptions,
     groupOptions,
     moduleOptions,
   );
-  const showLinkOffer = !!linkUrl && row.location !== linkUrl;
-
-  // Apply a selection-changing patch, autofilling the location from the new
-  // selection's link (see withLocationAutofill). Only routed through the
-  // type-determining controls (resource picker / module narrowing); the location
-  // input itself keeps the plain onChange so typed text is never clobbered.
-  const applyWithAutofill = (patch: Partial<WeeklyEntry>) =>
-    onChange(
-      withLocationAutofill(
-        row,
-        patch,
-        resourceOptions,
-        groupOptions,
-        moduleOptions,
-      ),
-    );
+  const showLinkOffer
+    = !!linkUrl && row.location !== "" && row.location !== linkUrl;
 
   return (
     <li
@@ -185,9 +170,8 @@ export function ScheduleEntryRow({
               value={row.id || null}
               onValueChange={val =>
                 // A different resource has different modules, so clear any
-                // existing narrowing when the picked item changes. Autofill the
-                // location from the newly-picked resource's link when possible.
-                applyWithAutofill({
+                // existing narrowing when the picked item changes.
+                onChange({
                   id: val ?? "",
                   moduleId: "",
                   moduleGroupId: "",
@@ -220,7 +204,7 @@ export function ScheduleEntryRow({
           row={row}
           groupOptions={groupOptions}
           moduleOptions={moduleOptions}
-          onChange={applyWithAutofill}
+          onChange={onChange}
         />
       )}
 
@@ -240,12 +224,17 @@ export function ScheduleEntryRow({
           />
           <input
             aria-label={`${ariaPrefix} location`}
-            value={row.location}
+            // Show the resource link as a placeholder (rather than baking it into
+            // the value), so a blank field reads as "uses the resource link" —
+            // both when empty and when the stored location equals the link.
+            value={row.location === linkUrl ? "" : row.location}
             onChange={e =>
               onChange({
                 location: e.target.value,
               })}
-            placeholder="Location (e.g. gym, Spanish app, or a URL)…"
+            placeholder={
+              linkUrl || "Location (e.g. gym, Spanish app, or a URL)…"
+            }
             className="
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "

--- a/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.stories.tsx
@@ -15,8 +15,8 @@ import {
   taskOptions,
 } from "@/test-utils/routinesFixtures";
 
-// resource-1 carries a link, so a routine entry pointing at it can offer/autofill
-// that url into its location field.
+// resource-1 carries a link, so a routine entry pointing at it shows that url as
+// its location placeholder (and can offer it when the field holds custom text).
 const resourceOptionsWithLink: SelectOption[] = [
   {
     value: "resource-1",
@@ -197,9 +197,10 @@ export const OffersLinkWhenLocationFilled: Story = {
   },
 };
 
-// Narrowing a resource entry (empty location) to a linked module group autofills
-// the location from the group's link.
-export const AutofillsOnNarrowing: Story = {
+// A resource entry with a blank location shows the resource's link as the
+// location placeholder (the value stays empty; it's persisted as the link on
+// save). No "use link" offer appears, since there's no different value to replace.
+export const ShowsResourceLinkAsPlaceholder: Story = {
   args: {
     value: weeklyToRows({
       1: {
@@ -207,25 +208,46 @@ export const AutofillsOnNarrowing: Story = {
         id: "resource-1",
       },
     }),
-    resourceOptions,
+    resourceOptions: resourceOptionsWithLink,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const location = canvas.getByLabelText("Monday location");
+    await expect(location).toHaveValue("");
+    await expect(location).toHaveAttribute(
+      "placeholder",
+      "https://duolingo.com",
+    );
+    await expect(
+      canvas.queryByLabelText("Monday use resource link"),
+    ).not.toBeInTheDocument();
+  },
+};
+
+// Narrowing a resource entry to a linked module group surfaces the group's link
+// (which wins over the resource's) as the location placeholder.
+export const ShowsNarrowedLinkAsPlaceholder: Story = {
+  args: {
+    value: weeklyToRows({
+      1: {
+        type: "resource",
+        id: "resource-1",
+        moduleGroupId: "group-1",
+      },
+    }),
+    resourceOptions: resourceOptionsWithLink,
     moduleGroupsByResource: moduleGroupsByResourceWithLink,
     modulesByResource,
   },
   play: async ({
     canvasElement,
-    args,
   }) => {
     const canvas = within(canvasElement);
-    const groupSelect = await canvas.findByLabelText("Monday module group");
-    await userEvent.selectOptions(groupSelect, "group-1");
-    await expect(args.onChange).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          day: "1",
-          moduleGroupId: "group-1",
-          location: "https://example.com/unit-1",
-        }),
-      ]),
+    await expect(canvas.getByLabelText("Monday location")).toHaveAttribute(
+      "placeholder",
+      "https://example.com/unit-1",
     );
   },
 };

--- a/packages/client/src/components/routines/index.ts
+++ b/packages/client/src/components/routines/index.ts
@@ -8,6 +8,7 @@ export {
   DAY_LABELS,
   DAY_ORDER,
   fillAllDays,
+  fillEffectiveLocations,
   formatCuratedDateLabel,
   MAX_CURATED_DAYS,
   representativeRow,

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -2,6 +2,7 @@ import type { RoutineCurated, RoutineWeekly } from "@emstack/types";
 
 import { describe, expect, test } from "vitest";
 
+import type { WeeklyRow } from "./weekly";
 import type { SelectOption } from "@/utils";
 
 import {
@@ -9,6 +10,7 @@ import {
   curatedToRows,
   effectiveEntryUrl,
   fillAllDays,
+  fillEffectiveLocations,
   representativeRow,
   rowsToCurated,
   rowsToWeekly,
@@ -636,5 +638,123 @@ describe("effectiveEntryUrl", () => {
         moduleOptions,
       ),
     ).toBe("");
+  });
+});
+
+describe("fillEffectiveLocations", () => {
+  const resourceOptions: SelectOption[] = [
+    {
+      value: "res-1",
+      label: "Duolingo",
+      url: "https://duolingo.com",
+    },
+    {
+      value: "res-2",
+      label: "Some Book",
+    },
+  ];
+  // res-1 narrows to grp-1 (which carries a url) and mod-1 (which also does).
+  const moduleGroupsByResource = new Map<string, SelectOption[]>([
+    [
+      "res-1",
+      [
+        {
+          value: "grp-1",
+          label: "Unit 1",
+          group: "",
+          url: "https://example.com/unit-1",
+        },
+      ],
+    ],
+  ]);
+  const modulesByResource = new Map<string, SelectOption[]>([
+    [
+      "res-1",
+      [
+        {
+          value: "mod-1",
+          label: "Lesson 1",
+          group: "grp-1",
+          url: "https://example.com/lesson-1",
+        },
+      ],
+    ],
+  ]);
+
+  // A full weekly row with overridable fields; defaults to a blank-location
+  // whole-resource entry on res-1.
+  function row(over: Partial<WeeklyRow> = {}): WeeklyRow {
+    return {
+      day: "1",
+      type: "resource",
+      id: "res-1",
+      moduleId: "",
+      moduleGroupId: "",
+      notes: "",
+      location: "",
+      prependText: "",
+      appendText: "",
+      ...over,
+    };
+  }
+
+  const fill = (rows: WeeklyRow[]) =>
+    fillEffectiveLocations(
+      rows,
+      resourceOptions,
+      moduleGroupsByResource,
+      modulesByResource,
+    );
+
+  test("fills a blank location from the resource's url", () => {
+    expect(fill([row()])[0].location).toBe("https://duolingo.com");
+  });
+
+  test("fills from the most-specific narrowing (module > group)", () => {
+    expect(fill([row({
+      moduleGroupId: "grp-1",
+    })])[0].location).toBe(
+      "https://example.com/unit-1",
+    );
+    expect(fill([row({
+      moduleId: "mod-1",
+    })])[0].location).toBe(
+      "https://example.com/lesson-1",
+    );
+  });
+
+  test("leaves a user-typed location untouched", () => {
+    expect(fill([row({
+      location: "my own note",
+    })])[0].location).toBe(
+      "my own note",
+    );
+  });
+
+  test("leaves the location blank when nothing in the chain has a link", () => {
+    expect(fill([row({
+      id: "res-2",
+    })])[0].location).toBe("");
+  });
+
+  test("ignores task / freeform entries", () => {
+    expect(fill([row({
+      type: "task",
+      id: "res-1",
+    })])[0].location).toBe("");
+    expect(fill([row({
+      type: "freeform",
+      id: "res-1",
+    })])[0].location).toBe("");
+  });
+
+  test("preserves the row's other fields (e.g. its day key)", () => {
+    const [filled] = fill([row({
+      day: "3",
+      notes: "hi",
+    })]);
+    expect(filled.day).toBe("3");
+    expect(filled.notes).toBe("hi");
+    expect(filled.location).toBe("https://duolingo.com");
   });
 });

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -296,40 +296,38 @@ export function effectiveEntryUrl(
   return selectedModule?.url || groupUrl || resourceUrl || "";
 }
 
-// Augment a selection-changing patch with a location autofilled from the entry's
-// link, when the field is empty or still holds the previous autofill (so it
-// tracks a re-narrowing) — never clobbering text the user typed. Returns the
-// patch unchanged when there's no link to apply. Shared by the weekly/curated
-// row editor and the daily editor so the autofill rule lives in one place.
-export function withLocationAutofill(
-  row: WeeklyEntry,
-  patch: Partial<WeeklyEntry>,
+// Default an empty location to the entry's effective link, so a resource entry
+// whose location is left blank persists (and elsewhere renders) its resource /
+// module / group url. Rows with text the user typed are left untouched, as are
+// task / freeform / no-link rows (effectiveEntryUrl returns "" for them). Applied
+// at save time — the editors show the link as a placeholder rather than baking it
+// into the field value, so this is where the placeholder url becomes the stored
+// value. Generic over the row shape so it serves both weekly rows (keyed by
+// `day`) and curated rows (keyed by `date`). `moduleGroupsByResource` /
+// `modulesByResource` are the same per-resource narrowing maps the editor uses.
+export function fillEffectiveLocations<T extends WeeklyEntry>(
+  rows: T[],
   resourceOptions: SelectOption[],
-  groupOptions: SelectOption[],
-  moduleOptions: SelectOption[],
-): Partial<WeeklyEntry> {
-  const prevUrl = effectiveEntryUrl(
-    row,
-    resourceOptions,
-    groupOptions,
-    moduleOptions,
-  );
-  const nextUrl = effectiveEntryUrl(
-    {
-      ...row,
-      ...patch,
-    },
-    resourceOptions,
-    groupOptions,
-    moduleOptions,
-  );
-  if (nextUrl && (row.location === "" || row.location === prevUrl)) {
-    return {
-      ...patch,
-      location: nextUrl,
-    };
-  }
-  return patch;
+  moduleGroupsByResource: Map<string, SelectOption[]>,
+  modulesByResource: Map<string, SelectOption[]>,
+): T[] {
+  return rows.map((row) => {
+    if (row.location) {
+      return row;
+    }
+    const url = effectiveEntryUrl(
+      row,
+      resourceOptions,
+      moduleGroupsByResource.get(row.id) ?? [],
+      modulesByResource.get(row.id) ?? [],
+    );
+    return url
+      ? {
+        ...row,
+        location: url,
+      }
+      : row;
+  });
 }
 
 // Display name for a weekly entry: freeform entries carry their own text in

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -12,6 +12,7 @@ import {
   curatedDateRange,
   curatedToRows,
   fillAllDays,
+  fillEffectiveLocations,
   MAX_CURATED_DAYS,
   representativeRow,
   rowsToCurated,
@@ -205,18 +206,39 @@ export function useRoutineDetailsForm(
           mode: value.mode,
           // Daily mode mirrors the single chosen entry onto all 7 days so
           // "today's item" resolves identically every day. Curated mode keys by
-          // date instead, so its weekly grid is cleared.
+          // date instead, so its weekly grid is cleared. fillEffectiveLocations
+          // bakes the resource link into any blank location (shown as a
+          // placeholder in the editor) so it's persisted.
           weekly:
             value.mode === "daily"
-              ? rowsToWeekly(fillAllDays(representativeRow(value.weekly)))
+              ? rowsToWeekly(
+                fillEffectiveLocations(
+                  fillAllDays(representativeRow(value.weekly)),
+                  resourceOptions,
+                  moduleGroupsByResource,
+                  modulesByResource,
+                ),
+              )
               : value.mode === "curated"
                 ? {}
-                : rowsToWeekly(value.weekly),
+                : rowsToWeekly(
+                  fillEffectiveLocations(
+                    value.weekly,
+                    resourceOptions,
+                    moduleGroupsByResource,
+                    modulesByResource,
+                  ),
+                ),
           // Curated schedule (date-keyed); cleared for weekly/daily routines.
           curated:
             value.mode === "curated"
               ? rowsToCurated(
-                value.curated,
+                fillEffectiveLocations(
+                  value.curated,
+                  resourceOptions,
+                  moduleGroupsByResource,
+                  modulesByResource,
+                ),
                 value.curatedEndDate ? dateToKey(value.curatedEndDate) : null,
               )
               : {

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.stories.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.stories.tsx
@@ -12,8 +12,8 @@ import {
   taskOptions,
 } from "@/test-utils/routinesFixtures";
 
-// resource-1 carries a link, so a daily entry pointing at it can offer/autofill
-// that url into its location field.
+// resource-1 carries a link, so a daily entry pointing at it shows that url as
+// its location placeholder (and can offer it when the field holds custom text).
 const resourceOptionsWithLink: SelectOption[] = [
   {
     value: "resource-1",
@@ -116,5 +116,30 @@ export const OffersLinkWhenLocationFilled: Story = {
         location: "https://duolingo.com",
       }),
     );
+  },
+};
+
+// A resource entry with a blank location shows the resource's link as the
+// location placeholder (persisted as the link on save); no "use link" offer
+// appears, since there's no different value to replace.
+export const ShowsResourceLinkAsPlaceholder: Story = {
+  args: {
+    type: "resource",
+    id: "resource-1",
+    resourceOptions: resourceOptionsWithLink,
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const location = canvas.getByLabelText("Daily task location");
+    await expect(location).toHaveValue("");
+    await expect(location).toHaveAttribute(
+      "placeholder",
+      "https://duolingo.com",
+    );
+    await expect(
+      canvas.queryByLabelText("Daily task use resource link"),
+    ).not.toBeInTheDocument();
   },
 };

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
@@ -26,7 +26,6 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
     inputValue,
     setInputValue,
     emit,
-    emitPicked,
     linkUrl,
     showPreview,
     preview,
@@ -43,7 +42,7 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
         id={id}
         itemOptions={itemOptions}
         optionsMap={optionsMap}
-        onEmit={emitPicked}
+        onEmit={emit}
         onInputValueChange={setInputValue}
         onRequestAddResource={() => setAddOpen(true)}
       />
@@ -64,17 +63,21 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
           />
           <input
             aria-label="Daily task location"
-            value={location}
+            // Show the resource link as a placeholder rather than baking it into
+            // the value, so a blank field reads as "uses the resource link".
+            value={location === linkUrl ? "" : location}
             onChange={e =>
               emit({
                 location: e.target.value,
               })}
-            placeholder="Location (e.g. gym, Spanish app, or a URL)…"
+            placeholder={
+              linkUrl || "Location (e.g. gym, Spanish app, or a URL)…"
+            }
             className="
               flex h-9 w-full rounded-md border bg-background px-2 text-sm
             "
           />
-          {linkUrl && location !== linkUrl && (
+          {linkUrl && location !== "" && location !== linkUrl && (
             <button
               type="button"
               aria-label="Daily task use resource link"

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
@@ -5,10 +5,7 @@ import { useMemo, useState } from "react";
 
 import { buildActionableSentence } from "@emstack/types";
 
-import {
-  effectiveEntryUrl,
-  withLocationAutofill,
-} from "@/components/routines/weekly";
+import { effectiveEntryUrl } from "@/components/routines/weekly";
 
 export interface WeeklyEntryEditorProps extends WeeklyEntry {
   onChange: (next: WeeklyEntry) => void;
@@ -63,7 +60,8 @@ export function useWeeklyEntryEditor({
   }
 
   // Daily mode has no module narrowing, so the entry's link is just the chosen
-  // resource's url (empty for task / freeform).
+  // resource's url (empty for task / freeform). Shown as the location input's
+  // placeholder and persisted on save when the field is left blank.
   const linkUrl = effectiveEntryUrl(
     {
       type,
@@ -75,29 +73,6 @@ export function useWeeklyEntryEditor({
     [],
     [],
   );
-
-  // Like emit, but autofills the location from the picked resource's link (see
-  // withLocationAutofill). Used by the item picker; the location input keeps emit
-  // so typed text is never overwritten. Daily mode has no module narrowing.
-  const emitPicked = (patch: Partial<WeeklyEntry>) =>
-    emit(
-      withLocationAutofill(
-        {
-          type,
-          id,
-          moduleId,
-          moduleGroupId,
-          notes,
-          location,
-          prependText,
-          appendText,
-        },
-        patch,
-        resourceOptions,
-        [],
-        [],
-      ),
-    );
 
   const itemName = type === "freeform" ? id : (optionsMap.get(id) ?? "");
   const showPreview
@@ -116,7 +91,6 @@ export function useWeeklyEntryEditor({
     inputValue,
     setInputValue,
     emit,
-    emitPicked,
     linkUrl,
     showPreview,
     preview,


### PR DESCRIPTION
## Summary

Refactors the location autofill behavior from an eager, selection-change-triggered approach to a lazy, save-time approach. Instead of autofilling the location field whenever a resource/module/group is selected, the location now shows the resource link as a placeholder in the editor and persists it as the stored value only when the field is left blank at save time.

## Key Changes

- **Replaced `withLocationAutofill()`** with a new `fillEffectiveLocations()` function that:
  - Operates on arrays of rows (generic over `WeeklyEntry` shape)
  - Applies at save time rather than on selection change
  - Only fills blank locations; preserves user-typed text
  - Takes pre-computed `moduleGroupsByResource` and `modulesByResource` maps instead of flat option arrays

- **Updated editors to show links as placeholders:**
  - `ScheduleEntryRow` (weekly editor) and `WeeklyEntryEditor` (daily editor) now display the effective link as the location input's placeholder
  - Removed autofill logic from resource/module picker callbacks
  - Location input value is normalized: displays empty when it equals the link URL (so the placeholder is visible)

- **Integrated `fillEffectiveLocations()` at save points:**
  - `useRoutineDetailsForm` calls it when saving weekly/curated/daily routines
  - Ensures blank locations are persisted as their resource links before submission

- **Updated stories and tests:**
  - New test suite for `fillEffectiveLocations()` covering resource/module/group narrowing, user-typed text preservation, and task/freeform entries
  - Story updates reflect the new placeholder-based UX (e.g., `ShowsResourceLinkAsPlaceholder` replaces `AutofillsOnNarrowing`)

## Implementation Details

- The location field's display value is computed as `location === linkUrl ? "" : location`, making the placeholder visible when the stored value matches the link
- The "use link" button only appears when the user has typed a value that differs from the link (`location !== "" && location !== linkUrl`)
- `fillEffectiveLocations()` is generic (`<T extends WeeklyEntry>`) to serve both weekly rows (keyed by `day`) and curated rows (keyed by `date`)
- Exported from `@emstack/routines` index for use in the form hook

https://claude.ai/code/session_01THQshfbqaygERe4x6D86AT