### PR TITLE
test: overnight audit sweep — mapResource coverage + CuratedEndDateField story

### DIFF
--- a/packages/client/src/components/routines/CuratedEndDateField.stories.tsx
+++ b/packages/client/src/components/routines/CuratedEndDateField.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { CuratedEndDateField } from "./CuratedEndDateField";
+
+// Fixed window so the story is deterministic: today through +14 days.
+const minDate = new Date("2026-07-11T00:00:00");
+const maxDate = new Date("2026-07-25T00:00:00");
+
+const meta = {
+  component: CuratedEndDateField,
+  args: {
+    value: null,
+    onSelect: fn(),
+    minDate,
+    maxDate,
+  },
+} satisfies Meta<typeof CuratedEndDateField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No end date chosen yet: the trigger shows the "Pick an end date" placeholder
+// and no Clear button is rendered.
+export const Empty: Story = {};
+
+// With a date selected, the trigger shows the formatted date and a Clear button
+// appears alongside it.
+export const WithValue: Story = {
+  args: {
+    value: new Date("2026-07-18T00:00:00"),
+  },
+};

--- a/packages/middleware/src/tests/resourceProjection.test.ts
+++ b/packages/middleware/src/tests/resourceProjection.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { mapResource } from "../utils/resourceProjection.ts";
+
+// The row shape mapResource consumes (not exported from the module).
+type Row = Parameters<typeof mapResource>[0];
+
+// A fully-null/empty row: exercises every default arm in mapResource.
+function emptyRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: "res-1",
+    name: "Some Resource",
+    type: null,
+    description: null,
+    url: null,
+    dateExpires: null,
+    progressCurrent: null,
+    progressTotal: null,
+    status: null,
+    providerIsSelf: null,
+    modulesAreExhaustive: null,
+    tracksProgress: null,
+    easeOfStarting: null,
+    timeNeeded: null,
+    interactivity: null,
+    cost: null,
+    modulesConfig: null,
+    courseProvider: null,
+    topicsToResources: [],
+    resourceTags: [],
+    ...overrides,
+  };
+}
+
+test("mapResource fills defaults for a fully-null row", () => {
+  const result = mapResource(emptyRow());
+
+  assert.strictEqual(result.type, "website");
+  assert.strictEqual(result.status, "inactive");
+  assert.strictEqual(result.progressCurrent, 0);
+  assert.strictEqual(result.progressTotal, 0);
+  assert.strictEqual(result.providerIsSelf, false);
+  assert.strictEqual(result.modulesAreExhaustive, false);
+  assert.strictEqual(result.tracksProgress, true);
+  assert.strictEqual(result.easeOfStarting, null);
+  assert.strictEqual(result.timeNeeded, null);
+  assert.strictEqual(result.interactivity, null);
+  assert.strictEqual(result.modulesConfig, null);
+  assert.strictEqual(result.provider, undefined);
+  assert.deepStrictEqual(result.topics, []);
+  assert.deepStrictEqual(result.tags, []);
+  assert.deepStrictEqual(result.cost, {
+    cost: null,
+    isCostFromPlatform: false,
+  });
+});
+
+test("mapResource passes through explicit values instead of defaults", () => {
+  const result = mapResource(
+    emptyRow({
+      type: "book",
+      description: "A book about things",
+      url: "https://example.com",
+      dateExpires: "2027-01-01",
+      progressCurrent: 3,
+      progressTotal: 10,
+      status: "active",
+      providerIsSelf: true,
+      modulesAreExhaustive: true,
+      tracksProgress: false,
+      easeOfStarting: "low",
+      timeNeeded: "medium",
+      interactivity: "high",
+    }),
+  );
+
+  assert.strictEqual(result.type, "book");
+  assert.strictEqual(result.description, "A book about things");
+  assert.strictEqual(result.url, "https://example.com");
+  assert.strictEqual(result.dateExpires, "2027-01-01");
+  assert.strictEqual(result.progressCurrent, 3);
+  assert.strictEqual(result.progressTotal, 10);
+  assert.strictEqual(result.status, "active");
+  assert.strictEqual(result.providerIsSelf, true);
+  assert.strictEqual(result.modulesAreExhaustive, true);
+  assert.strictEqual(result.tracksProgress, false);
+  assert.strictEqual(result.easeOfStarting, "low");
+  assert.strictEqual(result.timeNeeded, "medium");
+  assert.strictEqual(result.interactivity, "high");
+});
+
+test("mapResource treats falsy progress (0) as 0", () => {
+  const result = mapResource(emptyRow({
+    progressCurrent: 0,
+    progressTotal: 0,
+  }));
+  assert.strictEqual(result.progressCurrent, 0);
+  assert.strictEqual(result.progressTotal, 0);
+});
+
+test("mapResource projects the provider block from courseProvider", () => {
+  const withProvider = mapResource(
+    emptyRow({
+      courseProvider: {
+        id: "prov-1",
+        name: "Frontend Masters",
+        cost: null,
+        isCourseFeesShared: null,
+        resources: [],
+      },
+    }),
+  );
+  assert.deepStrictEqual(withProvider.provider, {
+    id: "prov-1",
+    name: "Frontend Masters",
+  });
+
+  // A provider with a null name projects to no provider block.
+  const namelessProvider = mapResource(
+    emptyRow({
+      courseProvider: {
+        id: "prov-2",
+        name: null,
+        cost: null,
+        isCourseFeesShared: null,
+        resources: [],
+      },
+    }),
+  );
+  assert.strictEqual(namelessProvider.provider, undefined);
+});
+
+test("mapResource derives platform-shared cost from the provider", () => {
+  const result = mapResource(
+    emptyRow({
+      cost: "50",
+      courseProvider: {
+        id: "prov-1",
+        name: "Platform",
+        cost: "120",
+        isCourseFeesShared: true,
+        resources: [{}, {}, {}],
+      },
+    }),
+  );
+  // isCourseFeesShared === true → cost comes from the provider, split across its resources.
+  assert.deepStrictEqual(result.cost, {
+    cost: "120",
+    isCostFromPlatform: true,
+    splitBy: 3,
+  });
+});
+
+test("mapResource uses the resource's own cost when fees are not shared", () => {
+  const result = mapResource(emptyRow({
+    cost: "50",
+  }));
+  assert.deepStrictEqual(result.cost, {
+    cost: "50",
+    isCostFromPlatform: false,
+  });
+});
+
+test("mapResource flattens topic links and drops null-sided rows", () => {
+  const result = mapResource(
+    emptyRow({
+      topicsToResources: [
+        {
+          topicId: "t1",
+          resourceId: "res-1",
+          topic: {
+            id: "t1",
+            name: "React",
+          },
+        },
+        {
+          topicId: "t2",
+          resourceId: "res-1",
+          topic: null,
+        },
+        {
+          topicId: "t3",
+          resourceId: "res-1",
+          topic: {
+            id: "t3",
+            name: "TypeScript",
+          },
+        },
+      ],
+    }),
+  );
+  assert.deepStrictEqual(result.topics, [
+    {
+      id: "t1",
+      name: "React",
+    },
+    {
+      id: "t3",
+      name: "TypeScript",
+    },
+  ]);
+});
+
+test("mapResource maps resourceTags down to their tag objects", () => {
+  const tagA = {
+    id: "tag-1",
+    groupId: "g1",
+    name: "frontend",
+  };
+  const tagB = {
+    id: "tag-2",
+    groupId: "g1",
+    name: "advanced",
+  };
+  const result = mapResource(
+    emptyRow({
+      resourceTags: [{
+        tag: tagA,
+      }, {
+        tag: tagB,
+      }],
+    }),
+  );
+  assert.deepStrictEqual(result.tags, [tagA, tagB]);
+});

