### PR TITLE
feat: bookmarks on todos and routine schedule entries

### DIFF
--- a/packages/client/src/components/bookmarks/SingleBookmarkPicker.tsx
+++ b/packages/client/src/components/bookmarks/SingleBookmarkPicker.tsx
@@ -1,0 +1,65 @@
+import type { TaskBookmark } from "@emstack/types";
+
+import { BookmarkPicker } from "./BookmarkPicker";
+
+// The flat, string-only shape a schedule row / entry stores for a bookmark
+// ("" = none). Shared by the weekly, curated, and Daily-mode entry editors.
+export interface SingleBookmarkValue {
+  bookmarkId: string;
+  title: string;
+  url: string;
+  sectionId: string;
+  sectionLabel: string;
+}
+
+const EMPTY: SingleBookmarkValue = {
+  bookmarkId: "",
+  title: "",
+  url: "",
+  sectionId: "",
+  sectionLabel: "",
+};
+
+interface SingleBookmarkPickerProps {
+  value: SingleBookmarkValue;
+  onChange: (next: SingleBookmarkValue) => void;
+}
+
+// A single-slot wrapper over the multi-select BookmarkPicker: keeps only the
+// most-recently chosen bookmark, for surfaces that reference exactly one (a
+// routine weekly / curated / daily schedule entry). Converts between the
+// string-only row shape and BookmarkPicker's TaskBookmark[].
+export function SingleBookmarkPicker({
+  value,
+  onChange,
+}: SingleBookmarkPickerProps) {
+  const pickerValue: TaskBookmark[] = value.bookmarkId
+    ? [{
+      bookmarkId: value.bookmarkId,
+      title: value.title,
+      url: value.url || null,
+      sectionId: value.sectionId || null,
+      sectionLabel: value.sectionLabel || null,
+    }]
+    : [];
+
+  return (
+    <BookmarkPicker
+      value={pickerValue}
+      onChange={(next) => {
+        const last = next[next.length - 1];
+        onChange(
+          last
+            ? {
+              bookmarkId: last.bookmarkId,
+              title: last.title,
+              url: last.url ?? "",
+              sectionId: last.sectionId ?? "",
+              sectionLabel: last.sectionLabel ?? "",
+            }
+            : EMPTY,
+        );
+      }}
+    />
+  );
+}

--- a/packages/client/src/components/formFields/index.ts
+++ b/packages/client/src/components/formFields/index.ts
@@ -1,3 +1,4 @@
 export { BookmarkPicker } from "@/components/bookmarks/BookmarkPicker";
+export { SingleBookmarkPicker } from "@/components/bookmarks/SingleBookmarkPicker";
 export { ResourceLinksPicker } from "@/components/tasks/ResourceLinksPicker";
 export { useAppForm } from "@/hooks/useAppForm";

