### PR TITLE
fix: drive routine progress from today's scheduled bookmark entry

### DIFF
--- a/packages/client/src/components/dailies/DailyProgressCell.stories.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { expect, within } from "storybook/test";
+
 import { DailyProgressCell } from "./DailyProgressCell";
 
 import { makeDaily } from "@/test-utils/dailiesFixtures";
@@ -45,6 +47,31 @@ export const BookmarkProgress: Story = {
         title: "Kubernetes for Developers",
       },
     }),
+  },
+};
+
+// A bookmark with no real progress (zero total) is not a ring: it falls
+// through to the infinity ("Daily Drills") icon, never an empty progress bar.
+export const BookmarkNoProgress: Story = {
+  args: {
+    daily: makeDaily({
+      bookmarkProgress: {
+        current: 0,
+        total: 0,
+        title: "Untracked Bookmark",
+      },
+    }),
+  },
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // No reading-progress ring — the bookmark branch is skipped for a zero total.
+    await expect(
+      canvas.queryByRole("button", {
+        name: /bookmark progress/i,
+      }),
+    ).toBeNull();
   },
 };
 

--- a/packages/client/src/components/dailies/DailyProgressCell.tsx
+++ b/packages/client/src/components/dailies/DailyProgressCell.tsx
@@ -90,13 +90,15 @@ export function DailyProgressCell({
   const bookmarkProgress = daily.bookmarkProgress;
 
   // Bookmark reading progress takes precedence: when the daily's active
-  // bookmark tracks progress in Simple Bookmarks, show how far through the
-  // material we are instead of the task's to-do completion.
-  if (bookmarkProgress) {
+  // bookmark tracks real progress in Simple Bookmarks (a positive total), show
+  // how far through the material we are instead of the task's to-do completion.
+  // A zero/absent total is not real progress, so fall through to the infinity
+  // icon rather than render an empty ring.
+  if (bookmarkProgress && bookmarkProgress.total > 0) {
     const {
       current, total, title,
     } = bookmarkProgress;
-    const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+    const percent = Math.round((current / total) * 100);
     return (
       <HoverProgressPopover
         ariaLabel={`Bookmark progress ${percent}%`}
@@ -106,7 +108,7 @@ export function DailyProgressCell({
         <div className="flex flex-col gap-1 text-sm">
           <div className="font-medium">{title}</div>
           <div className="text-muted-foreground">
-            {total > 0 ? `${current} / ${total} (${percent}%)` : "No progress yet"}
+            {`${current} / ${total} (${percent}%)`}
           </div>
         </div>
       </HoverProgressPopover>

--- a/packages/middleware/src/routes/api/routines/root.ts
+++ b/packages/middleware/src/routes/api/routines/root.ts
@@ -5,6 +5,7 @@ import { getBookmarkProgress } from "@/services/bookmarks";
 import { nullableRoutineModeEnum } from "@/utils/schemas";
 import { resolveRoutineConnections } from "@/utils/resolveRoutineConnections";
 import {
+  activeBookmarkForEntry,
   currentDateKey,
   entryForCompletionDate,
   mapRoutineToDaily,
@@ -67,9 +68,10 @@ export default async function (server: FastifyInstance) {
 
     // Batch-resolve every active task id up front to avoid N+1. (Bookmark and
     // freeform entries carry their own display label on the entry.) In the same
-    // pass, note each routine's "active bookmark" — today's scheduled bookmark
-    // entry, else the routine's first bookmark connection — so we can enrich it
-    // with reading progress from Simple Bookmarks below.
+    // pass, note each routine's "active bookmark" — strictly today's scheduled
+    // bookmark entry — so we can enrich it with reading progress from Simple
+    // Bookmarks below. Task days use the task's to-do progress instead, and a
+    // routine's categorical bookmark connection never drives the progress ring.
     const taskIds: string[] = [];
     const activeBookmarkByRoutine = new Map<string, { id: string;
       title: string; }>();
@@ -83,20 +85,9 @@ export default async function (server: FastifyInstance) {
       if (entry?.type === "task") {
         taskIds.push(entry.id);
       }
-      if (entry?.type === "bookmark") {
-        activeBookmarkByRoutine.set(routine.id, {
-          id: entry.id,
-          title: entry.title?.trim() || "Bookmark",
-        });
-      }
-      else {
-        const connection = routine.connections.find(c => c.type === "bookmark");
-        if (connection) {
-          activeBookmarkByRoutine.set(routine.id, {
-            id: connection.id,
-            title: connection.name?.trim() || "Bookmark",
-          });
-        }
+      const activeBookmark = activeBookmarkForEntry(entry);
+      if (activeBookmark) {
+        activeBookmarkByRoutine.set(routine.id, activeBookmark);
       }
     }
 
@@ -143,9 +134,11 @@ export default async function (server: FastifyInstance) {
         task,
       }, dateKey);
 
+      // Only a positive total is real reading progress; a zero/absent total
+      // leaves bookmarkProgress null so the cell shows the infinity icon.
       const activeBookmark = activeBookmarkByRoutine.get(routine.id);
       const progress = activeBookmark && progressMap.get(activeBookmark.id);
-      daily.bookmarkProgress = progress
+      daily.bookmarkProgress = progress && progress.total > 0
         ? {
           current: progress.current,
           total: progress.total,

--- a/packages/middleware/src/services/bookmarks.ts
+++ b/packages/middleware/src/services/bookmarks.ts
@@ -113,7 +113,10 @@ export async function getBookmarkProgress(
     for (const bookmark of all) {
       if (!wanted.has(bookmark.id)) continue;
       const value = bookmark.progressValues?.[0];
-      if (value) {
+      // A zero/absent total is not real progress (e.g. a bookmark that tracks
+      // progress but hasn't set a total) — treat it as "no progress" so the
+      // caller falls back to the infinity icon rather than an empty ring.
+      if (value && value.total > 0) {
         progress.set(bookmark.id, {
           current: value.current,
           total: value.total,

--- a/packages/middleware/src/tests/bookmarksProgress.test.ts
+++ b/packages/middleware/src/tests/bookmarksProgress.test.ts
@@ -39,6 +39,15 @@ test("getBookmarkProgress maps requested ids and drops bookmarks without progres
       id: "b",
       progressValues: [],
     },
+    // Requested and has a progress record, but a zero total is not real
+    // progress — omitted so the caller falls back to the infinity icon.
+    {
+      id: "d",
+      progressValues: [{
+        current: 0,
+        total: 0,
+      }],
+    },
     // Has progress but was not requested — ignored.
     {
       id: "c",
@@ -49,13 +58,14 @@ test("getBookmarkProgress maps requested ids and drops bookmarks without progres
     },
   ]);
 
-  const map = await getBookmarkProgress(["a", "b"]);
+  const map = await getBookmarkProgress(["a", "b", "d"]);
 
   assert.deepStrictEqual(map.get("a"), {
     current: 45,
     total: 320,
   });
   assert.strictEqual(map.has("b"), false);
+  assert.strictEqual(map.has("d"), false);
   assert.strictEqual(map.has("c"), false);
   assert.strictEqual(map.size, 1);
 });

--- a/packages/middleware/src/tests/routineProjection.test.ts
+++ b/packages/middleware/src/tests/routineProjection.test.ts
@@ -8,6 +8,7 @@ import assert from "node:assert";
 import { test } from "node:test";
 
 import {
+  activeBookmarkForEntry,
   activeEntry,
   curatedEntry,
   currentDateKey,
@@ -126,6 +127,41 @@ test("entryForCompletionDate resolves weekly by weekday, curated by date, daily 
     entryForCompletionDate("daily", weekly, null, "2026-06-16"),
     mondayTask,
   );
+});
+
+test("activeBookmarkForEntry returns the bookmark only for a bookmark entry", () => {
+  // Progress is driven strictly by today's scheduled entry: a bookmark entry
+  // yields its id + cached title (trimmed, defaulting to "Bookmark").
+  assert.deepStrictEqual(activeBookmarkForEntry(wednesdayBookmark), {
+    id: "bm-wed",
+    title: "Pimsleur",
+  });
+  assert.deepStrictEqual(
+    activeBookmarkForEntry({
+      type: "bookmark",
+      id: "bm-untitled",
+      title: "  ",
+    }),
+    {
+      id: "bm-untitled",
+      title: "Bookmark",
+    },
+  );
+});
+
+test("activeBookmarkForEntry ignores task, freeform, and empty days", () => {
+  // Task / freeform / unscheduled days get their progress elsewhere (the task's
+  // to-dos or none) — never from a bookmark, and never from a categorical
+  // bookmark connection, which this helper deliberately does not consult.
+  assert.strictEqual(activeBookmarkForEntry(mondayTask), null);
+  assert.strictEqual(
+    activeBookmarkForEntry({
+      type: "freeform",
+      id: "Stretch",
+    }),
+    null,
+  );
+  assert.strictEqual(activeBookmarkForEntry(null), null);
 });
 
 test("entryToCompletionParts freezes resolved name + affixes (the baked snapshot)", () => {

--- a/packages/middleware/src/utils/routineProjection.ts
+++ b/packages/middleware/src/utils/routineProjection.ts
@@ -18,6 +18,7 @@ import type {
 } from "./routineActionParts";
 import { resolveActionParts } from "./routineActionParts";
 import {
+  activeBookmarkForEntry,
   currentDateKey,
   entryForCompletionDate,
   representativeEntry,
@@ -27,7 +28,12 @@ import {
 // module (unit-tested there directly). Re-export only the ones the projection's
 // callers consume from here, so they keep a single import site; the rest are
 // imported from routineWeekday directly.
-export { currentDateKey, entryForCompletionDate, representativeEntry };
+export {
+  activeBookmarkForEntry,
+  currentDateKey,
+  entryForCompletionDate,
+  representativeEntry,
+};
 export type { ResolvedConnections, ResolvedTask };
 
 // The routine columns (plus its resolved connections) the projection reads.

--- a/packages/middleware/src/utils/routineWeekday.ts
+++ b/packages/middleware/src/utils/routineWeekday.ts
@@ -96,6 +96,24 @@ export function entryForCompletionDate(
   return representativeEntry(weekly);
 }
 
+// The bookmark whose reading progress drives a routine's projected progress ring
+// for a given day: strictly today's scheduled entry, and only when that entry is
+// a bookmark. Task, freeform, and unscheduled days yield null — their progress
+// comes from the task's to-dos (or none at all). A routine's categorical
+// bookmark *connection* deliberately never supplies progress here.
+export function activeBookmarkForEntry(
+  entry: RoutineReferenceItem | null,
+): { id: string;
+  title: string; } | null {
+  if (entry?.type !== "bookmark") {
+    return null;
+  }
+  return {
+    id: entry.id,
+    title: entry.title?.trim() || "Bookmark",
+  };
+}
+
 // Freeze a scheduled entry into the parts stored on a logged completion. The
 // freeform name is the entry's own text; a bookmark uses its cached title; a
 // task resolves via the given name map, falling back to its id when the target


### PR DESCRIPTION
## Context

The dashboard **Do Now** card and the routines tracker show a **Progress** cell (`DailyProgressCell`), recently wired to surface bookmark reading progress from the companion Simple Bookmarks app. Progress must come from bookmarks, resolved per three rules. Two behaviors diverged:

1. **Task days were hijacked by a categorical bookmark connection.** `routines/root.ts` resolved a routine's "active bookmark" as *today's bookmark entry **else** the routine's first bookmark connection* — and that `else` fired on task/freeform days too. A routine with different tasks each day that also had a bookmark connection showed the **connection's** progress instead of today's task progress.
2. **A zero-total bookmark rendered a "No progress yet" ring** instead of the infinity icon.

## Change

Progress is now driven **strictly by today's scheduled entry** — a routine's categorical bookmark *connection* never supplies progress.

| Today's entry | Progress cell |
|---|---|
| `bookmark` with `total > 0` | reading-progress ring (`current / total`) |
| `bookmark` with no/zero progress | ∞ infinity icon |
| `task` | today's task's to-do progress |
| `freeform` / no entry | ∞ infinity icon (connection ignored) |

- **`routineWeekday.ts`** — new pure `activeBookmarkForEntry(entry)` helper (returns the bookmark only for a bookmark entry; never consults connections), re-exported via `routineProjection.ts`.
- **`routines/root.ts`** — uses the helper; drops the connection fallback; gates `bookmarkProgress` on `total > 0`.
- **`services/bookmarks.ts`** — `getBookmarkProgress` drops zero-total records (authoritative "has progress" filter).
- **`DailyProgressCell.tsx`** — bookmark branch requires `total > 0`; removed the dead "No progress yet" path.

## Tests

- New `activeBookmarkForEntry` unit cases (task/freeform/empty → null — the connection-ignored regression guard).
- Zero-total drop case in `bookmarksProgress.test.ts`.
- `BookmarkNoProgress` story asserting no ring renders.
- Full middleware suite (95) ✓, full client suite incl. browser storybook (634) ✓, `typecheck` ✓, `lint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)