### PR TITLE
refactor: extract PageContainer component and replace container utility

### DIFF
--- a/packages/client/src/components/editPage/index.ts
+++ b/packages/client/src/components/editPage/index.ts
@@ -5,6 +5,7 @@
 // re-exports them so an edit page pulls its shell from one module.
 export { EditPageFooter } from "@/components/layout/EditPageFooter";
 export { EntityHeaderButton } from "@/components/layout/EntityHeaderButton";
+export { PageContainer } from "@/components/layout/PageContainer";
 export { PageHeader } from "@/components/layout/PageHeader";
 export { Button } from "@/components/ui/button";
 export { UnsavedChangesDialog } from "@/components/dialogs/UnsavedChangesDialog";

--- a/packages/client/src/components/layout/PageContainer.stories.tsx
+++ b/packages/client/src/components/layout/PageContainer.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PageContainer } from "./PageContainer";
+
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta = {
+  component: PageContainer,
+  args: {
+    children: "Page content",
+  },
+} satisfies Meta<typeof PageContainer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: smokeText("Page content"),
+};

--- a/packages/client/src/components/layout/PageContainer.tsx
+++ b/packages/client/src/components/layout/PageContainer.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Width-constraining page-body wrapper: centers content horizontally at the
+ * app's max content width. Replaces the old `container` CSS utility (which also
+ * bundled `flex`); pages add their own `flex flex-col gap-N` as needed.
+ */
+function PageContainer({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="page-container"
+      className={cn("mx-auto w-full max-w-[1200px] px-4", className)}
+      {...props}
+    />
+  );
+}
+
+export { PageContainer };

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -3,6 +3,8 @@ import type { ResourceProgress } from "@/components/ui/ProgressBar";
 
 import { Link } from "@tanstack/react-router";
 
+import { PageContainer } from "./PageContainer";
+
 import { ProgressBar } from "@/components/ui/ProgressBar";
 import { cn } from "@/lib/utils";
 
@@ -29,7 +31,7 @@ export function PageHeader({
         "py-4": !progressCurrent || progressCurrent === 0,
       })}
     >
