### PR TITLE
feat: associate todos and routines with Simple Bookmarks bookmarks

### DIFF
--- a/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
@@ -80,8 +80,7 @@ export function RoutineBox({
   // only applies when the grid is empty — i.e. no task, resource, or freeform
   // item is assigned at all. (connections are categorical, not the assignment.)
   const dailyHasNoAssignment
-    = isDaily
-      && !Object.values(weekly ?? {}).some(entry => !!entry?.id);
+    = isDaily && !Object.values(weekly ?? {}).some(entry => !!entry?.id);
   const scheduledCount = weekly
     ? Object.values(weekly).filter(Boolean).length
     : 0;
@@ -114,12 +113,24 @@ export function RoutineBox({
                       hover:bg-primary hover:text-primary-foreground
                     "
                   >
-                    <EntityLink
-                      entity={connectionEntityKind(c.type)}
-                      id={c.id}
-                    >
-                      {c.name ?? c.id}
-                    </EntityLink>
+                    {c.type === "bookmark"
+                      ? (
+                        <a
+                          href={c.url ?? undefined}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {c.name ?? c.id}
+                        </a>
+                      )
+                      : (
+                        <EntityLink
+                          entity={connectionEntityKind(c.type)}
+                          id={c.id}
+                        >
+                          {c.name ?? c.id}
+                        </EntityLink>
+                      )}
                   </Badge>
                 ))
               )

--- a/packages/client/src/components/tasks/todoPayload.ts
+++ b/packages/client/src/components/tasks/todoPayload.ts
@@ -15,5 +15,13 @@ export function toTodoInput(t: TaskTodo) {
     resourceId: t.resourceId ?? null,
     moduleGroupId: t.moduleGroupId ?? null,
     moduleId: t.moduleId ?? null,
+    // Round-trip bookmarks: task_todos are rebuilt on every save, so omitting
+    // these would drop a todo's bookmark associations on any edit.
+    bookmarks: (t.bookmarks ?? []).map(b => ({
+      id: b.id,
+      bookmarkId: b.bookmarkId,
+      title: b.title,
+      url: b.url,
+    })),
   };
 }

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -1,4 +1,5 @@
-import type { Routine } from "@emstack/types";
+import type { LocalConnectionType } from "@/utils";
+import type { RoutineConnection, Routine } from "@emstack/types";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -75,6 +76,17 @@ const detailsSchema = z.object({
   name: z.string().min(1, "Name is required").max(NAME_MAX_LENGTH),
   description: z.string().max(2000),
   connections: z.array(z.string()),
+  // Bookmark connections are managed by a separate async picker (search/create),
+  // not the preloaded connections multi-select; merged into `connections` on save.
+  bookmarks: z.array(
+    z.object({
+      id: z.string().optional(),
+      bookmarkId: z.string(),
+      title: z.string(),
+      url: z.string().nullable(),
+      position: z.number().nullable().optional(),
+    }),
+  ),
   status: z.enum(["active", "inactive", "complete", "paused"]),
   mode: z.enum(["weekly", "daily", "curated"]),
   weekly: z.array(weeklyRowSchema).length(7),
@@ -156,10 +168,21 @@ export function useRoutineDetailsForm(
 
   const startingValues = useMemo(() => {
     const curatedEndKey = routine.curated?.endDate ?? null;
+    const allConnections = routine.connections ?? [];
     return {
       name: routine.name ?? "",
       description: routine.description ?? "",
-      connections: (routine.connections ?? []).map(encodeConnection),
+      connections: allConnections
+        .filter((c): c is RoutineConnection & { type: LocalConnectionType } =>
+          c.type !== "bookmark")
+        .map(encodeConnection),
+      bookmarks: allConnections
+        .filter(c => c.type === "bookmark")
+        .map(c => ({
+          bookmarkId: c.id,
+          title: c.name ?? "",
+          url: c.url ?? null,
+        })),
       status: routine.status ?? "active",
       mode: routine.mode ?? "weekly",
       weekly: weeklyToRows(routine.weekly),
@@ -184,9 +207,18 @@ export function useRoutineDetailsForm(
     }) => {
       setIsSaving(true);
       try {
-        const connections = value.connections
+        const localConnections = value.connections
           .map(decodeConnection)
           .filter((c): c is NonNullable<typeof c> => c !== null);
+        // Bookmark connections carry their cached title/url so the server can
+        // store them (no local row to resolve on read).
+        const bookmarkConnections: RoutineConnection[] = value.bookmarks.map(b => ({
+          type: "bookmark",
+          id: b.bookmarkId,
+          name: b.title,
+          url: b.url,
+        }));
+        const connections = [...localConnections, ...bookmarkConnections];
 
         await upsertRoutine(routine.id, {
           name: value.name,

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
@@ -31,11 +31,9 @@ export function RoutineDetailsContent({
   data,
 }: RoutineDetailsContentProps) {
   const {
-    taskNames,
-    resourceNames,
-    moduleNames,
-    moduleGroupNames,
-  } = useTaskResourceNames();
+    taskNames, resourceNames, moduleNames, moduleGroupNames,
+  }
+    = useTaskResourceNames();
 
   const weekly = data.weekly ?? {};
   const isDaily = data.mode === "daily";
@@ -71,11 +69,7 @@ export function RoutineDetailsContent({
               font-medium
             "
           >
-            {isCurated
-              ? "Curated"
-              : isDaily
-                ? "Daily Task"
-                : "Weekly Schedule"}
+            {isCurated ? "Curated" : isDaily ? "Daily Task" : "Weekly Schedule"}
           </span>
         </InfoArea>
         <InfoArea
@@ -93,9 +87,9 @@ export function RoutineDetailsContent({
               <span className="inline-flex items-center gap-1">
                 <FlameIcon
                   size={16}
-                  className={chain > 0
-                    ? "text-orange-600"
-                    : "text-muted-foreground"}
+                  className={
+                    chain > 0 ? "text-orange-600" : "text-muted-foreground"
+                  }
                 />
                 <strong>{chain}</strong>
                 <span className="text-muted-foreground">day chain</span>
@@ -103,9 +97,9 @@ export function RoutineDetailsContent({
               <span className="inline-flex items-center gap-1">
                 <LaughIcon
                   size={16}
-                  className={total > 0
-                    ? "text-emerald-600"
-                    : "text-muted-foreground"}
+                  className={
+                    total > 0 ? "text-emerald-600" : "text-muted-foreground"
+                  }
                 />
                 <strong>{total}</strong>
                 <span className="text-muted-foreground">total days</span>
@@ -121,22 +115,44 @@ export function RoutineDetailsContent({
         <ul className="flex flex-col gap-1">
           {data.connections?.map(c => (
             <li key={`${c.type}:${c.id}`}>
-              <EntityLink
-                entity={connectionEntityKind(c.type)}
-                id={c.id}
-                className={`
-                  font-bold text-blue-800
-                  hover:text-blue-600
-                  dark:text-blue-300
-                `}
-              >
-                <span
-                  className="mr-2 text-xs text-muted-foreground uppercase"
-                >
-                  {c.type}
-                </span>
-                {c.name ?? c.id}
-              </EntityLink>
+              {c.type === "bookmark"
+                ? (
+                  <a
+                    href={c.url ?? undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={`
+                      font-bold text-blue-800
+                      hover:text-blue-600
+                      dark:text-blue-300
+                    `}
+                  >
+                    <span
+                      className="mr-2 text-xs text-muted-foreground uppercase"
+                    >
+                      {c.type}
+                    </span>
+                    {c.name ?? c.id}
+                  </a>
+                )
+                : (
+                  <EntityLink
+                    entity={connectionEntityKind(c.type)}
+                    id={c.id}
+                    className={`
+                      font-bold text-blue-800
+                      hover:text-blue-600
+                      dark:text-blue-300
+                    `}
+                  >
+                    <span
+                      className="mr-2 text-xs text-muted-foreground uppercase"
+                    >
+                      {c.type}
+                    </span>
+                    {c.name ?? c.id}
+                  </EntityLink>
+                )}
             </li>
           ))}
         </ul>
@@ -157,9 +173,7 @@ export function RoutineDetailsContent({
                     border-border/60 py-1
                   "
                 >
-                  <span className="text-sm font-medium">
-                    {DAY_LABELS[day]}
-                  </span>
+                  <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
                   {entry
                     ? (
                       <RoutineEntryLabel
@@ -171,9 +185,7 @@ export function RoutineDetailsContent({
                       />
                     )
                     : (
-                      <span
-                        className="text-sm text-muted-foreground italic"
-                      >
+                      <span className="text-sm text-muted-foreground italic">
                         Nothing scheduled
                       </span>
                     )}
@@ -190,9 +202,7 @@ export function RoutineDetailsContent({
         >
           {data.curated?.endDate && (
             <p className="mb-2 text-sm text-muted-foreground">
-              Ends
-              {" "}
-              {formatCuratedDateLabel(data.curated.endDate)}
+              Ends {formatCuratedDateLabel(data.curated.endDate)}
             </p>
           )}
           {curatedDates.length > 0
@@ -222,9 +232,7 @@ export function RoutineDetailsContent({
                           />
                         )
                         : (
-                          <span
-                            className="text-sm text-muted-foreground italic"
-                          >
+                          <span className="text-sm text-muted-foreground italic">
                             Nothing scheduled
                           </span>
                         )}

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
@@ -6,6 +6,7 @@ import { CuratedScheduleSection } from "./-CuratedScheduleSection";
 import { modeOptionsFor, STATUS_OPTIONS } from "../-routineFormMeta";
 import { WeeklyScheduleSection } from "./-WeeklyScheduleSection";
 
+import { BookmarkPicker } from "@/components/formFields";
 import { EditForm } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { useRoutineDetailsForm } from "@/hooks/useRoutineDetailsForm";
@@ -68,6 +69,18 @@ export function DetailsTab({
           />
         )}
       </form.AppField>
+
+      <form.Field name="bookmarks">
+        {field => (
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Bookmarks</span>
+            <BookmarkPicker
+              value={field.state.value}
+              onChange={next => field.handleChange(next)}
+            />
+          </div>
+        )}
+      </form.Field>
 
       <form.AppField name="status">
         {field => (

--- a/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.stories.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 
 import { TodoEditRow } from "./-TodoEditRow";
 
+import { QueryStub } from "@/test-utils/QueryStub";
 import { smokeText } from "@/test-utils/storyPlay";
 import { makeTaskTodo } from "@/test-utils/tasksFixtures";
 
@@ -27,9 +28,11 @@ const meta: Meta<typeof TodoEditRow> = {
   },
   decorators: [
     Story => (
-      <ul className="max-w-2xl rounded-md border">
-        <Story />
-      </ul>
+      <QueryStub>
+        <ul className="max-w-2xl rounded-md border">
+          <Story />
+        </ul>
+      </QueryStub>
     ),
   ],
 };

--- a/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Trash2Icon } from "lucide-react";
 
 import { DAILY_STATUS_OPTIONS } from "@/components/dailies/dailyStatusMeta";
+import { BookmarkPicker } from "@/components/formFields";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -98,9 +99,10 @@ export function TodoEditRow({
           </label>
           <Input
             value={draft.name}
-            onChange={e => patch({
-              name: e.target.value,
-            })}
+            onChange={e =>
+              patch({
+                name: e.target.value,
+              })}
             placeholder="What needs doing?"
             maxLength={TEXT_MAX_LENGTH}
             disabled={isSaving}
@@ -149,9 +151,10 @@ export function TodoEditRow({
             id={`todo-due-${draft.id}`}
             type="date"
             value={draft.dueDate ?? ""}
-            onChange={e => patch({
-              dueDate: e.target.value || null,
-            })}
+            onChange={e =>
+              patch({
+                dueDate: e.target.value || null,
+              })}
             disabled={isSaving}
             className="w-40"
           />
@@ -201,8 +204,7 @@ export function TodoEditRow({
                 && nextGroupId
                 && !modules.some(
                   m =>
-                    m.id === draft.moduleId
-                    && m.moduleGroupId === nextGroupId,
+                    m.id === draft.moduleId && m.moduleGroupId === nextGroupId,
                 )
                   ? null
                   : draft.moduleId,
@@ -227,12 +229,11 @@ export function TodoEditRow({
         <select
           aria-label="Module"
           value={draft.moduleId ?? ""}
-          onChange={e => patch({
-            moduleId: e.target.value || null,
-          })}
-          disabled={
-            isSaving || !draft.resourceId || modulesForRow.length === 0
-          }
+          onChange={e =>
+            patch({
+              moduleId: e.target.value || null,
+            })}
+          disabled={isSaving || !draft.resourceId || modulesForRow.length === 0}
           className={selectClass}
         >
           <option value="">— Any module —</option>
@@ -255,9 +256,10 @@ export function TodoEditRow({
       >
         <Input
           value={draft.url ?? ""}
-          onChange={e => patch({
-            url: e.target.value,
-          })}
+          onChange={e =>
+            patch({
+              url: e.target.value,
+            })}
           placeholder="Link (https://...)"
           type="url"
           disabled={isSaving}
@@ -265,13 +267,27 @@ export function TodoEditRow({
         />
         <Input
           value={draft.note ?? ""}
-          onChange={e => patch({
-            note: e.target.value,
-          })}
+          onChange={e =>
+            patch({
+              note: e.target.value,
+            })}
           placeholder="Note (optional)"
           maxLength={TEXT_MAX_LENGTH}
           disabled={isSaving}
           className="flex-1"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Bookmarks
+        </label>
+        <BookmarkPicker
+          value={draft.bookmarks ?? []}
+          onChange={next =>
+            patch({
+              bookmarks: next,
+            })}
         />
       </div>
 

--- a/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
@@ -118,9 +118,12 @@ export function TodosEditor({
   }
 
   function handleDelete(todoId: string) {
-    mutation.mutate(todos.filter(t => t.id !== todoId), {
-      onSuccess: () => setEditingId(null),
-    });
+    mutation.mutate(
+      todos.filter(t => t.id !== todoId),
+      {
+        onSuccess: () => setEditingId(null),
+      },
+    );
   }
 
   function cycleStatus(todo: TaskTodo) {
@@ -147,6 +150,7 @@ export function TodosEditor({
       resourceId: null,
       moduleGroupId: null,
       moduleId: null,
+      bookmarks: [],
     });
   }
 
@@ -205,9 +209,10 @@ export function TodosEditor({
               );
             }
             const statusOption = getDailyStatusOption(todo.status);
-            const linkedResource = todo.resource
-              ?? resourceOptions.find(r => r.id === todo.resourceId)
-              ?? null;
+            const linkedResource
+              = todo.resource
+                ?? resourceOptions.find(r => r.id === todo.resourceId)
+                ?? null;
             return (
               <li
                 key={todo.id}
@@ -250,6 +255,36 @@ export function TodosEditor({
                       {linkedResource.name}
                     </Badge>
                   )}
+                  {(todo.bookmarks ?? []).map(b => (
+                    <Badge
+                      key={b.bookmarkId}
+                      variant="outline"
+                      className="
+                        border-amber-200 bg-amber-50 text-amber-900
+                        dark:border-amber-900/50 dark:bg-amber-950/40
+                        dark:text-amber-200
+                      "
+                    >
+                      {b.url
+                        ? (
+                          <a
+                            href={b.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="
+                              inline-flex items-center gap-1
+                              hover:underline
+                            "
+                          >
+                            {b.title}
+                            <ExternalLinkIcon className="size-3" />
+                          </a>
+                        )
+                        : (
+                          b.title
+                        )}
+                    </Badge>
+                  ))}
                   <div
                     className="
                       ml-auto flex items-center gap-1 opacity-0 transition

--- a/packages/client/src/utils/routineConnections.ts
+++ b/packages/client/src/utils/routineConnections.ts
@@ -4,14 +4,19 @@ import type { RoutineConnectionType } from "@emstack/types";
 
 import { toOptions } from "./selectOptions";
 
-// EntityLink's entity kind (plural route segment) for each connection type.
-const ENTITY_KIND_BY_TYPE: Record<RoutineConnectionType, EntityKind> = {
+// Connection types with a local route/row. "bookmark" is external (no local
+// route) and is handled separately by a bookmark picker, so it never flows
+// through the encode/decode/EntityLink paths below.
+export type LocalConnectionType = Exclude<RoutineConnectionType, "bookmark">;
+
+// EntityLink's entity kind (plural route segment) for each local connection type.
+const ENTITY_KIND_BY_TYPE: Record<LocalConnectionType, EntityKind> = {
   topic: "topics",
   task: "tasks",
   resource: "resources",
 };
 
-export function connectionEntityKind(type: RoutineConnectionType) {
+export function connectionEntityKind(type: LocalConnectionType) {
   return ENTITY_KIND_BY_TYPE[type];
 }
 
@@ -19,26 +24,26 @@ export function connectionEntityKind(type: RoutineConnectionType) {
 // round-trip the entity type. Entity ids are uuids (no colon), so splitting on
 // the first colon is safe. Dropdown grouping is driven by each option's explicit
 // `group` field (see buildConnectionOptions), not by this value prefix.
-const GROUP_LABEL_BY_TYPE: Record<RoutineConnectionType, string> = {
+const GROUP_LABEL_BY_TYPE: Record<LocalConnectionType, string> = {
   topic: "Topic",
   task: "Task",
   resource: "Resource",
 };
-const TYPE_BY_GROUP_LABEL: Record<string, RoutineConnectionType> = {
+const TYPE_BY_GROUP_LABEL: Record<string, LocalConnectionType> = {
   Topic: "topic",
   Task: "task",
   Resource: "resource",
 };
 
 export function encodeConnection(c: {
-  type: RoutineConnectionType;
+  type: LocalConnectionType;
   id: string;
 }) {
   return `${GROUP_LABEL_BY_TYPE[c.type]}:${c.id}`;
 }
 
 export function decodeConnection(value: string): {
-  type: RoutineConnectionType;
+  type: LocalConnectionType;
   id: string;
 } | null {
   const idx = value.indexOf(":");

--- a/packages/middleware/src/db/schema/relations.ts
+++ b/packages/middleware/src/db/schema/relations.ts
@@ -8,7 +8,7 @@ import { courseProviders, interactions, moduleGroups, modules, resources } from 
 import { domains, domainWithinScopeTopics, radarBlips } from "./radar";
 import { routineConnections, routines } from "./routines";
 import { moduleGroupTags, moduleTags, resourceTags, tagGroups, tags, tasksToTags, topicsToTags } from "./tags";
-import { taskBookmarks, taskResources, tasks, tasksToResources, taskTodos, taskTypes } from "./tasks";
+import { taskBookmarks, taskResources, tasks, tasksToResources, taskTodos, taskTypes, todoBookmarks } from "./tasks";
 import { topics, topicsToResources } from "./topics";
 
 export const interactionsRelations = relations(interactions, ({
@@ -168,7 +168,7 @@ export const taskResourcesRelations = relations(taskResources, ({
 }));
 
 export const taskTodosRelations = relations(taskTodos, ({
-  one,
+  one, many,
 }) => ({
   task: one(tasks, {
     fields: [taskTodos.taskId],
@@ -185,6 +185,16 @@ export const taskTodosRelations = relations(taskTodos, ({
   module: one(modules, {
     fields: [taskTodos.moduleId],
     references: [modules.id],
+  }),
+  bookmarks: many(todoBookmarks),
+}));
+
+export const todoBookmarksRelations = relations(todoBookmarks, ({
+  one,
+}) => ({
+  todo: one(taskTodos, {
+    fields: [todoBookmarks.todoId],
+    references: [taskTodos.id],
   }),
 }));
 

--- a/packages/middleware/src/db/schema/routines.ts
+++ b/packages/middleware/src/db/schema/routines.ts
@@ -40,11 +40,14 @@ export const routines = pgTable("routines", {
   weeklyTarget: integer("weekly_target"),
 });
 
-// Polymorphic many-to-many link from a routine to Topics, Tasks, and/or
-// Resources. UUID PK so a routine can hold multiple links (mirrors
-// topics_to_resources / tasks_to_resources). `connected_id` has no FK because
-// it points at one of three tables; dangling rows (target deleted) are dropped
-// at read time, exactly like dangling weekly-grid entries.
+// Polymorphic many-to-many link from a routine to Topics, Tasks, Resources,
+// and/or external Simple Bookmarks bookmarks. UUID PK so a routine can hold
+// multiple links (mirrors topics_to_resources / tasks_to_resources).
+// `connected_id` has no FK because it points at one of several tables (or an
+// external bookmark). For local types, dangling rows (target deleted) are
+// dropped at read time. For "bookmark", there is no local row to resolve, so the
+// display title/url are cached here (cached_title/cached_url) and such rows are
+// never auto-dropped — matching the task/todo bookmark chips.
 export const routineConnections = pgTable("routine_connections", {
   id: varchar().primaryKey(),
   routineId: varchar("routine_id")
@@ -52,6 +55,9 @@ export const routineConnections = pgTable("routine_connections", {
     .references(() => routines.id),
   connectedType: varchar("connected_type").$type<RoutineConnectionType>().notNull(),
   connectedId: varchar("connected_id").notNull(),
+  // Cached label for "bookmark" connections (null for local types).
+  cachedTitle: varchar("cached_title"),
+  cachedUrl: varchar("cached_url"),
   position: integer(),
 });
 

--- a/packages/middleware/src/db/schema/tasks.ts
+++ b/packages/middleware/src/db/schema/tasks.ts
@@ -133,3 +133,23 @@ export const taskBookmarks = pgTable("task_bookmarks", {
   url: varchar(),
   position: integer(),
 });
+
+// Same as task_bookmarks, but associates a single todo with bookmarks. Cascades
+// with its todo: task_todos rows are rebuilt (delete + reinsert) on every task
+// save, so these rows are re-synced from the todo payload in the task handlers'
+// afterCreate/afterUpsert step (see syncTodoBookmarks). `bookmarkId` is the
+// external Simple Bookmarks id (no FK); `title` / `url` are the cached label.
+export const todoBookmarks = pgTable("todo_bookmarks", {
+  id: varchar().primaryKey(),
+  todoId: varchar("todo_id")
+    .notNull()
+    .references(() => taskTodos.id, {
+      onDelete: "cascade",
+    }),
+  bookmarkId: varchar("bookmark_id").notNull(),
+  title: varchar({
+    length: 500,
+  }).notNull(),
+  url: varchar(),
+  position: integer(),
+});

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -62,6 +62,8 @@ export default async function (server: FastifyInstance) {
             routineId: newId,
             connectedType: c.connectedType,
             connectedId: c.connectedId,
+            cachedTitle: c.cachedTitle,
+            cachedUrl: c.cachedUrl,
             position: c.position,
           })),
         );

--- a/packages/middleware/src/routes/api/tasks/createTask.ts
+++ b/packages/middleware/src/routes/api/tasks/createTask.ts
@@ -10,6 +10,7 @@ import {
   buildTodoRows,
   taskBodySchema,
 } from "./taskRows";
+import { syncTodoBookmarks } from "./syncTodoBookmarks";
 
 import type { TaskBody } from "./taskRows";
 
@@ -40,4 +41,7 @@ export default createCreateHandler<TaskBody>({
       buildRows: (body, id) => buildTodoRows(body.todos, id),
     },
   ],
+  // task_todos are inserted above; their bookmarks are a nested junction synced
+  // from the todo payload once the todo rows exist.
+  afterCreate: body => syncTodoBookmarks(body.todos),
 });

--- a/packages/middleware/src/routes/api/tasks/getTask.ts
+++ b/packages/middleware/src/routes/api/tasks/getTask.ts
@@ -148,6 +148,11 @@ export default async function (server: FastifyInstance) {
                   interactivity: true,
                 },
               },
+              bookmarks: {
+                orderBy: (b, {
+                  asc,
+                }) => asc(b.position),
+              },
             },
             orderBy: (t, {
               asc,

--- a/packages/middleware/src/routes/api/tasks/root.ts
+++ b/packages/middleware/src/routes/api/tasks/root.ts
@@ -130,6 +130,11 @@ export default async function (server: FastifyInstance) {
                 interactivity: true,
               },
             },
+            bookmarks: {
+              orderBy: (b, {
+                asc,
+              }) => asc(b.position),
+            },
           },
           orderBy: (t, {
             asc,

--- a/packages/middleware/src/routes/api/tasks/syncTodoBookmarks.ts
+++ b/packages/middleware/src/routes/api/tasks/syncTodoBookmarks.ts
@@ -1,0 +1,33 @@
+import { inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import { todoBookmarks } from "@/db/schema";
+
+import { buildTodoBookmarkRows } from "./taskRows";
+
+import type { TodoInput } from "./taskRows";
+
+// Re-sync todo_bookmarks after task_todos have been (re)written by the task
+// handlers. task_todos are rebuilt on every task save (delete + reinsert), which
+// cascade-clears their todo_bookmarks, so we rebuild them from the todo payload
+// here (run from afterCreate / afterUpsert). No-op when the request omitted
+// `todos` entirely (a field-only task update leaves todos and their bookmarks
+// untouched). Todos are keyed by their client-supplied id.
+export async function syncTodoBookmarks(
+  todos: readonly TodoInput[] | undefined,
+): Promise<void> {
+  if (todos === undefined) return;
+
+  const todoIds = todos
+    .map(t => t.id)
+    .filter((id): id is string => !!id);
+  if (todoIds.length > 0) {
+    await db.delete(todoBookmarks).where(inArray(todoBookmarks.todoId, todoIds));
+  }
+
+  const rows = todos.flatMap(t =>
+    t.id ? buildTodoBookmarkRows(t.bookmarks, t.id) ?? [] : []);
+  if (rows.length > 0) {
+    await db.insert(todoBookmarks).values(rows);
+  }
+}

--- a/packages/middleware/src/routes/api/tasks/taskRows.ts
+++ b/packages/middleware/src/routes/api/tasks/taskRows.ts
@@ -57,6 +57,7 @@ export interface TodoInput {
   resourceId?: string | null;
   moduleGroupId?: string | null;
   moduleId?: string | null;
+  bookmarks?: BookmarkInput[];
 }
 
 export interface TaskBody extends TaskBodyFields {
@@ -170,6 +171,36 @@ export function buildBookmarkRows(
     rows.push({
       id: b.id || makeId(),
       taskId,
+      bookmarkId: b.bookmarkId,
+      title: b.title,
+      url: b.url ?? null,
+      position: index,
+    });
+  });
+  return rows;
+}
+
+export function buildTodoBookmarkRows(
+  bookmarks: readonly BookmarkInput[] | undefined,
+  todoId: string,
+  makeId: () => string = uuidv4,
+) {
+  if (bookmarks === undefined) return undefined;
+  const seen = new Set<string>();
+  const rows: {
+    id: string;
+    todoId: string;
+    bookmarkId: string;
+    title: string;
+    url: string | null;
+    position: number;
+  }[] = [];
+  bookmarks.forEach((b, index) => {
+    if (seen.has(b.bookmarkId)) return;
+    seen.add(b.bookmarkId);
+    rows.push({
+      id: b.id || makeId(),
+      todoId,
       bookmarkId: b.bookmarkId,
       title: b.title,
       url: b.url ?? null,

--- a/packages/middleware/src/routes/api/tasks/upsertTask.ts
+++ b/packages/middleware/src/routes/api/tasks/upsertTask.ts
@@ -10,6 +10,7 @@ import {
   buildTodoRows,
   taskBodySchema,
 } from "./taskRows";
+import { syncTodoBookmarks } from "./syncTodoBookmarks";
 
 import type { TaskBody } from "./taskRows";
 
@@ -46,4 +47,7 @@ export default createUpsertHandler<TaskBody>({
       buildRows: (body, id) => buildTodoRows(body.todos, id),
     },
   ],
+  // task_todos are rebuilt above (delete + reinsert), cascade-clearing their
+  // todo_bookmarks; re-sync them from the todo payload once the rows exist.
+  afterUpsert: body => syncTodoBookmarks(body.todos),
 });

--- a/packages/middleware/src/utils/resolveRoutineConnections.ts
+++ b/packages/middleware/src/utils/resolveRoutineConnections.ts
@@ -6,6 +6,9 @@ import type { RoutineConnection } from "@emstack/types";
 export interface RawRoutineConnection {
   connectedType: RoutineConnectionType;
   connectedId: string;
+  // Bookmark connections carry their own cached label (no local row to resolve).
+  cachedTitle?: string | null;
+  cachedUrl?: string | null;
 }
 
 // A shared RoutineConnection with its display name resolved on read (always
@@ -75,7 +78,10 @@ export async function resolveRoutineConnections<
       : Promise.resolve([]),
   ]);
 
-  const nameByType: Record<RoutineConnectionType, Map<string, string>> = {
+  const nameByType: Record<
+    Exclude<RoutineConnectionType, "bookmark">,
+    Map<string, string>
+  > = {
     topic: new Map(topicRows.map(r => [r.id, r.name])),
     task: new Map(taskRows.map(r => [r.id, r.name])),
     resource: new Map(resourceRows.map(r => [r.id, r.name])),
@@ -87,6 +93,16 @@ export async function resolveRoutineConnections<
     } = row;
     const connections = (raw ?? [])
       .map((c): ResolvedRoutineConnection | null => {
+        // Bookmark connections have no local row — render the cached label and
+        // never drop them (a deleted bookmark just leaves a stale chip).
+        if (c.connectedType === "bookmark") {
+          return {
+            type: "bookmark",
+            id: c.connectedId,
+            name: c.cachedTitle ?? "Bookmark",
+            url: c.cachedUrl ?? null,
+          };
+        }
         const name = nameByType[c.connectedType].get(c.connectedId);
         return name
           ? {

--- a/packages/middleware/src/utils/routineConnectionRows.ts
+++ b/packages/middleware/src/utils/routineConnectionRows.ts
@@ -3,12 +3,18 @@ import { v4 as uuidv4 } from "uuid";
 import type { RoutineConnectionType } from "@/db/schema";
 import type { RoutineConnection } from "@emstack/types";
 
-// The write-side slice of a RoutineConnection: the client sends only type + id;
-// the display `name` is resolved on read (see resolveRoutineConnections).
-export type RoutineConnectionInput = Pick<RoutineConnection, "type" | "id">;
+// The write-side slice of a RoutineConnection: for local types the client sends
+// type + id (the display `name` is resolved on read); for "bookmark" it also
+// sends the cached `name`/`url` (see resolveRoutineConnections).
+export type RoutineConnectionInput = Pick<
+  RoutineConnection,
+  "type" | "id" | "name" | "url"
+>;
 
 // Dedupe by (type, id) and produce routine_connections rows with stable
 // positions, matching the junction-build pattern used for topics/tasks links.
+// For bookmark connections the cached title/url are persisted; for local types
+// they stay null (the name is resolved from the target table on read).
 export function buildRoutineConnectionRows(
   connections: readonly RoutineConnectionInput[] | undefined,
   routineId: string,
@@ -22,6 +28,8 @@ export function buildRoutineConnectionRows(
     routineId: string;
     connectedType: RoutineConnectionType;
     connectedId: string;
+    cachedTitle: string | null;
+    cachedUrl: string | null;
     position: number;
   }[] = [];
   for (const c of connections) {
@@ -38,6 +46,8 @@ export function buildRoutineConnectionRows(
       routineId,
       connectedType: c.type,
       connectedId: c.id,
+      cachedTitle: c.type === "bookmark" ? c.name ?? null : null,
+      cachedUrl: c.type === "bookmark" ? c.url ?? null : null,
       position: rows.length,
     });
   }

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -104,11 +104,13 @@ export const curatedSchema = {
   },
 } as const;
 
-// A routine's polymorphic connection to a topic / task / resource. `id` is the
-// connected entity's id; the resolved name is added on read, not accepted here.
+// A routine's polymorphic connection to a topic / task / resource / bookmark.
+// `id` is the connected entity's id. For local types the name is resolved on
+// read; for "bookmark" (external, no local row) the client also sends the cached
+// `name`/`url`, which are stored on the connection.
 const routineConnectionTypeEnum = {
   type: "string",
-  enum: ["topic", "task", "resource"],
+  enum: ["topic", "task", "resource", "bookmark"],
 } as const;
 
 const routineConnectionItemSchema = {
@@ -120,6 +122,9 @@ const routineConnectionItemSchema = {
     id: {
       type: "string",
     },
+    // Bookmark connections only: cached title/url (ignored for local types).
+    name: nullableString,
+    url: nullableString,
   },
 } as const;
 
@@ -423,5 +428,7 @@ export const todoSchema = {
     resourceId: nullableString,
     moduleGroupId: nullableString,
     moduleId: nullableString,
+    // Associations to Simple Bookmarks bookmarks (coexists with the resource link).
+    bookmarks: bookmarkLinksArraySchema,
   },
 } as const;

--- a/packages/middleware/src/utils/taskProjection.ts
+++ b/packages/middleware/src/utils/taskProjection.ts
@@ -66,6 +66,7 @@ interface TaskTodoRow {
   resource: LinkTargetRow | null;
   moduleGroup: LinkTargetRow | null;
   module: LinkTargetRow | null;
+  bookmarks: TaskBookmarkRow[];
 }
 
 // The fields mapTask reads. The single-task and list task queries produce a
@@ -180,6 +181,16 @@ export function mapTask(task: TaskProjectionRow): Task {
         moduleGroup: mapLinkTarget(t.moduleGroup),
         moduleId: t.moduleId ?? null,
         module: mapLinkTarget(t.module),
+        bookmarks: (t.bookmarks ?? [])
+          .slice()
+          .sort(byPosition)
+          .map((b): TaskBookmark => ({
+            id: b.id,
+            bookmarkId: b.bookmarkId,
+            title: b.title,
+            url: b.url ?? null,
+            position: b.position ?? null,
+          })),
       })),
   };
 }

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -5,15 +5,19 @@ export type RoutineReferenceType = "task" | "resource" | "freeform";
 
 // A routine can be connected to any number of these entity kinds. The
 // connection is the routine's categorical link (what it's "about"); it is
-// separate from the weekly grid, which is the per-day activity.
-export type RoutineConnectionType = "topic" | "task" | "resource";
+// separate from the weekly grid, which is the per-day activity. "bookmark"
+// points at an external Simple Bookmarks bookmark (no local row).
+export type RoutineConnectionType = "topic" | "task" | "resource" | "bookmark";
 
-// A single polymorphic connection. `name` is resolved on read for display and
-// omitted on write (the client sends only `type` + `id`).
+// A single polymorphic connection. For local types, `name` is resolved on read
+// and the client sends only `type` + `id`. For "bookmark", the bookmark lives in
+// a separate app with no local row, so the client sends `name` (cached title) +
+// `url` too and they are stored on the connection; `url` is the link-out target.
 export interface RoutineConnection {
   type: RoutineConnectionType;
   id: string;
   name?: string | null;
+  url?: string | null;
 }
 
 // A routine is a weekly schedule (each weekday can differ), a daily task (the

--- a/packages/types/src/TaskTodo.ts
+++ b/packages/types/src/TaskTodo.ts
@@ -1,5 +1,6 @@
 import type { DailyCompletionStatus } from "./Daily";
 import type { ResourceLinkNarrowing } from "./ResourceLinkTarget";
+import type { TaskBookmark } from "./TaskBookmark";
 
 // A todo within a Task List. Modeled like a Curated Routine entry
 // (RoutineReferenceItem): it carries a status (same 5-state set as routine
@@ -21,6 +22,9 @@ export interface TaskTodo extends ResourceLinkNarrowing {
   // Optional link to a top-level Resource. Both moduleGroupId/moduleId null =
   // whole-resource link; all three null = plain checklist item.
   resourceId?: string | null;
+  // Associations to Simple Bookmarks bookmarks (coexists with the resource link
+  // during the incremental migration to bookmark-backed links).
+  bookmarks?: TaskBookmark[];
 }
 
 // A todo is "complete" when its status reached the goal threshold. Shared by


### PR DESCRIPTION
## What & why

Increment 2 of the pivot to delegate link/resource record-keeping to the companion **Simple Bookmarks** app. Extends bookmark associations from tasks (#548) to **todos** and **routine connections**. Coexists with existing resource links — nothing removed.

> **Stacked on #548** (base `simplify-app`). Merge #548 first; this shows only the increment-2 diff.

## Changes

**Todos** (many bookmarks per todo)
- `todo_bookmarks` junction, cascades with `task_todos`. Because `task_todos` is rebuilt (delete + reinsert) on every task save, the junction is re-synced from the todo payload in the task handlers' `afterCreate`/`afterUpsert` (`syncTodoBookmarks`), and `toTodoInput` round-trips bookmarks so a status toggle can't wipe them.
- `BookmarkPicker` in `TodoEditRow`; bookmark chips on the read row.

**Routines** (new `"bookmark"` connection type)
- Added `"bookmark"` to `RoutineConnectionType` + `cached_title`/`cached_url` on `routine_connections`. The resolver renders bookmark connections **from the cache** (no lookup, never auto-dropped); `duplicateRoutine` carries the cache over.
- The connection picker is a preloaded combobox, so bookmarks (async search/create) get a **separate `BookmarkPicker`** on the routine form, merged into `connections` on save and split back out on load. Both connection render sites (`RoutineBox`, `RoutineDetailsContent`) branch bookmarks to an external link-out.

## Verification

- ✅ `pnpm typecheck` (all), `pnpm lint` (0 errors)
- ✅ middleware tests (76), client unit (469), affected Storybook stories (12; `TodoEditRow` rewrapped in `QueryStub`)
- ⏳ **Needs Docker + the Pi's Simple Bookmarks:** `pnpm push:dev` applies additively (`todo_bookmarks` new table; the two `routine_connections` columns nullable — no migration file). Then: add bookmarks to a todo and toggle its status (bookmarks should survive); attach a bookmark connection to a routine and confirm the link-out chip on the routine detail + daily tracker.

## Follow-ups (out of scope)

- Routine *create* form (`-NewRoutineForm`) doesn't yet offer bookmarks (edit form covers it).
- No new unit tests for the pure builders (`buildTodoBookmarkRows`, bookmark `buildRoutineConnectionRows`) — they mirror already-tested patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)