### PR TITLE
feat(dashboard): surface bookmark reading progress in the Do Now card

### DIFF
--- a/packages/client/src/components/dailies/DailyProgressCell.stories.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.stories.tsx
@@ -34,3 +34,37 @@ export const DailyDrills: Story = {
     daily: makeDaily({}),
   },
 };
+
+// Bookmark path: reading progress from Simple Bookmarks drives the ring.
+export const BookmarkProgress: Story = {
+  args: {
+    daily: makeDaily({
+      bookmarkProgress: {
+        current: 45,
+        total: 320,
+        title: "Kubernetes for Developers",
+      },
+    }),
+  },
+};
+
+// Bookmark progress takes precedence over task to-do progress.
+export const BookmarkOverTask: Story = {
+  args: {
+    daily: makeDaily({
+      task: {
+        id: "t1",
+        name: "Build the widget",
+        progress: {
+          todosTotal: 3,
+          todosComplete: 2,
+        },
+      },
+      bookmarkProgress: {
+        current: 10,
+        total: 40,
+        title: "Practical IoT Hacking",
+      },
+    }),
+  },
+};

--- a/packages/client/src/components/dailies/DailyProgressCell.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.tsx
@@ -87,6 +87,32 @@ function HoverProgressPopover({
 export function DailyProgressCell({
   daily,
 }: DailyProgressCellProps) {
+  const bookmarkProgress = daily.bookmarkProgress;
+
+  // Bookmark reading progress takes precedence: when the daily's active
+  // bookmark tracks progress in Simple Bookmarks, show how far through the
+  // material we are instead of the task's to-do completion.
+  if (bookmarkProgress) {
+    const {
+      current, total, title,
+    } = bookmarkProgress;
+    const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+    return (
+      <HoverProgressPopover
+        ariaLabel={`Bookmark progress ${percent}%`}
+        current={current}
+        total={total}
+      >
+        <div className="flex flex-col gap-1 text-sm">
+          <div className="font-medium">{title}</div>
+          <div className="text-muted-foreground">
+            {total > 0 ? `${current} / ${total} (${percent}%)` : "No progress yet"}
+          </div>
+        </div>
+      </HoverProgressPopover>
+    );
+  }
+
   const taskProgress = daily.task?.progress;
 
   if (taskProgress) {

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -1,6 +1,7 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
 import { db } from "@/db";
+import { getBookmarkProgress } from "@/services/bookmarks";
 import { nullableRoutineModeEnum } from "@/utils/schemas";
 import { resolveRoutineConnections } from "@/utils/resolveRoutineConnections";
 import {
@@ -65,8 +66,13 @@ export default async function (server: FastifyInstance) {
     const dateKey = currentDateKey();
 
     // Batch-resolve every active task id up front to avoid N+1. (Bookmark and
-    // freeform entries carry their own display label on the entry.)
+    // freeform entries carry their own display label on the entry.) In the same
+    // pass, note each routine's "active bookmark" — today's scheduled bookmark
+    // entry, else the routine's first bookmark connection — so we can enrich it
+    // with reading progress from Simple Bookmarks below.
     const taskIds: string[] = [];
+    const activeBookmarkByRoutine = new Map<string, { id: string;
+      title: string; }>();
     for (const routine of withConnections) {
       const entry = entryForCompletionDate(
         routine.mode,
@@ -76,6 +82,21 @@ export default async function (server: FastifyInstance) {
       );
       if (entry?.type === "task") {
         taskIds.push(entry.id);
+      }
+      if (entry?.type === "bookmark") {
+        activeBookmarkByRoutine.set(routine.id, {
+          id: entry.id,
+          title: entry.title?.trim() || "Bookmark",
+        });
+      }
+      else {
+        const connection = routine.connections.find(c => c.type === "bookmark");
+        if (connection) {
+          activeBookmarkByRoutine.set(routine.id, {
+            id: connection.id,
+            title: connection.name?.trim() || "Bookmark",
+          });
+        }
       }
     }
 
@@ -101,6 +122,13 @@ export default async function (server: FastifyInstance) {
 
     const taskMap = new Map(taskRows.map(t => [t.id, t]));
 
+    // Enrich active bookmarks with reading progress in a single call (best
+    // effort — an unreachable Simple Bookmarks yields an empty map and the
+    // dailies still render, falling back to task/infinity progress).
+    const progressMap = await getBookmarkProgress(
+      [...new Set([...activeBookmarkByRoutine.values()].map(b => b.id))],
+    );
+
     return withConnections.map((routine) => {
       const entry = entryForCompletionDate(
         routine.mode,
@@ -111,9 +139,21 @@ export default async function (server: FastifyInstance) {
       const task = entry?.type === "task"
         ? taskMap.get(entry.id) ?? null
         : null;
-      return mapRoutineToDaily(routine as RoutineRow, {
+      const daily = mapRoutineToDaily(routine as RoutineRow, {
         task,
       }, dateKey);
+
+      const activeBookmark = activeBookmarkByRoutine.get(routine.id);
+      const progress = activeBookmark && progressMap.get(activeBookmark.id);
+      daily.bookmarkProgress = progress
+        ? {
+          current: progress.current,
+          total: progress.total,
+          title: activeBookmark.title,
+        }
+        : null;
+
+      return daily;
     });
   });
 }

--- a/packages/middleware/src/services/bookmarks.ts
+++ b/packages/middleware/src/services/bookmarks.ts
@@ -24,6 +24,10 @@ interface RawBookmark {
   id: string;
   title?: string | null;
   url?: string | null;
+  // Numeric progress custom-properties (e.g. page 45 of 320). In practice a
+  // bookmark carries at most one, so consumers read progressValues[0].
+  progressValues?: { current: number;
+    total: number; }[] | null;
 }
 
 // The subset of GET /api/bookmarks/url-check we consume: the exact / path match
@@ -82,6 +86,47 @@ export async function searchBookmarks(
     : mapped;
 
   return matches.slice(0, limit);
+}
+
+/**
+ * Fetch numeric reading progress for a set of bookmark ids, keyed by id. Reuses
+ * the single full-list endpoint (Simple Bookmarks has no batch-by-id lookup and
+ * the library is bounded) and keeps only bookmarks that have progress. Best
+ * effort: any failure (unreachable app, bad response) resolves to an empty map
+ * so callers — the dashboard's daily projection — still render without it.
+ */
+export async function getBookmarkProgress(
+  ids: string[],
+): Promise<Map<string, { current: number;
+  total: number; }>> {
+  const progress = new Map<string, { current: number;
+    total: number; }>();
+  if (ids.length === 0) {
+    return progress;
+  }
+
+  const wanted = new Set(ids);
+  try {
+    const response = await bookmarksFetch("/api/bookmarks");
+    assertOk(response);
+    const all = (await response.json()) as RawBookmark[];
+    for (const bookmark of all) {
+      if (!wanted.has(bookmark.id)) continue;
+      const value = bookmark.progressValues?.[0];
+      if (value) {
+        progress.set(bookmark.id, {
+          current: value.current,
+          total: value.total,
+        });
+      }
+    }
+  }
+  catch {
+    // Simple Bookmarks unreachable or malformed — degrade to no progress.
+    return new Map();
+  }
+
+  return progress;
 }
 
 /** Resolve a URL to an already-saved bookmark, or null if none exists. */

--- a/packages/middleware/src/tests/bookmarksProgress.test.ts
+++ b/packages/middleware/src/tests/bookmarksProgress.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert";
+import { afterEach, test } from "node:test";
+
+import { getBookmarkProgress } from "../services/bookmarks.ts";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// Stub the single GET /api/bookmarks the service issues with a canned list.
+function stubBookmarks(all: unknown[]): { calls: number } {
+  const state = {
+    calls: 0,
+  };
+  globalThis.fetch = (async () => {
+    state.calls += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => all,
+    } as Response;
+  }) as typeof fetch;
+  return state;
+}
+
+test("getBookmarkProgress maps requested ids and drops bookmarks without progress", async () => {
+  stubBookmarks([
+    {
+      id: "a",
+      progressValues: [{
+        current: 45,
+        total: 320,
+      }],
+    },
+    // Requested but has no progress — omitted from the map.
+    {
+      id: "b",
+      progressValues: [],
+    },
+    // Has progress but was not requested — ignored.
+    {
+      id: "c",
+      progressValues: [{
+        current: 1,
+        total: 2,
+      }],
+    },
+  ]);
+
+  const map = await getBookmarkProgress(["a", "b"]);
+
+  assert.deepStrictEqual(map.get("a"), {
+    current: 45,
+    total: 320,
+  });
+  assert.strictEqual(map.has("b"), false);
+  assert.strictEqual(map.has("c"), false);
+  assert.strictEqual(map.size, 1);
+});
+
+test("getBookmarkProgress returns an empty map without fetching for no ids", async () => {
+  const state = stubBookmarks([]);
+  const map = await getBookmarkProgress([]);
+  assert.strictEqual(map.size, 0);
+  assert.strictEqual(state.calls, 0);
+});
+
+test("getBookmarkProgress degrades to an empty map when Simple Bookmarks is unreachable", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as typeof fetch;
+
+  const map = await getBookmarkProgress(["a"]);
+  assert.strictEqual(map.size, 0);
+});

--- a/packages/types/src/Daily.ts
+++ b/packages/types/src/Daily.ts
@@ -59,6 +59,17 @@ export interface DailyTaskProgress {
   todosComplete: number;
 }
 
+// Numeric reading/watching progress pulled from the companion Simple Bookmarks
+// app for the daily's active bookmark (today's scheduled bookmark entry, else
+// the routine's first bookmark connection). `current`/`total` come from the
+// bookmark's progressValues; `title` is the cached bookmark title for display.
+// Absent/null when the item has no bookmark or that bookmark has no progress.
+export interface DailyBookmarkProgress {
+  current: number;
+  total: number;
+  title: string;
+}
+
 export interface Daily {
   id: string;
   name: string;
@@ -94,6 +105,11 @@ export interface Daily {
     name: string;
     progress?: DailyTaskProgress;
   } | null;
+  // Reading/watching progress for the daily's active bookmark, fetched from
+  // Simple Bookmarks at projection time. When present it drives the tracker's
+  // Progress ring in place of task to-do progress; null when there's no linked
+  // bookmark or it has no tracked progress. Absent on non-routine dailies.
+  bookmarkProgress?: DailyBookmarkProgress | null;
   // Per-weekday scheduled grid (unresolved names). Present only on weekly-mode
   // routine projections; absent/null for daily-mode dailies.
   weekly?: RoutineWeekly | null;


### PR DESCRIPTION
## ELI5
The Do Now card on the dashboard shows a little progress ring next to each thing you plan to do. Until now that ring only counted checklist items. If the thing is a book or article you saved in the companion Bookmarks app, the ring now shows how far through it you actually are — so you can see at a glance that you're, say, on page 45 of 320.

## Summary
- Pull each Do Now item's active bookmark (today's scheduled entry, else the routine's first bookmark connection) and fetch its `current/total` reading progress from Simple Bookmarks in one best-effort call.
- Bookmark progress takes precedence over to-do progress in the Progress ring; falls back to the existing to-do ring / infinity icon when there's no bookmark or no tracked progress.
- Graceful degradation: an unreachable Bookmarks app yields no enrichment, so the dashboard still loads.
- New `Daily.bookmarkProgress` shared type; `getBookmarkProgress` service with unit tests; two new `DailyProgressCell` stories.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] Middleware tests (incl. new `bookmarksProgress.test.ts`: mapping, empty-ids, outage fallback) — 93/93
- [x] Full client Vitest suite (incl. new bookmark stories) — 633/633
- [ ] Manual: link a bookmark with progress (e.g. Kubernetes 0/320) as a routine's scheduled entry → Do Now row shows the bookmark ring; hover popover reads title + `0 / 320 (0%)`
- [ ] Manual: routine with task+todos but no bookmark still shows the to-do ring; plain Daily-Drills still shows the infinity icon
- [ ] Manual: point `BOOKMARKS_API_URL` at an unreachable host → dashboard still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)