### PR TITLE
fix(client): allow daily routine names to wrap in tracker table

### DIFF
--- a/packages/client/src/components/dailies/DailyTrackerRow.tsx
+++ b/packages/client/src/components/dailies/DailyTrackerRow.tsx
@@ -96,7 +96,7 @@ export function DailyTrackerRow({
         </EntityLink>
       </td>
       {vis.routine && (
-        <td className="p-2 whitespace-nowrap">{daily.name}</td>
+        <td className="max-w-48 p-2 wrap-break-word">{daily.name}</td>
       )}
       {vis.type && (
         <td className="p-2">


### PR DESCRIPTION
## Summary
Updated the Daily Tracker table cell styling to allow routine names to wrap instead of truncating, improving readability for longer names.

## Changes
- Modified the routine name column (`daily.name`) in `DailyTrackerRow` to use `max-w-48` and `wrap-break-word` classes instead of `whitespace-nowrap`
- Removed `p-2` padding class and replaced with `max-w-48 p-2 wrap-break-word` for proper text wrapping behavior

## Details
The previous `whitespace-nowrap` class prevented routine names from wrapping, which could cause layout issues or text overflow when names were longer than the available column width. The new styling constrains the column to a maximum width of 48 units (192px) while allowing text to break and wrap naturally, providing better UX for routines with longer names.

https://claude.ai/code/session_0148pPB5fsVewhcamcXFL9YG