### PR TITLE
feat: narrow bookmark associations to a specific section

### DIFF
--- a/packages/client/src/components/bookmarks/BookmarkPicker.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkPicker.tsx
@@ -8,6 +8,7 @@ import { ExternalLinkIcon, Loader2, PlusIcon, XIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
   createBookmark,
+  fetchBookmarkSections,
   isHttpUrl,
   queryKeys,
   resolveBookmark,
@@ -73,6 +74,23 @@ export function BookmarkPicker({
     onChange(value.filter(v => v.bookmarkId !== bookmarkId));
   }
 
+  function setSection(
+    bookmarkId: string,
+    sectionId: string | null,
+    sectionLabel: string | null,
+  ) {
+    onChange(
+      value.map(v =>
+        v.bookmarkId === bookmarkId
+          ? {
+            ...v,
+            sectionId,
+            sectionLabel,
+          }
+          : v),
+    );
+  }
+
   async function addByUrl() {
     if (!trimmed) return;
     setIsAdding(true);
@@ -106,43 +124,13 @@ export function BookmarkPicker({
       {value.length > 0 && (
         <ul className="flex flex-wrap gap-2">
           {value.map(b => (
-            <li
+            <BookmarkChip
               key={b.bookmarkId}
-              className="
-                flex items-center gap-1.5 rounded-md border border-border
-                bg-muted px-2 py-1 text-sm
-              "
-            >
-              {b.url
-                ? (
-                  <a
-                    href={b.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="
-                      inline-flex items-center gap-1
-                      hover:underline
-                    "
-                  >
-                    {b.title}
-                    <ExternalLinkIcon className="size-3" />
-                  </a>
-                )
-                : (
-                  <span>{b.title}</span>
-                )}
-              <button
-                type="button"
-                onClick={() => remove(b.bookmarkId)}
-                aria-label={`Remove ${b.title}`}
-                className="
-                  text-muted-foreground
-                  hover:text-foreground
-                "
-              >
-                <XIcon className="size-3.5" />
-              </button>
-            </li>
+              association={b}
+              onRemove={() => remove(b.bookmarkId)}
+              onChangeSection={(sectionId, sectionLabel) =>
+                setSection(b.bookmarkId, sectionId, sectionLabel)}
+            />
           ))}
         </ul>
       )}
@@ -250,5 +238,91 @@ export function BookmarkPicker({
 
       {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
+  );
+}
+
+interface BookmarkChipProps {
+  association: TaskBookmark;
+  onRemove: () => void;
+  onChangeSection: (sectionId: string | null, sectionLabel: string | null) => void;
+}
+
+// A single associated-bookmark chip: title link, remove, and — when the bookmark
+// has sections — a live-fetched dropdown to narrow the association to one section.
+function BookmarkChip({
+  association,
+  onRemove,
+  onChangeSection,
+}: BookmarkChipProps) {
+  const {
+    data: sections = [],
+  } = useQuery({
+    queryKey: queryKeys.bookmarks.sections(association.bookmarkId),
+    queryFn: () => fetchBookmarkSections(association.bookmarkId),
+  });
+
+  return (
+    <li
+      className="
+        flex items-center gap-1.5 rounded-md border border-border bg-muted px-2
+        py-1 text-sm
+      "
+    >
+      {association.url
+        ? (
+          <a
+            href={association.url}
+            target="_blank"
+            rel="noreferrer"
+            className="
+              inline-flex items-center gap-1
+              hover:underline
+            "
+          >
+            {association.title}
+            <ExternalLinkIcon className="size-3" />
+          </a>
+        )
+        : (
+          <span>{association.title}</span>
+        )}
+
+      {sections.length > 0 && (
+        <select
+          aria-label={`Section of ${association.title}`}
+          value={association.sectionId ?? ""}
+          onChange={(e) => {
+            const id = e.target.value || null;
+            const label = id
+              ? sections.find(s => s.id === id)?.label ?? null
+              : null;
+            onChangeSection(id, label);
+          }}
+          className="rounded-sm border bg-background px-1 py-0.5 text-xs"
+        >
+          <option value="">Whole bookmark</option>
+          {sections.map(s => (
+            <option
+              key={s.id}
+              value={s.id}
+            >
+              {s.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${association.title}`}
+        className="
+          text-muted-foreground
+          hover:text-foreground
+        "
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </li>
   );
 }

--- a/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
@@ -121,6 +121,7 @@ export function RoutineBox({
                           rel="noreferrer"
                         >
                           {c.name ?? c.id}
+                          {c.sectionLabel ? ` › ${c.sectionLabel}` : ""}
                         </a>
                       )
                       : (

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -1,5 +1,5 @@
 import type { LocalConnectionType } from "@/utils";
-import type { RoutineConnection, Routine } from "@emstack/types";
+import type { RoutineConnection, Routine, TaskBookmark } from "@emstack/types";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -84,6 +84,8 @@ const detailsSchema = z.object({
       bookmarkId: z.string(),
       title: z.string(),
       url: z.string().nullable(),
+      sectionId: z.string().nullable().optional(),
+      sectionLabel: z.string().nullable().optional(),
       position: z.number().nullable().optional(),
     }),
   ),
@@ -173,16 +175,22 @@ export function useRoutineDetailsForm(
       name: routine.name ?? "",
       description: routine.description ?? "",
       connections: allConnections
-        .filter((c): c is RoutineConnection & { type: LocalConnectionType } =>
-          c.type !== "bookmark")
+        .filter(
+          (c): c is RoutineConnection & { type: LocalConnectionType } =>
+            c.type !== "bookmark",
+        )
         .map(encodeConnection),
       bookmarks: allConnections
         .filter(c => c.type === "bookmark")
-        .map(c => ({
-          bookmarkId: c.id,
-          title: c.name ?? "",
-          url: c.url ?? null,
-        })),
+        .map(
+          (c): TaskBookmark => ({
+            bookmarkId: c.id,
+            title: c.name ?? "",
+            url: c.url ?? null,
+            sectionId: c.sectionId ?? null,
+            sectionLabel: c.sectionLabel ?? null,
+          }),
+        ),
       status: routine.status ?? "active",
       mode: routine.mode ?? "weekly",
       weekly: weeklyToRows(routine.weekly),
@@ -212,12 +220,16 @@ export function useRoutineDetailsForm(
           .filter((c): c is NonNullable<typeof c> => c !== null);
         // Bookmark connections carry their cached title/url so the server can
         // store them (no local row to resolve on read).
-        const bookmarkConnections: RoutineConnection[] = value.bookmarks.map(b => ({
-          type: "bookmark",
-          id: b.bookmarkId,
-          name: b.title,
-          url: b.url,
-        }));
+        const bookmarkConnections: RoutineConnection[] = value.bookmarks.map(
+          b => ({
+            type: "bookmark",
+            id: b.bookmarkId,
+            name: b.title,
+            url: b.url,
+            sectionId: b.sectionId ?? null,
+            sectionLabel: b.sectionLabel ?? null,
+          }),
+        );
         const connections = [...localConnections, ...bookmarkConnections];
 
         await upsertRoutine(routine.id, {
@@ -261,7 +273,9 @@ export function useRoutineDetailsForm(
                   moduleGroupsByResource,
                   modulesByResource,
                 ),
-                value.curatedEndDate ? getDateKey(value.curatedEndDate) : null,
+                value.curatedEndDate
+                  ? getDateKey(value.curatedEndDate)
+                  : null,
               )
               : {
                 endDate: null,
@@ -285,9 +299,11 @@ export function useRoutineDetailsForm(
   });
 
   const {
-    currentValues,
-    hasChanges,
-  } = useFormChangeState(form, startingValues);
+    currentValues, hasChanges,
+  } = useFormChangeState(
+    form,
+    startingValues,
+  );
   const isDaily = currentValues.mode === "daily";
   const isCurated = currentValues.mode === "curated";
 

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
@@ -133,6 +133,11 @@ export function RoutineDetailsContent({
                       {c.type}
                     </span>
                     {c.name ?? c.id}
+                    {c.sectionLabel && (
+                      <span className="ml-1 font-normal opacity-70">
+                        › {c.sectionLabel}
+                      </span>
+                    )}
                   </a>
                 )
                 : (

--- a/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
@@ -283,6 +283,11 @@ export function TodosEditor({
                         : (
                           b.title
                         )}
+                      {b.sectionLabel && (
+                        <span className="ml-1 opacity-70">
+                          › {b.sectionLabel}
+                        </span>
+                      )}
                     </Badge>
                   ))}
                   <div

--- a/packages/client/src/routes/tasks/$id/index.tsx
+++ b/packages/client/src/routes/tasks/$id/index.tsx
@@ -139,6 +139,11 @@ function SingleTask() {
                   : (
                     <span>{b.title}</span>
                   )}
+                {b.sectionLabel && (
+                  <span className="text-muted-foreground">
+                    › {b.sectionLabel}
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/packages/client/src/utils/api/bookmarks.ts
+++ b/packages/client/src/utils/api/bookmarks.ts
@@ -1,4 +1,4 @@
-import type { BookmarkSummary } from "@emstack/types";
+import type { BookmarkSection, BookmarkSummary } from "@emstack/types";
 
 import { fetchJson, postJson } from "./client";
 
@@ -9,6 +9,14 @@ import { fetchJson, postJson } from "./client";
 export function searchBookmarks(query: string): Promise<BookmarkSummary[]> {
   return fetchJson<BookmarkSummary[]>(
     `/api/bookmarks/search?q=${encodeURIComponent(query)}`,
+  );
+}
+
+export function fetchBookmarkSections(
+  bookmarkId: string,
+): Promise<BookmarkSection[]> {
+  return fetchJson<BookmarkSection[]>(
+    `/api/bookmarks/${encodeURIComponent(bookmarkId)}/sections`,
   );
 }
 

--- a/packages/client/src/utils/queryKeys.ts
+++ b/packages/client/src/utils/queryKeys.ts
@@ -70,6 +70,8 @@ export const queryKeys = {
   },
   bookmarks: {
     search: (query: string) => ["bookmarks", "search", query] as const,
+    sections: (bookmarkId: string) =>
+      ["bookmarks", "sections", bookmarkId] as const,
   },
   readwise: {
     readingList: () => ["readwise", "reading-list"] as const,

--- a/packages/middleware/src/db/schema/routines.ts
+++ b/packages/middleware/src/db/schema/routines.ts
@@ -58,6 +58,11 @@ export const routineConnections = pgTable("routine_connections", {
   // Cached label for "bookmark" connections (null for local types).
   cachedTitle: varchar("cached_title"),
   cachedUrl: varchar("cached_url"),
+  // Bookmark connections only: optional narrowing to a section (null = whole
+  // bookmark). `section_id` is the external SectionEntry id; `section_label` the
+  // cached label.
+  sectionId: varchar("section_id"),
+  sectionLabel: varchar("section_label"),
   position: integer(),
 });
 

--- a/packages/middleware/src/db/schema/tasks.ts
+++ b/packages/middleware/src/db/schema/tasks.ts
@@ -131,6 +131,11 @@ export const taskBookmarks = pgTable("task_bookmarks", {
     length: 500,
   }).notNull(),
   url: varchar(),
+  // Optional narrowing to a section of the bookmark (null = whole bookmark).
+  // `section_id` is the external SectionEntry id; `section_label` is the cached
+  // label so the chip renders without refetching.
+  sectionId: varchar("section_id"),
+  sectionLabel: varchar("section_label"),
   position: integer(),
 });
 
@@ -151,5 +156,8 @@ export const todoBookmarks = pgTable("todo_bookmarks", {
     length: 500,
   }).notNull(),
   url: varchar(),
+  // Optional narrowing to a section of the bookmark (null = whole bookmark).
+  sectionId: varchar("section_id"),
+  sectionLabel: varchar("section_label"),
   position: integer(),
 });

--- a/packages/middleware/src/routes/api/bookmarks/root.ts
+++ b/packages/middleware/src/routes/api/bookmarks/root.ts
@@ -4,10 +4,12 @@ import { FastifyInstance } from "fastify";
 import {
   BookmarksError,
   createBookmark,
+  getBookmarkSections,
   resolveBookmarkByUrl,
   searchBookmarks,
 } from "@/services/bookmarks";
 import { sendBadRequest } from "@/utils/errors";
+import { idParamSchema } from "@/utils/schemas";
 
 // Proxy endpoints backed by src/services/bookmarks.ts. They front the companion
 // Simple Bookmarks API so the browser stays same-origin, the bookmarks base URL
@@ -80,6 +82,30 @@ export default async function (server: FastifyInstance) {
         });
       }
       return sendBadRequest(reply, "Failed to resolve URL in Simple Bookmarks.");
+    }
+  });
+
+  const sectionsSchema = {
+    schema: {
+      description: "List a bookmark's sections (flattened, pickable)",
+      params: idParamSchema,
+    },
+  } as const;
+
+  fastify.get("/:id/sections", sectionsSchema, async (request, reply) => {
+    const {
+      id,
+    } = request.params;
+    try {
+      return await getBookmarkSections(id);
+    }
+    catch (err) {
+      if (err instanceof BookmarksError) {
+        return reply.code(err.statusCode).send({
+          message: err.message,
+        });
+      }
+      return sendBadRequest(reply, "Failed to load bookmark sections.");
     }
   });
 

--- a/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
+++ b/packages/middleware/src/routes/api/routines/duplicateRoutine.ts
@@ -64,6 +64,8 @@ export default async function (server: FastifyInstance) {
             connectedId: c.connectedId,
             cachedTitle: c.cachedTitle,
             cachedUrl: c.cachedUrl,
+            sectionId: c.sectionId,
+            sectionLabel: c.sectionLabel,
             position: c.position,
           })),
         );

--- a/packages/middleware/src/routes/api/tasks/taskRows.ts
+++ b/packages/middleware/src/routes/api/tasks/taskRows.ts
@@ -34,6 +34,8 @@ export interface BookmarkInput {
   bookmarkId: string;
   title: string;
   url?: string | null;
+  sectionId?: string | null;
+  sectionLabel?: string | null;
 }
 
 export interface TaskResourceInput {
@@ -163,6 +165,8 @@ export function buildBookmarkRows(
     bookmarkId: string;
     title: string;
     url: string | null;
+    sectionId: string | null;
+    sectionLabel: string | null;
     position: number;
   }[] = [];
   bookmarks.forEach((b, index) => {
@@ -174,6 +178,8 @@ export function buildBookmarkRows(
       bookmarkId: b.bookmarkId,
       title: b.title,
       url: b.url ?? null,
+      sectionId: b.sectionId ?? null,
+      sectionLabel: b.sectionLabel ?? null,
       position: index,
     });
   });
@@ -193,6 +199,8 @@ export function buildTodoBookmarkRows(
     bookmarkId: string;
     title: string;
     url: string | null;
+    sectionId: string | null;
+    sectionLabel: string | null;
     position: number;
   }[] = [];
   bookmarks.forEach((b, index) => {
@@ -204,6 +212,8 @@ export function buildTodoBookmarkRows(
       bookmarkId: b.bookmarkId,
       title: b.title,
       url: b.url ?? null,
+      sectionId: b.sectionId ?? null,
+      sectionLabel: b.sectionLabel ?? null,
       position: index,
     });
   });

--- a/packages/middleware/src/services/bookmarks.ts
+++ b/packages/middleware/src/services/bookmarks.ts
@@ -1,4 +1,4 @@
-import type { BookmarkSummary } from "@emstack/types";
+import type { BookmarkSection, BookmarkSummary } from "@emstack/types";
 
 // Base URL of the companion Simple Bookmarks app. Configurable so the same
 // build works across environments; defaults to the self-hosted instance.
@@ -94,6 +94,53 @@ export async function resolveBookmarkByUrl(url: string): Promise<BookmarkSummary
   const body = (await response.json()) as RawUrlCheckResult;
   const match = body.exactMatch ?? body.pathMatch ?? null;
   return match ? mapBookmark(match) : null;
+}
+
+// A bookmark's section entries live under one or more "sections" custom
+// properties; each entry is two-tier (a header with optional child leaves).
+interface RawSectionEntry {
+  id: string;
+  name?: string | null;
+  children?: RawSectionEntry[] | null;
+}
+interface RawSectionsValue {
+  sections?: RawSectionEntry[] | null;
+}
+interface RawBookmarkDetail {
+  sectionsValues?: RawSectionsValue[] | null;
+}
+
+/**
+ * Fetch a bookmark's sections, flattened to a pickable list. Any entry (tier-1
+ * header or tier-2 leaf) is selectable; leaves are labelled with their parent
+ * for context ("Part I › Chapter 3"). Entry ids are unique within a bookmark.
+ */
+export async function getBookmarkSections(
+  bookmarkId: string,
+): Promise<BookmarkSection[]> {
+  const response = await bookmarksFetch(
+    `/api/bookmarks/${encodeURIComponent(bookmarkId)}`,
+  );
+  assertOk(response);
+
+  const body = (await response.json()) as RawBookmarkDetail;
+  const sections: BookmarkSection[] = [];
+  for (const value of body.sectionsValues ?? []) {
+    for (const entry of value.sections ?? []) {
+      const name = entry.name?.trim() || "Untitled section";
+      sections.push({
+        id: entry.id,
+        label: name,
+      });
+      for (const child of entry.children ?? []) {
+        sections.push({
+          id: child.id,
+          label: `${name} › ${child.name?.trim() || "Untitled"}`,
+        });
+      }
+    }
+  }
+  return sections;
 }
 
 /**

--- a/packages/middleware/src/utils/resolveRoutineConnections.ts
+++ b/packages/middleware/src/utils/resolveRoutineConnections.ts
@@ -6,9 +6,12 @@ import type { RoutineConnection } from "@emstack/types";
 export interface RawRoutineConnection {
   connectedType: RoutineConnectionType;
   connectedId: string;
-  // Bookmark connections carry their own cached label (no local row to resolve).
+  // Bookmark connections carry their own cached label (no local row to resolve)
+  // plus optional section narrowing.
   cachedTitle?: string | null;
   cachedUrl?: string | null;
+  sectionId?: string | null;
+  sectionLabel?: string | null;
 }
 
 // A shared RoutineConnection with its display name resolved on read (always
@@ -101,6 +104,8 @@ export async function resolveRoutineConnections<
             id: c.connectedId,
             name: c.cachedTitle ?? "Bookmark",
             url: c.cachedUrl ?? null,
+            sectionId: c.sectionId ?? null,
+            sectionLabel: c.sectionLabel ?? null,
           };
         }
         const name = nameByType[c.connectedType].get(c.connectedId);

--- a/packages/middleware/src/utils/routineConnectionRows.ts
+++ b/packages/middleware/src/utils/routineConnectionRows.ts
@@ -8,7 +8,7 @@ import type { RoutineConnection } from "@emstack/types";
 // sends the cached `name`/`url` (see resolveRoutineConnections).
 export type RoutineConnectionInput = Pick<
   RoutineConnection,
-  "type" | "id" | "name" | "url"
+  "type" | "id" | "name" | "url" | "sectionId" | "sectionLabel"
 >;
 
 // Dedupe by (type, id) and produce routine_connections rows with stable
@@ -30,6 +30,8 @@ export function buildRoutineConnectionRows(
     connectedId: string;
     cachedTitle: string | null;
     cachedUrl: string | null;
+    sectionId: string | null;
+    sectionLabel: string | null;
     position: number;
   }[] = [];
   for (const c of connections) {
@@ -41,13 +43,16 @@ export function buildRoutineConnectionRows(
       continue;
     }
     seen.add(key);
+    const isBookmark = c.type === "bookmark";
     rows.push({
       id: uuidv4(),
       routineId,
       connectedType: c.type,
       connectedId: c.id,
-      cachedTitle: c.type === "bookmark" ? c.name ?? null : null,
-      cachedUrl: c.type === "bookmark" ? c.url ?? null : null,
+      cachedTitle: isBookmark ? c.name ?? null : null,
+      cachedUrl: isBookmark ? c.url ?? null : null,
+      sectionId: isBookmark ? c.sectionId ?? null : null,
+      sectionLabel: isBookmark ? c.sectionLabel ?? null : null,
       position: rows.length,
     });
   }

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -122,9 +122,12 @@ const routineConnectionItemSchema = {
     id: {
       type: "string",
     },
-    // Bookmark connections only: cached title/url (ignored for local types).
+    // Bookmark connections only: cached title/url + optional section narrowing
+    // (ignored for local types).
     name: nullableString,
     url: nullableString,
+    sectionId: nullableString,
+    sectionLabel: nullableString,
   },
 } as const;
 
@@ -371,6 +374,9 @@ const bookmarkLinkSchema = {
       type: "string",
     },
     url: nullableString,
+    // Optional narrowing to a section of the bookmark (null = whole bookmark).
+    sectionId: nullableString,
+    sectionLabel: nullableString,
   },
 } as const;
 

--- a/packages/middleware/src/utils/taskProjection.ts
+++ b/packages/middleware/src/utils/taskProjection.ts
@@ -32,7 +32,21 @@ interface TaskBookmarkRow {
   bookmarkId: string;
   title: string;
   url: string | null;
+  sectionId: string | null;
+  sectionLabel: string | null;
   position: number | null;
+}
+
+function mapBookmark(b: TaskBookmarkRow): TaskBookmark {
+  return {
+    id: b.id,
+    bookmarkId: b.bookmarkId,
+    title: b.title,
+    url: b.url ?? null,
+    sectionId: b.sectionId ?? null,
+    sectionLabel: b.sectionLabel ?? null,
+    position: b.position ?? null,
+  };
 }
 
 interface TaskResourceRow {
@@ -138,13 +152,7 @@ export function mapTask(task: TaskProjectionRow): Task {
     bookmarks: (task.bookmarks ?? [])
       .slice()
       .sort(byPosition)
-      .map((b): TaskBookmark => ({
-        id: b.id,
-        bookmarkId: b.bookmarkId,
-        title: b.title,
-        url: b.url ?? null,
-        position: b.position ?? null,
-      })),
+      .map(mapBookmark),
     resources: (task.resources ?? [])
       .slice()
       .sort(byPosition)
@@ -184,13 +192,7 @@ export function mapTask(task: TaskProjectionRow): Task {
         bookmarks: (t.bookmarks ?? [])
           .slice()
           .sort(byPosition)
-          .map((b): TaskBookmark => ({
-            id: b.id,
-            bookmarkId: b.bookmarkId,
-            title: b.title,
-            url: b.url ?? null,
-            position: b.position ?? null,
-          })),
+          .map(mapBookmark),
       })),
   };
 }

--- a/packages/types/src/Bookmark.ts
+++ b/packages/types/src/Bookmark.ts
@@ -10,3 +10,13 @@ export interface BookmarkSummary {
   // absent here too.
   url: string | null;
 }
+
+// One selectable section within a bookmark, flattened from the bookmark's
+// two-tier SectionEntry list (any entry — group or leaf — is selectable). `id`
+// is the SectionEntry id (unique within the bookmark); `label` is a readable
+// name with tier context (e.g. "Part I › Chapter 3"). Returned by the
+// course-tracker proxy GET /api/bookmarks/:id/sections.
+export interface BookmarkSection {
+  id: string;
+  label: string;
+}

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -18,6 +18,10 @@ export interface RoutineConnection {
   id: string;
   name?: string | null;
   url?: string | null;
+  // Bookmark connections only: optional narrowing to a section of the bookmark
+  // (null = whole bookmark). `sectionLabel` is the cached readable label.
+  sectionId?: string | null;
+  sectionLabel?: string | null;
 }
 
 // A routine is a weekly schedule (each weekday can differ), a daily task (the

--- a/packages/types/src/TaskBookmark.ts
+++ b/packages/types/src/TaskBookmark.ts
@@ -12,5 +12,10 @@ export interface TaskBookmark {
   bookmarkId: string;
   title: string;
   url: string | null;
+  // Optional narrowing to a specific section of the bookmark. Null = the whole
+  // bookmark. `sectionId` is the external SectionEntry id; `sectionLabel` is the
+  // cached readable label so the chip renders without refetching.
+  sectionId?: string | null;
+  sectionLabel?: string | null;
   position?: number | null;
 }


### PR DESCRIPTION
## What & why

Increment 3 of the pivot to delegate record-keeping to **Simple Bookmarks** — the depth feature the association work was building toward. Any bookmark association (**task**, **todo**, or **routine connection**) can now narrow to a specific **section** of the bookmark (a chapter/part), fetched live from its `SectionEntry` list. Still additive — nothing removed.

## Changes

**Middleware**
- `getBookmarkSections` proxy — `GET /api/bookmarks/:id/sections` reads the bookmark's `sectionsValues` and flattens the two-tier `SectionEntry` list into a pickable `{id,label}[]` (any entry selectable; leaf labels carry their parent, e.g. "Part I › Chapter 3").
- `section_id`/`section_label` (cached, nullable) on `task_bookmarks`, `todo_bookmarks`, and `routine_connections`; threaded through the row builders, task/todo projections, the routine resolver, and `duplicateRoutine`.

**Types** — `TaskBookmark` + `RoutineConnection` gain `sectionId`/`sectionLabel`; new `BookmarkSection`.

**Client** — the shared `BookmarkPicker` renders a **per-chip section dropdown** (live-fetched; "Whole bookmark" = null). Read-only chips (task detail, todo rows) and both routine connection render sites show `Title › Section`; the routine form round-trips the section.

## Verification

- ✅ `pnpm typecheck` (all), `pnpm lint` (0 errors)
- ✅ middleware tests (76), client unit (469), affected Storybook stories (12)
- ⏳ **Needs Docker + the Pi's Simple Bookmarks (with a sections-bearing bookmark):** `pnpm push:dev` applies additively (all new columns nullable — no migration file). Then: associate a book-like bookmark, confirm the section dropdown populates, pick a section, save, and verify the chip shows `Title › Section` on task/todo/routine surfaces.

## Notes

- One section per association (null = whole bookmark), mirroring the old single module narrowing.
- A bookmark with no sections (or an unreachable Simple Bookmarks) simply shows no dropdown — the association still works whole-bookmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)