### PR TITLE
feat(settings): configurable Simple Bookmarks endpoint, cache refresh, and click behavior

### DIFF
--- a/packages/client/src/components/bookmarks/BookmarkLinkingProvider.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkLinkingProvider.tsx
@@ -1,0 +1,44 @@
+import type { BookmarkLinkingValue } from "./bookmarkLinkingContext";
+
+import { useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  BookmarkLinkingContext,
+
+} from "./bookmarkLinkingContext";
+
+import { fetchSettings } from "@/utils/api/settings";
+import { queryKeys } from "@/utils/queryKeys";
+
+// Fetches the app settings once and shares the bookmark click preference +
+// resolved endpoint with every bookmark link via context, so the individual
+// render sites don't each issue a settings query. Mount once at the app root
+// (inside the QueryClientProvider).
+export function BookmarkLinkingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const {
+    data,
+  } = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: fetchSettings,
+  });
+
+  const value = useMemo<BookmarkLinkingValue>(
+    () => ({
+      clickTarget: data?.bookmarkClickTarget ?? "page",
+      apiUrl: data?.bookmarkApiUrlResolved ?? null,
+    }),
+    [data?.bookmarkClickTarget, data?.bookmarkApiUrlResolved],
+  );
+
+  return (
+    <BookmarkLinkingContext.Provider value={value}>
+      {children}
+    </BookmarkLinkingContext.Provider>
+  );
+}

--- a/packages/client/src/components/bookmarks/BookmarkPicker.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkPicker.tsx
@@ -5,7 +5,10 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ExternalLinkIcon, Loader2, PlusIcon, XIcon } from "lucide-react";
 