-      <div className="container">
+      <PageContainer>
         <div className="flex w-full flex-col items-start gap-1">
           {pageSection && (
             <div className="flex flex-row gap-3">
@@ -76,7 +78,7 @@ export function PageHeader({
             {children && <div>{children}</div>}
           </div>
         </div>
-      </div>
+      </PageContainer>
       {progressCurrent && progressCurrent !== 0
         ? (
           <ProgressBar

--- a/packages/client/src/components/layout/PageHeader.tsx
+++ b/packages/client/src/components/layout/PageHeader.tsx
@@ -61,7 +61,7 @@ export function PageHeader({
           )}
           <div
             className="
-              m-auto flex w-full flex-col items-start gap-2
+              mx-auto flex w-full flex-col items-start gap-2
               sm:flex-row sm:justify-between
             "
           >

--- a/packages/client/src/components/layout/index.ts
+++ b/packages/client/src/components/layout/index.ts
@@ -6,5 +6,6 @@ export { EditPageFooter } from "./EditPageFooter";
 export { InfoArea } from "./InfoArea";
 export { OverviewCardGrid } from "./OverviewCardGrid";
 export { PageActions } from "./PageActions";
+export { PageContainer } from "./PageContainer";
 export { PageHeader } from "./PageHeader";
 export { PageTabs } from "./PageTabs";

--- a/packages/client/src/components/listControls/index.ts
+++ b/packages/client/src/components/listControls/index.ts
@@ -10,4 +10,5 @@ export {
   ListEmptyStates,
   ListSearchInput,
 } from "./ListPageControls";
+export { PageContainer } from "@/components/layout/PageContainer";
 export { PageHeader } from "@/components/layout/PageHeader";

--- a/packages/client/src/components/ui/card.stories.tsx
+++ b/packages/client/src/components/ui/card.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import {
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardFooter,
@@ -9,6 +10,7 @@ import {
   CardTitle,
 } from "./card";
 
+import { Button } from "@/components/ui/button";
 import { smokeText } from "@/test-utils/storyPlay";
 
 const meta = {
@@ -32,6 +34,14 @@ export const Default: Story = {
       <CardHeader>
         <CardTitle>Card title</CardTitle>
         <CardDescription>Card description</CardDescription>
+        <CardAction>
+          <Button
+            variant="outline"
+            size="sm"
+          >
+            Action
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent>Card content</CardContent>
       <CardFooter>Card footer</CardFooter>

--- a/packages/client/src/components/ui/card.stories.tsx
+++ b/packages/client/src/components/ui/card.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./card";
+
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta = {
+  component: Card,
+  decorators: [
+    Story => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Card title</CardTitle>
+        <CardDescription>Card description</CardDescription>
+      </CardHeader>
+      <CardContent>Card content</CardContent>
+      <CardFooter>Card footer</CardFooter>
+    </Card>
+  ),
+  play: smokeText("Card title", "Card content"),
+};

--- a/packages/client/src/components/ui/card.tsx
+++ b/packages/client/src/components/ui/card.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        `
+          flex flex-col gap-6 rounded-xl border bg-card py-6
+          text-card-foreground shadow-sm
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        `
+          @container/card-header grid auto-rows-min items-start gap-1.5 px-6
+          has-data-[slot=card-action]:grid-cols-[1fr_auto]
+          [.border-b]:pb-6
+        `,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(`
+        flex items-center px-6
+        [.border-t]:pt-6
+      `, className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+};

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -123,10 +123,6 @@
     }
 }
 
-@utility container {
-    @apply mx-auto flex max-w-[1200px] w-full px-4;
-}
-
 @utility card-grid {
     @apply grid grid-cols-1 gap-4 gap-y-6 sm:grid-cols-2 md:grid-cols-3 w-full
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -124,7 +124,7 @@
 }
 
 @utility container {
-    @apply m-auto flex max-w-[1200px] w-full px-4;
+    @apply mx-auto flex max-w-[1200px] w-full px-4;
 }
 
 @utility card-grid {

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -5,7 +5,6 @@ import React, { useState } from "react";
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 
 import { QuickAddDialogs } from "@/components/dialogs/quickAdd";
-import { PageContainer } from "@/components/layout/PageContainer";
 import { AppBreadcrumb, AppSidebar } from "@/components/layout/sidebar";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -41,9 +40,9 @@ const RootLayout: React.FunctionComponent = () => {
             className="ml-auto flex items-center gap-2"
           />
         </header>
-        <PageContainer className="mb-8 flex flex-col py-4">
+        <div className="flex flex-1 flex-col pb-8">
           <Outlet />
-        </PageContainer>
+        </div>
       </SidebarInset>
       <QuickAddDialogs
         active={activeQuickAdd}

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 import { createRootRoute, Outlet } from "@tanstack/react-router";
 
 import { QuickAddDialogs } from "@/components/dialogs/quickAdd";
+import { PageContainer } from "@/components/layout/PageContainer";
 import { AppBreadcrumb, AppSidebar } from "@/components/layout/sidebar";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -40,9 +41,9 @@ const RootLayout: React.FunctionComponent = () => {
             className="ml-auto flex items-center gap-2"
           />
         </header>
-        <div className="container mb-8 flex-col py-4">
+        <PageContainer className="mb-8 flex flex-col py-4">
           <Outlet />
-        </div>
+        </PageContainer>
       </SidebarInset>
       <QuickAddDialogs
         active={activeQuickAdd}

--- a/packages/client/src/routes/actions/route.tsx
+++ b/packages/client/src/routes/actions/route.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { CalendarCheckIcon, ListTodoIcon } from "lucide-react";
 
-import { OverviewCardGrid, PageHeader } from "@/components/layout";
+import { OverviewCardGrid, PageContainer, PageHeader } from "@/components/layout";
 import { ENTITY_DESCRIPTIONS } from "@/lib/entityDescriptions";
 import { fetchRoutines, fetchTasks } from "@/utils";
 import {
@@ -36,7 +36,7 @@ function Actions() {
         pageTitle="Actions"
         description="The things you actually do — recurring routines and one-off tasks that move your learning forward."
       />
-      <div className="container">
+      <PageContainer>
         <OverviewCardGrid
           className="md:grid-cols-2"
           items={[
@@ -66,7 +66,7 @@ function Actions() {
             },
           ]}
         />
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/dashboard/-components/index.ts
+++ b/packages/client/src/routes/dashboard/-components/index.ts
@@ -17,6 +17,7 @@ export {
 } from "@/lib/dashboardTiles";
 export { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 export { LayoutNameDialog } from "@/components/dialogs/LayoutNameDialog";
+export { PageContainer } from "@/components/layout/PageContainer";
 export { PageHeader } from "@/components/layout/PageHeader";
 export { Button } from "@/components/ui/button";
 export { Tabs, TabsList } from "@/components/ui/tabs";

--- a/packages/client/src/routes/dashboard/route.tsx
+++ b/packages/client/src/routes/dashboard/route.tsx
@@ -21,6 +21,7 @@ import {
   LayoutTab,
   needsNormalization,
   normalizeTiles,
+  PageContainer,
   PageHeader,
   Tabs,
   TabsList,
@@ -229,7 +230,7 @@ function Dashboard() {
   return (
     <div>
       <PageHeader pageTitle="Dashboard" />
-      <div className="container flex flex-col gap-3">
+      <PageContainer className="flex flex-col gap-3">
         {isPending && (
           <p className="text-sm text-muted-foreground">Loading dashboard...</p>
         )}
@@ -283,7 +284,7 @@ function Dashboard() {
               )}
           </>
         )}
-      </div>
+      </PageContainer>
 
       <VisibleTilesDialog
         open={tilesTarget !== null}

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-NewRoutineForm.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-NewRoutineForm.tsx
@@ -5,7 +5,12 @@ import { Loader2 } from "lucide-react";
 import { MODE_OPTIONS } from "../-routineFormMeta";
 import { useNewRoutineForm } from "./-useNewRoutineForm";
 
-import { EditForm, EditPageFooter, PageHeader } from "@/components/layout";
+import {
+  EditForm,
+  EditPageFooter,
+  PageContainer,
+  PageHeader,
+} from "@/components/layout";
 import { Button } from "@/components/ui/button";
 
 interface NewRoutineFormProps {
@@ -32,7 +37,7 @@ export function NewRoutineForm({
         pageTitle="New Routine"
         pageSection="routines"
       />
-      <div className="mx-auto w-full max-w-[1200px] px-4">
+      <PageContainer>
         <EditForm
           onSubmit={form.handleSubmit}
           className="flex max-w-3xl flex-col gap-8"
@@ -69,7 +74,7 @@ export function NewRoutineForm({
             </Button>
           </EditPageFooter>
         </EditForm>
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-NewRoutineForm.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-NewRoutineForm.tsx
@@ -32,7 +32,7 @@ export function NewRoutineForm({
         pageTitle="New Routine"
         pageSection="routines"
       />
-      <div className="m-auto w-full max-w-[1200px] px-4">
+      <div className="mx-auto w-full max-w-[1200px] px-4">
         <EditForm
           onSubmit={form.handleSubmit}
           className="flex max-w-3xl flex-col gap-8"

--- a/packages/client/src/routes/routines/$id/edit/route.tsx
+++ b/packages/client/src/routes/routines/$id/edit/route.tsx
@@ -13,7 +13,12 @@ import {
 } from "./-components";
 
 import { UnsavedChangesDialog } from "@/components/dialogs/UnsavedChangesDialog";
-import { EditPageFooter, PageHeader, PageTabs } from "@/components/layout";
+import {
+  EditPageFooter,
+  PageContainer,
+  PageHeader,
+  PageTabs,
+} from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import {
@@ -195,7 +200,7 @@ function ExistingRoutineEdit({
           </Button>
         </Link>
       </PageHeader>
-      <div className="container flex flex-col gap-6">
+      <PageContainer className="flex flex-col gap-6">
         <PageTabs
           value={tab}
           onValueChange={changeTab}
@@ -251,7 +256,7 @@ function ExistingRoutineEdit({
             Done
           </Button>
         </EditPageFooter>
-      </div>
+      </PageContainer>
       <UnsavedChangesDialog shouldBlockFn={shouldBlockFn(anyTabHasChanges)} />
     </div>
   );

--- a/packages/client/src/routes/routines/$id/index.tsx
+++ b/packages/client/src/routes/routines/$id/index.tsx
@@ -11,7 +11,7 @@ import { RoutineDetailsContent } from "./-components/-RoutineDetailsContent";
 import { RoutineTodayCard } from "./-components/-RoutineTodayCard";
 
 import { DAILY_DETAIL_TABS } from "@/components/dailies";
-import { PageActions, PageHeader } from "@/components/layout";
+import { PageActions, PageContainer, PageHeader } from "@/components/layout";
 import { EntityError, EntityPending } from "@/components/listControls/EntityStates";
 import { Button } from "@/components/ui/button";
 import { fetchSingleRoutine } from "@/utils";
@@ -107,7 +107,7 @@ function SingleRoutine() {
           </Button>
         </Link>
       </PageActions>
-      <div className="container flex flex-col gap-12">
+      <PageContainer className="flex flex-col gap-12">
         <RoutineTodayCard data={data} />
         <DailyDetailsPanel
           dailyId={id}
@@ -135,7 +135,7 @@ function SingleRoutine() {
           )}
           detailsContent={<RoutineDetailsContent data={data} />}
         />
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/routines/-components/-RoutinesList.tsx
+++ b/packages/client/src/routes/routines/-components/-RoutinesList.tsx
@@ -12,6 +12,7 @@ import {
   FilterSelect,
   ListEmptyStates,
   ListSearchInput,
+  PageContainer,
 } from "@/components/listControls";
 import {
   Select,
@@ -118,7 +119,7 @@ export function RoutinesList({
   );
 
   return (
-    <div className="container flex flex-col gap-4">
+    <PageContainer className="flex flex-col gap-4">
       {routines.length > 0 && (
         <div className="mb-4 flex flex-wrap items-center gap-3">
           <ListSearchInput
@@ -183,6 +184,6 @@ export function RoutinesList({
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/packages/client/src/routes/routines/tracker/-components/-TrackerTables.tsx
+++ b/packages/client/src/routes/routines/tracker/-components/-TrackerTables.tsx
@@ -15,6 +15,7 @@ import {
   DailyTrackerRow,
   TooManyDailiesWarning,
 } from "@/components/dailies";
+import { PageContainer } from "@/components/layout/PageContainer";
 import { DataTable } from "@/components/ui/data-table";
 import {
   getDaysBetweenFirstAndLastEntry,
@@ -142,7 +143,7 @@ export function TrackerTables({
   recentDaysCount,
 }: RoutineTrackerState) {
   return (
-    <div className="container flex flex-col gap-4">
+    <PageContainer className="flex flex-col gap-4">
       {(!baseSorted || baseSorted.length === 0) && (
         <p className="text-sm text-muted-foreground">
           <i>No routines yet!</i>
@@ -249,6 +250,6 @@ export function TrackerTables({
           />
         </DashboardCard>
       )}
-    </div>
+    </PageContainer>
   );
 }

--- a/packages/client/src/routes/settings/route.tsx
+++ b/packages/client/src/routes/settings/route.tsx
@@ -14,7 +14,7 @@ import {
   TodoistSection,
 } from "./-components";
 
-import { PageHeader, PageTabs } from "@/components/layout";
+import { PageContainer, PageHeader, PageTabs } from "@/components/layout";
 
 const TAB_VALUES = [
   "tasks",
@@ -60,7 +60,7 @@ function Settings() {
   return (
     <div>
       <PageHeader pageTitle="Settings" />
-      <div className="container">
+      <PageContainer>
         <PageTabs
           value={tab}
           onValueChange={changeTab}
@@ -114,7 +114,7 @@ function Settings() {
             },
           ]}
         />
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/tasks/$id/edit/route.tsx
+++ b/packages/client/src/routes/tasks/$id/edit/route.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   EditPageFooter,
   EntityHeaderButton,
+  PageContainer,
   PageHeader,
   UnsavedChangesDialog,
 } from "@/components/editPage";
@@ -150,7 +151,7 @@ function SingleTaskEdit() {
           />
         )}
       </PageHeader>
-      <div className="mx-auto w-full max-w-[1200px] px-4">
+      <PageContainer>
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -249,7 +250,7 @@ function SingleTaskEdit() {
           </EditPageFooter>
         </form>
         <UnsavedChangesDialog shouldBlockFn={shouldBlockFn(hasChanges)} />
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/tasks/$id/edit/route.tsx
+++ b/packages/client/src/routes/tasks/$id/edit/route.tsx
@@ -150,7 +150,7 @@ function SingleTaskEdit() {
           />
         )}
       </PageHeader>
-      <div className="m-auto w-full max-w-[1200px] px-4">
+      <div className="mx-auto w-full max-w-[1200px] px-4">
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/client/src/routes/tasks/$id/index.tsx
+++ b/packages/client/src/routes/tasks/$id/index.tsx
@@ -6,7 +6,12 @@ import { LinkedRoutinesSection } from "./-components/-LinkedRoutinesSection";
 import { TodosEditor } from "./-components/-TodosEditor";
 
 import { OpenBookmarkPageButton } from "@/components/bookmarks";
-import { InfoArea, PageActions, PageHeader } from "@/components/layout";
+import {
+  InfoArea,
+  PageActions,
+  PageContainer,
+  PageHeader,
+} from "@/components/layout";
 import {
   EntityError,
   EntityPending,
@@ -86,7 +91,7 @@ function SingleTask() {
         pageTitle={data.name}
         pageSection="tasks"
       />
-      <div className="container flex flex-col gap-12">
+      <PageContainer className="flex flex-col gap-12">
         <InfoArea
           header="Routines"
           condition={true}
@@ -162,7 +167,7 @@ function SingleTask() {
         >
           <TodosEditor task={data} />
         </InfoArea>
-      </div>
+      </PageContainer>
     </div>
   );
 }

--- a/packages/client/src/routes/tasks/index.tsx
+++ b/packages/client/src/routes/tasks/index.tsx
@@ -13,6 +13,7 @@ import {
   EntityPending,
   ListEmptyStates,
   ListSearchInput,
+  PageContainer,
   PageHeader,
 } from "@/components/listControls";
 import { Button } from "@/components/ui/button";
@@ -82,7 +83,7 @@ function Tasks() {
         pageSection=""
         description={ENTITY_DESCRIPTIONS.tasks}
       />
-      <div className="container flex flex-col gap-4">
+      <PageContainer className="flex flex-col gap-4">
         {data && data.length > 0 && (
           <div className="mb-4 flex flex-wrap items-center gap-3">
             <ListSearchInput
@@ -109,7 +110,7 @@ function Tasks() {
             ))}
           </div>
         )}
-      </div>
+      </PageContainer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Introduces a new `PageContainer` component to replace the ad-hoc `container` CSS utility class, providing a consistent, reusable width-constraining wrapper for page content across the application.

## Key Changes

- **New `PageContainer` component** (`packages/client/src/components/layout/PageContainer.tsx`):
  - Centers content horizontally at max-width 1200px with responsive padding
  - Replaces inline `className="m-auto w-full max-w-[1200px] px-4"` patterns
  - Includes Storybook story and test utilities

- **New `Card` component family** (`packages/client/src/components/ui/card.tsx`):
  - Comprehensive card UI primitives: `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardAction`, `CardContent`, `CardFooter`
  - Includes Storybook story with smoke tests
  - Uses container queries and semantic data-slot attributes for flexible layouts

- **Removed `@utility container` CSS rule** from `packages/client/src/index.css`:
  - The old utility bundled `flex` with width constraints; `PageContainer` is explicit and composable
  - Pages now add their own `flex flex-col gap-N` as needed

- **Updated 13 route/component files** to use `PageContainer`:
  - `packages/client/src/routes/routines/$id/edit/-components/form-tabs/-NewRoutineForm.tsx`
  - `packages/client/src/routes/routines/$id/edit/route.tsx`
  - `packages/client/src/routes/routines/$id/index.tsx`
  - `packages/client/src/routes/routines/-components/-RoutinesList.tsx`
  - `packages/client/src/routes/routines/tracker/-components/-TrackerTables.tsx`
  - `packages/client/src/routes/tasks/$id/index.tsx`
  - `packages/client/src/routes/tasks/$id/edit/route.tsx`
  - `packages/client/src/routes/tasks/index.tsx`
  - `packages/client/src/routes/actions/route.tsx`
  - `packages/client/src/routes/settings/route.tsx`
  - `packages/client/src/routes/dashboard/route.tsx`
  - `packages/client/src/components/layout/PageHeader.tsx`
  - `packages/client/src/routes/__root.tsx`

- **Updated exports** in layout and list-controls index files to expose `PageContainer`

## Implementation Details

- `PageContainer` uses `data-slot="page-container"` for semantic targeting and debugging
- Maintains the same max-width (1200px) and padding (4 units) as the old utility
- Replaces both `className="container"` and inline `className="m-auto w-full max-w-[1200px] px-4"` patterns
- `PageHeader` now internally uses `PageContainer`, ensuring consistent layout hierarchy
- Fixed `PageHeader` margin class from `m-auto` to `mx-auto` for clarity
- Root layout adjusted to use `flex flex-1 flex-col` instead of the old container utility

https://claude.ai/code/session_01EoiGvnpzsFhrL9tMe5eyKt