### PR TITLE
fix(client): make courses & topics tables responsive on mobile

### DIFF
--- a/packages/client/src/components/tables/CoursesTable.stories.tsx
+++ b/packages/client/src/components/tables/CoursesTable.stories.tsx
@@ -30,3 +30,19 @@ export const Default: Story = {
     await expect(await canvas.findByText("Course 3")).toBeInTheDocument();
   },
 };
+
+// Low-priority columns collapse on narrow screens via `hidden <bp>:table-cell`
+// (applied to the column's <th> and <td>); essential columns stay visible.
+export const ResponsiveColumns: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // Essential columns are never hidden.
+    await expect(await canvas.findByText("Name")).not.toHaveClass("hidden");
+    // Detail columns hide below their breakpoint.
+    await expect(await canvas.findByText("Provider")).toHaveClass("hidden");
+    await expect(await canvas.findByText("Cost")).toHaveClass("hidden");
+    await expect(await canvas.findByText("Expires")).toHaveClass("hidden");
+  },
+};

--- a/packages/client/src/components/tables/CoursesTable.tsx
+++ b/packages/client/src/components/tables/CoursesTable.tsx
@@ -12,6 +12,14 @@ interface CoursesTableProps {
   courses: ResourceInResources[];
 }
 
+// Responsive column hiding: DataTable applies these classes to both the
+// column's <th> and <td>, so `hidden <bp>:table-cell` collapses a column below
+// the breakpoint and restores it above it (the table still scrolls as a
+// fallback). Keeps narrow phones to the essential identity/action columns.
+const HIDE_SM = "hidden sm:table-cell";
+const HIDE_MD = "hidden md:table-cell";
+const HIDE_LG = "hidden lg:table-cell";
+
 function formatProgress(course: ResourceInResources): string {
   if (!course.progressTotal) return "—";
   const pct = Math.round((course.progressCurrent / course.progressTotal) * 100);
@@ -64,8 +72,8 @@ const columns: ColumnDef<ResourceInResources>[] = [
     id: "provider",
     header: "Provider",
     meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
+      headClassName: `whitespace-nowrap ${HIDE_MD}`,
+      cellClassName: `whitespace-nowrap ${HIDE_MD}`,
     },
     cell: ({
       row,
@@ -92,8 +100,8 @@ const columns: ColumnDef<ResourceInResources>[] = [
     id: "topics",
     header: "Topics",
     meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
+      headClassName: `whitespace-nowrap ${HIDE_LG}`,
+      cellClassName: `whitespace-nowrap ${HIDE_LG}`,
     },
     cell: ({
       row,
@@ -113,8 +121,8 @@ const columns: ColumnDef<ResourceInResources>[] = [
     id: "progress",
     header: "Progress",
     meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
+      headClassName: `whitespace-nowrap ${HIDE_SM}`,
+      cellClassName: `whitespace-nowrap ${HIDE_SM}`,
     },
     cell: ({
       row,
@@ -124,8 +132,8 @@ const columns: ColumnDef<ResourceInResources>[] = [
     id: "cost",
     header: "Cost",
     meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
+      headClassName: `whitespace-nowrap ${HIDE_LG}`,
+      cellClassName: `whitespace-nowrap ${HIDE_LG}`,
     },
     cell: ({
       row,
@@ -135,8 +143,8 @@ const columns: ColumnDef<ResourceInResources>[] = [
     id: "expires",
     header: "Expires",
     meta: {
-      headClassName: "whitespace-nowrap",
-      cellClassName: "whitespace-nowrap",
+      headClassName: `whitespace-nowrap ${HIDE_LG}`,
+      cellClassName: `whitespace-nowrap ${HIDE_LG}`,
     },
     cell: ({
       row,

--- a/packages/client/src/components/tables/TopicsTable.stories.tsx
+++ b/packages/client/src/components/tables/TopicsTable.stories.tsx
@@ -29,6 +29,23 @@ export const Default: Story = {
   },
 };
 
+// Low-priority columns collapse on narrow screens via `hidden <bp>:table-cell`
+// (applied to the column's <th> and <td>); name stays visible.
+export const ResponsiveColumns: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // Name header (wrapped in a sort button) lives in a never-hidden <th>.
+    const nameHead = (await canvas.findByText("Name")).closest("th");
+    await expect(nameHead).not.toHaveClass("hidden");
+    // Detail columns hide below their breakpoint.
+    await expect(await canvas.findByText("Description")).toHaveClass("hidden");
+    const domainsHead = (await canvas.findByText("Domains")).closest("th");
+    await expect(domainsHead).toHaveClass("hidden");
+  },
+};
+
 export const WithSelection: Story = {
   args: {
     selection: {

--- a/packages/client/src/components/tables/TopicsTable.tsx
+++ b/packages/client/src/components/tables/TopicsTable.tsx
@@ -46,6 +46,13 @@ interface TopicsTableProps extends TopicsTableSortControl {
   selection?: TopicsTableSelection;
 }
 
+// Responsive column hiding: DataTable applies these to both the <th> and <td>,
+// so `hidden <bp>:table-cell` collapses a column below the breakpoint and
+// restores it above it. Keeps narrow phones to select + name.
+const HIDE_SM = "hidden sm:table-cell";
+const HIDE_MD = "hidden md:table-cell";
+const HIDE_LG = "hidden lg:table-cell";
+
 // name/domains sort ascending on first click; the count columns sort descending.
 const SORT_DESC_FIRST: Record<TopicsTableSortColumn, boolean> = {
   name: false,
@@ -176,8 +183,8 @@ export function TopicsTable({
           />
         ),
         meta: {
-          headClassName: "whitespace-nowrap",
-          cellClassName: "whitespace-nowrap",
+          headClassName: `whitespace-nowrap ${HIDE_LG}`,
+          cellClassName: `whitespace-nowrap ${HIDE_LG}`,
         },
         cell: ({
           row,
@@ -188,7 +195,8 @@ export function TopicsTable({
         enableSorting: false,
         header: "Description",
         meta: {
-          cellClassName: "max-w-md",
+          headClassName: HIDE_MD,
+          cellClassName: `max-w-md ${HIDE_MD}`,
         },
         cell: ({
           row,
@@ -217,8 +225,8 @@ export function TopicsTable({
         ),
         meta: {
           align: "right",
-          headClassName: "whitespace-nowrap",
-          cellClassName: "tabular-nums",
+          headClassName: `whitespace-nowrap ${HIDE_SM}`,
+          cellClassName: `tabular-nums ${HIDE_SM}`,
         },
         cell: ({
           row,
@@ -238,8 +246,8 @@ export function TopicsTable({
         ),
         meta: {
           align: "right",
-          headClassName: "whitespace-nowrap",
-          cellClassName: "tabular-nums",
+          headClassName: `whitespace-nowrap ${HIDE_SM}`,
+          cellClassName: `tabular-nums ${HIDE_SM}`,
         },
         cell: ({
           row,
@@ -259,8 +267,8 @@ export function TopicsTable({
         ),
         meta: {
           align: "right",
-          headClassName: "whitespace-nowrap",
-          cellClassName: "tabular-nums",
+          headClassName: `whitespace-nowrap ${HIDE_SM}`,
+          cellClassName: `tabular-nums ${HIDE_SM}`,
         },
         cell: ({
           row,


### PR DESCRIPTION
The Courses and Topics tables rendered every column with whitespace-nowrap,
forcing a wide horizontal scroll that made them unreadable on phones.

Hide low-priority columns on narrow screens and progressively reveal them as
the viewport widens, via `hidden <bp>:table-cell` on each column's meta (applied
to both the <th> and <td> by DataTable). Essential columns (name, status,
select, link) stay visible; the existing overflow-x-auto remains as a fallback.

- Courses: progress at sm, provider at md, topics/cost/expires at lg.
- Topics: resource/task/daily counts at sm, description at md, domains at lg.

Add ResponsiveColumns stories asserting the hide classes are wired.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016XeApwq5QUtnLUqeioKtPS