### PR TITLE
fix(client): exclude "touched" status from hasStatusForDay

### DIFF
--- a/packages/client/src/utils/dailyHelpers.test.ts
+++ b/packages/client/src/utils/dailyHelpers.test.ts
@@ -211,7 +211,7 @@ describe("isScheduledForDay", () => {
 });
 
 describe("hasStatusForDay", () => {
-  test("real statuses count; incomplete and no-entry do not", () => {
+  test("goal/exceeded/freeze count; touched, incomplete and no-entry do not", () => {
     const real = (status: DailyCompletion["status"]) =>
       hasStatusForDay({
         completions: [{
@@ -221,8 +221,8 @@ describe("hasStatusForDay", () => {
       }, TODAY);
     expect(real("goal")).toBe(true);
     expect(real("exceeded")).toBe(true);
-    expect(real("touched")).toBe(true);
     expect(real("freeze")).toBe(true);
+    expect(real("touched")).toBe(false);
     expect(real("incomplete")).toBe(false);
     expect(hasStatusForDay({
       completions: [],
@@ -305,6 +305,20 @@ describe("classifyDaily", () => {
         completions: [{
           date: TODAY,
           status: "incomplete",
+        }],
+        weeklyTarget: null,
+      }, TODAY, "sunday"),
+    ).toBe("now");
+  });
+
+  test("touched today stays in now", () => {
+    expect(
+      classifyDaily({
+        weekly: thursdayWeekly,
+        mode: "weekly",
+        completions: [{
+          date: TODAY,
+          status: "touched",
         }],
         weeklyTarget: null,
       }, TODAY, "sunday"),

--- a/packages/client/src/utils/dailyHelpers.ts
+++ b/packages/client/src/utils/dailyHelpers.ts
@@ -274,14 +274,14 @@ export function isScheduledForDay(
   return DAY_KEYS.some(key => Boolean(weekly[key]?.id));
 }
 
-// True when today already carries a "real" completion status. "incomplete" is
-// deliberately excluded — an explicitly-incomplete day still needs doing.
+// True when today already carries a "real" completion status. "incomplete" and
+// "touched" are deliberately excluded — both mean the item still needs doing.
 export function hasStatusForDay(
   daily: Pick<Daily, "completions">,
   todayKey: string = getTodayKey(),
 ): boolean {
   const status = findStatusForDate(daily, todayKey);
-  return status !== null && status !== "incomplete";
+  return status !== null && status !== "incomplete" && status !== "touched";
 }
 
 // Whether a routine still has something to do today: scheduled for today and


### PR DESCRIPTION
## Summary
Corrects the `hasStatusForDay` function to treat "touched" status the same as "incomplete" — both indicate an item still needs action and should not count as a completed day.

## Changes
- **`hasStatusForDay` logic:** Added "touched" to the exclusion list alongside "incomplete", so only "goal", "exceeded", and "freeze" statuses count as having a real completion for the day
- **Test updates:** 
  - Updated test description to reflect that "goal/exceeded/freeze count; touched, incomplete and no-entry do not"
  - Inverted expectation for "touched" from `true` to `false`
  - Added new test case "touched today stays in now" to verify `classifyDaily` correctly handles touched status as an in-progress item
- **Documentation:** Updated the function's JSDoc comment to clarify that both "incomplete" and "touched" are deliberately excluded

## Implementation Details
The change ensures consistency in how daily completion statuses are classified: "touched" (user has interacted with the item but not completed it) is now treated as equivalent to "incomplete" rather than as a real completion status. This affects the daily classification logic, keeping items with only a "touched" status in the "now" (needs doing) category rather than marking them as "done".

https://claude.ai/code/session_015hgt8iTfzq6r3XzzLtQctt