--- a/packages/client/src/components/routines/RoutineEntryLabel.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.tsx
@@ -38,25 +38,42 @@ export function RoutineEntryLabel({
   // (freeform) — no type badge, so it can sit inside an actionable sentence.
   const nameNode = entry.type === "freeform"
     ? entry.id
-    : (
-      <EntityLink
-        entity={entry.type === "task" ? "tasks" : "resources"}
-        id={entry.id}
-        className="
-          text-blue-800
-          hover:text-blue-600
-          dark:text-blue-300
-        "
-      >
-        {routineEntryName(
-          entry,
-          taskNames,
-          resourceNames,
-          moduleNames,
-          moduleGroupNames,
-        )}
-      </EntityLink>
-    );
+    : entry.type === "bookmark"
+      ? (
+        // External bookmark: link out (no local route), cached title + section.
+        <a
+          href={entry.url ?? undefined}
+          target="_blank"
+          rel="noreferrer"
+          className="
+            text-blue-800
+            hover:text-blue-600
+            dark:text-blue-300
+          "
+        >
+          {entry.title ?? entry.id}
+          {entry.sectionLabel ? ` › ${entry.sectionLabel}` : ""}
+        </a>
+      )
+      : (
+        <EntityLink
+          entity={entry.type === "task" ? "tasks" : "resources"}
+          id={entry.id}
+          className="
+            text-blue-800
+            hover:text-blue-600
+            dark:text-blue-300
+          "
+        >
+          {routineEntryName(
+            entry,
+            taskNames,
+            resourceNames,
+            moduleNames,
+            moduleGroupNames,
+          )}
+        </EntityLink>
+      );
 
   const actionable = (
     <ActionableSentence

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -3,11 +3,9 @@ import type { SelectOption } from "@/utils";
 
 import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
-import { BookmarkPicker } from "@/components/formFields";
 import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
-import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
+import { ScheduleItemControl } from "@/components/routines/ScheduleItemControl";
 import { effectiveEntryUrl } from "@/components/routines/weekly";
-import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
 interface ScheduleEntryRowProps {
   // Displayed label for the row (e.g. "Monday" or "Mon, Jun 15").
@@ -157,89 +155,20 @@ export function ScheduleEntryRow({
           <option value="freeform">Freeform</option>
         </select>
 
-        {row.type === "freeform"
-          ? (
-            <input
-              aria-label={`${ariaPrefix} description`}
-              value={row.id}
-              onChange={e =>
-                onChange({
-                  id: e.target.value,
-                })}
-              placeholder="Describe the activity…"
-              className="
-                flex h-9 w-full rounded-md border bg-background px-2 text-sm
-              "
-            />
-          )
-          : row.type === "bookmark"
-            ? (
-              // Single-slot bookmark: reuse the multi-select picker, keeping only
-              // the most-recently chosen bookmark (a schedule entry is one item).
-              <BookmarkPicker
-                value={row.id
-                  ? [{
-                    bookmarkId: row.id,
-                    title: row.title,
-                    url: row.url || null,
-                    sectionId: row.sectionId || null,
-                    sectionLabel: row.sectionLabel || null,
-                  }]
-                  : []}
-                onChange={(next) => {
-                  const last = next[next.length - 1];
-                  onChange(
-                    last
-                      ? {
-                        id: last.bookmarkId,
-                        title: last.title,
-                        url: last.url ?? "",
-                        sectionId: last.sectionId ?? "",
-                        sectionLabel: last.sectionLabel ?? "",
-                      }
-                      : {
-                        id: "",
-                        title: "",
-                        url: "",
-                        sectionId: "",
-                        sectionLabel: "",
-                      },
-                  );
-                }}
-              />
-            )
-            : (
-              <Combobox
-                items={itemOptions.map(o => o.value)}
-                value={row.id || null}
-                onValueChange={val =>
-                // A different resource has different modules, so clear any
-                // existing narrowing when the picked item changes.
-                  onChange({
-                    id: val ?? "",
-                    moduleId: "",
-                    moduleGroupId: "",
-                  })}
-                onInputValueChange={val => onInputValueChange(val)}
-                itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-              >
-                <ComboboxInput
-                  placeholder={
-                    row.type === "task"
-                      ? "Search tasks..."
-                      : row.type === "resource"
-                        ? "Search resources..."
-                        : "Pick a type first"
-                  }
-                  showClear
-                  disabled={!row.type}
-                />
-                <TaskResourceComboboxContent
-                  optionsMap={optionsMap}
-                  onAddNew={row.type === "resource" ? onAddResource : undefined}
-                />
-              </Combobox>
-            )}
+        <ScheduleItemControl
+          ariaPrefix={ariaPrefix}
+          type={row.type}
+          id={row.id}
+          title={row.title}
+          url={row.url}
+          sectionId={row.sectionId}
+          sectionLabel={row.sectionLabel}
+          itemOptions={itemOptions}
+          optionsMap={optionsMap}
+          onChange={onChange}
+          onInputValueChange={onInputValueChange}
+          onAddResource={onAddResource}
+        />
       </div>
 
       {showModulePickers && (

--- a/packages/client/src/components/routines/ScheduleEntryRow.tsx
+++ b/packages/client/src/components/routines/ScheduleEntryRow.tsx
@@ -3,6 +3,7 @@ import type { SelectOption } from "@/utils";
 
 import { buildActionableSentence, resourceEntryLabel } from "@emstack/types";
 
+import { BookmarkPicker } from "@/components/formFields";
 import { ModuleNarrowingFields } from "@/components/routines/ModuleNarrowingFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { effectiveEntryUrl } from "@/components/routines/weekly";
@@ -48,13 +49,15 @@ function rowPreview(
   const itemName
     = row.type === "freeform"
       ? row.id
-      : row.type === "resource"
-        ? resourceEntryLabel({
-          resourceName: optionsMap.get(row.id) ?? "",
-          moduleName: moduleLabel,
-          groupName: groupLabel,
-        })
-        : (optionsMap.get(row.id) ?? "");
+      : row.type === "bookmark"
+        ? (row.title || row.id)
+        : row.type === "resource"
+          ? resourceEntryLabel({
+            resourceName: optionsMap.get(row.id) ?? "",
+            moduleName: moduleLabel,
+            groupName: groupLabel,
+          })
+          : (optionsMap.get(row.id) ?? "");
   return {
     showPreview:
       !!itemName && (!!row.prependText.trim() || !!row.appendText.trim()),
@@ -129,7 +132,7 @@ export function ScheduleEntryRow({
           value={row.type}
           onChange={(e) => {
             // Changing the type clears the chosen item (different option set),
-            // any module narrowing, and any note/location.
+            // any module / bookmark narrowing, and any note/location.
             onChange({
               type: e.target.value as WeeklyRowType,
               id: "",
@@ -137,6 +140,10 @@ export function ScheduleEntryRow({
               moduleGroupId: "",
               notes: "",
               location: "",
+              title: "",
+              url: "",
+              sectionId: "",
+              sectionLabel: "",
             });
           }}
           className="
@@ -146,6 +153,7 @@ export function ScheduleEntryRow({
           <option value="">— None —</option>
           <option value="task">Task</option>
           <option value="resource">Resource</option>
+          <option value="bookmark">Bookmark</option>
           <option value="freeform">Freeform</option>
         </select>
 
@@ -164,38 +172,74 @@ export function ScheduleEntryRow({
               "
             />
           )
-          : (
-            <Combobox
-              items={itemOptions.map(o => o.value)}
-              value={row.id || null}
-              onValueChange={val =>
+          : row.type === "bookmark"
+            ? (
+              // Single-slot bookmark: reuse the multi-select picker, keeping only
+              // the most-recently chosen bookmark (a schedule entry is one item).
+              <BookmarkPicker
+                value={row.id
+                  ? [{
+                    bookmarkId: row.id,
+                    title: row.title,
+                    url: row.url || null,
+                    sectionId: row.sectionId || null,
+                    sectionLabel: row.sectionLabel || null,
+                  }]
+                  : []}
+                onChange={(next) => {
+                  const last = next[next.length - 1];
+                  onChange(
+                    last
+                      ? {
+                        id: last.bookmarkId,
+                        title: last.title,
+                        url: last.url ?? "",
+                        sectionId: last.sectionId ?? "",
+                        sectionLabel: last.sectionLabel ?? "",
+                      }
+                      : {
+                        id: "",
+                        title: "",
+                        url: "",
+                        sectionId: "",
+                        sectionLabel: "",
+                      },
+                  );
+                }}
+              />
+            )
+            : (
+              <Combobox
+                items={itemOptions.map(o => o.value)}
+                value={row.id || null}
+                onValueChange={val =>
                 // A different resource has different modules, so clear any
                 // existing narrowing when the picked item changes.
-                onChange({
-                  id: val ?? "",
-                  moduleId: "",
-                  moduleGroupId: "",
-                })}
-              onInputValueChange={val => onInputValueChange(val)}
-              itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-            >
-              <ComboboxInput
-                placeholder={
-                  row.type === "task"
-                    ? "Search tasks..."
-                    : row.type === "resource"
-                      ? "Search resources..."
-                      : "Pick a type first"
-                }
-                showClear
-                disabled={!row.type}
-              />
-              <TaskResourceComboboxContent
-                optionsMap={optionsMap}
-                onAddNew={row.type === "resource" ? onAddResource : undefined}
-              />
-            </Combobox>
-          )}
+                  onChange({
+                    id: val ?? "",
+                    moduleId: "",
+                    moduleGroupId: "",
+                  })}
+                onInputValueChange={val => onInputValueChange(val)}
+                itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+              >
+                <ComboboxInput
+                  placeholder={
+                    row.type === "task"
+                      ? "Search tasks..."
+                      : row.type === "resource"
+                        ? "Search resources..."
+                        : "Pick a type first"
+                  }
+                  showClear
+                  disabled={!row.type}
+                />
+                <TaskResourceComboboxContent
+                  optionsMap={optionsMap}
+                  onAddNew={row.type === "resource" ? onAddResource : undefined}
+                />
+              </Combobox>
+            )}
       </div>
 
       {showModulePickers && (

--- a/packages/client/src/components/routines/ScheduleItemControl.tsx
+++ b/packages/client/src/components/routines/ScheduleItemControl.tsx
@@ -1,0 +1,112 @@
+import type { WeeklyEntry, WeeklyRowType } from "./weekly";
+import type { SelectOption } from "@/utils";
+import type { ReactNode } from "react";
+
+import { SingleBookmarkPicker } from "@/components/formFields";
+import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
+import { Combobox, ComboboxInput } from "@/components/ui/combobox";
+
+interface ScheduleItemControlProps {
+  // Prefix for aria-labels (e.g. "Monday", "Mon, Jun 15", or "Daily task").
+  ariaPrefix: string;
+  type: WeeklyRowType;
+  id: string;
+  title: string;
+  url: string;
+  sectionId: string;
+  sectionLabel: string;
+  itemOptions: SelectOption[];
+  optionsMap: Map<string, string>;
+  onChange: (patch: Partial<WeeklyEntry>) => void;
+  onInputValueChange: (val: string) => void;
+  onAddResource: () => void;
+}
+
+// The item picker for a schedule entry — a freeform text input, a single-slot
+// bookmark picker, or a task/resource combobox, chosen by `type`. The type
+// <select> lives in the caller; this is just the value control. Shared by the
+// weekly/curated grid rows (ScheduleEntryRow) and the Daily-mode editor.
+export function ScheduleItemControl({
+  ariaPrefix,
+  type,
+  id,
+  title,
+  url,
+  sectionId,
+  sectionLabel,
+  itemOptions,
+  optionsMap,
+  onChange,
+  onInputValueChange,
+  onAddResource,
+}: ScheduleItemControlProps): ReactNode {
+  if (type === "freeform") {
+    return (
+      <input
+        aria-label={`${ariaPrefix} description`}
+        value={id}
+        onChange={e =>
+          onChange({
+            id: e.target.value,
+          })}
+        placeholder="Describe the activity…"
+        className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
+      />
+    );
+  }
+
+  if (type === "bookmark") {
+    return (
+      <SingleBookmarkPicker
+        value={{
+          bookmarkId: id,
+          title,
+          url,
+          sectionId,
+          sectionLabel,
+        }}
+        onChange={next =>
+          onChange({
+            id: next.bookmarkId,
+            title: next.title,
+            url: next.url,
+            sectionId: next.sectionId,
+            sectionLabel: next.sectionLabel,
+          })}
+      />
+    );
+  }
+
+  return (
+    <Combobox
+      items={itemOptions.map(o => o.value)}
+      value={id || null}
+      onValueChange={val =>
+        // A different resource has different modules, so clear any existing
+        // narrowing when the picked item changes (no-op for task/daily).
+        onChange({
+          id: val ?? "",
+          moduleId: "",
+          moduleGroupId: "",
+        })}
+      onInputValueChange={val => onInputValueChange(val)}
+      itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+    >
+      <ComboboxInput
+        placeholder={
+          type === "task"
+            ? "Search tasks..."
+            : type === "resource"
+              ? "Search resources..."
+              : "Pick a type first"
+        }
+        showClear
+        disabled={!type}
+      />
+      <TaskResourceComboboxContent
+        optionsMap={optionsMap}
+        onAddNew={type === "resource" ? onAddResource : undefined}
+      />
+    </Combobox>
+  );
+}

--- a/packages/client/src/components/routines/WeeklyScheduleField.tsx
+++ b/packages/client/src/components/routines/WeeklyScheduleField.tsx
@@ -68,6 +68,10 @@ export function WeeklyScheduleField({
             location: "",
             prependText: "",
             appendText: "",
+            title: "",
+            url: "",
+            sectionId: "",
+            sectionLabel: "",
           };
           const {
             groupOptions, moduleOptions,

--- a/packages/client/src/components/routines/weekly.test.ts
+++ b/packages/client/src/components/routines/weekly.test.ts
@@ -215,6 +215,10 @@ describe("representativeRow (Daily Task mode)", () => {
       location: "",
       prependText: "",
       appendText: "",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
     });
   });
 
@@ -236,6 +240,10 @@ describe("representativeRow (Daily Task mode)", () => {
       location: "the gym",
       prependText: "Review",
       appendText: "for 10 minutes",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
     });
   });
 
@@ -249,6 +257,10 @@ describe("representativeRow (Daily Task mode)", () => {
       location: "",
       prependText: "",
       appendText: "",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
     });
   });
 });
@@ -297,6 +309,10 @@ describe("curated schedule helpers", () => {
       location: "",
       prependText: "",
       appendText: "",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
     });
     expect(rows[1]).toMatchObject({
       date: "2026-06-15",
@@ -341,7 +357,10 @@ describe("curated schedule helpers", () => {
       },
     };
     const keys = curatedDateRange("2026-06-14", original.endDate);
-    const restored = rowsToCurated(curatedToRows(original, keys), original.endDate);
+    const restored = rowsToCurated(
+      curatedToRows(original, keys),
+      original.endDate,
+    );
     expect(restored.entries["2026-06-15"]).toEqual({
       type: "task",
       id: "task-1",
@@ -694,6 +713,10 @@ describe("fillEffectiveLocations", () => {
       location: "",
       prependText: "",
       appendText: "",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
       ...over,
     };
   }
@@ -711,48 +734,68 @@ describe("fillEffectiveLocations", () => {
   });
 
   test("fills from the most-specific narrowing (module > group)", () => {
-    expect(fill([row({
-      moduleGroupId: "grp-1",
-    })])[0].location).toBe(
-      "https://example.com/unit-1",
-    );
-    expect(fill([row({
-      moduleId: "mod-1",
-    })])[0].location).toBe(
-      "https://example.com/lesson-1",
-    );
+    expect(
+      fill([
+        row({
+          moduleGroupId: "grp-1",
+        }),
+      ])[0].location,
+    ).toBe("https://example.com/unit-1");
+    expect(
+      fill([
+        row({
+          moduleId: "mod-1",
+        }),
+      ])[0].location,
+    ).toBe("https://example.com/lesson-1");
   });
 
   test("leaves a user-typed location untouched", () => {
-    expect(fill([row({
-      location: "my own note",
-    })])[0].location).toBe(
-      "my own note",
-    );
+    expect(
+      fill([
+        row({
+          location: "my own note",
+        }),
+      ])[0].location,
+    ).toBe("my own note");
   });
 
   test("leaves the location blank when nothing in the chain has a link", () => {
-    expect(fill([row({
-      id: "res-2",
-    })])[0].location).toBe("");
+    expect(
+      fill([
+        row({
+          id: "res-2",
+        }),
+      ])[0].location,
+    ).toBe("");
   });
 
   test("ignores task / freeform entries", () => {
-    expect(fill([row({
-      type: "task",
-      id: "res-1",
-    })])[0].location).toBe("");
-    expect(fill([row({
-      type: "freeform",
-      id: "res-1",
-    })])[0].location).toBe("");
+    expect(
+      fill([
+        row({
+          type: "task",
+          id: "res-1",
+        }),
+      ])[0].location,
+    ).toBe("");
+    expect(
+      fill([
+        row({
+          type: "freeform",
+          id: "res-1",
+        }),
+      ])[0].location,
+    ).toBe("");
   });
 
   test("preserves the row's other fields (e.g. its day key)", () => {
-    const [filled] = fill([row({
-      day: "3",
-      notes: "hi",
-    })]);
+    const [filled] = fill([
+      row({
+        day: "3",
+        notes: "hi",
+      }),
+    ]);
     expect(filled.day).toBe("3");
     expect(filled.notes).toBe("hi");
     expect(filled.location).toBe("https://duolingo.com");

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -68,9 +68,29 @@ export const DAY_LABELS: Record<RoutineWeekday, string> = {
   6: "Saturday",
 };
 
+// Any row-like source of the editable entry fields: a stored RoutineReferenceItem,
+// a WeeklyRow/WeeklyEntry, or the loose entry `fillAllDays` accepts. All fields
+// optional (and nullable, for the stored item), defaulting to "".
+interface EntryFieldsSource {
+  type?: WeeklyRowType | RoutineReferenceType | null;
+  id?: string | null;
+  moduleId?: string | null;
+  moduleGroupId?: string | null;
+  notes?: string | null;
+  location?: string | null;
+  prependText?: string | null;
+  appendText?: string | null;
+  title?: string | null;
+  url?: string | null;
+  sectionId?: string | null;
+  sectionLabel?: string | null;
+}
+
 // The shared editable fields of a schedule row, defaulted from an optional stored
-// entry (empty slots become blank strings). Callers add the `day` / `date` key.
-function entryRowFields(entry: RoutineReferenceItem | undefined): WeeklyEntry {
+// entry / row (empty slots become blank strings). Callers add the `day` / `date`
+// key. The single place the entry field set is enumerated — weeklyToRows,
+// curatedToRows, representativeRow, and fillAllDays all route through it.
+function entryRowFields(entry: EntryFieldsSource | undefined): WeeklyEntry {
   return {
     type: entry?.type ?? "",
     id: entry?.id ?? "",
@@ -169,66 +189,14 @@ export function rowsToWeekly(rows: WeeklyRow[]): RoutineWeekly {
 // surfaces; otherwise the controlled type <select> would snap back to "None" and
 // the item picker would never enable.
 export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
-  const found = rows.find(r => r.type !== "");
-  return found
-    ? {
-      type: found.type,
-      id: found.id,
-      moduleId: found.moduleId,
-      moduleGroupId: found.moduleGroupId,
-      notes: found.notes,
-      location: found.location,
-      prependText: found.prependText,
-      appendText: found.appendText,
-      title: found.title,
-      url: found.url,
-      sectionId: found.sectionId,
-      sectionLabel: found.sectionLabel,
-    }
-    : {
-      type: "",
-      id: "",
-      moduleId: "",
-      moduleGroupId: "",
-      notes: "",
-      location: "",
-      prependText: "",
-      appendText: "",
-      title: "",
-      url: "",
-      sectionId: "",
-      sectionLabel: "",
-    };
+  return entryRowFields(rows.find(r => r.type !== ""));
 }
 
-export function fillAllDays(entry: {
-  type: WeeklyRowType;
-  id: string;
-  moduleId?: string;
-  moduleGroupId?: string;
-  notes?: string;
-  location?: string;
-  prependText?: string;
-  appendText?: string;
-  title?: string;
-  url?: string;
-  sectionId?: string;
-  sectionLabel?: string;
-}): WeeklyRow[] {
+export function fillAllDays(entry: EntryFieldsSource): WeeklyRow[] {
+  const fields = entryRowFields(entry);
   return ALL_DAYS.map(day => ({
     day,
-    type: entry.type,
-    id: entry.id,
-    moduleId: entry.moduleId ?? "",
-    moduleGroupId: entry.moduleGroupId ?? "",
-    notes: entry.notes ?? "",
-    location: entry.location ?? "",
-    prependText: entry.prependText ?? "",
-    appendText: entry.appendText ?? "",
-    title: entry.title ?? "",
-    url: entry.url ?? "",
-    sectionId: entry.sectionId ?? "",
-    sectionLabel: entry.sectionLabel ?? "",
+    ...fields,
   }));
 }
 

--- a/packages/client/src/components/routines/weekly.ts
+++ b/packages/client/src/components/routines/weekly.ts
@@ -11,7 +11,7 @@ import type {
 // implementation is the cross-package `@emstack/types` helper the middleware shares.
 export { routineEntryName as weeklyEntryName } from "@emstack/types";
 
-export type WeeklyRowType = "" | "task" | "resource" | "freeform";
+export type WeeklyRowType = "" | "task" | "resource" | "freeform" | "bookmark";
 
 // Curated mode picks an end date at most this many days past today; the per-date
 // editor never shows more rows than that.
@@ -34,6 +34,12 @@ export interface WeeklyRow {
   // sentence. "" = nothing to prepend/append.
   prependText: string;
   appendText: string;
+  // Bookmark entries only: cached title/url + optional section narrowing.
+  // "" = none. `id` holds the external bookmarkId.
+  title: string;
+  url: string;
+  sectionId: string;
+  sectionLabel: string;
 }
 
 // A weekly entry without its day key — the shared item shape Daily Task mode
@@ -74,6 +80,10 @@ function entryRowFields(entry: RoutineReferenceItem | undefined): WeeklyEntry {
     location: entry?.location ?? "",
     prependText: entry?.prependText ?? "",
     appendText: entry?.appendText ?? "",
+    title: entry?.title ?? "",
+    url: entry?.url ?? "",
+    sectionId: entry?.sectionId ?? "",
+    sectionLabel: entry?.sectionLabel ?? "",
   };
 }
 
@@ -107,6 +117,21 @@ function referenceItemFromRow(
     }
     else if (row.moduleGroupId) {
       item.moduleGroupId = row.moduleGroupId;
+    }
+  }
+  // Bookmark entries carry their cached title/url + optional section narrowing.
+  if (type === "bookmark") {
+    if (row.title) {
+      item.title = row.title;
+    }
+    if (row.url) {
+      item.url = row.url;
+    }
+    if (row.sectionId) {
+      item.sectionId = row.sectionId;
+    }
+    if (row.sectionLabel) {
+      item.sectionLabel = row.sectionLabel;
     }
   }
   if (row.notes) {
@@ -155,6 +180,10 @@ export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
       location: found.location,
       prependText: found.prependText,
       appendText: found.appendText,
+      title: found.title,
+      url: found.url,
+      sectionId: found.sectionId,
+      sectionLabel: found.sectionLabel,
     }
     : {
       type: "",
@@ -165,6 +194,10 @@ export function representativeRow(rows: WeeklyRow[]): WeeklyEntry {
       location: "",
       prependText: "",
       appendText: "",
+      title: "",
+      url: "",
+      sectionId: "",
+      sectionLabel: "",
     };
 }
 
@@ -177,6 +210,10 @@ export function fillAllDays(entry: {
   location?: string;
   prependText?: string;
   appendText?: string;
+  title?: string;
+  url?: string;
+  sectionId?: string;
+  sectionLabel?: string;
 }): WeeklyRow[] {
   return ALL_DAYS.map(day => ({
     day,
@@ -188,6 +225,10 @@ export function fillAllDays(entry: {
     location: entry.location ?? "",
     prependText: entry.prependText ?? "",
     appendText: entry.appendText ?? "",
+    title: entry.title ?? "",
+    url: entry.url ?? "",
+    sectionId: entry.sectionId ?? "",
+    sectionLabel: entry.sectionLabel ?? "",
   }));
 }
 

--- a/packages/client/src/hooks/useRoutineDetailsForm.ts
+++ b/packages/client/src/hooks/useRoutineDetailsForm.ts
@@ -38,17 +38,25 @@ import {
 } from "@/utils";
 import { queryKeys } from "@/utils/queryKeys";
 
+const scheduleRowFields = {
+  type: z.enum(["", "task", "resource", "freeform", "bookmark"]),
+  id: z.string(),
+  moduleId: z.string(),
+  moduleGroupId: z.string(),
+  notes: z.string(),
+  location: z.string(),
+  prependText: z.string(),
+  appendText: z.string(),
+  title: z.string(),
+  url: z.string(),
+  sectionId: z.string(),
+  sectionLabel: z.string(),
+} as const;
+
 const weeklyRowSchema = z
   .object({
     day: z.enum(["0", "1", "2", "3", "4", "5", "6"]),
-    type: z.enum(["", "task", "resource", "freeform"]),
-    id: z.string(),
-    moduleId: z.string(),
-    moduleGroupId: z.string(),
-    notes: z.string(),
-    location: z.string(),
-    prependText: z.string(),
-    appendText: z.string(),
+    ...scheduleRowFields,
   })
   .refine(row => row.type === "" || row.id.length > 0, {
     message: "Required",
@@ -58,14 +66,7 @@ const weeklyRowSchema = z
 const curatedRowSchema = z
   .object({
     date: z.string(),
-    type: z.enum(["", "task", "resource", "freeform"]),
-    id: z.string(),
-    moduleId: z.string(),
-    moduleGroupId: z.string(),
-    notes: z.string(),
-    location: z.string(),
-    prependText: z.string(),
-    appendText: z.string(),
+    ...scheduleRowFields,
   })
   .refine(row => row.type === "" || row.id.length > 0, {
     message: "Required",
@@ -346,6 +347,10 @@ export function useRoutineDetailsForm(
             location: "",
             prependText: "",
             appendText: "",
+            title: "",
+            url: "",
+            sectionId: "",
+            sectionLabel: "",
           },
       ),
     );

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-TaskResourceFreeformPicker.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-TaskResourceFreeformPicker.tsx
@@ -1,12 +1,19 @@
 import type { WeeklyEntry, WeeklyRowType } from "@/components/routines/weekly";
 import type { SelectOption } from "@/utils";
+import type { ReactNode } from "react";
 
+import { BookmarkPicker } from "@/components/formFields";
 import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
 import { Combobox, ComboboxInput } from "@/components/ui/combobox";
 
 interface TaskResourceFreeformPickerProps {
   type: WeeklyRowType;
   id: string;
+  // Bookmark entries only: cached title/url + optional section narrowing.
+  title: string;
+  url: string;
+  sectionId: string;
+  sectionLabel: string;
   itemOptions: SelectOption[];
   optionsMap: Map<string, string>;
   onEmit: (patch: Partial<WeeklyEntry>) => void;
@@ -14,17 +21,105 @@ interface TaskResourceFreeformPickerProps {
   onRequestAddResource: () => void;
 }
 
-// The type selector + item picker row: a task/resource combobox or a freeform
-// text input depending on the chosen type. Internal to -WeeklyEntryEditor.
+// The type selector + item picker row: a task/resource combobox, a bookmark
+// picker, or a freeform text input depending on the chosen type. Internal to
+// -WeeklyEntryEditor.
 export function TaskResourceFreeformPicker({
   type,
   id,
+  title,
+  url,
+  sectionId,
+  sectionLabel,
   itemOptions,
   optionsMap,
   onEmit,
   onInputValueChange,
   onRequestAddResource,
 }: TaskResourceFreeformPickerProps) {
+  let itemControl: ReactNode;
+  if (type === "freeform") {
+    itemControl = (
+      <input
+        aria-label="Daily task description"
+        value={id}
+        onChange={e =>
+          onEmit({
+            id: e.target.value,
+          })}
+        placeholder="Describe the activity…"
+        className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
+      />
+    );
+  }
+  else if (type === "bookmark") {
+    // Single-slot bookmark: reuse the multi-select picker, keeping only the
+    // most-recently chosen bookmark (an entry is one item).
+    itemControl = (
+      <BookmarkPicker
+        value={id
+          ? [{
+            bookmarkId: id,
+            title,
+            url: url || null,
+            sectionId: sectionId || null,
+            sectionLabel: sectionLabel || null,
+          }]
+          : []}
+        onChange={(next) => {
+          const last = next[next.length - 1];
+          onEmit(
+            last
+              ? {
+                id: last.bookmarkId,
+                title: last.title,
+                url: last.url ?? "",
+                sectionId: last.sectionId ?? "",
+                sectionLabel: last.sectionLabel ?? "",
+              }
+              : {
+                id: "",
+                title: "",
+                url: "",
+                sectionId: "",
+                sectionLabel: "",
+              },
+          );
+        }}
+      />
+    );
+  }
+  else {
+    itemControl = (
+      <Combobox
+        items={itemOptions.map(o => o.value)}
+        value={id || null}
+        onValueChange={val =>
+          onEmit({
+            id: val ?? "",
+          })}
+        onInputValueChange={val => onInputValueChange(val)}
+        itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
+      >
+        <ComboboxInput
+          placeholder={
+            type === "task"
+              ? "Search tasks..."
+              : type === "resource"
+                ? "Search resources..."
+                : "Pick a type first"
+          }
+          showClear
+          disabled={!type}
+        />
+        <TaskResourceComboboxContent
+          optionsMap={optionsMap}
+          onAddNew={type === "resource" ? onRequestAddResource : undefined}
+        />
+      </Combobox>
+    );
+  }
+
   return (
     <div className="grid grid-cols-[140px_1fr] items-center gap-2">
       <select
@@ -32,7 +127,7 @@ export function TaskResourceFreeformPicker({
         value={type}
         onChange={e =>
           // Changing the type clears the chosen item (different option set)
-          // and any note/location/prepend/append.
+          // and any note/location/prepend/append/bookmark fields.
           onEmit({
             type: e.target.value as WeeklyRowType,
             id: "",
@@ -40,58 +135,21 @@ export function TaskResourceFreeformPicker({
             location: "",
             prependText: "",
             appendText: "",
+            title: "",
+            url: "",
+            sectionId: "",
+            sectionLabel: "",
           })}
         className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
       >
         <option value="">— None —</option>
         <option value="task">Task</option>
         <option value="resource">Resource</option>
+        <option value="bookmark">Bookmark</option>
         <option value="freeform">Freeform</option>
       </select>
 
-      {type === "freeform"
-        ? (
-          <input
-            aria-label="Daily task description"
-            value={id}
-            onChange={e =>
-              onEmit({
-                id: e.target.value,
-              })}
-            placeholder="Describe the activity…"
-            className="
-              flex h-9 w-full rounded-md border bg-background px-2 text-sm
-            "
-          />
-        )
-        : (
-          <Combobox
-            items={itemOptions.map(o => o.value)}
-            value={id || null}
-            onValueChange={val =>
-              onEmit({
-                id: val ?? "",
-              })}
-            onInputValueChange={val => onInputValueChange(val)}
-            itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-          >
-            <ComboboxInput
-              placeholder={
-                type === "task"
-                  ? "Search tasks..."
-                  : type === "resource"
-                    ? "Search resources..."
-                    : "Pick a type first"
-              }
-              showClear
-              disabled={!type}
-            />
-            <TaskResourceComboboxContent
-              optionsMap={optionsMap}
-              onAddNew={type === "resource" ? onRequestAddResource : undefined}
-            />
-          </Combobox>
-        )}
+      {itemControl}
     </div>
   );
 }

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-TaskResourceFreeformPicker.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-TaskResourceFreeformPicker.tsx
@@ -1,10 +1,7 @@
 import type { WeeklyEntry, WeeklyRowType } from "@/components/routines/weekly";
 import type { SelectOption } from "@/utils";
-import type { ReactNode } from "react";
 
-import { BookmarkPicker } from "@/components/formFields";
-import { TaskResourceComboboxContent } from "@/components/routines/TaskResourceComboboxContent";
-import { Combobox, ComboboxInput } from "@/components/ui/combobox";
+import { ScheduleItemControl } from "@/components/routines/ScheduleItemControl";
 
 interface TaskResourceFreeformPickerProps {
   type: WeeklyRowType;
@@ -21,9 +18,9 @@ interface TaskResourceFreeformPickerProps {
   onRequestAddResource: () => void;
 }
 
-// The type selector + item picker row: a task/resource combobox, a bookmark
-// picker, or a freeform text input depending on the chosen type. Internal to
-// -WeeklyEntryEditor.
+// The type selector + item picker row for Daily-mode: the value control is the
+// shared ScheduleItemControl (task/resource combobox, bookmark picker, or
+// freeform input). Internal to -WeeklyEntryEditor.
 export function TaskResourceFreeformPicker({
   type,
   id,
@@ -37,89 +34,6 @@ export function TaskResourceFreeformPicker({
   onInputValueChange,
   onRequestAddResource,
 }: TaskResourceFreeformPickerProps) {
-  let itemControl: ReactNode;
-  if (type === "freeform") {
-    itemControl = (
-      <input
-        aria-label="Daily task description"
-        value={id}
-        onChange={e =>
-          onEmit({
-            id: e.target.value,
-          })}
-        placeholder="Describe the activity…"
-        className="flex h-9 w-full rounded-md border bg-background px-2 text-sm"
-      />
-    );
-  }
-  else if (type === "bookmark") {
-    // Single-slot bookmark: reuse the multi-select picker, keeping only the
-    // most-recently chosen bookmark (an entry is one item).
-    itemControl = (
-      <BookmarkPicker
-        value={id
-          ? [{
-            bookmarkId: id,
-            title,
-            url: url || null,
-            sectionId: sectionId || null,
-            sectionLabel: sectionLabel || null,
-          }]
-          : []}
-        onChange={(next) => {
-          const last = next[next.length - 1];
-          onEmit(
-            last
-              ? {
-                id: last.bookmarkId,
-                title: last.title,
-                url: last.url ?? "",
-                sectionId: last.sectionId ?? "",
-                sectionLabel: last.sectionLabel ?? "",
-              }
-              : {
-                id: "",
-                title: "",
-                url: "",
-                sectionId: "",
-                sectionLabel: "",
-              },
-          );
-        }}
-      />
-    );
-  }
-  else {
-    itemControl = (
-      <Combobox
-        items={itemOptions.map(o => o.value)}
-        value={id || null}
-        onValueChange={val =>
-          onEmit({
-            id: val ?? "",
-          })}
-        onInputValueChange={val => onInputValueChange(val)}
-        itemToStringLabel={(val: string) => optionsMap.get(val) ?? ""}
-      >
-        <ComboboxInput
-          placeholder={
-            type === "task"
-              ? "Search tasks..."
-              : type === "resource"
-                ? "Search resources..."
-                : "Pick a type first"
-          }
-          showClear
-          disabled={!type}
-        />
-        <TaskResourceComboboxContent
-          optionsMap={optionsMap}
-          onAddNew={type === "resource" ? onRequestAddResource : undefined}
-        />
-      </Combobox>
-    );
-  }
-
   return (
     <div className="grid grid-cols-[140px_1fr] items-center gap-2">
       <select
@@ -149,7 +63,20 @@ export function TaskResourceFreeformPicker({
         <option value="freeform">Freeform</option>
       </select>
 
-      {itemControl}
+      <ScheduleItemControl
+        ariaPrefix="Daily task"
+        type={type}
+        id={id}
+        title={title}
+        url={url}
+        sectionId={sectionId}
+        sectionLabel={sectionLabel}
+        itemOptions={itemOptions}
+        optionsMap={optionsMap}
+        onChange={onEmit}
+        onInputValueChange={onInputValueChange}
+        onAddResource={onRequestAddResource}
+      />
     </div>
   );
 }

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-WeeklyEntryEditor.tsx
@@ -2,10 +2,7 @@ import type { WeeklyEntryEditorProps } from "./-useWeeklyEntryEditor";
 
 import { ActionableSentencePreview } from "./-ActionableSentencePreview";
 import { TaskResourceFreeformPicker } from "./-TaskResourceFreeformPicker";
-import {
-  useWeeklyEntryEditor,
-
-} from "./-useWeeklyEntryEditor";
+import { useWeeklyEntryEditor } from "./-useWeeklyEntryEditor";
 
 import { QuickAddResourceDialog } from "@/components/dialogs/quickAdd/QuickAddResourceDialog";
 
@@ -16,7 +13,16 @@ import { QuickAddResourceDialog } from "@/components/dialogs/quickAdd/QuickAddRe
 // and derivations live in -useWeeklyEntryEditor.
 export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
   const {
-    type, id, notes, location, prependText, appendText,
+    type,
+    id,
+    notes,
+    location,
+    prependText,
+    appendText,
+    title,
+    url,
+    sectionId,
+    sectionLabel,
   } = props;
   const {
     itemOptions,
@@ -40,6 +46,10 @@ export function WeeklyEntryEditor(props: WeeklyEntryEditorProps) {
       <TaskResourceFreeformPicker
         type={type}
         id={id}
+        title={title}
+        url={url}
+        sectionId={sectionId}
+        sectionLabel={sectionLabel}
         itemOptions={itemOptions}
         optionsMap={optionsMap}
         onEmit={emit}

--- a/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
+++ b/packages/client/src/routes/routines/$id/edit/-components/weekly-entry/-useWeeklyEntryEditor.ts
@@ -30,6 +30,10 @@ export function useWeeklyEntryEditor({
   location,
   prependText,
   appendText,
+  title,
+  url,
+  sectionId,
+  sectionLabel,
   onChange,
   taskOptions,
   resourceOptions,
@@ -55,6 +59,10 @@ export function useWeeklyEntryEditor({
       location,
       prependText,
       appendText,
+      title,
+      url,
+      sectionId,
+      sectionLabel,
       ...patch,
     });
   }
@@ -74,7 +82,12 @@ export function useWeeklyEntryEditor({
     [],
   );
 
-  const itemName = type === "freeform" ? id : (optionsMap.get(id) ?? "");
+  const itemName
+    = type === "freeform"
+      ? id
+      : type === "bookmark"
+        ? title || id
+        : (optionsMap.get(id) ?? "");
   const showPreview
     = !!itemName && (!!prependText.trim() || !!appendText.trim());
   const preview = buildActionableSentence({

--- a/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.stories.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.stories.tsx
@@ -14,14 +14,6 @@ const meta: Meta<typeof TodoEditRow> = {
     todo: makeTaskTodo({
       name: "Read the introduction",
     }),
-    resourceOptions: [
-      {
-        id: "resource-1",
-        name: "Starter repo",
-      },
-    ],
-    moduleGroups: [],
-    modules: [],
     isSaving: false,
     onSave: fn(),
     onCancel: fn(),

--- a/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoEditRow.tsx
@@ -1,4 +1,4 @@
-import type { Module, ModuleGroup, TaskTodo } from "@emstack/types";
+import type { TaskTodo } from "@emstack/types";
 
 import { useState } from "react";
 
@@ -19,10 +19,6 @@ import { TEXT_MAX_LENGTH } from "@/constants/stringLimits";
 
 interface TodoEditRowProps {
   todo: TaskTodo;
-  resourceOptions: { id: string;
-    name: string; }[];
-  moduleGroups: ModuleGroup[];
-  modules: Module[];
   isNew?: boolean;
   isSaving: boolean;
   onSave: (todo: TaskTodo) => void;
@@ -30,21 +26,10 @@ interface TodoEditRowProps {
   onDelete?: () => void;
 }
 
-const NO_RESOURCE = "__none";
-
-const selectClass = `
-  flex h-9 w-full rounded-md border bg-background px-2 text-sm
-  disabled:cursor-not-allowed disabled:opacity-50
-`;
-
-// Inline editor for a single todo: name, status, due date, an optional resource
-// link (with module-group / module narrowing), location and url. Mirrors a
-// Curated Routine entry's editing shape.
+// Inline editor for a single todo: name, status, due date, associated
+// bookmarks (with optional section narrowing), location and url.
 export function TodoEditRow({
   todo,
-  resourceOptions,
-  moduleGroups,
-  modules,
   isNew = false,
   isSaving,
   onSave,
@@ -59,19 +44,6 @@ export function TodoEditRow({
       ...next,
     }));
   }
-
-  const groupsForResource = draft.resourceId
-    ? moduleGroups.filter(g => g.resourceId === draft.resourceId)
-    : [];
-  const modulesForRow = !draft.resourceId
-    ? []
-    : draft.moduleGroupId
-      ? modules.filter(
-        m =>
-          m.resourceId === draft.resourceId
-          && m.moduleGroupId === draft.moduleGroupId,
-      )
-      : modules.filter(m => m.resourceId === draft.resourceId);
 
   function handleSave() {
     const name = draft.name.trim();
@@ -159,93 +131,6 @@ export function TodoEditRow({
             className="w-40"
           />
         </div>
-      </div>
-
-      <div
-        className="
-          grid grid-cols-1 gap-2
-          sm:grid-cols-3
-        "
-      >
-        <select
-          aria-label="Resource"
-          value={draft.resourceId ?? NO_RESOURCE}
-          onChange={(e) => {
-            const value = e.target.value;
-            patch({
-              resourceId: value === NO_RESOURCE ? null : value,
-              moduleGroupId: null,
-              moduleId: null,
-            });
-          }}
-          disabled={isSaving}
-          className={selectClass}
-        >
-          <option value={NO_RESOURCE}>— No resource —</option>
-          {resourceOptions.map(r => (
-            <option
-              key={r.id}
-              value={r.id}
-            >
-              {r.name}
-            </option>
-          ))}
-        </select>
-
-        <select
-          aria-label="Module Group"
-          value={draft.moduleGroupId ?? ""}
-          onChange={(e) => {
-            const nextGroupId = e.target.value || null;
-            patch({
-              moduleGroupId: nextGroupId,
-              moduleId:
-                draft.moduleId
-                && nextGroupId
-                && !modules.some(
-                  m =>
-                    m.id === draft.moduleId && m.moduleGroupId === nextGroupId,
-                )
-                  ? null
-                  : draft.moduleId,
-            });
-          }}
-          disabled={
-            isSaving || !draft.resourceId || groupsForResource.length === 0
-          }
-          className={selectClass}
-        >
-          <option value="">— Any group —</option>
-          {groupsForResource.map(g => (
-            <option
-              key={g.id}
-              value={g.id}
-            >
-              {g.name}
-            </option>
-          ))}
-        </select>
-
-        <select
-          aria-label="Module"
-          value={draft.moduleId ?? ""}
-          onChange={e =>
-            patch({
-              moduleId: e.target.value || null,
-            })}
-          disabled={isSaving || !draft.resourceId || modulesForRow.length === 0}
-          className={selectClass}
-        >
-          <option value="">— Any module —</option>
-          {modulesForRow.map(m => (
-            <option
-              key={m.id}
-              value={m.id}
-            >
-              {m.name}
-            </option>
-          ))}
-        </select>
       </div>
 
       <div

--- a/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
@@ -2,7 +2,7 @@ import type { Task, TaskTodo } from "@emstack/types";
 
 import { useMemo, useState } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ExternalLinkIcon, PencilIcon, PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 
@@ -13,22 +13,15 @@ import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
 import { toTodoInput } from "@/components/tasks/todoPayload";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  fetchModuleGroups,
-  fetchModules,
-  fetchResources,
-  upsertTask,
-} from "@/utils";
-import { queryKeys } from "@/utils/queryKeys";
+import { upsertTask } from "@/utils";
 import { uuidv4 } from "@/utils/uuid";
 
 interface TodosEditorProps {
   task: Task;
 }
 
-// The merged To-Do editor: each todo carries a status, an optional due date, an
-// optional linked resource (with narrowing) and a note — replacing the old
-// separate To-Do's checklist and Resources table.
+// The To-Do editor: each todo carries a status, an optional due date, a note,
+// and associated bookmarks (with optional section narrowing).
 export function TodosEditor({
   task,
 }: TodosEditorProps) {
@@ -49,36 +42,6 @@ export function TodosEditor({
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftNew, setDraftNew] = useState<TaskTodo | null>(null);
-
-  const {
-    data: resources,
-  } = useQuery({
-    queryKey: queryKeys.resources.list(),
-    queryFn: () => fetchResources(),
-  });
-  const {
-    data: moduleGroups,
-  } = useQuery({
-    queryKey: ["module-groups-all"],
-    queryFn: () => fetchModuleGroups(),
-  });
-  const {
-    data: modules,
-  } = useQuery({
-    queryKey: ["modules-all"],
-    queryFn: () => fetchModules(),
-  });
-
-  const resourceOptions = useMemo(
-    () =>
-      [...(resources ?? [])]
-        .map(r => ({
-          id: r.id,
-          name: r.name,
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [resources],
-  );
 
   const mutation = useMutation({
     mutationFn: (nextTodos: TaskTodo[]) =>
@@ -183,9 +146,6 @@ export function TodosEditor({
             <TodoEditRow
               key={draftNew.id}
               todo={draftNew}
-              resourceOptions={resourceOptions}
-              moduleGroups={moduleGroups ?? []}
-              modules={modules ?? []}
               isNew
               isSaving={mutation.isPending}
               onSave={saveNew}
@@ -198,9 +158,6 @@ export function TodosEditor({
                 <TodoEditRow
                   key={todo.id}
                   todo={todo}
-                  resourceOptions={resourceOptions}
-                  moduleGroups={moduleGroups ?? []}
-                  modules={modules ?? []}
                   isSaving={mutation.isPending}
                   onSave={saveEdit}
                   onCancel={() => setEditingId(null)}
@@ -209,10 +166,6 @@ export function TodosEditor({
               );
             }
             const statusOption = getDailyStatusOption(todo.status);
-            const linkedResource
-              = todo.resource
-                ?? resourceOptions.find(r => r.id === todo.resourceId)
-                ?? null;
             return (
               <li
                 key={todo.id}
@@ -241,18 +194,6 @@ export function TodosEditor({
                       className="bg-muted/40"
                     >
                       due {todo.dueDate}
-                    </Badge>
-                  )}
-                  {linkedResource && (
-                    <Badge
-                      variant="outline"
-                      className="
-                        border-blue-200 bg-blue-50 text-blue-900
-                        dark:border-blue-900/50 dark:bg-blue-950/40
-                        dark:text-blue-200
-                      "
-                    >
-                      {linkedResource.name}
                     </Badge>
                   )}
                   {(todo.bookmarks ?? []).map(b => (

--- a/packages/middleware/src/utils/routineActionParts.ts
+++ b/packages/middleware/src/utils/routineActionParts.ts
@@ -47,6 +47,10 @@ function resolveBaseName(
   entry: RoutineReferenceItem | null,
   resolved: ResolvedConnections,
 ): string | null {
+  // External bookmark: the cached title is on the entry (nothing to resolve).
+  if (entry?.type === "bookmark") {
+    return entry.title ?? entry.id;
+  }
   if (resolved.resource) {
     return resourceEntryLabel({
       resourceName: resolved.resource.name,

--- a/packages/middleware/src/utils/routineWeekday.ts
+++ b/packages/middleware/src/utils/routineWeekday.ts
@@ -115,15 +115,17 @@ export function entryToCompletionParts(
   const name
     = entry.type === "freeform"
       ? entry.id
-      : entry.type === "task"
-        ? taskNames.get(entry.id) ?? entry.id
-        : resourceEntryLabel({
-          resourceName: resourceNames.get(entry.id) ?? entry.id,
-          moduleName: entry.moduleId ? moduleNames.get(entry.moduleId) : null,
-          groupName: entry.moduleGroupId
-            ? moduleGroupNames.get(entry.moduleGroupId)
-            : null,
-        });
+      : entry.type === "bookmark"
+        ? entry.title ?? entry.id
+        : entry.type === "task"
+          ? taskNames.get(entry.id) ?? entry.id
+          : resourceEntryLabel({
+            resourceName: resourceNames.get(entry.id) ?? entry.id,
+            moduleName: entry.moduleId ? moduleNames.get(entry.moduleId) : null,
+            groupName: entry.moduleGroupId
+              ? moduleGroupNames.get(entry.moduleGroupId)
+              : null,
+          });
   return {
     prependText: entry.prependText ?? null,
     name,

--- a/packages/middleware/src/utils/schemas.ts
+++ b/packages/middleware/src/utils/schemas.ts
@@ -57,7 +57,7 @@ const routineReferenceItemSchema = {
   properties: {
     type: {
       type: "string",
-      enum: ["task", "resource", "freeform"],
+      enum: ["task", "resource", "freeform", "bookmark"],
     },
     id: {
       type: "string",
@@ -70,6 +70,11 @@ const routineReferenceItemSchema = {
     location: nullableString,
     prependText: nullableString,
     appendText: nullableString,
+    // Bookmark entries only: cached title/url + optional section narrowing.
+    title: nullableString,
+    url: nullableString,
+    sectionId: nullableString,
+    sectionLabel: nullableString,
   },
 } as const;
 
@@ -208,7 +213,7 @@ export const completionSchema = {
       properties: {
         type: {
           type: "string",
-          enum: ["task", "resource", "freeform"],
+          enum: ["task", "resource", "freeform", "bookmark"],
         },
         id: {
           type: "string",

--- a/packages/types/src/Routine.ts
+++ b/packages/types/src/Routine.ts
@@ -1,7 +1,7 @@
 import type { DailyCompletion, DailyCriteria } from "./Daily";
 import type { EntityStatus } from "./EntityStatus";
 
-export type RoutineReferenceType = "task" | "resource" | "freeform";
+export type RoutineReferenceType = "task" | "resource" | "freeform" | "bookmark";
 
 // A routine can be connected to any number of these entity kinds. The
 // connection is the routine's categorical link (what it's "about"); it is
@@ -50,6 +50,14 @@ export interface RoutineReferenceItem {
   // means the name stands alone.
   prependText?: string | null;
   appendText?: string | null;
+  // Bookmark entries (type === "bookmark") only. A bookmark is external (no
+  // loadable entity), so its display title/url are cached on the entry; `id` is
+  // the external bookmarkId. Optional section narrowing mirrors the resource
+  // module narrowing above.
+  title?: string | null;
+  url?: string | null;
+  sectionId?: string | null;
+  sectionLabel?: string | null;
 }
 
 // Day-of-week keys follow Date.getDay(): "0" = Sunday ... "6" = Saturday.

--- a/packages/types/src/routineEntryName.ts
+++ b/packages/types/src/routineEntryName.ts
@@ -17,6 +17,10 @@ export function routineEntryName(
   if (entry.type === "freeform") {
     return entry.id;
   }
+  if (entry.type === "bookmark") {
+    // External bookmark: no id→name map; the cached title lives on the entry.
+    return entry.title ?? entry.id;
+  }
   if (entry.type === "task") {
     return taskNames.get(entry.id) ?? entry.id;
   }


### PR DESCRIPTION
Two bookmark refinements found while dogfooding the deployed app. Two commits:

## 1. Todos associate with bookmarks, not resources
The bookmark + section picker (from the earlier increments) is now the primary link on todos, so the resource + module-narrowing selects are removed from the todo editor and the read-row resource badge is dropped. The `task_todos` resource columns stay in the DB (hidden) and go with the eventual Resource removal.

## 2. Schedule bookmarks in routine weekly/curated entries
Adds `"bookmark"` as a `RoutineReferenceType`, so a **weekly**, **curated**, or **Daily-mode** schedule entry can be a Simple Bookmarks bookmark alongside task/resource/freeform.

- **types**: `RoutineReferenceItem` gains cached `title`/`url`/`sectionId`/`sectionLabel` (a bookmark is external — no id→name lookup); `routineEntryName` resolves the cached title.
- **middleware**: the reference-item and completion `entryRef` JSON-schemas gain `"bookmark"`; completion-parts baking (`routineWeekday`) and the action-parts projection (`routineActionParts`) use the cached title — the two silent-fallthrough sites that would otherwise mis-render a bookmark as a resource.
- **client**: `weekly.ts` row model + zod row schemas carry the fields; `ScheduleEntryRow` and the Daily-mode picker gain a **Bookmark** type backed by a single-slot `BookmarkPicker` (with its live section dropdown); `RoutineEntryLabel` links bookmark entries out (`Title › Section`).

## Verification
- ✅ `pnpm typecheck` (all), `pnpm lint` (0 errors)
- ✅ middleware tests (84), client unit (469), affected Storybook stories (27)
- ⏳ **Needs Docker + the Pi's Simple Bookmarks:** `pnpm push:dev` is additive (new nullable columns only, no migration). Then: on a task, edit a todo and confirm only the bookmark picker shows (no resource select); on a routine, set a weekly/curated/daily entry to a bookmark and confirm it renders + links out in the schedule and daily tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)