+import { OpenBookmarkPageButton } from "./OpenBookmarkPageButton";
+
 import { Input } from "@/components/ui/input";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import {
   createBookmark,
   fetchBookmarkSections,
@@ -244,7 +247,10 @@ export function BookmarkPicker({
 interface BookmarkChipProps {
   association: TaskBookmark;
   onRemove: () => void;
-  onChangeSection: (sectionId: string | null, sectionLabel: string | null) => void;
+  onChangeSection: (
+    sectionId: string | null,
+    sectionLabel: string | null,
+  ) => void;
 }
 
 // A single associated-bookmark chip: title link, remove, and — when the bookmark
@@ -261,6 +267,15 @@ function BookmarkChip({
     queryFn: () => fetchBookmarkSections(association.bookmarkId),
   });
 
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
+  const linkable = {
+    externalId: association.bookmarkId,
+    url: association.url,
+  };
+  const href = resolveHref(linkable);
+
   return (
     <li
       className="
@@ -268,10 +283,10 @@ function BookmarkChip({
         py-1 text-sm
       "
     >
-      {association.url
+      {href
         ? (
           <a
-            href={association.url}
+            href={href}
             target="_blank"
             rel="noreferrer"
             className="
@@ -286,6 +301,7 @@ function BookmarkChip({
         : (
           <span>{association.title}</span>
         )}
+      <OpenBookmarkPageButton linkable={linkable} />
 
       {sections.length > 0 && (
         <select
@@ -294,7 +310,7 @@ function BookmarkChip({
           onChange={(e) => {
             const id = e.target.value || null;
             const label = id
-              ? sections.find(s => s.id === id)?.label ?? null
+              ? (sections.find(s => s.id === id)?.label ?? null)
               : null;
             onChangeSection(id, label);
           }}

--- a/packages/client/src/components/bookmarks/OpenBookmarkPageButton.stories.tsx
+++ b/packages/client/src/components/bookmarks/OpenBookmarkPageButton.stories.tsx
@@ -1,0 +1,83 @@
+import type { AppSettingsSummary } from "@emstack/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { BookmarkLinkingProvider } from "./BookmarkLinkingProvider";
+import { OpenBookmarkPageButton } from "./OpenBookmarkPageButton";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { seededSettingsClient } from "@/test-utils/settingsFixtures";
+
+// The button reads the app-wide bookmark preference from settings via context,
+// so each story seeds the settings query and wraps in the provider.
+function withSettings(overrides: Partial<AppSettingsSummary>) {
+  const client = seededSettingsClient(overrides);
+  return function Decorator(Story: () => React.ReactElement) {
+    return (
+      <QueryStub client={client}>
+        <BookmarkLinkingProvider>
+          <Story />
+        </BookmarkLinkingProvider>
+      </QueryStub>
+    );
+  };
+}
+
+const meta = {
+  component: OpenBookmarkPageButton,
+  args: {
+    linkable: {
+      externalId: "abc123",
+      url: "https://example.com/article",
+    },
+  },
+} satisfies Meta<typeof OpenBookmarkPageButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// With the "page" preference and an endpoint configured, the shortcut to the
+// Simple Bookmarks page is shown.
+export const Visible: Story = {
+  decorators: [
+    withSettings({
+      bookmarkApiUrlResolved: "http://eserve-raspi:3000",
+      bookmarkClickTarget: "page",
+    }),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const link = await canvas.findByRole("link", {
+      name: /open bookmark page/i,
+    });
+    await expect(link).toHaveAttribute(
+      "href",
+      "http://eserve-raspi:3000/bookmarks/abc123",
+    );
+  },
+};
+
+// When the primary click already opens the bookmark page, the shortcut is
+// redundant and hidden.
+export const HiddenForBookmarkTarget: Story = {
+  decorators: [
+    withSettings({
+      bookmarkApiUrlResolved: "http://eserve-raspi:3000",
+      bookmarkClickTarget: "bookmark",
+    }),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("link", {
+        name: /open bookmark page/i,
+      }),
+    ).toBeNull();
+  },
+};

--- a/packages/client/src/components/bookmarks/OpenBookmarkPageButton.tsx
+++ b/packages/client/src/components/bookmarks/OpenBookmarkPageButton.tsx
@@ -1,0 +1,52 @@
+import type { BookmarkLinkable } from "./bookmarkLinks";
+
+import { BookMarkedIcon } from "lucide-react";
+
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
+import { cn } from "@/lib/utils";
+
+interface OpenBookmarkPageButtonProps {
+  linkable: BookmarkLinkable;
+  className?: string;
+}
+
+// A small secondary affordance that opens the bookmark's Simple Bookmarks page.
+// Shown only when the primary click goes somewhere else (clickTarget "page") and
+// an endpoint is configured, so it never duplicates the title link and stays
+// hidden entirely when no app URL is known.
+export function OpenBookmarkPageButton({
+  linkable,
+  className,
+}: OpenBookmarkPageButtonProps) {
+  const {
+    clickTarget, bookmarkPageUrl,
+  } = useBookmarkLinking();
+
+  if (clickTarget !== "page") {
+    return null;
+  }
+
+  const href = bookmarkPageUrl(linkable);
+  if (!href) {
+    return null;
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Open bookmark page"
+      title="Open bookmark page"
+      className={cn(
+        `
+          inline-flex text-muted-foreground
+          hover:text-foreground
+        `,
+        className,
+      )}
+    >
+      <BookMarkedIcon className="size-3" />
+    </a>
+  );
+}

--- a/packages/client/src/components/bookmarks/bookmarkLinkingContext.ts
+++ b/packages/client/src/components/bookmarks/bookmarkLinkingContext.ts
@@ -1,0 +1,17 @@
+import type { BookmarkClickTarget } from "@emstack/types";
+
+import { createContext } from "react";
+
+export interface BookmarkLinkingValue {
+  clickTarget: BookmarkClickTarget;
+  // Effective Simple Bookmarks base URL, or null when unknown (settings not
+  // loaded / no endpoint), in which case bookmark-page links can't be built.
+  apiUrl: string | null;
+}
+
+// Defaults for components rendered outside a provider (stories, tests): behave
+// exactly like the pre-setting app — open the underlying page, no app deep-link.
+export const BookmarkLinkingContext = createContext<BookmarkLinkingValue>({
+  clickTarget: "page",
+  apiUrl: null,
+});

--- a/packages/client/src/components/bookmarks/bookmarkLinks.test.ts
+++ b/packages/client/src/components/bookmarks/bookmarkLinks.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBookmarkPageUrl, resolveBookmarkHref } from "./bookmarkLinks";
+
+const API = "http://eserve-raspi:3000";
+
+describe("buildBookmarkPageUrl", () => {
+  it("builds the app page URL and encodes the id", () => {
+    expect(buildBookmarkPageUrl("abc 123", API)).toBe(
+      "http://eserve-raspi:3000/bookmarks/abc%20123",
+    );
+  });
+
+  it("strips trailing slashes on the base URL", () => {
+    expect(buildBookmarkPageUrl("a", "http://x:3000///")).toBe(
+      "http://x:3000/bookmarks/a",
+    );
+  });
+
+  it("returns null when the endpoint or id is missing", () => {
+    expect(buildBookmarkPageUrl("a", null)).toBeNull();
+    expect(buildBookmarkPageUrl("", API)).toBeNull();
+  });
+});
+
+describe("resolveBookmarkHref", () => {
+  const linkable = {
+    externalId: "a",
+    url: "https://example.com/article",
+  };
+
+  it("opens the underlying page for the 'page' target", () => {
+    expect(resolveBookmarkHref(linkable, "page", API)).toBe(
+      "https://example.com/article",
+    );
+  });
+
+  it("opens the bookmark page for the 'bookmark' target", () => {
+    expect(resolveBookmarkHref(linkable, "bookmark", API)).toBe(
+      "http://eserve-raspi:3000/bookmarks/a",
+    );
+  });
+
+  it("falls back to the bookmark page when 'page' has no url", () => {
+    expect(
+      resolveBookmarkHref({
+        externalId: "a",
+        url: null,
+      }, "page", API),
+    ).toBe("http://eserve-raspi:3000/bookmarks/a");
+  });
+
+  it("falls back to the url when 'bookmark' has no endpoint", () => {
+    expect(resolveBookmarkHref(linkable, "bookmark", null)).toBe(
+      "https://example.com/article",
+    );
+  });
+
+  it("returns null when neither is available", () => {
+    expect(
+      resolveBookmarkHref({
+        externalId: "a",
+        url: null,
+      }, "page", null),
+    ).toBeNull();
+  });
+});

--- a/packages/client/src/components/bookmarks/bookmarkLinks.ts
+++ b/packages/client/src/components/bookmarks/bookmarkLinks.ts
@@ -1,0 +1,37 @@
+import type { BookmarkClickTarget } from "@emstack/types";
+
+// The minimal identity a bookmark link needs, normalized across the different
+// association shapes (TaskBookmark.bookmarkId, RoutineConnection.id,
+// RoutineReferenceItem.id all map to `externalId`).
+export interface BookmarkLinkable {
+  externalId: string;
+  url: string | null;
+}
+
+// The browser URL for a bookmark's own page in the Simple Bookmarks app, or null
+// when the app URL or the bookmark id is unknown (so callers fall back to the
+// underlying link or render plain text).
+export function buildBookmarkPageUrl(
+  externalId: string,
+  apiUrl: string | null,
+): string | null {
+  if (!apiUrl || !externalId) {
+    return null;
+  }
+  return `${apiUrl.replace(/\/+$/, "")}/bookmarks/${encodeURIComponent(externalId)}`;
+}
+
+// Resolve where clicking a bookmark should go, honoring the app-wide preference:
+// "bookmark" opens its Simple Bookmarks page (falling back to the underlying url
+// if the app URL is unknown); "page" opens the underlying url (falling back to
+// the bookmark page). Returns null when neither is available.
+export function resolveBookmarkHref(
+  {
+    externalId, url,
+  }: BookmarkLinkable,
+  clickTarget: BookmarkClickTarget,
+  apiUrl: string | null,
+): string | null {
+  const pageUrl = buildBookmarkPageUrl(externalId, apiUrl);
+  return clickTarget === "bookmark" ? pageUrl ?? url : url ?? pageUrl;
+}

--- a/packages/client/src/components/bookmarks/index.ts
+++ b/packages/client/src/components/bookmarks/index.ts
@@ -1,0 +1,10 @@
+// Public surface of the bookmarks feature folder. The pickers keep their direct
+// imports; this barrel groups the link-resolution pieces so the many render
+// sites pull them from one module.
+export { OpenBookmarkPageButton } from "./OpenBookmarkPageButton";
+export { BookmarkLinkingProvider } from "./BookmarkLinkingProvider";
+export {
+  buildBookmarkPageUrl,
+  resolveBookmarkHref,
+  type BookmarkLinkable,
+} from "./bookmarkLinks";

--- a/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
+++ b/packages/client/src/components/contentBoxComponents/RoutineBox.tsx
@@ -4,9 +4,12 @@ import type {
   RoutineWeekday,
 } from "@emstack/types";
 
+import { Fragment } from "react";
+
 import { Link } from "@tanstack/react-router";
 import { AlertTriangleIcon, FlameIcon, LaughIcon } from "lucide-react";
 
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
 import { Description, EntityLink } from "@/components/boxElements";
 import {
   ContentBox,
@@ -24,6 +27,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { cn } from "@/lib/utils";
 import {
   connectionEntityKind,
@@ -75,6 +79,9 @@ export function RoutineBox({
   completions,
   todayAction,
 }: Routine & { todayAction?: RoutineTodayAction | null }) {
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
   const isDaily = mode === "daily";
   // A daily routine mirrors the same entry on every weekday, so the caution
   // only applies when the grid is empty — i.e. no task, resource, or freeform
@@ -104,35 +111,49 @@ export function RoutineBox({
             {connections && connections.length > 0
               ? (
                 connections.map(c => (
-                  <Badge
-                    key={`${c.type}:${c.id}`}
-                    asChild
-                    variant="secondary"
-                    className="
-                      bg-muted
-                      hover:bg-primary hover:text-primary-foreground
-                    "
-                  >
-                    {c.type === "bookmark"
-                      ? (
-                        <a
-                          href={c.url ?? undefined}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          {c.name ?? c.id}
-                          {c.sectionLabel ? ` › ${c.sectionLabel}` : ""}
-                        </a>
-                      )
-                      : (
-                        <EntityLink
-                          entity={connectionEntityKind(c.type)}
-                          id={c.id}
-                        >
-                          {c.name ?? c.id}
-                        </EntityLink>
-                      )}
-                  </Badge>
+                  <Fragment key={`${c.type}:${c.id}`}>
+                    <Badge
+                      asChild
+                      variant="secondary"
+                      className="
+                        bg-muted
+                        hover:bg-primary hover:text-primary-foreground
+                      "
+                    >
+                      {c.type === "bookmark"
+                        ? (
+                          <a
+                            href={
+                              resolveHref({
+                                externalId: c.id,
+                                url: c.url ?? null,
+                              }) ?? undefined
+                            }
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {c.name ?? c.id}
+                            {c.sectionLabel ? ` › ${c.sectionLabel}` : ""}
+                          </a>
+                        )
+                        : (
+                          <EntityLink
+                            entity={connectionEntityKind(c.type)}
+                            id={c.id}
+                          >
+                            {c.name ?? c.id}
+                          </EntityLink>
+                        )}
+                    </Badge>
+                    {c.type === "bookmark" && (
+                      <OpenBookmarkPageButton
+                        linkable={{
+                          externalId: c.id,
+                          url: c.url ?? null,
+                        }}
+                      />
+                    )}
+                  </Fragment>
                 ))
               )
               : (

--- a/packages/client/src/components/dialogs/quickAdd/QuickAddDialogs.stories.tsx
+++ b/packages/client/src/components/dialogs/quickAdd/QuickAddDialogs.stories.tsx
@@ -20,6 +20,9 @@ const client = seededQueryClient([
       readwiseKeyHint: "…aB3x",
       todoistConfigured: true,
       todoistKeyHint: "…aB3x",
+      bookmarkApiUrl: null,
+      bookmarkApiUrlResolved: "http://eserve-raspi:3000",
+      bookmarkClickTarget: "page",
     } satisfies AppSettingsSummary,
   ],
 ]);

--- a/packages/client/src/components/routines/RoutineEntryLabel.tsx
+++ b/packages/client/src/components/routines/RoutineEntryLabel.tsx
@@ -3,8 +3,10 @@ import type { RoutineReferenceItem } from "@emstack/types";
 import { routineEntryName } from "@emstack/types";
 import { MapPinIcon } from "lucide-react";
 
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
 import { EntityLink } from "@/components/boxElements";
 import { ActionableSentence } from "@/components/dailies/ActionableSentence";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 
 interface RoutineEntryLabelProps {
   entry: RoutineReferenceItem;
@@ -23,40 +25,61 @@ export function RoutineEntryLabel({
   taskNames,
   showMeta = true,
 }: RoutineEntryLabelProps) {
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
+
   // The entry's name as a clickable link (task) or plain text (freeform) — no
   // type badge, so it can sit inside an actionable sentence.
-  const nameNode = entry.type === "freeform"
-    ? entry.id
-    : entry.type === "bookmark"
-      ? (
-        // External bookmark: link out (no local route), cached title + section.
-        <a
-          href={entry.url ?? undefined}
-          target="_blank"
-          rel="noreferrer"
-          className="
-            text-blue-800
-            hover:text-blue-600
-            dark:text-blue-300
-          "
-        >
-          {entry.title ?? entry.id}
-          {entry.sectionLabel ? ` › ${entry.sectionLabel}` : ""}
-        </a>
-      )
-      : (
-        <EntityLink
-          entity="tasks"
-          id={entry.id}
-          className="
-            text-blue-800
-            hover:text-blue-600
-            dark:text-blue-300
-          "
-        >
-          {routineEntryName(entry, taskNames)}
-        </EntityLink>
+  function renderName() {
+    if (entry.type === "freeform") {
+      return entry.id;
+    }
+    if (entry.type === "bookmark") {
+      // External bookmark: link out (honoring the click preference), cached title
+      // + section, plus a shortcut to its Simple Bookmarks page.
+      const linkable = {
+        externalId: entry.id,
+        url: entry.url ?? null,
+      };
+      return (
+        <>
+          <a
+            href={resolveHref(linkable) ?? undefined}
+            target="_blank"
+            rel="noreferrer"
+            className="
+              text-blue-800
+              hover:text-blue-600
+              dark:text-blue-300
+            "
+          >
+            {entry.title ?? entry.id}
+            {entry.sectionLabel ? ` › ${entry.sectionLabel}` : ""}
+          </a>
+          <OpenBookmarkPageButton
+            linkable={linkable}
+            className="ml-1 align-middle"
+          />
+        </>
       );
+    }
+    return (
+      <EntityLink
+        entity="tasks"
+        id={entry.id}
+        className="
+          text-blue-800
+          hover:text-blue-600
+          dark:text-blue-300
+        "
+      >
+        {routineEntryName(entry, taskNames)}
+      </EntityLink>
+    );
+  }
+
+  const nameNode = renderName();
 
   const actionable = (
     <ActionableSentence

--- a/packages/client/src/hooks/useBookmarkLinking.ts
+++ b/packages/client/src/hooks/useBookmarkLinking.ts
@@ -1,0 +1,30 @@
+import type { BookmarkLinkable } from "@/components/bookmarks/bookmarkLinks";
+
+import { useContext, useMemo } from "react";
+
+import { BookmarkLinkingContext } from "@/components/bookmarks/bookmarkLinkingContext";
+import {
+  buildBookmarkPageUrl,
+  resolveBookmarkHref,
+
+} from "@/components/bookmarks/bookmarkLinks";
+
+// Read the current bookmark-linking preference and get href builders for a
+// bookmark. `resolveHref` follows the app-wide preference; `bookmarkPageUrl` is
+// always the Simple Bookmarks page (or null when the endpoint is unknown).
+export function useBookmarkLinking() {
+  const {
+    clickTarget, apiUrl,
+  } = useContext(BookmarkLinkingContext);
+
+  return useMemo(
+    () => ({
+      clickTarget,
+      resolveHref: (linkable: BookmarkLinkable) =>
+        resolveBookmarkHref(linkable, clickTarget, apiUrl),
+      bookmarkPageUrl: (linkable: BookmarkLinkable) =>
+        buildBookmarkPageUrl(linkable.externalId, apiUrl),
+    }),
+    [clickTarget, apiUrl],
+  );
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import { routeTree } from "./routeTree.gen.ts";
 
+import { BookmarkLinkingProvider } from "@/components/bookmarks";
 import { STORAGE_KEYS } from "@/constants/storageKeys";
 import { ThemeProvider } from "@/context/ThemeProvider.tsx";
 
@@ -31,15 +32,17 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider
-          defaultTheme="light"
-          storageKey={STORAGE_KEYS.theme}
-        >
-          <RouterProvider
-            router={router}
-            context={queryClient}
-          />
-        </ThemeProvider>
+        <BookmarkLinkingProvider>
+          <ThemeProvider
+            defaultTheme="light"
+            storageKey={STORAGE_KEYS.theme}
+          >
+            <RouterProvider
+              router={router}
+              context={queryClient}
+            />
+          </ThemeProvider>
+        </BookmarkLinkingProvider>
       </QueryClientProvider>
     </StrictMode>,
   );

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
@@ -2,6 +2,7 @@ import type { Routine } from "@emstack/types";
 
 import { FlameIcon, LaughIcon } from "lucide-react";
 
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
 import { EntityLink } from "@/components/boxElements";
 import { InfoArea } from "@/components/layout";
 import {
@@ -11,6 +12,7 @@ import {
   formatCuratedDateLabel,
   RoutineEntryLabel,
 } from "@/components/routines";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
 import {
   connectionEntityKind,
@@ -32,8 +34,10 @@ export function RoutineDetailsContent({
 }: RoutineDetailsContentProps) {
   const {
     taskNames,
-  }
-    = useTaskResourceNames();
+  } = useTaskResourceNames();
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
 
   const weekly = data.weekly ?? {};
   const isDaily = data.mode === "daily";
@@ -117,28 +121,41 @@ export function RoutineDetailsContent({
             <li key={`${c.type}:${c.id}`}>
               {c.type === "bookmark"
                 ? (
-                  <a
-                    href={c.url ?? undefined}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={`
-                      font-bold text-blue-800
-                      hover:text-blue-600
-                      dark:text-blue-300
-                    `}
-                  >
-                    <span
-                      className="mr-2 text-xs text-muted-foreground uppercase"
+                  <span className="inline-flex items-center gap-1">
+                    <a
+                      href={
+                        resolveHref({
+                          externalId: c.id,
+                          url: c.url ?? null,
+                        }) ?? undefined
+                      }
+                      target="_blank"
+                      rel="noreferrer"
+                      className={`
+                        font-bold text-blue-800
+                        hover:text-blue-600
+                        dark:text-blue-300
+                      `}
                     >
-                      {c.type}
-                    </span>
-                    {c.name ?? c.id}
-                    {c.sectionLabel && (
-                      <span className="ml-1 font-normal opacity-70">
-                        › {c.sectionLabel}
+                      <span
+                        className="mr-2 text-xs text-muted-foreground uppercase"
+                      >
+                        {c.type}
                       </span>
-                    )}
-                  </a>
+                      {c.name ?? c.id}
+                      {c.sectionLabel && (
+                        <span className="ml-1 font-normal opacity-70">
+                          › {c.sectionLabel}
+                        </span>
+                      )}
+                    </a>
+                    <OpenBookmarkPageButton
+                      linkable={{
+                        externalId: c.id,
+                        url: c.url ?? null,
+                      }}
+                    />
+                  </span>
                 )
                 : (
                   <EntityLink

--- a/packages/client/src/routes/settings/-components/connections/-BookmarksSection.stories.tsx
+++ b/packages/client/src/routes/settings/-components/connections/-BookmarksSection.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, within } from "storybook/test";
+
+import { BookmarksSection } from "./-BookmarksSection";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { seededSettingsClient } from "@/test-utils/settingsFixtures";
+
+const meta = {
+  component: BookmarksSection,
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededSettingsClient({
+          bookmarkApiUrl: null,
+          bookmarkApiUrlResolved: "http://eserve-raspi:3000",
+          bookmarkClickTarget: "page",
+        })}
+      >
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+} satisfies Meta<typeof BookmarksSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    // The resolved default endpoint seeds the input placeholder.
+    await expect(
+      canvas.getByPlaceholderText("http://eserve-raspi:3000"),
+    ).toBeInTheDocument();
+    // Both click-behavior choices render.
+    await expect(
+      canvas.getByText(/open the page itself/i),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/open the bookmark's page/i),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /clear & refresh/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};
+
+// A configured override pre-fills the endpoint input and shows the reset action.
+export const WithOverride: Story = {
+  decorators: [
+    Story => (
+      <QueryStub
+        client={seededSettingsClient({
+          bookmarkApiUrl: "http://my-bookmarks:8080",
+          bookmarkApiUrlResolved: "http://my-bookmarks:8080",
+          bookmarkClickTarget: "bookmark",
+        })}
+      >
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByDisplayValue("http://my-bookmarks:8080"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", {
+        name: /reset to default/i,
+      }),
+    ).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/settings/-components/connections/-BookmarksSection.tsx
+++ b/packages/client/src/routes/settings/-components/connections/-BookmarksSection.tsx
@@ -1,0 +1,178 @@
+import type { AppSettingsUpdate, BookmarkClickTarget } from "@emstack/types";
+
+import { useEffect, useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { fetchSettings, updateSettings } from "@/utils/api/settings";
+import { queryKeys } from "@/utils/queryKeys";
+
+const CLICK_TARGET_OPTIONS: { value: BookmarkClickTarget;
+  label: string; }[] = [
+  {
+    value: "page",
+    label: "Open the page itself (the article/book/video)",
+  },
+  {
+    value: "bookmark",
+    label: "Open the bookmark's page in Simple Bookmarks",
+  },
+];
+
+export function BookmarksSection() {
+  const queryClient = useQueryClient();
+
+  const settingsQuery = useQuery({
+    queryKey: queryKeys.settings.detail(),
+    queryFn: fetchSettings,
+  });
+  const data = settingsQuery.data;
+
+  // Seed the endpoint input from the stored override once, then let the user
+  // edit freely (blank = fall back to the env/default endpoint).
+  const [endpoint, setEndpoint] = useState("");
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    if (data && !seeded) {
+      setEndpoint(data.bookmarkApiUrl ?? "");
+      setSeeded(true);
+    }
+  }, [data, seeded]);
+
+  const saveMutation = useMutation({
+    mutationFn: (update: AppSettingsUpdate) => updateSettings(update),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.settings.detail(),
+      });
+      toast.success("Bookmark settings saved");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  // No server-side cache exists — refreshing just drops the browser's cached
+  // bookmark data and the routine/daily projections that carry reading progress,
+  // so both refetch from Simple Bookmarks.
+  function refreshBookmarkData() {
+    queryClient.invalidateQueries({
+      queryKey: ["bookmarks"],
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.dailies.list(),
+    });
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.routines.list(),
+    });
+    toast.success("Refreshing bookmark data…");
+  }
+
+  const clickTarget = data?.bookmarkClickTarget ?? "page";
+  const resolved = data?.bookmarkApiUrlResolved ?? "";
+  const trimmed = endpoint.trim();
+  const storedOverride = data?.bookmarkApiUrl ?? "";
+  const endpointDirty = trimmed !== storedOverride;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-xl font-semibold">Bookmarks</h2>
+      <p className="text-sm text-muted-foreground">
+        Course Tracker links to bookmarks in the companion
+        {" "}
+        <span className="font-medium">Simple Bookmarks</span>
+        {" "}
+        app. Point it at
+        your instance, choose what clicking a bookmark opens, and refresh the
+        cached bookmark data on demand.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <label
+          className="text-sm font-medium"
+          htmlFor="bookmark-endpoint"
+        >
+          Endpoint URL
+        </label>
+        <Input
+          id="bookmark-endpoint"
+          type="url"
+          autoComplete="off"
+          value={endpoint}
+          onChange={e => setEndpoint(e.target.value)}
+          placeholder={resolved || "http://eserve-raspi:3000"}
+          className="sm:max-w-md"
+        />
+        <p className="text-xs text-muted-foreground">
+          Leave blank to use the server default
+          {resolved ? ` (${resolved})` : ""}.
+        </p>
+        <div className="flex gap-2">
+          <Button
+            onClick={() =>
+              saveMutation.mutate({
+                bookmarkApiUrl: trimmed || null,
+              })}
+            disabled={!endpointDirty || saveMutation.isPending}
+          >
+            Save endpoint
+          </Button>
+          {storedOverride && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setEndpoint("");
+                saveMutation.mutate({
+                  bookmarkApiUrl: null,
+                });
+              }}
+              disabled={saveMutation.isPending}
+            >
+              Reset to default
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium">Clicking a bookmark</span>
+        <RadioGroup
+          value={clickTarget}
+          onValueChange={value =>
+            saveMutation.mutate({
+              bookmarkClickTarget: value as BookmarkClickTarget,
+            })}
+          disabled={saveMutation.isPending}
+        >
+          {CLICK_TARGET_OPTIONS.map(option => (
+            <label
+              key={option.value}
+              className="flex items-center gap-2 text-sm"
+            >
+              <RadioGroupItem value={option.value} />
+              {option.label}
+            </label>
+          ))}
+        </RadioGroup>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium">Cached bookmark data</span>
+        <div>
+          <Button
+            variant="outline"
+            onClick={refreshBookmarkData}
+          >
+            Clear &amp; refresh
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Refetches bookmark titles, sections, and reading progress from Simple
+          Bookmarks.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/routes/settings/-components/connections/index.ts
+++ b/packages/client/src/routes/settings/-components/connections/index.ts
@@ -4,3 +4,4 @@
 export { ReadwiseSection } from "./-ReadwiseSection";
 export { TodoistSection } from "./-TodoistSection";
 export { GoogleCalendarSection } from "./-GoogleCalendarSection";
+export { BookmarksSection } from "./-BookmarksSection";

--- a/packages/client/src/routes/settings/-components/index.ts
+++ b/packages/client/src/routes/settings/-components/index.ts
@@ -12,6 +12,7 @@ export {
   ReadwiseSection,
   TodoistSection,
   GoogleCalendarSection,
+  BookmarksSection,
 } from "./connections";
 export { ThemeSection } from "./display";
 export { DataToolsSection } from "./advanced";

--- a/packages/client/src/routes/settings/route.tsx
+++ b/packages/client/src/routes/settings/route.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 import {
+  BookmarksSection,
   CriteriaTemplatesSection,
   DashboardLayoutsSection,
   DataToolsSection,
@@ -97,6 +98,7 @@ function Settings() {
                   <ReadwiseSection />
                   <TodoistSection />
                   <GoogleCalendarSection />
+                  <BookmarksSection />
                 </>
               ),
             },

--- a/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
@@ -8,11 +8,13 @@ import { toast } from "sonner";
 
 import { TodoEditRow } from "./-TodoEditRow";
 
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
 import { DailyStatusCircle } from "@/components/dailies/DailyStatusCircle";
 import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
 import { toTodoInput } from "@/components/tasks/todoPayload";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { upsertTask } from "@/utils";
 import { uuidv4 } from "@/utils/uuid";
 
@@ -42,6 +44,10 @@ export function TodosEditor({
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftNew, setDraftNew] = useState<TaskTodo | null>(null);
+
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
 
   const mutation = useMutation({
     mutationFn: (nextTodos: TaskTodo[]) =>
@@ -193,41 +199,52 @@ export function TodosEditor({
                       due {todo.dueDate}
                     </Badge>
                   )}
-                  {(todo.bookmarks ?? []).map(b => (
-                    <Badge
-                      key={b.bookmarkId}
-                      variant="outline"
-                      className="
-                        border-amber-200 bg-amber-50 text-amber-900
-                        dark:border-amber-900/50 dark:bg-amber-950/40
-                        dark:text-amber-200
-                      "
-                    >
-                      {b.url
-                        ? (
-                          <a
-                            href={b.url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="
-                              inline-flex items-center gap-1
-                              hover:underline
-                            "
-                          >
-                            {b.title}
-                            <ExternalLinkIcon className="size-3" />
-                          </a>
-                        )
-                        : (
-                          b.title
+                  {(todo.bookmarks ?? []).map((b) => {
+                    const linkable = {
+                      externalId: b.bookmarkId,
+                      url: b.url,
+                    };
+                    const href = resolveHref(linkable);
+                    return (
+                      <Badge
+                        key={b.bookmarkId}
+                        variant="outline"
+                        className="
+                          border-amber-200 bg-amber-50 text-amber-900
+                          dark:border-amber-900/50 dark:bg-amber-950/40
+                          dark:text-amber-200
+                        "
+                      >
+                        {href
+                          ? (
+                            <a
+                              href={href}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="
+                                inline-flex items-center gap-1
+                                hover:underline
+                              "
+                            >
+                              {b.title}
+                              <ExternalLinkIcon className="size-3" />
+                            </a>
+                          )
+                          : (
+                            b.title
+                          )}
+                        <OpenBookmarkPageButton
+                          linkable={linkable}
+                          className="ml-1"
+                        />
+                        {b.sectionLabel && (
+                          <span className="ml-1 opacity-70">
+                            › {b.sectionLabel}
+                          </span>
                         )}
-                      {b.sectionLabel && (
-                        <span className="ml-1 opacity-70">
-                          › {b.sectionLabel}
-                        </span>
-                      )}
-                    </Badge>
-                  ))}
+                      </Badge>
+                    );
+                  })}
                   <div
                     className="
                       ml-auto flex items-center gap-1 opacity-0 transition

--- a/packages/client/src/routes/tasks/$id/index.tsx
+++ b/packages/client/src/routes/tasks/$id/index.tsx
@@ -5,12 +5,14 @@ import { EditIcon, ExternalLinkIcon } from "lucide-react";
 import { LinkedRoutinesSection } from "./-components/-LinkedRoutinesSection";
 import { TodosEditor } from "./-components/-TodosEditor";
 
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
 import { InfoArea, PageActions, PageHeader } from "@/components/layout";
 import {
   EntityError,
   EntityPending,
 } from "@/components/listControls/EntityStates";
 import { Button } from "@/components/ui/button";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { fetchRoutines, fetchSingleTask } from "@/utils";
 
 export const Route = createFileRoute("/tasks/$id/")({
@@ -43,6 +45,10 @@ function SingleTask() {
     queryKey: ["routines"],
     queryFn: () => fetchRoutines(),
   });
+
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
 
   if (isPending) {
     return <TaskPending />;
@@ -95,39 +101,47 @@ function SingleTask() {
           condition={(data.bookmarks ?? []).length > 0}
         >
           <ul className="flex flex-wrap gap-2">
-            {(data.bookmarks ?? []).map(b => (
-              <li
-                key={b.bookmarkId}
-                className="
-                  flex items-center gap-1.5 rounded-md border border-border
-                  bg-muted px-2 py-1 text-sm
-                "
-              >
-                {b.url
-                  ? (
-                    <a
-                      href={b.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="
-                        inline-flex items-center gap-1
-                        hover:underline
-                      "
-                    >
-                      {b.title}
-                      <ExternalLinkIcon className="size-3" />
-                    </a>
-                  )
-                  : (
-                    <span>{b.title}</span>
+            {(data.bookmarks ?? []).map((b) => {
+              const linkable = {
+                externalId: b.bookmarkId,
+                url: b.url,
+              };
+              const href = resolveHref(linkable);
+              return (
+                <li
+                  key={b.bookmarkId}
+                  className="
+                    flex items-center gap-1.5 rounded-md border border-border
+                    bg-muted px-2 py-1 text-sm
+                  "
+                >
+                  {href
+                    ? (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="
+                          inline-flex items-center gap-1
+                          hover:underline
+                        "
+                      >
+                        {b.title}
+                        <ExternalLinkIcon className="size-3" />
+                      </a>
+                    )
+                    : (
+                      <span>{b.title}</span>
+                    )}
+                  <OpenBookmarkPageButton linkable={linkable} />
+                  {b.sectionLabel && (
+                    <span className="text-muted-foreground">
+                      › {b.sectionLabel}
+                    </span>
                   )}
-                {b.sectionLabel && (
-                  <span className="text-muted-foreground">
-                    › {b.sectionLabel}
-                  </span>
-                )}
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         </InfoArea>
         <InfoArea

--- a/packages/client/src/test-utils/settingsFixtures.ts
+++ b/packages/client/src/test-utils/settingsFixtures.ts
@@ -22,6 +22,9 @@ function makeAppSettings(
     readwiseKeyHint: null,
     todoistConfigured: false,
     todoistKeyHint: null,
+    bookmarkApiUrl: null,
+    bookmarkApiUrlResolved: "http://eserve-raspi:3000",
+    bookmarkClickTarget: "page",
     ...overrides,
   };
 }

--- a/packages/middleware/.env.example
+++ b/packages/middleware/.env.example
@@ -17,5 +17,7 @@ TODOIST_API_KEY=
 
 # Base URL of the companion Simple Bookmarks app that owns links/bookmarks.
 # The middleware proxies bookmark search/resolve/create to it (browser stays
-# same-origin). Defaults to http://eserve-raspi:3000 when unset.
+# same-origin). This is the default/fallback — it can be overridden at runtime
+# from Settings → Connections → Bookmarks (stored in app_settings). Defaults to
+# http://eserve-raspi:3000 when unset.
 BOOKMARKS_API_URL=http://eserve-raspi:3000

--- a/packages/middleware/src/db/schema/settings.ts
+++ b/packages/middleware/src/db/schema/settings.ts
@@ -1,5 +1,5 @@
 import { jsonb, pgTable, varchar } from "drizzle-orm/pg-core";
-import type { CalendarFeed } from "@emstack/types";
+import type { BookmarkClickTarget, CalendarFeed } from "@emstack/types";
 
 // Single-row application settings. The row is keyed by a constant id ("global")
 // and created on first write via onConflictDoUpdate — there is no multi-user
@@ -17,4 +17,13 @@ export const appSettings = pgTable("app_settings", {
     .$type<CalendarFeed[]>()
     .notNull()
     .default([]),
+  // Optional override for the Simple Bookmarks base URL. Null = use the
+  // BOOKMARKS_API_URL env var / built-in default (see services/bookmarks.ts).
+  bookmarkApiUrl: varchar("bookmark_api_url"),
+  // Whether clicking a bookmark opens its underlying page or its Simple
+  // Bookmarks page. Defaults to "page" (the underlying link).
+  bookmarkClickTarget: varchar("bookmark_click_target")
+    .$type<BookmarkClickTarget>()
+    .notNull()
+    .default("page"),
 });

--- a/packages/middleware/src/routes/api/settings/root.ts
+++ b/packages/middleware/src/routes/api/settings/root.ts
@@ -1,8 +1,9 @@
 import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts";
 import { FastifyInstance } from "fastify";
-import type { AppSettingsSummary } from "@emstack/types";
+import type { AppSettingsSummary, BookmarkClickTarget } from "@emstack/types";
 import { db } from "@/db";
 import { appSettings } from "@/db/schema";
+import { resolveBookmarksBaseUrl } from "@/services/bookmarks";
 
 // Build a short, non-reversible hint so the UI can confirm a key is saved
 // without ever exposing the secret itself.
@@ -25,6 +26,10 @@ export default async function (server: FastifyInstance) {
         readwiseKeyHint: maskKey(readwiseKey),
         todoistConfigured: Boolean(todoistKey),
         todoistKeyHint: maskKey(todoistKey),
+        bookmarkApiUrl: row?.bookmarkApiUrl ?? null,
+        bookmarkApiUrlResolved: resolveBookmarksBaseUrl(row?.bookmarkApiUrl),
+        bookmarkClickTarget:
+          (row?.bookmarkClickTarget as BookmarkClickTarget | undefined) ?? "page",
       };
     },
   );

--- a/packages/middleware/src/routes/api/settings/updateSettings.ts
+++ b/packages/middleware/src/routes/api/settings/updateSettings.ts
@@ -8,6 +8,13 @@ import { nullableString } from "@/utils/schemas";
 // concept, so every write targets the same row.
 const SETTINGS_ROW_ID = "global";
 
+// "page" (underlying link) or "bookmark" (Simple Bookmarks page); null clears
+// back to the "page" default.
+const nullableBookmarkClickTargetEnum = {
+  type: ["string", "null"],
+  enum: ["page", "bookmark", null],
+} as const;
+
 const updateSchema = {
   schema: {
     description: "Update application settings (e.g. the Readwise or Todoist API keys)",
@@ -16,6 +23,8 @@ const updateSchema = {
       properties: {
         readwiseApiKey: nullableString,
         todoistApiKey: nullableString,
+        bookmarkApiUrl: nullableString,
+        bookmarkClickTarget: nullableBookmarkClickTargetEnum,
       },
     },
   },
@@ -42,6 +51,13 @@ export default async function (server: FastifyInstance) {
       }
       if (request.body.todoistApiKey !== undefined) {
         updates.todoistApiKey = normalizeKey(request.body.todoistApiKey);
+      }
+      if (request.body.bookmarkApiUrl !== undefined) {
+        updates.bookmarkApiUrl = normalizeKey(request.body.bookmarkApiUrl);
+      }
+      if (request.body.bookmarkClickTarget !== undefined) {
+        // A blank/null choice clears back to the "page" default.
+        updates.bookmarkClickTarget = request.body.bookmarkClickTarget ?? "page";
       }
 
       if (Object.keys(updates).length > 0) {

--- a/packages/middleware/src/services/bookmarks.ts
+++ b/packages/middleware/src/services/bookmarks.ts
@@ -4,9 +4,35 @@ import type { BookmarkSection, BookmarkSummary } from "@emstack/types";
 // build works across environments; defaults to the self-hosted instance.
 const DEFAULT_BASE_URL = "http://eserve-raspi:3000";
 
-function baseUrl(): string {
-  const configured = process.env.BOOKMARKS_API_URL?.trim();
+// Resolve the effective base URL from an optional stored override: the DB value
+// wins, then the BOOKMARKS_API_URL env var, then the built-in default. Trailing
+// slashes are stripped so callers can concatenate paths. Pure (no DB read) so it
+// is unit-testable and reused by the settings GET to report the resolved value.
+export function resolveBookmarksBaseUrl(override?: string | null): string {
+  const configured = override?.trim() || process.env.BOOKMARKS_API_URL?.trim();
   return (configured || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+// The effective base URL, reading the stored override from app settings first
+// (mirrors getReadwiseToken's DB-first-then-env resolution). `db` is imported
+// lazily so this module stays free of a static `@/db` dependency — that keeps it
+// loadable under `node --test` (which doesn't resolve the `@/` alias), matching
+// the googleCalendarIcs/googleCalendar split. If settings can't be read, fall
+// back to the env/default URL so bookmark proxying still works.
+export async function getBookmarksBaseUrl(): Promise<string> {
+  try {
+    const {
+      db,
+    } = await import("@/db");
+    const {
+      appSettings,
+    } = await import("@/db/schema");
+    const [row] = await db.select().from(appSettings).limit(1);
+    return resolveBookmarksBaseUrl(row?.bookmarkApiUrl);
+  }
+  catch {
+    return resolveBookmarksBaseUrl(null);
+  }
 }
 
 /** Error carrying an HTTP status so the route can map it to a friendly reply. */
@@ -50,7 +76,7 @@ function mapBookmark(b: RawBookmark): BookmarkSummary {
 async function bookmarksFetch(path: string, init?: RequestInit): Promise<Response> {
   try {
     // fallow-ignore-next-line security-sink
-    return await fetch(`${baseUrl()}${path}`, init);
+    return await fetch(`${await getBookmarksBaseUrl()}${path}`, init);
   }
   catch {
     throw new BookmarksError("Could not reach Simple Bookmarks.", 502);

--- a/packages/middleware/src/tests/bookmarksBaseUrl.test.ts
+++ b/packages/middleware/src/tests/bookmarksBaseUrl.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+import { afterEach, test } from "node:test";
+
+import { resolveBookmarksBaseUrl } from "../services/bookmarks.ts";
+
+const DEFAULT_BASE_URL = "http://eserve-raspi:3000";
+const realEnv = process.env.BOOKMARKS_API_URL;
+
+afterEach(() => {
+  if (realEnv === undefined) delete process.env.BOOKMARKS_API_URL;
+  else process.env.BOOKMARKS_API_URL = realEnv;
+});
+
+test("resolveBookmarksBaseUrl prefers the stored override over env and default", () => {
+  process.env.BOOKMARKS_API_URL = "http://from-env:3000";
+  assert.strictEqual(
+    resolveBookmarksBaseUrl("http://override:9000"),
+    "http://override:9000",
+  );
+});
+
+test("resolveBookmarksBaseUrl strips trailing slashes", () => {
+  assert.strictEqual(
+    resolveBookmarksBaseUrl("http://override:9000///"),
+    "http://override:9000",
+  );
+});
+
+test("resolveBookmarksBaseUrl falls back to env when the override is blank", () => {
+  process.env.BOOKMARKS_API_URL = "http://from-env:3000/";
+  assert.strictEqual(resolveBookmarksBaseUrl("   "), "http://from-env:3000");
+  assert.strictEqual(resolveBookmarksBaseUrl(null), "http://from-env:3000");
+  assert.strictEqual(resolveBookmarksBaseUrl(undefined), "http://from-env:3000");
+});
+
+test("resolveBookmarksBaseUrl falls back to the built-in default when nothing is set", () => {
+  delete process.env.BOOKMARKS_API_URL;
+  assert.strictEqual(resolveBookmarksBaseUrl(null), DEFAULT_BASE_URL);
+});

--- a/packages/types/src/AppSettings.ts
+++ b/packages/types/src/AppSettings.ts
@@ -1,3 +1,5 @@
+import type { BookmarkClickTarget } from "./BookmarkClickTarget";
+
 // Response shape for GET /api/settings. Raw API tokens are never sent to the
 // client — only whether each integration is configured plus a short masked hint.
 export interface AppSettingsSummary {
@@ -5,6 +7,15 @@ export interface AppSettingsSummary {
   readwiseKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
   todoistConfigured: boolean;
   todoistKeyHint: string | null; // e.g. "…aB3x" (last 4 chars) or null
+  // Simple Bookmarks endpoint. `bookmarkApiUrl` is the stored override (null when
+  // falling back to the env var / built-in default); `bookmarkApiUrlResolved` is
+  // the effective base URL, sent so the client can build links into the app. The
+  // endpoint is a LAN/tailscale address, not a secret, so it's returned plainly.
+  bookmarkApiUrl: string | null;
+  bookmarkApiUrlResolved: string;
+  // Whether clicking a bookmark opens its underlying page or its Simple Bookmarks
+  // page.
+  bookmarkClickTarget: BookmarkClickTarget;
 }
 
 // Request body for PUT /api/settings. Only the keys present in the body are
@@ -12,4 +23,6 @@ export interface AppSettingsSummary {
 export interface AppSettingsUpdate {
   readwiseApiKey?: string | null;
   todoistApiKey?: string | null;
+  bookmarkApiUrl?: string | null;
+  bookmarkClickTarget?: BookmarkClickTarget;
 }

--- a/packages/types/src/BookmarkClickTarget.ts
+++ b/packages/types/src/BookmarkClickTarget.ts
@@ -1,0 +1,4 @@
+// How clicking a bookmark link behaves app-wide: open the bookmark's underlying
+// page (the article/book/video itself), or the bookmark's own page in the
+// companion Simple Bookmarks app. Stored as a global app setting.
+export type BookmarkClickTarget = "page" | "bookmark";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export * from "./DailyCriteriaTemplate.js";
 export * from "./DashboardLayout.js";
 export * from "./Readwise.js";
 export * from "./Bookmark.js";
+export * from "./BookmarkClickTarget.js";
 export * from "./Routine.js";
 export * from "./RoutineTemplate.js";
 export * from "./Tag.js";


### PR DESCRIPTION
## Context

The companion **Simple Bookmarks** app is wired into emstack through the middleware proxy. Three things were hardwired or missing; this PR puts them under user control in **Settings → Third Party Connections → Bookmarks**.

## What's new

| Ask | Implementation |
|---|---|
| **Change the endpoint** | `BOOKMARKS_API_URL` becomes an overridable app setting (`bookmarkApiUrl`). The service resolves **db-override → env → default** (mirrors `getReadwiseToken`). The effective URL is returned to the client so it can build links into the app. |
| **Clear & refresh cache** | There is **no server-side cache** (the middleware refetches the full list per request), so the button invalidates the browser's `["bookmarks"]` + `["dailies"]` + `["routines"]` queries — bookmark data and reading progress refetch. |
| **Change click behavior** | Global `bookmarkClickTarget` (`page` \| `bookmark`, default `page`). Applied across all **6 bookmark render sites** via a `BookmarkLinkingProvider` context + `useBookmarkLinking` hook and a pure `resolveBookmarkHref` helper. Bookmark-page URL = `{endpoint}/bookmarks/{id}`. |
| **Just open the bookmark page** | `OpenBookmarkPageButton` — a small always-available shortcut beside each bookmark (hidden when it would duplicate the primary link). |

## Design notes

- **Context with safe defaults:** the click preference flows through React context defaulting to "open the underlying page", so leaf components (`RoutineEntryLabel`, `RoutineBox`, …) render unchanged in stories/tests **without** a QueryClient — no story churn.
- **`node --test` compatibility:** `getBookmarksBaseUrl` uses a lazy `import("@/db")` (with env fallback) so `services/bookmarks.ts` stays free of a static `@/db` import — keeping it loadable under `node --test`, which doesn't resolve the `@/` alias. Matches the existing `googleCalendarIcs`/`googleCalendar` split.
- **Schema:** additive nullable + defaulted columns (`bookmark_api_url`, `bookmark_click_target`) → `drizzle-kit push`, no data migration.

## Tests

- **Middleware:** new `resolveBookmarksBaseUrl` precedence test; existing `getBookmarkProgress` test still green. Full suite 99 ✓.
- **Client:** new `bookmarkLinks` unit test; `OpenBookmarkPageButton` + `BookmarksSection` stories with play assertions; the 6 render-site stories still pass. Full suite 646 ✓ (incl. browser storybook).
- `typecheck` ✓, `lint` ✓ (0 errors).
- **Not run:** live-app smoke (change endpoint / toggle / click a bookmark) — needs Docker for the DB, which wasn't available in the dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)