### PR TITLE
fix(client): add width constraint to dashboard dailies connector

### DIFF
--- a/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailiesBody.tsx
+++ b/packages/client/src/routes/dashboard/-components/dashboardCards/DashboardDailies/-DashboardDailiesBody.tsx
@@ -79,7 +79,7 @@ export function DashboardDailiesBody({
           statusCellClassName="p-2"
           firstConnectorClassName="
             absolute top-1/2 right-[calc(50%+12px)] -left-2
-            z-0 -translate-y-1/2
+            z-0 w-auto -translate-y-1/2
           "
           taskId={null}
           columns={columns}


### PR DESCRIPTION
## Summary
Fixes a layout issue in the DashboardDailiesBody component where the first connector line was not properly constrained horizontally.

## Changes
- Added `w-auto` class to the `firstConnectorClassName` of the timeline connector in the dashboard dailies view
  - This ensures the connector line respects its calculated width rather than expanding unexpectedly
  - Maintains the existing positioning (absolute, top-centered, right/left offsets) while adding proper width behavior

## Details
The connector line uses absolute positioning with calculated right and left offsets (`right-[calc(50%+12px)] -left-2`). Adding `w-auto` ensures the width is determined by these constraints rather than defaulting to full width, preventing layout overflow or misalignment in the timeline visualization.

https://claude.ai/code/session_018QPTF6YCPgND7yMxUmqN5X