### PR TITLE
chore: make docker-compose ports configurable via env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ Project skills live in `.claude/skills/<name>/SKILL.md`. The `/`-command name co
 | `POSTGRES_USER` | docker-compose | Database user | `postgres` |
 | `POSTGRES_PASSWORD` | docker-compose | Database password | `password` |
 | `POSTGRES_DB` | docker-compose | Database name | `coursetracker` |
+| `POSTGRES_HOST_PORT` | docker-compose | Host port mapped to the db container's `5432` | `5432` |
+| `GATEWAY_HOST_PORT` | docker-compose | Host port mapped to the gateway container's `3000` | `3000` |
 
 See `packages/middleware/.env.example` for env templates.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s
@@ -19,7 +19,7 @@ services:
       context: ./
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "${GATEWAY_HOST_PORT:-3000}:3000"
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@db:5432/${POSTGRES_DB:-coursetracker}
     depends_on:


### PR DESCRIPTION
## Summary
Make the host ports for PostgreSQL and the gateway service configurable through environment variables in `docker-compose.yml`, allowing developers to avoid port conflicts when running multiple instances or on systems with port restrictions.

## Changes
- **docker-compose.yml:** Updated port mappings to use environment variables with sensible defaults:
  - PostgreSQL: `${POSTGRES_HOST_PORT:-5432}:5432` (default `5432`)
  - Gateway: `${GATEWAY_HOST_PORT:-3000}:3000` (default `3000`)
- **CLAUDE.md:** Documented the two new environment variables in the configuration table with their purposes and defaults

## Implementation Details
Both variables use the `${VAR:-default}` syntax to maintain backward compatibility — existing setups without these variables defined will continue to use the original ports (5432 and 3000 respectively). Developers can now override these by setting `POSTGRES_HOST_PORT` and `GATEWAY_HOST_PORT` in their `.env` file or shell environment before running `docker compose up`.

https://claude.ai/code/session_01JJVBQcSZznsYqwZUqhdDA7