### PR TITLE
feat: add PageActions slot and quick-add dialogs for domains & topics

### DIFF
--- a/packages/client/src/components/dialogs/quickAdd/QuickAddDialogs.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddDialogs.tsx
@@ -1,11 +1,13 @@
 import type { QuickAddKey } from "./quickAddOptions";
 
+import { QuickAddDomainDialog } from "./QuickAddDomainDialog";
 import { QuickAddProviderDialog } from "./QuickAddProviderDialog";
 import { QuickAddReadwiseDialog } from "./QuickAddReadwiseDialog";
 import { QuickAddResourceDialog } from "./QuickAddResourceDialog";
 import { QuickAddRoutineDialog } from "./QuickAddRoutineDialog";
 import { QuickAddTaskDialog } from "./QuickAddTaskDialog";
 import { QuickAddTodoistDialog } from "./QuickAddTodoistDialog";
+import { QuickAddTopicDialog } from "./QuickAddTopicDialog";
 
 interface QuickAddDialogsProps {
   active: QuickAddKey | null;
@@ -40,6 +42,14 @@ export function QuickAddDialogs({
       />
       <QuickAddProviderDialog
         open={active === "provider"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddTopicDialog
+        open={active === "topic"}
+        onOpenChange={onOpenChange}
+      />
+      <QuickAddDomainDialog
+        open={active === "domain"}
         onOpenChange={onOpenChange}
       />
       <QuickAddRoutineDialog

--- a/packages/client/src/components/dialogs/quickAdd/QuickAddDomainDialog.stories.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddDomainDialog.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { QuickAddDomainDialog } from "./QuickAddDomainDialog";
+
+import {
+  expectCancelClosesDialog,
+  expectDialogFields,
+  routerQueryDecorator,
+} from "@/test-utils/quickAddStoryHelpers";
+
+const meta: Meta<typeof QuickAddDomainDialog> = {
+  component: QuickAddDomainDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate → QueryStub + RouterStub.
+  decorators: [routerQueryDecorator()],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Default: Story = {
+  play: expectDialogFields({
+    title: "Add Domain",
+    fields: ["Name"],
+  }),
+};
+
+// Cancel closes the dialog via onOpenChange(false).
+export const Cancel: Story = {
+  play: expectCancelClosesDialog,
+};

--- a/packages/client/src/components/dialogs/quickAdd/QuickAddDomainDialog.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddDomainDialog.tsx
@@ -1,0 +1,59 @@
+import type { ControlledDialogProps } from "@/types/dialogProps";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
+
+import { createDomain } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+export function QuickAddDomainDialog({
+  open,
+  onOpenChange,
+}: ControlledDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    // Domains use `title` for display (every other entity uses `name`).
+    mutationFn: (domainTitle: string) =>
+      createDomain({
+        title: domainTitle,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.domains.list(),
+      });
+      onOpenChange(false);
+      toast.success("Domain created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/domains/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <QuickAddNameDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Add Domain"
+      entity="domain"
+      placeholder="Domain name"
+      isPending={mutation.isPending}
+      onSubmit={name => mutation.mutate(name)}
+    />
+  );
+}

--- a/packages/client/src/components/dialogs/quickAdd/QuickAddTopicDialog.stories.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddTopicDialog.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { QuickAddTopicDialog } from "./QuickAddTopicDialog";
+
+import {
+  expectCancelClosesDialog,
+  expectDialogFields,
+  routerQueryDecorator,
+} from "@/test-utils/quickAddStoryHelpers";
+
+const meta: Meta<typeof QuickAddTopicDialog> = {
+  component: QuickAddTopicDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+  },
+  // useMutation + useNavigate → QueryStub + RouterStub.
+  decorators: [routerQueryDecorator()],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Dialog content portals to document.body.
+export const Default: Story = {
+  play: expectDialogFields({
+    title: "Add Topic",
+    fields: ["Name"],
+  }),
+};
+
+// Cancel closes the dialog via onOpenChange(false).
+export const Cancel: Story = {
+  play: expectCancelClosesDialog,
+};

--- a/packages/client/src/components/dialogs/quickAdd/QuickAddTopicDialog.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddTopicDialog.tsx
@@ -1,0 +1,58 @@
+import type { ControlledDialogProps } from "@/types/dialogProps";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { QuickAddNameDialog } from "./QuickAddNameDialog";
+
+import { createTopic } from "@/utils";
+import { queryKeys } from "@/utils/queryKeys";
+
+export function QuickAddTopicDialog({
+  open,
+  onOpenChange,
+}: ControlledDialogProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (topicName: string) =>
+      createTopic({
+        name: topicName,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.topics.list(),
+      });
+      onOpenChange(false);
+      toast.success("Topic created", {
+        action: {
+          label: "Edit",
+          onClick: () =>
+            navigate({
+              to: "/topics/$id/edit",
+              params: {
+                id: result.id,
+              },
+            }),
+        },
+      });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  return (
+    <QuickAddNameDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Add Topic"
+      entity="topic"
+      placeholder="Topic name"
+      isPending={mutation.isPending}
+      onSubmit={name => mutation.mutate(name)}
+    />
+  );
+}

--- a/packages/client/src/components/dialogs/quickAdd/quickAddOptions.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/quickAddOptions.tsx
@@ -4,9 +4,11 @@ import {
   BookOpenIcon,
   Building2Icon,
   CircleCheckIcon,
+  CompassIcon,
   LibraryIcon,
   ListTodoIcon,
   RepeatIcon,
+  TagIcon,
 } from "lucide-react";
 
 export type QuickAddKey
@@ -14,6 +16,8 @@ export type QuickAddKey
     | "todoist"
     | "resource"
     | "provider"
+    | "topic"
+    | "domain"
     | "routine"
     | "task";
 
@@ -51,6 +55,18 @@ export const QUICK_ADD_OPTIONS: QuickAddOption[] = [
     key: "provider",
     label: "Provider",
     icon: Building2Icon,
+    group: "tracker",
+  },
+  {
+    key: "topic",
+    label: "Topic",
+    icon: TagIcon,
+    group: "tracker",
+  },
+  {
+    key: "domain",
+    label: "Domain",
+    icon: CompassIcon,
     group: "tracker",
   },
   {

--- a/packages/client/src/components/layout/PageActions.tsx
+++ b/packages/client/src/components/layout/PageActions.tsx
@@ -1,0 +1,20 @@
+import { createPortal } from "react-dom";
+
+import { usePageActionsSlot } from "@/hooks/usePageActionsSlot";
+
+/**
+ * Renders its children into the shared top-bar action slot (opposite the
+ * breadcrumbs). Listing pages put their "Add New" button here; detail pages put
+ * their "Edit" button here. Renders nothing until the slot element has mounted.
+ */
+export function PageActions({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const {
+    node,
+  } = usePageActionsSlot();
+  if (!node) return null;
+  return createPortal(children, node);
+}

--- a/packages/client/src/components/layout/index.ts
+++ b/packages/client/src/components/layout/index.ts
@@ -7,6 +7,7 @@ export { EntityHeaderButton } from "./EntityHeaderButton";
 export { InfoArea } from "./InfoArea";
 export { InfoRow } from "./InfoRow";
 export { OverviewCardGrid } from "./OverviewCardGrid";
+export { PageActions } from "./PageActions";
 export { PageHeader } from "./PageHeader";
 export { PageTabs } from "./PageTabs";
 export { ResourceLinksSection } from "./ResourceLinksSection";

--- a/packages/client/src/components/layout/sidebar/AppSidebar.tsx
+++ b/packages/client/src/components/layout/sidebar/AppSidebar.tsx
@@ -57,7 +57,7 @@ export function AppSidebar({
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain />
+        <NavMain onQuickAdd={onQuickAdd} />
       </SidebarContent>
       <SidebarFooter>
         <SidebarMenu>

--- a/packages/client/src/components/layout/sidebar/NavCategory.tsx
+++ b/packages/client/src/components/layout/sidebar/NavCategory.tsx
@@ -1,13 +1,15 @@
 import type { NavCategory as NavCategoryConfig } from "./navConfig";
+import type { QuickAddKey } from "@/components/dialogs/quickAdd";
 
 import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { ChevronRightIcon } from "lucide-react";
+import { ArrowRightIcon, ChevronRightIcon, PlusIcon } from "lucide-react";
 
 import { NAV_CATEGORY_LIMIT } from "./navConfig";
 
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
@@ -29,8 +31,10 @@ import {
  */
 export function NavCategory({
   category,
+  onQuickAdd,
 }: {
   category: NavCategoryConfig;
+  onQuickAdd: (key: QuickAddKey) => void;
 }) {
   const [open, setOpen] = useState(false);
   const Icon = category.icon;
@@ -109,9 +113,23 @@ export function NavCategory({
                   to={category.listTo}
                   className="[&.active]:font-medium"
                 >
+                  <ArrowRightIcon className="size-4" />
                   See All
                 </Link>
               </SidebarMenuSubButton>
+            </SidebarMenuSubItem>
+            <SidebarMenuSubItem>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-start"
+                onClick={() => onQuickAdd(category.quickAddKey)}
+              >
+                <PlusIcon className="size-4" />
+                New
+                {" "}
+                {category.label}
+              </Button>
             </SidebarMenuSubItem>
           </SidebarMenuSub>
         </CollapsibleContent>

--- a/packages/client/src/components/layout/sidebar/NavMain.tsx
+++ b/packages/client/src/components/layout/sidebar/NavMain.tsx
@@ -1,3 +1,5 @@
+import type { QuickAddKey } from "@/components/dialogs/quickAdd";
+
 import { Link } from "@tanstack/react-router";
 
 import { NavCategory } from "./NavCategory";
@@ -13,7 +15,11 @@ import {
 import { useShowOnboard } from "@/hooks/useShowOnboard";
 
 /** The sidebar body: standalone links plus the collapsible record sections. */
-export function NavMain() {
+export function NavMain({
+  onQuickAdd,
+}: {
+  onQuickAdd: (key: QuickAddKey) => void;
+}) {
   const showOnboard = useShowOnboard();
   const standaloneLinks = showOnboard
     ? [...STANDALONE_LINKS, ONBOARD_LINK]
@@ -52,6 +58,7 @@ export function NavMain() {
               <NavCategory
                 key={category.label}
                 category={category}
+                onQuickAdd={onQuickAdd}
               />
             ))}
           </SidebarMenu>

--- a/packages/client/src/components/layout/sidebar/navConfig.ts
+++ b/packages/client/src/components/layout/sidebar/navConfig.ts
@@ -1,3 +1,4 @@
+import type { QuickAddKey } from "@/components/dialogs/quickAdd";
 import type { LinkProps } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
 
@@ -38,6 +39,8 @@ export interface NavCategory {
   icon: LucideIcon;
   /** "See All" target — the category's list page. */
   listTo: LinkProps["to"];
+  /** Quick Add entity key opened by the category's "+" button. */
+  quickAddKey: QuickAddKey;
   /** Per-item detail link descriptor (e.g. `/providers/$id`). */
   getDetailLink: (id: string) => LinkProps;
   /** TanStack Query cache key for the category's list. */
@@ -82,6 +85,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Providers",
         icon: Building2Icon,
         listTo: "/providers",
+        quickAddKey: "provider",
         getDetailLink: id => ({
           to: "/providers/$id",
           params: {
@@ -99,6 +103,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Resources",
         icon: LibraryIcon,
         listTo: "/resources",
+        quickAddKey: "resource",
         getDetailLink: id => ({
           to: "/resources/$id",
           params: {
@@ -116,6 +121,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Topics",
         icon: TagIcon,
         listTo: "/topics",
+        quickAddKey: "topic",
         getDetailLink: id => ({
           to: "/topics/$id",
           params: {
@@ -138,6 +144,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Domains",
         icon: CompassIcon,
         listTo: "/domains",
+        quickAddKey: "domain",
         getDetailLink: id => ({
           to: "/domains/$id",
           params: {
@@ -161,6 +168,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Routines",
         icon: RepeatIcon,
         listTo: "/routines",
+        quickAddKey: "routine",
         getDetailLink: id => ({
           to: "/routines/$id",
           params: {
@@ -178,6 +186,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "Task Lists",
         icon: CircleCheckIcon,
         listTo: "/tasks",
+        quickAddKey: "task",
         getDetailLink: id => ({
           to: "/tasks/$id",
           params: {

--- a/packages/client/src/context/PageActionsProvider.tsx
+++ b/packages/client/src/context/PageActionsProvider.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+import { PageActionsSlotContext } from "./PageActionsSlotContext";
+
+/**
+ * Holds a reference to the top-bar action slot so pages can portal an action
+ * button into the shared header without prop drilling through the single
+ * router `Outlet`.
+ */
+export function PageActionsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [node, setNode] = useState<HTMLElement | null>(null);
+
+  return (
+    <PageActionsSlotContext.Provider
+      value={{
+        node,
+        setNode,
+      }}
+    >
+      {children}
+    </PageActionsSlotContext.Provider>
+  );
+}

--- a/packages/client/src/context/PageActionsSlotContext.ts
+++ b/packages/client/src/context/PageActionsSlotContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+export interface PageActionsSlotState {
+  /** The header element that page actions portal into (null until mounted). */
+  node: HTMLElement | null;
+  /** Callback ref the header passes to register/clear the slot element. */
+  setNode: (el: HTMLElement | null) => void;
+}
+
+export const PageActionsSlotContext
+  = createContext<PageActionsSlotState | null>(null);

--- a/packages/client/src/hooks/usePageActionsSlot.ts
+++ b/packages/client/src/hooks/usePageActionsSlot.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+
+import { PageActionsSlotContext } from "@/context/PageActionsSlotContext";
+
+export const usePageActionsSlot = () => {
+  const context = useContext(PageActionsSlotContext);
+
+  if (!context) {
+    throw new Error("usePageActionsSlot must be used within a PageActionsProvider");
+  }
+  return context;
+};

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -13,9 +13,14 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
+import { PageActionsProvider } from "@/context/PageActionsProvider";
+import { usePageActionsSlot } from "@/hooks/usePageActionsSlot";
 
-const RootComponent: React.FunctionComponent = () => {
+const RootLayout: React.FunctionComponent = () => {
   const [activeQuickAdd, setActiveQuickAdd] = useState<QuickAddKey | null>(null);
+  const {
+    setNode,
+  } = usePageActionsSlot();
 
   return (
     <SidebarProvider>
@@ -30,8 +35,12 @@ const RootComponent: React.FunctionComponent = () => {
             className="mr-2 h-4"
           />
           <AppBreadcrumb />
+          <div
+            ref={setNode}
+            className="ml-auto flex items-center gap-2"
+          />
         </header>
-        <div className="container mb-8 py-4">
+        <div className="container mb-8 flex-col py-4">
           <Outlet />
         </div>
       </SidebarInset>
@@ -43,6 +52,12 @@ const RootComponent: React.FunctionComponent = () => {
     </SidebarProvider>
   );
 };
+
+const RootComponent: React.FunctionComponent = () => (
+  <PageActionsProvider>
+    <RootLayout />
+  </PageActionsProvider>
+);
 
 export const Route = createRootRoute({
   component: RootComponent,

--- a/packages/client/src/routes/domains/$id/index.tsx
+++ b/packages/client/src/routes/domains/$id/index.tsx
@@ -8,7 +8,7 @@ import {
   TopicLinkList,
 } from "./-components/topicLists";
 
-import { InfoArea, PageHeader } from "@/components/layout";
+import { InfoArea, PageActions, PageHeader } from "@/components/layout";
 import {
   EntityError,
   EntityPending,
@@ -88,20 +88,22 @@ function SingleDomain() {
               </Button>
             </Link>
           )}
-          <Link
-            to="/domains/$id/edit"
-            params={{
-              id: data?.id + "",
-            }}
-          >
-            <Button variant="secondary">
-              Edit Domain
-              {" "}
-              <EditIcon />
-            </Button>
-          </Link>
         </div>
       </PageHeader>
+      <PageActions>
+        <Link
+          to="/domains/$id/edit"
+          params={{
+            id: data?.id + "",
+          }}
+        >
+          <Button variant="secondary">
+            Edit Domain
+            {" "}
+            <EditIcon />
+          </Button>
+        </Link>
+      </PageActions>
       <div className="container flex flex-col gap-12">
         <div
           className={`

--- a/packages/client/src/routes/domains/index.tsx
+++ b/packages/client/src/routes/domains/index.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRightIcon, PlusIcon } from "lucide-react";
 
 import { ContentBox, DomainBox } from "@/components/contentBoxComponents";
+import { PageActions } from "@/components/layout/PageActions";
 import {
   EntityError,
   EntityPending,
@@ -66,11 +67,7 @@ function DomainsIndex() {
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Domains"
-        pageSection=""
-        description={ENTITY_DESCRIPTIONS.domains}
-      >
+      <PageActions>
         <Link
           to="/domains/$id/edit"
           params={{
@@ -82,7 +79,12 @@ function DomainsIndex() {
             New Domain
           </Button>
         </Link>
-      </PageHeader>
+      </PageActions>
+      <PageHeader
+        pageTitle="Domains"
+        pageSection=""
+        description={ENTITY_DESCRIPTIONS.domains}
+      />
       <div className="container">
         <div className="card-grid">
           {(!data || data.length === 0) && (

--- a/packages/client/src/routes/providers/$id/index.tsx
+++ b/packages/client/src/routes/providers/$id/index.tsx
@@ -8,7 +8,7 @@ import {
   ResourceLinksSection,
   YesNoDisplay,
 } from "@/components/infoCard";
-import { EntityHeaderButton, PageHeader } from "@/components/layout";
+import { EntityHeaderButton, PageActions, PageHeader } from "@/components/layout";
 import { EntityError, EntityPending } from "@/components/listControls/EntityStates";
 import { Button } from "@/components/ui/button";
 import { fetchSingleProvider } from "@/utils";
@@ -56,16 +56,18 @@ function SingleProviders() {
               </Button>
             </a>
           )}
-          <EntityHeaderButton
-            to="/providers/$id/edit"
-            params={{
-              id: data?.id + "",
-            }}
-            label="Edit Provider"
-            icon={<EditIcon />}
-          />
         </div>
       </PageHeader>
+      <PageActions>
+        <EntityHeaderButton
+          to="/providers/$id/edit"
+          params={{
+            id: data?.id + "",
+          }}
+          label="Edit Provider"
+          icon={<EditIcon />}
+        />
+      </PageActions>
       <div className="container flex flex-col gap-12">
         <InfoArea
           header="About"

--- a/packages/client/src/routes/providers/index.tsx
+++ b/packages/client/src/routes/providers/index.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
 import { ContentBox, ProviderBox } from "@/components/contentBoxComponents";
+import { PageActions } from "@/components/layout/PageActions";
 import {
   EntityError,
   EntityPending,
@@ -39,11 +40,7 @@ function Providers() {
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Providers"
-        pageSection=""
-        description={ENTITY_DESCRIPTIONS.providers}
-      >
+      <PageActions>
         <Link
           to="/providers/$id/edit"
           params={{
@@ -55,7 +52,12 @@ function Providers() {
             New Provider
           </Button>
         </Link>
-      </PageHeader>
+      </PageActions>
+      <PageHeader
+        pageTitle="Providers"
+        pageSection=""
+        description={ENTITY_DESCRIPTIONS.providers}
+      />
       <div className="container">
         <div className="card-grid">
           {(!data || data.length === 0) && (

--- a/packages/client/src/routes/resources/index.tsx
+++ b/packages/client/src/routes/resources/index.tsx
@@ -4,6 +4,7 @@ import { PlusIcon } from "lucide-react";
 
 import { ResourcesList } from "./-components/-ResourcesList";
 
+import { PageActions } from "@/components/layout/PageActions";
 import {
   EntityError,
   EntityPending,
@@ -64,11 +65,7 @@ function Courses() {
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Your Resources"
-        pageSection=""
-        description={ENTITY_DESCRIPTIONS.resources}
-      >
+      <PageActions>
         <Link
           to="/resources/$id/edit"
           params={{
@@ -80,7 +77,12 @@ function Courses() {
             New Course
           </Button>
         </Link>
-      </PageHeader>
+      </PageActions>
+      <PageHeader
+        pageTitle="Your Resources"
+        pageSection=""
+        description={ENTITY_DESCRIPTIONS.resources}
+      />
       <ResourcesList
         resources={resources ?? []}
         providers={providers ?? []}

--- a/packages/client/src/routes/routines/$id/index.tsx
+++ b/packages/client/src/routes/routines/$id/index.tsx
@@ -11,7 +11,7 @@ import { RoutineDetailsContent } from "./-components/-RoutineDetailsContent";
 import { RoutineTodayCard } from "./-components/-RoutineTodayCard";
 
 import { DAILY_DETAIL_TABS } from "@/components/dailies";
-import { PageHeader } from "@/components/layout";
+import { PageActions, PageHeader } from "@/components/layout";
 import { EntityError, EntityPending } from "@/components/listControls/EntityStates";
 import { Button } from "@/components/ui/button";
 import { fetchSingleRoutine } from "@/utils";
@@ -91,20 +91,22 @@ function SingleRoutine() {
           {data.mode === "curated" && (
             <ConvertToTaskListButton routineId={data.id} />
           )}
-          <Link
-            to="/routines/$id/edit"
-            params={{
-              id: data.id,
-            }}
-          >
-            <Button variant="secondary">
-              Edit Routine
-              {" "}
-              <EditIcon />
-            </Button>
-          </Link>
         </div>
       </PageHeader>
+      <PageActions>
+        <Link
+          to="/routines/$id/edit"
+          params={{
+            id: data.id,
+          }}
+        >
+          <Button variant="secondary">
+            Edit Routine
+            {" "}
+            <EditIcon />
+          </Button>
+        </Link>
+      </PageActions>
       <div className="container flex flex-col gap-12">
         <RoutineTodayCard data={data} />
         <DailyDetailsPanel

--- a/packages/client/src/routes/routines/index.tsx
+++ b/packages/client/src/routes/routines/index.tsx
@@ -11,6 +11,7 @@ import { CalendarCheckIcon, PlusIcon } from "lucide-react";
 
 import { RoutinesList } from "./-components/-RoutinesList";
 
+import { PageActions } from "@/components/layout/PageActions";
 import {
   EntityError,
   EntityPending,
@@ -108,16 +109,7 @@ function Routines() {
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Routines"
-        pageSection=""
-      >
-        <Link to="/routines/tracker">
-          <Button variant="outline">
-            <CalendarCheckIcon className="size-4" />
-            Daily Tracker
-          </Button>
-        </Link>
+      <PageActions>
         <Link
           to="/routines/$id/edit"
           params={{
@@ -127,6 +119,17 @@ function Routines() {
           <Button variant="outline">
             <PlusIcon className="size-4" />
             New Routine
+          </Button>
+        </Link>
+      </PageActions>
+      <PageHeader
+        pageTitle="Routines"
+        pageSection=""
+      >
+        <Link to="/routines/tracker">
+          <Button variant="outline">
+            <CalendarCheckIcon className="size-4" />
+            Daily Tracker
           </Button>
         </Link>
       </PageHeader>

--- a/packages/client/src/routes/tasks/$id/index.tsx
+++ b/packages/client/src/routes/tasks/$id/index.tsx
@@ -5,7 +5,7 @@ import { EditIcon } from "lucide-react";
 import { LinkedRoutinesSection } from "./-components/-LinkedRoutinesSection";
 import { TodosEditor } from "./-components/-TodosEditor";
 
-import { InfoArea, PageHeader } from "@/components/layout";
+import { InfoArea, PageActions, PageHeader } from "@/components/layout";
 import { EntityError, EntityPending } from "@/components/listControls/EntityStates";
 import { Button } from "@/components/ui/button";
 import { fetchRoutines, fetchSingleTask } from "@/utils";
@@ -58,25 +58,24 @@ function SingleTask() {
 
   return (
     <div>
+      <PageActions>
+        <Link
+          to="/tasks/$id/edit"
+          params={{
+            id: data.id,
+          }}
+        >
+          <Button variant="secondary">
+            Edit Task List
+            {" "}
+            <EditIcon />
+          </Button>
+        </Link>
+      </PageActions>
       <PageHeader
         pageTitle={data.name}
         pageSection="tasks"
-      >
-        <div className="flex flex-row flex-wrap gap-2">
-          <Link
-            to="/tasks/$id/edit"
-            params={{
-              id: data.id,
-            }}
-          >
-            <Button variant="secondary">
-              Edit Task List
-              {" "}
-              <EditIcon />
-            </Button>
-          </Link>
-        </div>
-      </PageHeader>
+      />
       <div className="container flex flex-col gap-12">
         <InfoArea
           header="Routines"

--- a/packages/client/src/routes/tasks/index.tsx
+++ b/packages/client/src/routes/tasks/index.tsx
@@ -7,6 +7,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 
 import { TaskBox } from "@/components/contentBoxComponents";
+import { PageActions } from "@/components/layout/PageActions";
 import {
   ClearFiltersButton,
   EntityError,
@@ -107,11 +108,7 @@ function Tasks() {
 
   return (
     <div>
-      <PageHeader
-        pageTitle="Task Lists"
-        pageSection=""
-        description={ENTITY_DESCRIPTIONS.tasks}
-      >
+      <PageActions>
         <Link
           to="/tasks/$id/edit"
           params={{
@@ -123,7 +120,12 @@ function Tasks() {
             New Task List
           </Button>
         </Link>
-      </PageHeader>
+      </PageActions>
+      <PageHeader
+        pageTitle="Task Lists"
+        pageSection=""
+        description={ENTITY_DESCRIPTIONS.tasks}
+      />
       <div className="container flex flex-col gap-4">
         {data && data.length > 0 && (
           <div className="mb-4 flex flex-wrap items-center gap-3">

--- a/packages/client/src/routes/topics/$id/index.tsx
+++ b/packages/client/src/routes/topics/$id/index.tsx
@@ -8,6 +8,7 @@ import { RoutineLinkList } from "./-components/-RoutineLinkList";
 import {
   EntityHeaderButton,
   InfoArea,
+  PageActions,
   PageHeader,
   ResourceLinksSection,
 } from "@/components/layout";
@@ -50,21 +51,20 @@ function SingleTopic() {
 
   return (
     <div>
+      <PageActions>
+        <EntityHeaderButton
+          to="/topics/$id/edit"
+          params={{
+            id: data?.id + "",
+          }}
+          label="Edit Topic"
+          icon={<EditIcon />}
+        />
+      </PageActions>
       <PageHeader
         pageTitle={data?.name}
         pageSection="topics"
-      >
-        <div className="flex flex-row gap-2">
-          <EntityHeaderButton
-            to="/topics/$id/edit"
-            params={{
-              id: data?.id + "",
-            }}
-            label="Edit Topic"
-            icon={<EditIcon />}
-          />
-        </div>
-      </PageHeader>
+      />
       <div className="container flex flex-col gap-12">
         <InfoArea
           header="About"


### PR DESCRIPTION
## Summary

Refactors the page header layout to use a portal-based `PageActions` slot system, allowing listing and detail pages to render action buttons (e.g., "New", "Edit") in a shared top-bar area without prop drilling. Adds quick-add dialogs for domains and topics, and integrates quick-add shortcuts into the sidebar navigation.

## Key Changes

- **PageActions slot system:** Introduced `PageActionsProvider`, `PageActionsSlotContext`, and `usePageActionsSlot` hook to manage a shared action button area in the header. Pages now use `<PageActions>` to portal their buttons into the top-right of the header instead of nesting them in `PageHeader`.

- **Refactored page layouts:** Moved action buttons from `PageHeader` children to `PageActions` in:
  - Single task, domain, routine, topic, and provider detail pages
  - Listing pages (routines, domains, providers, resources, tasks)

- **New quick-add dialogs:** Added `QuickAddDomainDialog` and `QuickAddTopicDialog` components with corresponding Storybook stories, following the existing pattern of `QuickAddNameDialog` wrapper.

- **Sidebar quick-add integration:** 
  - Updated `NavCategory` to accept `onQuickAdd` callback and render a "New [Entity]" button in the expanded category menu
  - Added `quickAddKey` field to `NavCategory` config interface
  - Threaded `onQuickAdd` callback through `NavMain` → `AppSidebar` → root layout

- **Quick-add options:** Extended `QUICK_ADD_OPTIONS` to include domain and topic entries with appropriate icons (CompassIcon, TagIcon).

- **Root layout refactoring:** Wrapped the root layout in `PageActionsProvider` and added a ref-based slot element in the header for portaling action buttons.

## Implementation Details

- The `PageActions` component uses `createPortal` to render children into the header's action slot, which only renders once the slot element has mounted (null-check prevents errors during initial render).
- Domain quick-add uses `title` field (domains are unique in using `title` instead of `name`); topic quick-add uses `name`.
- Both new dialogs follow the established pattern: mutation → invalidate query → close dialog → show toast with optional "Edit" action.
- Sidebar buttons are styled as outline variants with icons and full-width layout for consistency.

https://claude.ai/code/session_01TtBK3RqYVuWzaJ5X84tWPv