--- a/packages/middleware/src/utils/processResourceLinks.ts
+++ b/packages/middleware/src/utils/processResourceLinks.ts
@@ -1,4 +1,4 @@
-import { TopicsToResources } from "@emstack/types";
+import type { TopicsToResources } from "@emstack/types";
 
 interface NamedRef {
   id: string;

--- a/packages/middleware/src/utils/resourceProjection.ts
+++ b/packages/middleware/src/utils/resourceProjection.ts
@@ -1,6 +1,8 @@
-import { processCost } from "@/utils/processCost";
-import { toProviderBlock } from "@/utils/providerProjection";
-import { processResourceLinks } from "@/utils/processResourceLinks";
+// Sibling utils are imported relatively (not via the `@/` alias) so the Node
+// test runner can load this module directly — see the middleware CLAUDE.md.
+import { processCost } from "./processCost.ts";
+import { toProviderBlock } from "./providerProjection.ts";
+import { processResourceLinks } from "./processResourceLinks.ts";
 import type {
   CostData,
   Resource,


### PR DESCRIPTION
## Overnight audit sweep

Autonomous multi-phase [`overnight-audit`](.claude/skills/overnight-audit/SKILL.md) health sweep. The codebase was already in good shape, so this sweep is coverage-focused — the fallow health penalties that remain (`hotspots`, `unit_size`) need risky large-function splits, which are deliberately **not** bundled here (see *Deferred* below).

### Health — before → after

| Metric | Before | After |
|---|---|---|
| `fallow health` score | 78 / 100 (B) | 78 / 100 (B) |
| Dead-code issues | 0 | 0 |
| Duplication % | 0.86 % (threshold 6.5 %) | 0.86 % |
| Complexity findings over cap | 0 | 0 |

Score is unchanged by design: dead-code/dupes/complexity are already clean, and the remaining `hotspots: 10` / `unit_size: 10` penalties are driven by large functions whose splits carry real blast radius and belong in their own PRs.

### Changes by phase

- **Phase 1 (dead code):** already 0 — nothing to remove.
- **Phase 2 (test coverage):** added 8 behavior tests for `mapResource` (`packages/middleware/src/utils/resourceProjection.ts`), an untested churn hotspot. It was untested because it imported its sibling utils via the `@/` alias, which the Node test runner can't resolve — switched those three imports to relative `.ts` paths (the documented middleware convention for `node --test` loadability) and fixed `processResourceLinks.ts` to use `import type` for its type-only `@emstack/types` import (required for Node's type stripping). Tests cover every default arm, explicit pass-through, falsy-progress handling, provider projection, platform-shared vs. own cost, topic-link flattening, and tag mapping.
- **Phase 3 (duplicates):** 0.86 %, far under the 6.5 % budget — nothing actionable.
- **Phase 4 (complexity):** 0 findings over the cyclomatic 30 / cognitive 25 caps — nothing forced.
- **Phase 5 (large files):** deferred — see below.
- **Phase 6 (stories):** added a Storybook story for `CuratedEndDateField` (empty + selected states), verified in the storybook Vitest project (headless Chromium).
- **Phase 7 (skills/guards):** noted as follow-up — no repo-skill drift was fixed in this run.

### Verification (full gate, mirrors CI)

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (5 pre-existing warnings, none in changed files)
- middleware + types tests — **84 / 84** pass
- client Vitest (unit + storybook projects) — **1036 / 1036** pass across 307 files

### Deferred / remaining safe work (not in this PR)

- **Large-function splits (biggest health lever, `unit_size`/`hotspots`):** `useResourceModules` (588 lines), `ModuleSuggestDialog` (472), `DetailsTab` (311), `BlipTable` (307), `useBlipLlmReview` (306), the `dashboard` route (305). Each is a risky decomposition that should land on its own branch/PR with a pinned test — per the skill's own rules.
- **Story coverage:** ~11 renderable components still lack stories (e.g. `ScheduleEntryRow`, `CuratedScheduleField`, `ModuleNarrowingFields`, sidebar/layout components from the recent sidebar-07 / PageActions work). `PageActions` is a skip-and-note (renders `null` outside its portal slot). The remaining uncovered `*.tsx` are column-def / variant-helper modules that render no component.
- **`resourceProjection.ts`** now testable — further edge cases (e.g. `modulesConfig` shapes) could be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
