### PR TITLE
refactor: overnight codebase health sweep

### DIFF
--- a/.claude/skills/add-entity/SKILL.md
+++ b/.claude/skills/add-entity/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # Add a new entity (course-tracker)
 
-Work through the layers in order; each one depends on the previous. `references/file-checklist.md` lists every file a finished entity touches — diff your work against it before declaring done. Mirror an existing entity of similar shape throughout (junctions → **topics**; plain → **providers**; JSONB-heavy → **routines**).
+Work through the layers in order; each one depends on the previous. `references/file-checklist.md` lists every file a finished entity touches — diff your work against it before declaring done. Mirror an existing entity of similar shape throughout (junction-ful → **tasks**; plain → **task-types**; JSONB-heavy → **routines**).
 
 ## 1. Schema — `packages/middleware/src/db/schema/`
 
@@ -23,7 +23,7 @@ Work through the layers in order; each one depends on the previous. `references/
 
 ## 3. Middleware — `packages/middleware/src/routes/api/<name>/`
 
-Files (see `topics/` for the junction-ful version, `providers/` for the minimal one):
+Files (see `tasks/` for the junction-ful version, `task-types/` for the minimal one):
 
 - `<name>Rows.ts` — `<Name>Body` interface, `<name>BodySchema` (reuse `src/utils/schemas.ts` fragments; import it **relatively** — `../../../utils/schemas.ts` — so `node --test` can load the file), `build<Name>Row`, junction row builders (return `undefined` when input absent, `[]` to clear).
 - `create<Name>.ts` — `createCreateHandler` from `src/utils/createCreateHandler.ts`.
@@ -39,21 +39,21 @@ Files (see `topics/` for the junction-ful version, `providers/` for the minimal 
 
 ## 5. Client routes — `packages/client/src/routes/`
 
-- `<name>.tsx` (layout, usually a bare `<Outlet/>`), `<name>.index.tsx` (list), `<name>.$id.tsx`, `<name>.$id.index.tsx` (detail), `<name>.$id.edit.tsx` (edit/create — `id === "new"`).
-- Edit page: `useEditFormPage` (`makeSubmitHandler` + `makeDeleteHandler` + `shouldBlockFn`), `useAppForm` with a zod schema, `EditPageFooter` + `UnsavedChangesDialog`. Copy `topics.$id.edit.tsx`.
-- Loading/error: `EntityPending` / `EntityError` from `components/EntityStates.tsx`.
+- Folder-based routes: `<name>/route.tsx` (layout, usually a bare `<Outlet/>`), `<name>/index.tsx` (list), `<name>/$id/route.tsx`, `<name>/$id/index.tsx` (detail), `<name>/$id/edit/route.tsx` (edit/create — `id === "new"`).
+- Edit page: `useEditFormPage` (`makeSubmitHandler` + `makeDeleteHandler` + `shouldBlockFn`), `useAppForm` with a zod schema, `EditPageFooter` + `UnsavedChangesDialog`. Copy `tasks/$id/edit/route.tsx`.
+- Loading/error: `EntityPending` / `EntityError` from `components/listControls/EntityStates.tsx`.
 - List card → new `components/contentBoxComponents/<Name>Box.tsx` if the list shows cards (add it to the `contentBoxComponents/index.ts` barrel).
 - Regenerate the route tree: `pnpm --filter=@emstack/client run routeTree` (never edit `routeTree.gen.ts`).
 
 ## 6. Navigation
 
-- `src/routes/__root.tsx`: add a `<Link>` inside the matching `NavDropdown` (desktop) **and** the mobile menu lower in the file.
+- `components/layout/sidebar/navConfig.ts`: add a `NavCategory` (list link, quick-add key, detail-link builder, lazy `load`) under the matching `NavSection` — the collapsible sidebar renders from this config.
 - `components/layout/PageHeader.tsx`: add the new `pageSection` if the header maps sections.
 
 ## 7. Verify
 
 ```bash
-pnpm push:dev && pnpm typecheck && pnpm lint && pnpm test && pnpm build
+pnpm push:dev && pnpm typecheck && pnpm lint && pnpm --filter=@emstack/client exec vitest run && pnpm --filter=@emstack/middleware test && pnpm build
 ```
 
 Runtime smoke (server running via `pnpm dev`): POST → GET list → GET single → PUT → DELETE through `http://localhost:3001/api/<name>`, then click through list → create → edit → delete in the UI at `http://localhost:5173`. Check `git diff --stat`: `routeTree.gen.ts` should be regenerated, nothing else unexpected.

--- a/.claude/skills/add-entity/references/file-checklist.md
+++ b/.claude/skills/add-entity/references/file-checklist.md
@@ -29,13 +29,13 @@ factory refactors that landed since. `<name>` = plural kebab/camel entity name.
 
 - [ ] `packages/client/src/utils/api/<name>.ts` — `createEntityClient` + named exports
 - [ ] `packages/client/src/utils/api/index.ts` — re-export
-- [ ] `packages/client/src/routes/<name>.tsx` — layout
-- [ ] `packages/client/src/routes/<name>.index.tsx` — list page
-- [ ] `packages/client/src/routes/<name>.$id.tsx` — detail layout
-- [ ] `packages/client/src/routes/<name>.$id.index.tsx` — detail page
-- [ ] `packages/client/src/routes/<name>.$id.edit.tsx` — edit/create page
+- [ ] `packages/client/src/routes/<name>/route.tsx` — layout
+- [ ] `packages/client/src/routes/<name>/index.tsx` — list page
+- [ ] `packages/client/src/routes/<name>/$id/route.tsx` — detail layout
+- [ ] `packages/client/src/routes/<name>/$id/index.tsx` — detail page
+- [ ] `packages/client/src/routes/<name>/$id/edit/route.tsx` — edit/create page
 - [ ] `packages/client/src/components/contentBoxComponents/<Name>Box.tsx` — list card (if cards; add to the `contentBoxComponents/index.ts` barrel)
 - [ ] `packages/client/src/components/<name>/…` — entity-specific widgets (as needed)
-- [ ] `packages/client/src/routes/__root.tsx` — desktop nav + mobile nav links
+- [ ] `packages/client/src/components/layout/sidebar/navConfig.ts` — sidebar NavCategory entry
 - [ ] `packages/client/src/components/layout/PageHeader.tsx` — page section (if mapped)
 - [ ] `packages/client/src/routeTree.gen.ts` — regenerated, never hand-edited

--- a/.claude/skills/add-field-to-entity/SKILL.md
+++ b/.claude/skills/add-field-to-entity/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: add-field-to-entity
 description: >-
-  Add a new field/column to an existing entity (topic, task, resource,
-  routine, daily, provider, domain, module, tag…) end to end: DB schema,
-  shared type, API handlers, client form and detail display. Use when asked
-  to "add a field", "store X on Y", or "let users set X".
+  Add a new field/column to an existing entity (task, routine, task type,
+  tag, tag group, daily criteria template, routine template, dashboard
+  layout, settings…) end to end: DB schema, shared type, API handlers,
+  client form and detail display. Use when asked to "add a field", "store X
+  on Y", or "let users set X".
 ---
 
 # Add a field to an existing entity (course-tracker)
@@ -13,32 +14,32 @@ The layers, in dependency order. Skipping one is the classic source of "saves bu
 
 ## 1. Database (`packages/middleware/src/db/schema/`)
 
-- Add the column to the entity's table (file split by domain: `courses.ts` holds resources/providers/modules, `topics.ts`, `tasks.ts`, `routines.ts`, `dailyCriteriaTemplates.ts`, `radar.ts`, `tags.ts`). New enums go in `enums.ts`.
+- Add the column to the entity's table (file split by domain: `tasks.ts` holds tasks/task types/todos/bookmark junctions, `routines.ts` holds routines/connections/templates, `tags.ts`, `dailyCriteriaTemplates.ts`, `dashboardLayouts.ts`, `settings.ts`). New enums go in `enums.ts`.
 - Plain new nullable column → `pnpm push:dev` is enough. Rename / backfill / data move → **use the `add-db-migration` skill** for a runtime migration first.
 
 ## 2. Shared type (`packages/types/src/`)
 
-- Add the field to the entity's interface (e.g. `Topic.ts`, `Task.ts`, `Resource.ts`). Build it so consumers see it: `pnpm --filter=@emstack/types build` (or rely on `pnpm dev`'s watch).
+- Add the field to the entity's interface (e.g. `Task.ts`, `Routine.ts`, `Tag.ts`). Build it so consumers see it: `pnpm --filter=@emstack/types build` (or rely on `pnpm dev`'s watch).
 
 ## 3. Middleware (`packages/middleware/src/routes/api/<entity>/`)
 
 - **`<entity>Rows.ts`** is the single source shared by create + upsert: add the field to the `<Entity>Body` interface, the `<entity>BodySchema` JSON schema (reuse `nullableString` / `nullableBoolean` / `nullableInteger` etc. from `src/utils/schemas.ts`), and `build<Entity>Row`.
 - Note: rows files import `schemas.ts` **relatively** (`../../../utils/schemas.ts`), not via `@/`, so `node --test` can load them.
 - **`upsert<Entity>.ts`**: add the column name to `updateableColumns` (and to `buildSetClause` if the entity uses partial-merge, like routines).
-- **GET handlers**: if the entity has a projection (`src/utils/taskProjection.ts`, `resourceProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`), add the field there — both list (`root.ts`) and single (`get<Entity>.ts`) flow through it.
+- **GET handlers**: if the entity has a projection (`src/utils/taskProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`, `todoDailyProjection.ts`), add the field there — both list (`root.ts`) and single (`get<Entity>.ts`) flow through it. Remember dailies are a projection of routines, not their own table.
 - **`duplicate<Entity>.ts`** (if it exists): copy the new field, or duplicates silently drop it.
 
 ## 4. Client
 
-- **Edit page** `packages/client/src/routes/<entity>.$id.edit.tsx`:
+- **Edit page** `packages/client/src/routes/<entity>/$id/edit/route.tsx`:
   - add to the zod `formSchema`, to `startingValues` (with `data?.field ?? <default>`), to the payload passed to the submit handler, and a `form.AppField` control (`InputField`, `TextareaField`, `NumberField`, `RadioGroupField`, `DatePickerField`, `ComboboxField`, `MultiComboboxField` — registered in `hooks/useAppForm.ts`).
-- **Detail page** `<entity>.$id.index.tsx`: display the field (see `components/layout/InfoRow.tsx` / `InfoArea.tsx` patterns).
+- **Detail page** `<entity>/$id/index.tsx`: display the field (import the read-only sections through the `components/infoCard` barrel — `InfoArea`, `InfoRow`).
 - List/card views (`components/contentBoxComponents/*`) only if the field belongs there.
 
 ## 5. Verify
 
 ```bash
-pnpm push:dev && pnpm typecheck && pnpm lint && pnpm test
+pnpm push:dev && pnpm typecheck && pnpm lint && pnpm verify:changed
 ```
 
 Then runtime-check round-tripping (server must be running — `pnpm dev`):
@@ -51,4 +52,4 @@ curl -s -X PUT  http://localhost:3001/api/<entity>s/<id> -H 'Content-Type: appli
   -d '{"name":"smoke2","<field>":"value2"}'      # update persists
 ```
 
-Gotcha: a PUT that omits optional junction arrays (tagIds, resourceLinks…) deliberately leaves those rows untouched — don't "fix" that.
+Gotcha: a PUT that omits optional junction arrays (tagIds, bookmarks, todos…) deliberately leaves those rows untouched — don't "fix" that.

--- a/.claude/skills/add-stories/SKILL.md
+++ b/.claude/skills/add-stories/SKILL.md
@@ -20,16 +20,16 @@ components themselves. The one exception is route shells (Tier C below), where
 the prescribed move is a behavior-preserving *extract* before storying.
 
 Coverage is tracked in a **story-coverage tracker** issue, split into per-area
-sub-issues (formFields, layout, resources, routes, …) — same model as the
+sub-issues (formFields, layout, dailies, routes, …) — same model as the
 import/max-dependencies cleanup tracker. This skill is the repeatable procedure
 for one such area.
 
 Stories already exist for ~40-50% of components; whole areas are done
-(`contentBoxComponents/`, `boxElements/`, `dailies/`, `radar/`, `tables/`). Don't
+(`contentBoxComponents/`, `boxElements/`, `dailies/`, `routines/`). Don't
 re-story those. The shared infra is already in place — reuse it, don't reinvent.
 
 > _Components, files, and fixtures named below (e.g. `InfoRow`,
-> `-ResourcesList.stories.tsx`, `useResourceModules`) are illustrations — they
+> `-TodoEditRow.stories.tsx`, `useDailyCompletions`) are illustrations — they
 > show the **shape** of the pattern, not required targets. Apply the method to
 > whatever's in your scope. Per-area worked examples (fixtures added, tricky
 > decorators) live in `references/area-notes.md` — illustrative reference, not
@@ -38,8 +38,7 @@ re-story those. The shared infra is already in place — reuse it, don't reinven
 ## 1. Inventory the target area — what's actually uncovered
 
 Story files are **co-located** next to the component and a story's filename
-**need not match** its component file (e.g. `radarLegendItem.tsx` →
-`BlipLegendItem.stories.tsx`). So don't audit by filename match alone — grep each
+**need not match** its component file. So don't audit by filename match alone — grep each
 component's export for a referencing story. A quick first pass for a folder:
 
 ```bash
@@ -79,7 +78,7 @@ Open the file and look at what it imports/calls — that dictates the decorators
 ## 3. Author the story (the canonical pattern)
 
 Mirror `components/ui/Badge.stories.tsx` (Tier A) and
-`routes/resources.-components/-ResourcesList.stories.tsx` (Tier B). Rules:
+`routes/tasks/$id/-components/-TodoEditRow.stories.tsx` (Tier B). Rules:
 
 - **CSF3:** `import type { Meta, StoryObj } from "@storybook/react-vite";`
 - **Test helpers from `storybook/test`** — the bare package, **NOT**
@@ -101,7 +100,8 @@ Mirror `components/ui/Badge.stories.tsx` (Tier A) and
   (trips `no-empty-function`).
 - **Mock data from fixtures.** Use the `make*` factories in
   `src/test-utils/*Fixtures.ts` (`boxFixtures`, `dailiesFixtures`,
-  `radarFixtures`) — `makeResource`, `makeDaily`, `makeBlip`, `makeTopics`, … —
+  `tasksFixtures`, `routinesFixtures`) — `makeDaily`, `makeTaskTodo`,
+  `makeRoutine`, … —
   with partial overrides. Extend a factory rather than hand-rolling literals. If
   an area has no factory yet and you're writing several stories, add a
   `test-utils/<area>Fixtures.ts` instead of duplicating args per story.
@@ -119,7 +119,6 @@ There are **no global decorators** in `.storybook/preview.ts`, and don't add any
   that *reads* via `useQuery`, build a `QueryClient`, seed it with
   `setQueryData(queryKeys.…, data)` (keys from `@/utils/queryKeys`), and pass it
   as the `client` prop so the component sees data without a network call.
-- **Settings** → `SettingsProvider` from `@/context/SettingsProvider`.
 - **Tooltips** → `TooltipProvider` from `@/components/ui/tooltip`.
 - **Radix menu items** (`DropdownMenuItem` and friends) need their menu context:
   wrap in `<DropdownMenu open><DropdownMenuContent forceMount>…</…>`. The content
@@ -129,8 +128,7 @@ There are **no global decorators** in `.storybook/preview.ts`, and don't add any
   `<svg>`, `TableRow` in `<Table><TableBody>`. Give width-dependent components a
   sizing wrapper (`<div className="max-w-sm">`).
 - **Persisted UI state** (localStorage view-mode etc.) → reset in
-  `beforeEach: () => window.localStorage.clear()`
-  (see `-ResourcesList.stories.tsx`).
+  `beforeEach: () => window.localStorage.clear()`.
 
 Compose decorators by nesting (outermost first), e.g.
 `RouterStub > TooltipProvider > sizing div > Story`.
@@ -139,13 +137,13 @@ Compose decorators by nesting (outermost first), e.g.
 
 Route shells are thin glue (fetch + `useSearch` → render a presentational child).
 The established convention covers them by **storying their extracted leaf**, which
-already takes plain props (`-ResourcesList` gets `resources`/`providers`/`topics`;
-`-DashboardGrid` exports `GridTile`). So:
+already takes plain props (`-DashboardGrid` exports `GridTile`;
+`-TodosEditor` delegates rows to `-TodoReadRow`/`-TodoEditRow`). So:
 
-1. **Route already delegates to a props-driven `routes/<x>.-components/-X.tsx`
+1. **Route already delegates to a props-driven `routes/<x>/-components/-X.tsx`
    leaf** → story that leaf (Tier A/B). Done.
 2. **Route holds inline render logic worth covering** → first *extract* it into a
-   `routes/<x>.-components/-X.tsx` presentational component (props in,
+   `routes/<x>/-components/-X.tsx` presentational component (props in,
    behavior-preserving — mirrors the existing route structure), wire the route to
    render it, regenerate the route tree
    (`pnpm --filter=@emstack/client run routeTree`, expect no routing diff — the

--- a/.claude/skills/check-components/SKILL.md
+++ b/.claude/skills/check-components/SKILL.md
@@ -26,11 +26,11 @@ Two homes for components (see `packages/client/CLAUDE.md`):
   `components/ui/` (the shadcn primitives, incl. `button`, `combobox`, `popover`,
   `input`, …), `components/layout/`, `components/formFields/`, and the shared
   `components/dialogs/` family. Also feature folders (`dailies/`, `routines/`,
-  `radar/`, `tasks/`, `resources/`, `boxes/`, …). No component lives directly in
+  `tasks/`, `bookmarks/`, `contentBoxComponents/`, …). No component lives directly in
   `components/` — everything is in a themed subdirectory.
-- **Route-private** — sibling `*.-components/` folders (the `.-` prefix keeps
-  them out of TanStack routing), imported by relative path like
-  `./dashboard.-components/-DashboardGrid`.
+- **Route-private** — `-components/` folders nested in a route's directory
+  (the leading `-` keeps them out of TanStack routing), imported by relative
+  path like `./-components` from the route file.
 
 Two things drift over time, and this skill checks both:
 
@@ -47,7 +47,7 @@ Parse `$ARGUMENTS`:
 
 - **Empty** → scan the whole client (`packages/client/src`).
 - **A route name or folder path** (e.g. `/check-components dashboard` or
-  `/check-components packages/client/src/components/radar`) → scope the scan to
+  `/check-components packages/client/src/components/dailies`) → scope the scan to
   that route family / directory.
 
 Assume `pnpm install` has been run. All paths below are relative to the repo root.
@@ -58,14 +58,14 @@ Enumerate the route-private folders and their **owning route prefix** (derive it
 from the folder name — strip the `.-components` suffix and any dynamic segments):
 
 ```bash
-# All route-private folders (there are ~4 today)
-ls -d packages/client/src/routes/*.-components 2>/dev/null
+# All route-private folders
+find packages/client/src/routes -type d -name '-components' 2>/dev/null
 ```
 
-- `dashboard.-components/` → route family **`dashboard`**
-- `settings.-components/` → **`settings`**
-- `routines.$id.edit.-components/` → **`routines`**
-- `domains.$id.edit.-components/` → **`domains`**
+- `dashboard/-components/` → route family **`dashboard`**
+- `settings/-components/` → **`settings`**
+- `routines/$id/-components/` and `routines/$id/edit/-components/` → **`routines`**
+- `tasks/$id/-components/` → **`tasks`**
 
 Then enumerate the shared library and mark the **off-limits primitives** — these
 are *never* colocation candidates no matter how few consumers they have:
@@ -85,10 +85,10 @@ For each candidate component, find every importer across the **whole package**
 (consumers live in routes, hooks, and other components). Match both import forms:
 
 ```bash
-# absolute alias form, e.g. @/components/radar/BlipLegend
+# absolute alias form, e.g. @/components/dailies/DailyStatusCircle
 grep -rn "@/components/<subpath>/<Name>" packages/client/src --include=*.tsx --include=*.ts
-# relative route-private form, e.g. ./dashboard.-components/-DashboardGrid
-grep -rn "\.-components/-<Name>" packages/client/src --include=*.tsx --include=*.ts
+# relative route-private form, e.g. ./-components/-DashboardGrid
+grep -rn "\-components/-<Name>" packages/client/src --include=*.tsx --include=*.ts
 ```
 
 Derive each importer's **route family** from its path under `src/routes/` (the
@@ -148,7 +148,7 @@ Produce a findings report grouped **one section per category**, and **within eac
 category split by feature or path group**:
 
 - **Colocate** (Check 1) — split by target route family (colocate-`dailies`,
-  colocate-`radar`, …)
+  colocate-`tasks`, …)
 - **Promote** (Check 2a) — split by source `*.-components/` folder
 - **Dedupe** (Check 2b) — split by feature / the shared component involved
 

--- a/.claude/skills/condense-components/SKILL.md
+++ b/.claude/skills/condense-components/SKILL.md
@@ -20,11 +20,13 @@ duplicate type/interface declarations, run that too.
 
 Shared primitives live in `packages/client/src/components/ui/` (shadcn-derived)
 and the root-level `components/*.tsx` vendored files. Feature components live in
-`components/<feature>/` (`radar/`, `dailies/`, `tasks/`, …). Most condensing is
+`components/<feature>/` (`bookmarks/`, `dailies/`, `tasks/`, …). Most condensing is
 pulling hand-rolled markup back toward a primitive, or lifting a copy-pasted
 block into one shared component.
 
-> _Components named below (e.g. `BlipLegendItem`, `SelectAllCheckbox`) are
+> _Components named below (e.g. `SelectAllCheckbox`) are **historical**
+> illustrations — several (the radar/topics examples) were since removed with
+> their subsystems, but the condensation patterns they teach still apply. They are
 > illustrations from earlier runs of this skill — they show the **shape** of a
 > fix, not required targets. Apply the method to whatever's in your scope._
 
@@ -100,7 +102,7 @@ content/render slots so it stays dumb.
 - **Don't over-parameterize.** A "shared" component with one caller, or three
   render-slot props that each fire once, earns nothing — inline it.
 - **Keep the home right.** Cross-cutting primitives go in `components/ui/`;
-  feature-only pieces stay in `components/<feature>/`. Don't drag a radar-specific
+  feature-only pieces stay in `components/<feature>/`. Don't drag a feature-specific
   component into `ui/` just because it was extracted.
 - **Match existing layout/styling.** A reuse that shifts padding, rounding, or
   font size is a behavior change — verify the merged classes render the same.
@@ -124,7 +126,7 @@ include (`**/*.test.{ts,tsx}`) finds tests either way.
 
 If the ask is broader than the components you touched — e.g. "every component in
 this folder needs a story" — first reuse the mock-data factories: extract shared
-`make*` builders into `test-utils/radarFixtures.ts` (blips/quadrants/rings/topics
+`make*` builders into a shared `test-utils/<area>Fixtures.ts` (see `tasksFixtures.ts`
 + a `byId` map helper) instead of re-rolling args in each story. One
 `*.stories.tsx` per component file covering the primary export (plus meaningful
 siblings — e.g. both illustrations); heavy containers get a single representative
@@ -164,8 +166,7 @@ render story. A render-only story (no `play`) still smoke-tests rendering.
 - **jsdom gotcha**: `fireEvent.click` fires `onChange` even on a `disabled`
   input, so don't assert "disabled ⇒ handler not called" in jsdom — assert the
   `disabled` attribute instead.
-- **Story file naming need not match the component file** (e.g. `radarLegendItem.tsx`
-  → `BlipLegendItem.stories.tsx`). Don't audit coverage by filename match alone;
+- **Story file naming need not match the component file.** Don't audit coverage by filename match alone;
   grep each component's export for a referencing `.stories.tsx`.
 
 ## 6. Verify

--- a/.claude/skills/organize-components/SKILL.md
+++ b/.claude/skills/organize-components/SKILL.md
@@ -29,10 +29,10 @@ those are handed off (`condense-components`, `condense-types`).
 - Route-private components live in a sibling `*.-components/` folder; the `.-`
   prefix keeps them out of TanStack routing. Component files keep a leading `-`
   (e.g. `-DetailsTab.tsx`) **inside subfolders too**.
-- Precedent for subfolders: `routes/domains.$id.-components/` is split into
-  `radar/` and `topicLists/`, each with an `index.ts` barrel that re-exports only
+- Precedent for subfolders: `routes/dashboard/-components/` is split into
+  `layout/` and `dashboardCards/`, each with an `index.ts` barrel that re-exports only
   the **public surface**; extracted internal leaves are intentionally not
-  re-exported (read `domains.$id.-components/radar/index.ts` for the comment
+  re-exported (read `dashboard/-components/index.ts` for the comment
   style).
 - Shared library lives in `src/components/**` (imported via `@/components/...`).
   No component sits at the `components/` root — a `components/structure.test.ts`
@@ -42,7 +42,7 @@ those are handed off (`condense-components`, `condense-types`).
 
 Parse `$ARGUMENTS`:
 
-- **A folder/route** (e.g. `/organize-components domains.$id.edit` or a full
+- **A folder/route** (e.g. `/organize-components routines/$id/edit` or a full
   `packages/client/src/routes/<x>.-components` path) → organize that folder.
 - **Empty** → ask which `*.-components/` folder to organize, or list candidates:
   ```bash
@@ -60,8 +60,8 @@ what it imports/renders. Identify:
   presentational panel — these belong together).
 - **Shared-parent groups** (components only ever rendered by one other component
   in the folder).
-- **Same-concern families** (e.g. all the radar-config pieces, all the
-  domain-metadata forms).
+- **Same-concern families** (e.g. all the dashboard-layout pieces, all the
+  routine-template forms).
 
 For a large folder, delegate the read to an **Explore agent** and have it return a
 grouped inventory with `file:line` references.
@@ -143,7 +143,7 @@ Shared notes:
 - **Unify near-identical siblings.** If two blocks differ only by their data
   (e.g. an "adopted" vs "ignored" strip), extract **one** parameterized leaf and
   render it twice with different props rather than two near-copies.
-- If a shared data type lives in the parent (e.g. `BlipDraft`, a `*Draft`
+- If a shared data type lives in the parent (e.g. a `*Draft`
   interface), import it `import type` into the leaf — type-only imports don't
   create a runtime cycle even when the parent also imports the leaf.
 - **Don't over-decompose.** Leave already-small components, containers, and the
@@ -185,7 +185,7 @@ repo CSF3 conventions (see `/add-stories` and the sibling stories in the folder)
   include `fn()` spies (import `fn` from `storybook/test`) — `satisfies Meta` +
   `fn()` triggers TS2742, so reserve `satisfies` for spy-free metas.
 - Reuse fixture factories from `@/test-utils/*Fixtures.ts` (e.g.
-  `radarFixtures` → `makeTopics`/`makeQuadrants`/`makeRings`/`makeBlips`) rather
+  `tasksFixtures` → `makeTaskTodo`/`makeTagGroup`) rather
   than hand-rolling literals. Mirror the args the sibling container story already
   builds.
 - Add decorators only when the component needs them: a `<ul>` wrapper for a leaf

--- a/.claude/skills/overnight-cleanup/SKILL.md
+++ b/.claude/skills/overnight-cleanup/SKILL.md
@@ -150,7 +150,7 @@ A source file is "covered" when a test exercises its behavior. Treat a source fi
   - `packages/types/src/routineEntryName.ts` — `routineEntryName` (see 2.4)
   - `packages/types/src/actionableSentence.ts` — `buildActionableSentence`
   - `packages/client/src/lib/*` (e.g. `dashboardTiles.ts`, `entityDescriptions.ts`) and `packages/client/src/utils/*`
-  - `packages/middleware/src/utils/*` projections (`taskProjection.ts`, `resourceProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`) and `packages/middleware/src/services/*`
+  - `packages/middleware/src/utils/*` projections (`taskProjection.ts`, `dailyProjection.ts`, `routineProjection.ts`, `todoDailyProjection.ts`) and `packages/middleware/src/services/*`
 - Prefer pure functions / utilities / services first (no DOM or HTTP harness); component tests second.
 
 **2.3 — Write the tests (match the package's runner).** Use the runner belonging to the package. Mirror a neighboring test for imports and harness — client tests reuse `src/test-utils/` fixtures and decorators; middleware tests follow `packages/middleware/src/tests/`. Write **behavior** tests (representative + edge inputs: empty, boundary, fallback arm), not change-detector snapshots. Cover each condition arm plus the default path for branchy logic. The `tdd` skill covers this repo's test-first flow if useful.
@@ -381,7 +381,7 @@ Iteration N:
 
 Ephemeral container, no human watching. Build the run so a crash costs at most one phase.
 
-- **Checkpoint by pushing, not just committing.** Push after **every iteration** (`git push -u origin claude/overnight-cleanup-skill-ql29ur`, with retry/backoff on network errors per the session's git instructions) — unpushed commits die with the container.
+- **Checkpoint by pushing, not just committing.** Push after **every iteration** (`git push -u origin <your session's designated claude/* branch>`, with retry/backoff on network errors per the session's git instructions) — unpushed commits die with the container.
 - **Cap the work** — ~6 loop iterations max; stop early on the "same score" rule. Never loop one phase forever: if a finding hasn't moved after ~2 attempts, skip it, note it, move on.
 - **Resume safely** — at startup read `git log --oneline` and the run-log to see which phases already committed this run; don't redo or double-commit.
 - **Never leave the tree dirty or red** — if a phase can't go green quickly, `git restore` / `git stash` it and continue. A clean tree at every phase boundary is what makes a crash recoverable.
@@ -421,7 +421,7 @@ Do this only at the very end — after all phases, all commits, and the branch i
 **Push the sweep branch** (retry with backoff on network errors):
 
 ```bash
-git push -u origin claude/overnight-cleanup-skill-ql29ur
+git push -u origin <your session's designated claude/* branch>
 ```
 
 **Open the PR** against `master` with the GitHub MCP tools (`mcp__github__create_pull_request`; if a PR already exists for the branch, **update** it via `mcp__github__update_pull_request` instead of opening a second). CI's `pr-title` check lints the title independently of commits, so get it right the first time:

--- a/.claude/skills/reduce-imports/SKILL.md
+++ b/.claude/skills/reduce-imports/SKILL.md
@@ -13,12 +13,12 @@ description: >-
 
 `pnpm lint` warns on `import/max-dependencies` for many files in
 `packages/client`. The cleanup is tracked in an **import/max-dependencies
-cleanup tracker** issue, split into per-area issues (dailies, resources,
+cleanup tracker** issue, split into per-area issues (dailies, tasks,
 routines, routes, …). This skill is the repeatable procedure for one such area.
 Quality only — behavior must not change. For behavior cleanups use `/simplify`;
 for bugs use `/code-review`.
 
-> _Hooks, files, and components named below (e.g. `useResourceModules`,
+> _Hooks, files, and components named below (e.g. `useDailyCompletions`,
 > `DailyRecentDaysStrip`) are illustrations — they show the **shape** of a fix,
 > not required targets. Apply the method to whatever's in your scope. Per-area
 > worked examples and learnings live in `references/area-notes.md` — illustrative
@@ -74,7 +74,7 @@ those imports; the component is left rendering JSX from a
 presentational-ready return value.
 
 Mirror the existing bundled-hook pattern — for example:
-- `hooks/useResourceModules.ts` — rich `{ data…, mutations…, handlers… }` return.
+- `hooks/useDailyCompletions.ts` — rich `{ data…, mutations…, handlers… }` return.
 - `hooks/useDailyTracker.tsx`, `hooks/useDailyCompletions.ts` — feature hooks
   returning pre-derived rows + action callbacks. Return *computed* values
   (formatted labels, `canGoNext`, per-row flags) so the component imports no

--- a/packages/client/src/components/bookmarks/BookmarksFieldGroup.stories.tsx
+++ b/packages/client/src/components/bookmarks/BookmarksFieldGroup.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { BookmarksFieldGroup } from "./BookmarksFieldGroup";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta: Meta<typeof BookmarksFieldGroup> = {
+  component: BookmarksFieldGroup,
+  args: {
+    value: [],
+    onChange: fn(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub>
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </QueryStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  play: smokeText("Bookmarks"),
+};
+
+export const WithSelection: Story = {
+  args: {
+    value: [
+      {
+        id: "tb-1",
+        bookmarkId: "bm-1",
+        title: "Pimsleur Spanish",
+        url: "https://example.com/pimsleur",
+        position: 0,
+      },
+    ],
+  },
+  play: smokeText("Bookmarks", "Pimsleur Spanish"),
+};

--- a/packages/client/src/components/bookmarks/BookmarksFieldGroup.tsx
+++ b/packages/client/src/components/bookmarks/BookmarksFieldGroup.tsx
@@ -1,0 +1,26 @@
+import type { TaskBookmark } from "@emstack/types";
+
+import { BookmarkPicker } from "./BookmarkPicker";
+
+interface BookmarksFieldGroupProps {
+  value: TaskBookmark[];
+  onChange: (next: TaskBookmark[]) => void;
+}
+
+// The labeled "Bookmarks" form block shared by the task and routine edit
+// forms: a field caption over the Simple Bookmarks picker. Callers wrap it in
+// their own form.Field so the form wiring stays typed per form instance.
+export function BookmarksFieldGroup({
+  value,
+  onChange,
+}: BookmarksFieldGroupProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-medium">Bookmarks</span>
+      <BookmarkPicker
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/CompletionsMonthNav.stories.tsx
+++ b/packages/client/src/components/dailies/CompletionsMonthNav.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { CompletionsMonthNav } from "./CompletionsMonthNav";
+
+import { smokeText } from "@/test-utils/storyPlay";
+
+const june = {
+  year: 2026,
+  month: 5,
+};
+
+const meta: Meta<typeof CompletionsMonthNav> = {
+  component: CompletionsMonthNav,
+  args: {
+    viewMonth: june,
+    currentMonth: june,
+    earliestYear: 2024,
+    monthLabel: "June 2026",
+    monthPickerOpen: false,
+    setMonthPickerOpen: fn(),
+    selectMonth: fn(),
+    goToPrevMonth: fn(),
+    goToNextMonth: fn(),
+    canGoPrev: true,
+    canGoNext: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const CurrentMonth: Story = {
+  play: smokeText("June 2026"),
+};
+
+export const PastMonth: Story = {
+  args: {
+    viewMonth: {
+      year: 2026,
+      month: 2,
+    },
+    monthLabel: "March 2026",
+    canGoNext: true,
+  },
+  play: smokeText("March 2026"),
+};
+
+export const PickerOpen: Story = {
+  args: {
+    monthPickerOpen: true,
+  },
+  play: smokeText("June 2026"),
+};

--- a/packages/client/src/components/dailies/CompletionsMonthNav.tsx
+++ b/packages/client/src/components/dailies/CompletionsMonthNav.tsx
@@ -1,0 +1,98 @@
+import type { ViewMonth } from "@/components/dailies/MonthYearPicker";
+
+import {
+  CalendarIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react";
+
+import { MonthYearPicker } from "./completionControls";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface CompletionsMonthNavProps {
+  viewMonth: ViewMonth;
+  currentMonth: ViewMonth;
+  earliestYear: number;
+  monthLabel: string;
+  monthPickerOpen: boolean;
+  setMonthPickerOpen: (open: boolean) => void;
+  selectMonth: (m: ViewMonth) => void;
+  goToPrevMonth: () => void;
+  goToNextMonth: () => void;
+  canGoPrev: boolean;
+  canGoNext: boolean;
+}
+
+// The logged-entries month switcher: prev/next arrows around a popover
+// month-and-year picker, all driven by useDailyCompletions' month state.
+export function CompletionsMonthNav({
+  viewMonth,
+  currentMonth,
+  earliestYear,
+  monthLabel,
+  monthPickerOpen,
+  setMonthPickerOpen,
+  selectMonth,
+  goToPrevMonth,
+  goToNextMonth,
+  canGoPrev,
+  canGoNext,
+}: CompletionsMonthNavProps) {
+  return (
+    <div className="flex flex-row items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={goToPrevMonth}
+        disabled={!canGoPrev}
+        aria-label="Previous month"
+      >
+        <ChevronLeftIcon className="size-4" />
+      </Button>
+      <Popover
+        open={monthPickerOpen}
+        onOpenChange={setMonthPickerOpen}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="min-w-40 justify-center font-normal"
+          >
+            <CalendarIcon className="mr-2 size-4" />
+            {monthLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-auto p-0"
+          align="end"
+        >
+          <MonthYearPicker
+            viewMonth={viewMonth}
+            currentMonth={currentMonth}
+            earliestYear={earliestYear}
+            onChange={selectMonth}
+          />
+        </PopoverContent>
+      </Popover>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={goToNextMonth}
+        disabled={!canGoNext}
+        aria-label="Next month"
+      >
+        <ChevronRightIcon className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/DailyCompletionEntryRow.stories.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionEntryRow.stories.tsx
@@ -1,0 +1,105 @@
+import type { DailyCompletionRow } from "@/hooks/useDailyCompletions";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { DailyCompletionEntryRow } from "./DailyCompletionEntryRow";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+import { smokeText } from "@/test-utils/storyPlay";
+
+const baseRow: DailyCompletionRow = {
+  dateKey: "2026-06-11",
+  status: "goal",
+  note: null,
+  dateLabel: "Thu, Jun 11",
+  hasStatusEntry: true,
+  isFuture: false,
+  isToday: false,
+  hasActions: true,
+  isExpanded: false,
+  showVerticalConnector: false,
+  nextStatus: null,
+  scheduledEntry: null,
+  bakedParts: null,
+};
+
+const meta: Meta<typeof DailyCompletionEntryRow> = {
+  component: DailyCompletionEntryRow,
+  args: {
+    row: baseRow,
+    taskNames: new Map([["task-1", "Spanish drills"]]),
+    mutationPending: false,
+    onToggleExpanded: fn(),
+    onSetStatus: fn(),
+    onSetNote: fn(),
+    onDeleteEntry: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <ul className="max-w-2xl divide-y rounded-md border">
+          <Story />
+        </ul>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Logged: Story = {
+  play: smokeText("Thu, Jun 11"),
+};
+
+export const WithBakedSentence: Story = {
+  args: {
+    row: {
+      ...baseRow,
+      bakedParts: {
+        prependText: "Review",
+        name: "Spanish flashcards",
+        appendText: "for 10 minutes",
+      },
+    },
+  },
+  play: smokeText(/Spanish flashcards/),
+};
+
+export const WithScheduledEntryFallback: Story = {
+  args: {
+    row: {
+      ...baseRow,
+      scheduledEntry: {
+        type: "task",
+        id: "task-1",
+      },
+    },
+  },
+  play: smokeText("Spanish drills"),
+};
+
+export const WithNote: Story = {
+  args: {
+    row: {
+      ...baseRow,
+      note: "Felt easy today.",
+    },
+  },
+  play: smokeText("Felt easy today."),
+};
+
+export const FutureUnlogged: Story = {
+  args: {
+    row: {
+      ...baseRow,
+      status: null,
+      hasStatusEntry: false,
+      isFuture: true,
+      hasActions: false,
+    },
+  },
+  play: smokeText("Thu, Jun 11"),
+};

--- a/packages/client/src/components/dailies/DailyCompletionEntryRow.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionEntryRow.tsx
@@ -1,0 +1,203 @@
+import type { DailyCompletionRow } from "@/hooks/useDailyCompletions";
+import type { DailyCompletionStatus } from "@emstack/types";
+
+import { ChevronDownIcon, Trash2Icon } from "lucide-react";
+
+import { DailyStatusButtons, NoteEditButton } from "./completionControls";
+import { DailyStatusCircle, DailyStatusConnector } from "./dailyCells";
+
+import { ActionableSentence } from "@/components/dailies/ActionableSentence";
+import { RoutineEntryLabel } from "@/components/routines/RoutineEntryLabel";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface DailyCompletionEntryRowProps {
+  row: DailyCompletionRow;
+  // Resolves task ids in the live scheduled-entry fallback.
+  taskNames: Map<string, string>;
+  mutationPending: boolean;
+  onToggleExpanded: (dateKey: string) => void;
+  onSetStatus: (dateKey: string, status: DailyCompletionStatus | null) => void;
+  onSetNote: (dateKey: string, note: string | null) => void;
+  onDeleteEntry: (dateKey: string) => void;
+}
+
+// One date row of the logged-entries list: status circle + connector, date and
+// resolved schedule label, note popover, and the (mobile-collapsible) status /
+// note / delete actions.
+export function DailyCompletionEntryRow({
+  row,
+  taskNames,
+  mutationPending,
+  onToggleExpanded,
+  onSetStatus,
+  onSetNote,
+  onDeleteEntry,
+}: DailyCompletionEntryRowProps) {
+  const {
+    dateKey,
+    status,
+    note,
+    dateLabel,
+    hasStatusEntry,
+    isFuture,
+    hasActions,
+    isExpanded,
+    showVerticalConnector,
+    nextStatus,
+    scheduledEntry,
+    bakedParts,
+  } = row;
+  return (
+    <li
+      className={cn(
+        "group flex flex-row flex-wrap items-center justify-between gap-2 p-2",
+        isFuture && "opacity-60",
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-row items-center gap-3">
+        <div className="relative flex shrink-0 flex-col items-center">
+          <DailyStatusCircle
+            status={status}
+            size="lg"
+          />
+          {showVerticalConnector && (
+            <DailyStatusConnector
+              orientation="vertical"
+              left={status}
+              right={nextStatus}
+              className={cn(
+                "absolute top-full z-0 h-[18px] w-0.5",
+                isExpanded && "max-md:hidden",
+              )}
+            />
+          )}
+        </div>
+        <div className="flex min-w-0 shrink-0 flex-col">
+          <span className="text-sm font-medium">{dateLabel}</span>
+          {/* Prefer the baked snapshot (frozen at save time); fall back
+              to the live scheduled entry for unbaked/legacy rows. */}
+          {bakedParts
+            ? (
+              <span className="text-xs text-muted-foreground">
+                <ActionableSentence
+                  prependText={bakedParts.prependText}
+                  appendText={bakedParts.appendText}
+                  name={bakedParts.name}
+                />
+              </span>
+            )
+            : scheduledEntry
+              ? (
+                <span className="text-xs text-muted-foreground">
+                  <RoutineEntryLabel
+                    entry={scheduledEntry}
+                    taskNames={taskNames}
+                    showMeta={false}
+                  />
+                </span>
+              )
+              : null}
+        </div>
+        {note && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="
+                  min-w-0 truncate text-left text-sm text-muted-foreground
+                  hover:text-foreground
+                "
+                title={note}
+              >
+                {note}
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-80 max-w-[90vw]"
+              align="start"
+            >
+              <p className="text-sm/relaxed whitespace-pre-wrap">
+                {note}
+              </p>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+      {hasActions && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onToggleExpanded(dateKey)}
+          className="
+            shrink-0
+            md:hidden
+          "
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? "Hide actions" : "Show actions"}
+        >
+          <ChevronDownIcon
+            className={cn(
+              "size-4 transition-transform",
+              isExpanded && "rotate-180",
+            )}
+          />
+        </Button>
+      )}
+      {hasActions && (
+        <div
+          className={cn(
+            `
+              flex-row items-center gap-1
+              max-md:w-full max-md:justify-end
+              md:pointer-events-none md:flex md:opacity-0 md:transition-opacity
+              md:group-focus-within:pointer-events-auto
+              md:group-focus-within:opacity-100
+              md:group-hover:pointer-events-auto md:group-hover:opacity-100
+            `,
+            isExpanded ? "flex" : "hidden",
+          )}
+        >
+          <DailyStatusButtons
+            currentStatus={status}
+            disabled={mutationPending}
+            onChange={newStatus => onSetStatus(dateKey, newStatus)}
+            iconOnly
+          />
+          <NoteEditButton
+            initialNote={note}
+            disabled={mutationPending}
+            onSave={newNote => onSetNote(dateKey, newNote)}
+          />
+          {hasStatusEntry
+            ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={mutationPending}
+                onClick={() => onDeleteEntry(dateKey)}
+                className="text-destructive"
+                title="Delete entry"
+                aria-label="Delete entry"
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            )
+            : (
+              <div
+                aria-hidden
+                className="size-8"
+              />
+            )}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/packages/client/src/components/dailies/DailyCompletionsManager.tsx
+++ b/packages/client/src/components/dailies/DailyCompletionsManager.tsx
@@ -1,30 +1,9 @@
 import type { Daily } from "@emstack/types";
 
-import {
-  CalendarIcon,
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  Trash2Icon,
-} from "lucide-react";
+import { CompletionsMonthNav } from "./CompletionsMonthNav";
+import { DailyCompletionEntryRow } from "./DailyCompletionEntryRow";
 
-import {
-  DailyStatusButtons,
-  MonthYearPicker,
-  NoteEditButton,
-} from "./completionControls";
-import { DailyStatusCircle, DailyStatusConnector } from "./dailyCells";
-
-import { ActionableSentence } from "@/components/dailies/ActionableSentence";
-import { RoutineEntryLabel } from "@/components/routines/RoutineEntryLabel";
-import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { useDailyCompletions } from "@/hooks/useDailyCompletions";
-import { cn } from "@/lib/utils";
 
 interface DailyCompletionsManagerProps {
   daily: Daily;
@@ -63,55 +42,19 @@ export function DailyCompletionsManager({
         className="flex flex-row flex-wrap items-center justify-between gap-2"
       >
         <h3 className="text-lg font-semibold">Logged entries</h3>
-        <div className="flex flex-row items-center gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={goToPrevMonth}
-            disabled={!canGoPrev}
-            aria-label="Previous month"
-          >
-            <ChevronLeftIcon className="size-4" />
-          </Button>
-          <Popover
-            open={monthPickerOpen}
-            onOpenChange={setMonthPickerOpen}
-          >
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="min-w-40 justify-center font-normal"
-              >
-                <CalendarIcon className="mr-2 size-4" />
-                {monthLabel}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              className="w-auto p-0"
-              align="end"
-            >
-              <MonthYearPicker
-                viewMonth={viewMonth}
-                currentMonth={currentMonth}
-                earliestYear={earliestYear}
-                onChange={selectMonth}
-              />
-            </PopoverContent>
-          </Popover>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={goToNextMonth}
-            disabled={!canGoNext}
-            aria-label="Next month"
-          >
-            <ChevronRightIcon className="size-4" />
-          </Button>
-        </div>
+        <CompletionsMonthNav
+          viewMonth={viewMonth}
+          currentMonth={currentMonth}
+          earliestYear={earliestYear}
+          monthLabel={monthLabel}
+          monthPickerOpen={monthPickerOpen}
+          setMonthPickerOpen={setMonthPickerOpen}
+          selectMonth={selectMonth}
+          goToPrevMonth={goToPrevMonth}
+          goToNextMonth={goToNextMonth}
+          canGoPrev={canGoPrev}
+          canGoNext={canGoNext}
+        />
       </div>
       {!hasRows && (
         <p className="text-sm text-muted-foreground">
@@ -120,179 +63,18 @@ export function DailyCompletionsManager({
       )}
       {hasRows && (
         <ul className="flex flex-col divide-y rounded-md border">
-          {/* Pre-existing complexity hotspot (untested render callback);
-              suppressed so unrelated edits don't trip the audit gate. */}
-          {/* fallow-ignore-next-line complexity */}
-          {rows.map((row) => {
-            const {
-              dateKey,
-              status,
-              note,
-              dateLabel,
-              hasStatusEntry,
-              isFuture,
-              hasActions,
-              isExpanded,
-              showVerticalConnector,
-              nextStatus,
-              scheduledEntry,
-              bakedParts,
-            } = row;
-            return (
-              <li
-                key={dateKey}
-                className={cn(
-                  `
-                    group flex flex-row flex-wrap items-center justify-between
-                    gap-2 p-2
-                  `,
-                  isFuture && "opacity-60",
-                )}
-              >
-                <div className="flex min-w-0 flex-1 flex-row items-center gap-3">
-                  <div className="relative flex shrink-0 flex-col items-center">
-                    <DailyStatusCircle
-                      status={status}
-                      size="lg"
-                    />
-                    {showVerticalConnector && (
-                      <DailyStatusConnector
-                        orientation="vertical"
-                        left={status}
-                        right={nextStatus}
-                        className={cn(
-                          "absolute top-full z-0 h-[18px] w-0.5",
-                          isExpanded && "max-md:hidden",
-                        )}
-                      />
-                    )}
-                  </div>
-                  <div className="flex min-w-0 shrink-0 flex-col">
-                    <span className="text-sm font-medium">{dateLabel}</span>
-                    {/* Prefer the baked snapshot (frozen at save time); fall back
-                        to the live scheduled entry for unbaked/legacy rows. */}
-                    {bakedParts
-                      ? (
-                        <span className="text-xs text-muted-foreground">
-                          <ActionableSentence
-                            prependText={bakedParts.prependText}
-                            appendText={bakedParts.appendText}
-                            name={bakedParts.name}
-                          />
-                        </span>
-                      )
-                      : scheduledEntry
-                        ? (
-                          <span className="text-xs text-muted-foreground">
-                            <RoutineEntryLabel
-                              entry={scheduledEntry}
-                              taskNames={taskNames}
-                              showMeta={false}
-                            />
-                          </span>
-                        )
-                        : null}
-                  </div>
-                  {note && (
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <button
-                          type="button"
-                          className="
-                            min-w-0 truncate text-left text-sm
-                            text-muted-foreground
-                            hover:text-foreground
-                          "
-                          title={note}
-                        >
-                          {note}
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverContent
-                        className="w-80 max-w-[90vw]"
-                        align="start"
-                      >
-                        <p className="text-sm/relaxed whitespace-pre-wrap">
-                          {note}
-                        </p>
-                      </PopoverContent>
-                    </Popover>
-                  )}
-                </div>
-                {hasActions && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => toggleExpanded(dateKey)}
-                    className="
-                      shrink-0
-                      md:hidden
-                    "
-                    aria-expanded={isExpanded}
-                    aria-label={isExpanded ? "Hide actions" : "Show actions"}
-                  >
-                    <ChevronDownIcon
-                      className={cn(
-                        "size-4 transition-transform",
-                        isExpanded && "rotate-180",
-                      )}
-                    />
-                  </Button>
-                )}
-                {hasActions && (
-                  <div
-                    className={cn(
-                      `
-                        flex-row items-center gap-1
-                        max-md:w-full max-md:justify-end
-                        md:pointer-events-none md:flex md:opacity-0
-                        md:transition-opacity
-                        md:group-focus-within:pointer-events-auto
-                        md:group-focus-within:opacity-100
-                        md:group-hover:pointer-events-auto
-                        md:group-hover:opacity-100
-                      `,
-                      isExpanded ? "flex" : "hidden",
-                    )}
-                  >
-                    <DailyStatusButtons
-                      currentStatus={status}
-                      disabled={mutationPending}
-                      onChange={newStatus => setStatus(dateKey, newStatus)}
-                      iconOnly
-                    />
-                    <NoteEditButton
-                      initialNote={note}
-                      disabled={mutationPending}
-                      onSave={newNote => setNote(dateKey, newNote)}
-                    />
-                    {hasStatusEntry
-                      ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          disabled={mutationPending}
-                          onClick={() => deleteEntry(dateKey)}
-                          className="text-destructive"
-                          title="Delete entry"
-                          aria-label="Delete entry"
-                        >
-                          <Trash2Icon className="size-4" />
-                        </Button>
-                      )
-                      : (
-                        <div
-                          aria-hidden
-                          className="size-8"
-                        />
-                      )}
-                  </div>
-                )}
-              </li>
-            );
-          })}
+          {rows.map(row => (
+            <DailyCompletionEntryRow
+              key={row.dateKey}
+              row={row}
+              taskNames={taskNames}
+              mutationPending={mutationPending}
+              onToggleExpanded={toggleExpanded}
+              onSetStatus={setStatus}
+              onSetNote={setNote}
+              onDeleteEntry={deleteEntry}
+            />
+          ))}
         </ul>
       )}
     </div>

--- a/packages/client/src/routes/dashboard/-components/index.ts
+++ b/packages/client/src/routes/dashboard/-components/index.ts
@@ -5,18 +5,15 @@
 export {
   AddLayoutDialog,
   DashboardGrid,
+  LayoutManagerDialogs,
   LayoutTab,
+  useDashboardTileSaver,
   VisibleTilesDialog,
 } from "./layout";
 export {
   buildDefaultTiles,
-  needsNormalization,
   normalizeTiles,
-  tilesEqual,
-  toggleTile,
 } from "@/lib/dashboardTiles";
-export { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
-export { LayoutNameDialog } from "@/components/dialogs/LayoutNameDialog";
 export { PageContainer } from "@/components/layout/PageContainer";
 export { PageHeader } from "@/components/layout/PageHeader";
 export { Button } from "@/components/ui/button";

--- a/packages/client/src/routes/dashboard/-components/layout/-LayoutManagerDialogs.stories.tsx
+++ b/packages/client/src/routes/dashboard/-components/layout/-LayoutManagerDialogs.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen } from "storybook/test";
+
+import { LayoutManagerDialogs } from "./-LayoutManagerDialogs";
+
+const layout = {
+  id: "dl-1",
+  name: "Morning focus",
+  position: 0,
+  tiles: [],
+  isTemplate: false,
+};
+
+const meta: Meta<typeof LayoutManagerDialogs> = {
+  component: LayoutManagerDialogs,
+  args: {
+    renameTarget: null,
+    isRenaming: false,
+    closeRename: fn(),
+    submitRename: fn(),
+    saveAsTarget: null,
+    isSavingPreset: false,
+    closeSaveAs: fn(),
+    submitSaveAs: fn(),
+    deleteTarget: null,
+    closeDelete: fn(),
+    confirmDelete: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Rename: Story = {
+  args: {
+    renameTarget: layout,
+  },
+  play: async () => {
+    await expect(await screen.findByText("Rename layout")).toBeInTheDocument();
+  },
+};
+
+export const SaveAs: Story = {
+  args: {
+    saveAsTarget: layout,
+  },
+  play: async () => {
+    await expect(await screen.findByText("Save as layout")).toBeInTheDocument();
+  },
+};
+
+export const ConfirmDelete: Story = {
+  args: {
+    deleteTarget: layout,
+  },
+  play: async () => {
+    await expect(await screen.findByText("Delete layout?")).toBeInTheDocument();
+    await expect(screen.getByText(/Morning focus/)).toBeInTheDocument();
+  },
+};

--- a/packages/client/src/routes/dashboard/-components/layout/-LayoutManagerDialogs.tsx
+++ b/packages/client/src/routes/dashboard/-components/layout/-LayoutManagerDialogs.tsx
@@ -1,0 +1,77 @@
+import type { DashboardLayout } from "@emstack/types";
+
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { LayoutNameDialog } from "@/components/dialogs/LayoutNameDialog";
+
+interface LayoutManagerDialogsProps {
+  renameTarget: DashboardLayout | null;
+  isRenaming: boolean;
+  closeRename: () => void;
+  submitRename: (name: string) => void;
+  saveAsTarget: DashboardLayout | null;
+  isSavingPreset: boolean;
+  closeSaveAs: () => void;
+  submitSaveAs: (name: string) => void;
+  deleteTarget: DashboardLayout | null;
+  closeDelete: () => void;
+  confirmDelete: () => void;
+}
+
+// The rename / save-as / delete dialog trio driven by
+// useDashboardLayoutManager's dialog state. Purely presentational: each dialog
+// opens when its manager target is set and routes submit/cancel back to the
+// manager's handlers.
+export function LayoutManagerDialogs({
+  renameTarget,
+  isRenaming,
+  closeRename,
+  submitRename,
+  saveAsTarget,
+  isSavingPreset,
+  closeSaveAs,
+  submitSaveAs,
+  deleteTarget,
+  closeDelete,
+  confirmDelete,
+}: LayoutManagerDialogsProps) {
+  return (
+    <>
+      <LayoutNameDialog
+        open={renameTarget !== null}
+        title="Rename layout"
+        initialName={renameTarget?.name ?? ""}
+        isSaving={isRenaming}
+        onOpenChange={(open) => {
+          if (!open) closeRename();
+        }}
+        onSubmit={submitRename}
+      />
+
+      <LayoutNameDialog
+        open={saveAsTarget !== null}
+        title="Save as layout"
+        submitLabel="Save"
+        initialName={saveAsTarget?.name ?? ""}
+        isSaving={isSavingPreset}
+        onOpenChange={(open) => {
+          if (!open) closeSaveAs();
+        }}
+        onSubmit={submitSaveAs}
+      />
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Delete layout?"
+        description={
+          deleteTarget
+            ? `"${deleteTarget.name}" will be removed. This can't be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={confirmDelete}
+        onCancel={closeDelete}
+      />
+    </>
+  );
+}

--- a/packages/client/src/routes/dashboard/-components/layout/-useDashboardTileSaver.ts
+++ b/packages/client/src/routes/dashboard/-components/layout/-useDashboardTileSaver.ts
@@ -1,0 +1,146 @@
+import type {
+  DashboardLayout,
+  DashboardLayoutTile,
+  DashboardTileId,
+} from "@emstack/types";
+
+import { useEffect, useRef } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  needsNormalization,
+  normalizeTiles,
+  tilesEqual,
+  toggleTile,
+} from "@/lib/dashboardTiles";
+import { upsertDashboardLayout } from "@/utils/api";
+import { queryKeys } from "@/utils/queryKeys";
+
+const SAVE_DEBOUNCE_MS = 600;
+
+interface UseDashboardTileSaverArgs {
+  activeLayout: DashboardLayout | null;
+  // The active layout's tiles after legacy-id normalization (what the grid renders).
+  normalizedTiles: DashboardLayoutTile[];
+  invalidate: () => Promise<void>;
+}
+
+// The dashboard's tile-persistence machinery: debounced saves for grid
+// moves/resizes (optimistic cache write, no refetch mid-drag), immediate saves
+// for tile toggles/patches, and a one-shot self-heal that persists normalized
+// tiles when a layout still holds a legacy id.
+export function useDashboardTileSaver({
+  activeLayout,
+  normalizedTiles,
+  invalidate,
+}: UseDashboardTileSaverArgs) {
+  const queryClient = useQueryClient();
+
+  // Tile moves/resizes save through an optimistic cache write with no
+  // invalidate on success — a refetch mid-drag would snap tiles back.
+  const saveTilesMutation = useMutation({
+    mutationFn: ({
+      layout,
+      tiles,
+    }: {
+      layout: DashboardLayout;
+      tiles: DashboardLayoutTile[];
+    }) =>
+      upsertDashboardLayout(layout.id, {
+        name: layout.name,
+        position: layout.position ?? null,
+        tiles,
+        isTemplate: layout.isTemplate ?? false,
+      }),
+    onMutate: ({
+      layout, tiles,
+    }) => {
+      queryClient.setQueryData<DashboardLayout[]>(
+        queryKeys.dashboardLayouts.list(),
+        prev =>
+          prev?.map(l =>
+            l.id === layout.id
+              ? {
+                ...l,
+                tiles,
+              }
+              : l),
+      );
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+      void invalidate();
+    },
+  });
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  useEffect(() => () => clearTimeout(saveTimerRef.current), []);
+
+  // Self-heal: persist the normalized tiles once when a layout still holds a
+  // legacy id, so the database catches up even without a manual drag/resize.
+  const healedRef = useRef<Set<string>>(new Set());
+  const {
+    mutate: saveTiles,
+  } = saveTilesMutation;
+  useEffect(() => {
+    if (!activeLayout || !needsNormalization(activeLayout.tiles)) return;
+    if (healedRef.current.has(activeLayout.id)) return;
+    healedRef.current.add(activeLayout.id);
+    saveTiles({
+      layout: activeLayout,
+      tiles: normalizeTiles(activeLayout.tiles),
+    });
+  }, [activeLayout, saveTiles]);
+
+  const handleTilesChange = (tiles: DashboardLayoutTile[]) => {
+    // Ignore the grid's mount/compaction echoes — only real moves save.
+    if (!activeLayout || tilesEqual(tiles, normalizedTiles)) return;
+    clearTimeout(saveTimerRef.current);
+    const layout = activeLayout;
+    saveTimerRef.current = setTimeout(() => {
+      saveTilesMutation.mutate({
+        layout,
+        tiles,
+      });
+    }, SAVE_DEBOUNCE_MS);
+  };
+
+  const handleToggleTile = (
+    layout: DashboardLayout,
+    tileId: DashboardTileId,
+  ) => {
+    clearTimeout(saveTimerRef.current);
+    saveTilesMutation.mutate({
+      layout,
+      tiles: toggleTile(normalizeTiles(layout.tiles), tileId),
+    });
+  };
+
+  const handleUpdateTile = (
+    tileId: DashboardTileId,
+    patch: Partial<DashboardLayoutTile>,
+  ) => {
+    if (!activeLayout) return;
+    clearTimeout(saveTimerRef.current);
+    saveTilesMutation.mutate({
+      layout: activeLayout,
+      tiles: normalizedTiles.map(t =>
+        t.tileId === tileId
+          ? {
+            ...t,
+            ...patch,
+          }
+          : t),
+    });
+  };
+
+  return {
+    handleTilesChange,
+    handleToggleTile,
+    handleUpdateTile,
+  };
+}

--- a/packages/client/src/routes/dashboard/-components/layout/index.ts
+++ b/packages/client/src/routes/dashboard/-components/layout/index.ts
@@ -1,4 +1,6 @@
 export { AddLayoutDialog } from "./-AddLayoutDialog";
 export { DashboardGrid } from "./-DashboardGrid";
+export { LayoutManagerDialogs } from "./-LayoutManagerDialogs";
 export { LayoutTab } from "./-LayoutTab";
+export { useDashboardTileSaver } from "./-useDashboardTileSaver";
 export { VisibleTilesDialog } from "./-VisibleTilesDialog";

--- a/packages/client/src/routes/dashboard/route.tsx
+++ b/packages/client/src/routes/dashboard/route.tsx
@@ -1,12 +1,8 @@
-import type {
-  DashboardLayout,
-  DashboardLayoutTile,
-  DashboardTileId,
-} from "@emstack/types";
+import type { DashboardLayoutTile } from "@emstack/types";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -15,34 +11,27 @@ import {
   AddLayoutDialog,
   buildDefaultTiles,
   Button,
-  ConfirmDialog,
   DashboardGrid,
-  LayoutNameDialog,
+  LayoutManagerDialogs,
   LayoutTab,
-  needsNormalization,
   normalizeTiles,
   PageContainer,
   PageHeader,
   Tabs,
   TabsList,
-  tilesEqual,
-  toggleTile,
+  useDashboardTileSaver,
   VisibleTilesDialog,
 } from "./-components";
 
 import { useActiveDashboardLayoutId } from "@/hooks/useActiveDashboardLayoutId";
 import { useDashboardLayoutManager } from "@/hooks/useDashboardLayoutManager";
-import { createDashboardLayout, upsertDashboardLayout } from "@/utils/api";
-import { queryKeys } from "@/utils/queryKeys";
+import { createDashboardLayout } from "@/utils/api";
 
 export const Route = createFileRoute("/dashboard")({
   component: Dashboard,
 });
 
-const SAVE_DEBOUNCE_MS = 600;
-
 function Dashboard() {
-  const queryClient = useQueryClient();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [tilesTargetId, setTilesTargetId] = useState<string | null>(null);
 
@@ -127,105 +116,15 @@ function Dashboard() {
     }
   }, [isPending, error, layouts, autoCreate]);
 
-  // Tile moves/resizes save through an optimistic cache write with no
-  // invalidate on success — a refetch mid-drag would snap tiles back.
-  const saveTilesMutation = useMutation({
-    mutationFn: ({
-      layout,
-      tiles,
-    }: {
-      layout: DashboardLayout;
-      tiles: DashboardLayoutTile[];
-    }) =>
-      upsertDashboardLayout(layout.id, {
-        name: layout.name,
-        position: layout.position ?? null,
-        tiles,
-        isTemplate: layout.isTemplate ?? false,
-      }),
-    onMutate: ({
-      layout, tiles,
-    }) => {
-      queryClient.setQueryData<DashboardLayout[]>(
-        queryKeys.dashboardLayouts.list(),
-        prev =>
-          prev?.map(l =>
-            l.id === layout.id
-              ? {
-                ...l,
-                tiles,
-              }
-              : l),
-      );
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-      void invalidate();
-    },
-  });
-
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-  useEffect(() => () => clearTimeout(saveTimerRef.current), []);
-
-  // Self-heal: persist the normalized tiles once when a layout still holds a
-  // legacy id, so the database catches up even without a manual drag/resize.
-  const healedRef = useRef<Set<string>>(new Set());
   const {
-    mutate: saveTiles,
-  } = saveTilesMutation;
-  useEffect(() => {
-    if (!activeLayout || !needsNormalization(activeLayout.tiles)) return;
-    if (healedRef.current.has(activeLayout.id)) return;
-    healedRef.current.add(activeLayout.id);
-    saveTiles({
-      layout: activeLayout,
-      tiles: normalizeTiles(activeLayout.tiles),
-    });
-  }, [activeLayout, saveTiles]);
-
-  const handleTilesChange = (tiles: DashboardLayoutTile[]) => {
-    // Ignore the grid's mount/compaction echoes — only real moves save.
-    if (!activeLayout || tilesEqual(tiles, normalizedTiles)) return;
-    clearTimeout(saveTimerRef.current);
-    const layout = activeLayout;
-    saveTimerRef.current = setTimeout(() => {
-      saveTilesMutation.mutate({
-        layout,
-        tiles,
-      });
-    }, SAVE_DEBOUNCE_MS);
-  };
-
-  const handleToggleTile = (
-    layout: DashboardLayout,
-    tileId: DashboardTileId,
-  ) => {
-    clearTimeout(saveTimerRef.current);
-    saveTilesMutation.mutate({
-      layout,
-      tiles: toggleTile(normalizeTiles(layout.tiles), tileId),
-    });
-  };
-
-  const handleUpdateTile = (
-    tileId: DashboardTileId,
-    patch: Partial<DashboardLayoutTile>,
-  ) => {
-    if (!activeLayout) return;
-    clearTimeout(saveTimerRef.current);
-    saveTilesMutation.mutate({
-      layout: activeLayout,
-      tiles: normalizedTiles.map(t =>
-        t.tileId === tileId
-          ? {
-            ...t,
-            ...patch,
-          }
-          : t),
-    });
-  };
+    handleTilesChange,
+    handleToggleTile,
+    handleUpdateTile,
+  } = useDashboardTileSaver({
+    activeLayout,
+    normalizedTiles,
+    invalidate,
+  });
 
   return (
     <div>
@@ -307,41 +206,18 @@ function Dashboard() {
           })}
       />
 
-      <LayoutNameDialog
-        open={renameTarget !== null}
-        title="Rename layout"
-        initialName={renameTarget?.name ?? ""}
-        isSaving={isRenaming}
-        onOpenChange={(open) => {
-          if (!open) closeRename();
-        }}
-        onSubmit={submitRename}
-      />
-
-      <LayoutNameDialog
-        open={saveAsTarget !== null}
-        title="Save as layout"
-        submitLabel="Save"
-        initialName={saveAsTarget?.name ?? ""}
-        isSaving={isSavingPreset}
-        onOpenChange={(open) => {
-          if (!open) closeSaveAs();
-        }}
-        onSubmit={submitSaveAs}
-      />
-
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title="Delete layout?"
-        description={
-          deleteTarget
-            ? `"${deleteTarget.name}" will be removed. This can't be undone.`
-            : undefined
-        }
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        onConfirm={confirmDelete}
-        onCancel={closeDelete}
+      <LayoutManagerDialogs
+        renameTarget={renameTarget}
+        isRenaming={isRenaming}
+        closeRename={closeRename}
+        submitRename={submitRename}
+        saveAsTarget={saveAsTarget}
+        isSavingPreset={isSavingPreset}
+        closeSaveAs={closeSaveAs}
+        submitSaveAs={submitSaveAs}
+        deleteTarget={deleteTarget}
+        closeDelete={closeDelete}
+        confirmDelete={confirmDelete}
       />
     </div>
   );

--- a/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
+++ b/packages/client/src/routes/routines/$id/edit/-components/form-tabs/-DetailsTab.tsx
@@ -6,7 +6,7 @@ import { CuratedScheduleSection } from "./-CuratedScheduleSection";
 import { modeOptionsFor, STATUS_OPTIONS } from "../-routineFormMeta";
 import { WeeklyScheduleSection } from "./-WeeklyScheduleSection";
 
-import { BookmarkPicker } from "@/components/formFields";
+import { BookmarksFieldGroup } from "@/components/bookmarks/BookmarksFieldGroup";
 import { EditForm } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { useRoutineDetailsForm } from "@/hooks/useRoutineDetailsForm";
@@ -69,13 +69,10 @@ export function DetailsTab({
 
       <form.Field name="bookmarks">
         {field => (
-          <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium">Bookmarks</span>
-            <BookmarkPicker
-              value={field.state.value}
-              onChange={next => field.handleChange(next)}
-            />
-          </div>
+          <BookmarksFieldGroup
+            value={field.state.value}
+            onChange={next => field.handleChange(next)}
+          />
         )}
       </form.Field>
 

--- a/packages/client/src/routes/tasks/$id/-components/-TodoReadRow.stories.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoReadRow.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { TodoReadRow } from "./-TodoReadRow";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { smokeText } from "@/test-utils/storyPlay";
+import { makeTaskTodo } from "@/test-utils/tasksFixtures";
+
+const meta: Meta<typeof TodoReadRow> = {
+  component: TodoReadRow,
+  args: {
+    todo: makeTaskTodo({
+      name: "Read the introduction",
+    }),
+    actionsDisabled: false,
+    onToggleStatus: fn(),
+    onStartEdit: fn(),
+  },
+  decorators: [
+    Story => (
+      <QueryStub>
+        <ul className="max-w-2xl rounded-md border">
+          <Story />
+        </ul>
+      </QueryStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  play: smokeText("Read the introduction"),
+};
+
+export const WithDueDateAndNote: Story = {
+  args: {
+    todo: makeTaskTodo({
+      name: "Finish unit 2",
+      dueDate: "2026-07-20",
+      note: "Focus on the listening drills.",
+    }),
+  },
+  play: smokeText("Finish unit 2", "due 2026-07-20", "Focus on the listening drills."),
+};
+
+export const WithBookmark: Story = {
+  args: {
+    todo: makeTaskTodo({
+      name: "Work through the course page",
+      bookmarks: [
+        {
+          id: "tb-1",
+          bookmarkId: "bm-1",
+          title: "Pimsleur Spanish",
+          url: "https://example.com/pimsleur",
+          sectionLabel: "Unit 3",
+          position: 0,
+        },
+      ],
+    }),
+  },
+  play: smokeText("Work through the course page", "Pimsleur Spanish"),
+};

--- a/packages/client/src/routes/tasks/$id/-components/-TodoReadRow.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodoReadRow.tsx
@@ -1,0 +1,153 @@
+import type { TaskTodo } from "@emstack/types";
+
+import { ExternalLinkIcon, PencilIcon } from "lucide-react";
+
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
+import { DailyStatusCircle } from "@/components/dailies/DailyStatusCircle";
+import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
+
+interface TodoReadRowProps {
+  todo: TaskTodo;
+  // Blocks the row's actions while a save is in flight or another row edits.
+  actionsDisabled: boolean;
+  onToggleStatus: () => void;
+  onStartEdit: () => void;
+}
+
+// A todo's read-mode list row: status toggle, name, due-date badge, bookmark
+// chips, and the hover-revealed link/edit actions. The edit-mode counterpart
+// is TodoEditRow.
+export function TodoReadRow({
+  todo,
+  actionsDisabled,
+  onToggleStatus,
+  onStartEdit,
+}: TodoReadRowProps) {
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
+  const statusOption = getDailyStatusOption(todo.status);
+
+  return (
+    <li
+      className="
+        group flex flex-col gap-1 p-3
+        hover:bg-muted/40
+      "
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onToggleStatus}
+          disabled={actionsDisabled}
+          aria-label={`Status: ${statusOption.label}. Toggle.`}
+          title={statusOption.label}
+        >
+          <DailyStatusCircle
+            status={todo.status}
+            size="sm"
+          />
+        </button>
+        <span className="text-sm font-medium">{todo.name}</span>
+        {todo.dueDate && (
+          <Badge
+            variant="outline"
+            className="bg-muted/40"
+          >
+            due {todo.dueDate}
+          </Badge>
+        )}
+        {(todo.bookmarks ?? []).map((b) => {
+          const linkable = {
+            externalId: b.bookmarkId,
+            url: b.url,
+          };
+          const href = resolveHref(linkable);
+          return (
+            <Badge
+              key={b.bookmarkId}
+              variant="outline"
+              className="
+                border-amber-200 bg-amber-50 text-amber-900
+                dark:border-amber-900/50 dark:bg-amber-950/40
+                dark:text-amber-200
+              "
+            >
+              {href
+                ? (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="
+                      inline-flex items-center gap-1
+                      hover:underline
+                    "
+                  >
+                    {b.title}
+                    <ExternalLinkIcon className="size-3" />
+                  </a>
+                )
+                : (
+                  b.title
+                )}
+              <OpenBookmarkPageButton
+                linkable={linkable}
+                className="ml-1"
+              />
+              {b.sectionLabel && (
+                <span className="ml-1 opacity-70">
+                  › {b.sectionLabel}
+                </span>
+              )}
+            </Badge>
+          );
+        })}
+        <div
+          className="
+            ml-auto flex items-center gap-1 opacity-0 transition
+            group-hover:opacity-100
+            focus-within:opacity-100
+          "
+        >
+          {todo.url && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              asChild
+              title={todo.url}
+            >
+              <a
+                href={todo.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Open link for ${todo.name}`}
+              >
+                <ExternalLinkIcon className="size-3.5" />
+              </a>
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onStartEdit}
+            disabled={actionsDisabled}
+            aria-label={`Edit ${todo.name}`}
+          >
+            <PencilIcon className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+      {todo.note && (
+        <p className="pl-6 text-sm text-muted-foreground">
+          {todo.note}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
+++ b/packages/client/src/routes/tasks/$id/-components/-TodosEditor.tsx
@@ -3,23 +3,29 @@ import type { Task, TaskTodo } from "@emstack/types";
 import { useMemo, useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ExternalLinkIcon, PencilIcon, PlusIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { TodoEditRow } from "./-TodoEditRow";
+import { TodoReadRow } from "./-TodoReadRow";
 
-import { OpenBookmarkPageButton } from "@/components/bookmarks";
-import { DailyStatusCircle } from "@/components/dailies/DailyStatusCircle";
-import { getDailyStatusOption } from "@/components/dailies/dailyStatusMeta";
 import { toTodoInput } from "@/components/tasks/todoPayload";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { upsertTask } from "@/utils";
 import { uuidv4 } from "@/utils/uuid";
 
 interface TodosEditorProps {
   task: Task;
+}
+
+// Due-dated todos first (soonest first), then by position.
+function compareTodosForDisplay(a: TaskTodo, b: TaskTodo): number {
+  const ad = a.dueDate ?? "";
+  const bd = b.dueDate ?? "";
+  if (ad && bd && ad !== bd) return ad.localeCompare(bd);
+  if (ad && !bd) return -1;
+  if (!ad && bd) return 1;
+  return (a.position ?? 0) - (b.position ?? 0);
 }
 
 // The To-Do editor: each todo carries a status, an optional due date, a note,
@@ -29,25 +35,12 @@ export function TodosEditor({
 }: TodosEditorProps) {
   const queryClient = useQueryClient();
   const todos = useMemo(
-    () =>
-      [...(task.todos ?? [])].sort((a, b) => {
-        // Due-dated todos first (soonest first), then by position.
-        const ad = a.dueDate ?? "";
-        const bd = b.dueDate ?? "";
-        if (ad && bd && ad !== bd) return ad.localeCompare(bd);
-        if (ad && !bd) return -1;
-        if (!ad && bd) return 1;
-        return (a.position ?? 0) - (b.position ?? 0);
-      }),
+    () => [...(task.todos ?? [])].sort(compareTodosForDisplay),
     [task.todos],
   );
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftNew, setDraftNew] = useState<TaskTodo | null>(null);
-
-  const {
-    resolveHref,
-  } = useBookmarkLinking();
 
   const mutation = useMutation({
     mutationFn: (nextTodos: TaskTodo[]) =>
@@ -155,9 +148,9 @@ export function TodosEditor({
               onCancel={() => setDraftNew(null)}
             />
           )}
-          {todos.map((todo) => {
-            if (todo.id === editingId) {
-              return (
+          {todos.map(todo =>
+            todo.id === editingId
+              ? (
                 <TodoEditRow
                   key={todo.id}
                   todo={todo}
@@ -166,133 +159,19 @@ export function TodosEditor({
                   onCancel={() => setEditingId(null)}
                   onDelete={() => handleDelete(todo.id)}
                 />
-              );
-            }
-            const statusOption = getDailyStatusOption(todo.status);
-            return (
-              <li
-                key={todo.id}
-                className="
-                  group flex flex-col gap-1 p-3
-                  hover:bg-muted/40
-                "
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => cycleStatus(todo)}
-                    disabled={mutation.isPending || isAnyEditing}
-                    aria-label={`Status: ${statusOption.label}. Toggle.`}
-                    title={statusOption.label}
-                  >
-                    <DailyStatusCircle
-                      status={todo.status}
-                      size="sm"
-                    />
-                  </button>
-                  <span className="text-sm font-medium">{todo.name}</span>
-                  {todo.dueDate && (
-                    <Badge
-                      variant="outline"
-                      className="bg-muted/40"
-                    >
-                      due {todo.dueDate}
-                    </Badge>
-                  )}
-                  {(todo.bookmarks ?? []).map((b) => {
-                    const linkable = {
-                      externalId: b.bookmarkId,
-                      url: b.url,
-                    };
-                    const href = resolveHref(linkable);
-                    return (
-                      <Badge
-                        key={b.bookmarkId}
-                        variant="outline"
-                        className="
-                          border-amber-200 bg-amber-50 text-amber-900
-                          dark:border-amber-900/50 dark:bg-amber-950/40
-                          dark:text-amber-200
-                        "
-                      >
-                        {href
-                          ? (
-                            <a
-                              href={href}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="
-                                inline-flex items-center gap-1
-                                hover:underline
-                              "
-                            >
-                              {b.title}
-                              <ExternalLinkIcon className="size-3" />
-                            </a>
-                          )
-                          : (
-                            b.title
-                          )}
-                        <OpenBookmarkPageButton
-                          linkable={linkable}
-                          className="ml-1"
-                        />
-                        {b.sectionLabel && (
-                          <span className="ml-1 opacity-70">
-                            › {b.sectionLabel}
-                          </span>
-                        )}
-                      </Badge>
-                    );
-                  })}
-                  <div
-                    className="
-                      ml-auto flex items-center gap-1 opacity-0 transition
-                      group-hover:opacity-100
-                      focus-within:opacity-100
-                    "
-                  >
-                    {todo.url && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        asChild
-                        title={todo.url}
-                      >
-                        <a
-                          href={todo.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`Open link for ${todo.name}`}
-                        >
-                          <ExternalLinkIcon className="size-3.5" />
-                        </a>
-                      </Button>
-                    )}
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => {
-                        setDraftNew(null);
-                        setEditingId(todo.id);
-                      }}
-                      disabled={mutation.isPending || isAnyEditing}
-                      aria-label={`Edit ${todo.name}`}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
-                  </div>
-                </div>
-                {todo.note && (
-                  <p className="pl-6 text-sm text-muted-foreground">
-                    {todo.note}
-                  </p>
-                )}
-              </li>
-            );
-          })}
+              )
+              : (
+                <TodoReadRow
+                  key={todo.id}
+                  todo={todo}
+                  actionsDisabled={mutation.isPending || isAnyEditing}
+                  onToggleStatus={() => cycleStatus(todo)}
+                  onStartEdit={() => {
+                    setDraftNew(null);
+                    setEditingId(todo.id);
+                  }}
+                />
+              ))}
         </ul>
       )}
     </div>

--- a/packages/client/src/routes/tasks/$id/edit/route.tsx
+++ b/packages/client/src/routes/tasks/$id/edit/route.tsx
@@ -6,6 +6,7 @@ import { EyeIcon, Loader2 } from "lucide-react";
 
 import { formSchema } from "./-components/-taskFormSchema";
 
+import { BookmarksFieldGroup } from "@/components/bookmarks/BookmarksFieldGroup";
 import {
   Button,
   EditPageFooter,
@@ -14,7 +15,7 @@ import {
   PageHeader,
   UnsavedChangesDialog,
 } from "@/components/editPage";
-import { BookmarkPicker, useAppForm } from "@/components/formFields";
+import { useAppForm } from "@/components/formFields";
 import { toTodoInput } from "@/components/tasks/todoPayload";
 import { useEditFormPage } from "@/hooks/useEditFormPage";
 import { useFormChangeState } from "@/hooks/useFormChangeState";
@@ -195,13 +196,10 @@ function SingleTaskEdit() {
 
           <form.Field name="bookmarks">
             {field => (
-              <div className="flex flex-col gap-2">
-                <span className="text-sm font-medium">Bookmarks</span>
-                <BookmarkPicker
-                  value={field.state.value}
-                  onChange={next => field.handleChange(next)}
-                />
-              </div>
+              <BookmarksFieldGroup
+                value={field.state.value}
+                onChange={next => field.handleChange(next)}
+              />
             )}
           </form.Field>
 

--- a/packages/client/src/utils/dailyHelpers.test.ts
+++ b/packages/client/src/utils/dailyHelpers.test.ts
@@ -1,6 +1,6 @@
 import type { Daily, DailyCompletion, RoutineWeekly } from "@emstack/types";
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   classifyDaily,
@@ -353,11 +353,16 @@ describe("classifyDaily", () => {
 
 describe("getTodayKey", () => {
   test("returns a YYYY-MM-DD key matching the local date", () => {
-    const key = getTodayKey();
-    expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    const now = new Date();
-    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-    expect(key).toBe(expected);
+    // Pin the clock: deriving the expected key from a second `new Date()`
+    // races the midnight rollover.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(2026, 5, 11, 22, 30));
+      expect(getTodayKey()).toBe("2026-06-11");
+    }
+    finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
+++ b/packages/middleware/src/routes/api/routines/bakeRoutineCompletions.ts
@@ -7,6 +7,7 @@ import {
   entryToCompletionParts,
   entryToCompletionRef,
 } from "@/utils/routineWeekday";
+import { taskNamesByIds } from "@/utils/taskNames";
 
 import type { RoutineBody } from "./routineRows";
 import type { DailyCompletion, RoutineReferenceItem } from "@emstack/types";
@@ -84,19 +85,7 @@ export async function bakeRoutineCompletions(
     }
   }
 
-  const taskRows = taskIds.size
-    ? await db.query.tasks.findMany({
-      where: (t, {
-        inArray,
-      }) => inArray(t.id, [...taskIds]),
-      columns: {
-        id: true,
-        name: true,
-      },
-    })
-    : [];
-
-  const taskNames = new Map(taskRows.map(r => [r.id, r.name]));
+  const taskNames = await taskNamesByIds(taskIds);
 
   const baked: DailyCompletion[] = completions.map((c) => {
     if (!(c.status && c.entryParts === undefined)) {

--- a/packages/middleware/src/routes/api/routines/convertToTaskList.ts
+++ b/packages/middleware/src/routes/api/routines/convertToTaskList.ts
@@ -11,6 +11,7 @@ import { db } from "@/db";
 import { routines, taskTodos, tasks } from "@/db/schema";
 import { sendBadRequest, sendNotFound } from "@/utils/errors";
 import { idParamSchema } from "@/utils/schemas";
+import { taskNamesByIds } from "@/utils/taskNames";
 
 import type { DailyCompletionStatus, RoutineReferenceItem } from "@emstack/types";
 
@@ -80,19 +81,7 @@ export default async function (server: FastifyInstance) {
         }
       }
 
-      const taskRows = taskIds.size
-        ? await db.query.tasks.findMany({
-          where: (t, {
-            inArray,
-          }) => inArray(t.id, [...taskIds]),
-          columns: {
-            id: true,
-            name: true,
-          },
-        })
-        : [];
-
-      const taskNames = new Map(taskRows.map(r => [r.id, r.name]));
+      const taskNames = await taskNamesByIds(taskIds);
 
       const newTaskId = uuidv4();
       const todoRows = dateKeys.map((key, index) => {

--- a/packages/middleware/src/routes/api/tasks/taskRows.ts
+++ b/packages/middleware/src/routes/api/tasks/taskRows.ts
@@ -87,17 +87,16 @@ export function buildTagRows(
   }));
 }
 
-export function buildBookmarkRows(
-  bookmarks: readonly BookmarkInput[] | undefined,
-  taskId: string,
-  makeId: () => string = uuidv4,
+// Shared core of the task-level and todo-level bookmark builders: dedupe by
+// bookmarkId (an owner holds at most one row per bookmark) and normalize the
+// cached fields. The owner column is spread on by the exported wrappers.
+function buildBookmarkRowsCore(
+  bookmarks: readonly BookmarkInput[],
+  makeId: () => string,
 ) {
-  if (bookmarks === undefined) return undefined;
-  // Dedupe by bookmarkId so a task holds at most one row per bookmark.
   const seen = new Set<string>();
   const rows: {
     id: string;
-    taskId: string;
     bookmarkId: string;
     title: string;
     url: string | null;
@@ -110,7 +109,6 @@ export function buildBookmarkRows(
     seen.add(b.bookmarkId);
     rows.push({
       id: b.id || makeId(),
-      taskId,
       bookmarkId: b.bookmarkId,
       title: b.title,
       url: b.url ?? null,
@@ -122,38 +120,28 @@ export function buildBookmarkRows(
   return rows;
 }
 
+export function buildBookmarkRows(
+  bookmarks: readonly BookmarkInput[] | undefined,
+  taskId: string,
+  makeId: () => string = uuidv4,
+) {
+  if (bookmarks === undefined) return undefined;
+  return buildBookmarkRowsCore(bookmarks, makeId).map(row => ({
+    taskId,
+    ...row,
+  }));
+}
+
 export function buildTodoBookmarkRows(
   bookmarks: readonly BookmarkInput[] | undefined,
   todoId: string,
   makeId: () => string = uuidv4,
 ) {
   if (bookmarks === undefined) return undefined;
-  const seen = new Set<string>();
-  const rows: {
-    id: string;
-    todoId: string;
-    bookmarkId: string;
-    title: string;
-    url: string | null;
-    sectionId: string | null;
-    sectionLabel: string | null;
-    position: number;
-  }[] = [];
-  bookmarks.forEach((b, index) => {
-    if (seen.has(b.bookmarkId)) return;
-    seen.add(b.bookmarkId);
-    rows.push({
-      id: b.id || makeId(),
-      todoId,
-      bookmarkId: b.bookmarkId,
-      title: b.title,
-      url: b.url ?? null,
-      sectionId: b.sectionId ?? null,
-      sectionLabel: b.sectionLabel ?? null,
-      position: index,
-    });
-  });
-  return rows;
+  return buildBookmarkRowsCore(bookmarks, makeId).map(row => ({
+    todoId,
+    ...row,
+  }));
 }
 
 export function buildTodoRows(

--- a/packages/middleware/src/tests/errors.test.ts
+++ b/packages/middleware/src/tests/errors.test.ts
@@ -1,0 +1,63 @@
+import type { FastifyReply } from "fastify";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { sendBadRequest, sendConflict, sendNotFound } from "../utils/errors.ts";
+
+// A minimal reply double capturing what the helpers set. The helpers only use
+// status().send(), so this stub is the whole surface they touch.
+function fakeReply() {
+  const calls: { status?: number;
+    body?: unknown; } = {};
+  const reply = {
+    status(code: number) {
+      calls.status = code;
+      return reply;
+    },
+    send(body: unknown) {
+      calls.body = body;
+      return reply;
+    },
+  };
+  return {
+    reply: reply as unknown as FastifyReply,
+    calls,
+  };
+}
+
+test("sendNotFound replies 404 with the resource in the message", () => {
+  const {
+    reply, calls,
+  } = fakeReply();
+  sendNotFound(reply, "Routine");
+  assert.strictEqual(calls.status, 404);
+  assert.deepStrictEqual(calls.body, {
+    status: "error",
+    message: "Routine not found",
+  });
+});
+
+test("sendBadRequest replies 400 with the given message", () => {
+  const {
+    reply, calls,
+  } = fakeReply();
+  sendBadRequest(reply, "missing name");
+  assert.strictEqual(calls.status, 400);
+  assert.deepStrictEqual(calls.body, {
+    status: "error",
+    message: "missing name",
+  });
+});
+
+test("sendConflict replies 409 with the given message", () => {
+  const {
+    reply, calls,
+  } = fakeReply();
+  sendConflict(reply, "already exists");
+  assert.strictEqual(calls.status, 409);
+  assert.deepStrictEqual(calls.body, {
+    status: "error",
+    message: "already exists",
+  });
+});

--- a/packages/middleware/src/tests/routineConnectionRows.test.ts
+++ b/packages/middleware/src/tests/routineConnectionRows.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import type { RoutineConnectionInput } from "../utils/routineConnectionRows.ts";
+import { buildRoutineConnectionRows } from "../utils/routineConnectionRows.ts";
+
+const taskConnection: RoutineConnectionInput = {
+  type: "task",
+  id: "task-1",
+};
+
+const bookmarkConnection: RoutineConnectionInput = {
+  type: "bookmark",
+  id: "bm-1",
+  name: "Pimsleur",
+  url: "https://example.com/pimsleur",
+  sectionId: "sec-1",
+  sectionLabel: "Unit 3",
+};
+
+test("buildRoutineConnectionRows returns an empty list for undefined input", () => {
+  assert.deepStrictEqual(buildRoutineConnectionRows(undefined, "r-1"), []);
+});
+
+test("buildRoutineConnectionRows persists cached fields for bookmarks only", () => {
+  const rows = buildRoutineConnectionRows(
+    [taskConnection, bookmarkConnection],
+    "r-1",
+  );
+
+  assert.strictEqual(rows.length, 2);
+  const [task, bookmark] = rows;
+
+  // Local types resolve their display name from the target table on read, so
+  // nothing is cached even if the client sent a name.
+  assert.strictEqual(task.connectedType, "task");
+  assert.strictEqual(task.connectedId, "task-1");
+  assert.strictEqual(task.cachedTitle, null);
+  assert.strictEqual(task.cachedUrl, null);
+  assert.strictEqual(task.sectionId, null);
+  assert.strictEqual(task.sectionLabel, null);
+
+  assert.strictEqual(bookmark.connectedType, "bookmark");
+  assert.strictEqual(bookmark.cachedTitle, "Pimsleur");
+  assert.strictEqual(bookmark.cachedUrl, "https://example.com/pimsleur");
+  assert.strictEqual(bookmark.sectionId, "sec-1");
+  assert.strictEqual(bookmark.sectionLabel, "Unit 3");
+
+  for (const row of rows) {
+    assert.strictEqual(row.routineId, "r-1");
+    assert.ok(row.id);
+  }
+});
+
+test("buildRoutineConnectionRows nulls missing bookmark cache fields", () => {
+  const [row] = buildRoutineConnectionRows(
+    [
+      {
+        type: "bookmark",
+        id: "bm-bare",
+      },
+    ],
+    "r-1",
+  );
+  assert.strictEqual(row.cachedTitle, null);
+  assert.strictEqual(row.cachedUrl, null);
+  assert.strictEqual(row.sectionId, null);
+  assert.strictEqual(row.sectionLabel, null);
+});
+
+test("buildRoutineConnectionRows dedupes by (type, id) keeping the first", () => {
+  const rows = buildRoutineConnectionRows(
+    [
+      bookmarkConnection,
+      {
+        ...bookmarkConnection,
+        name: "Duplicate",
+      },
+      // Same id under a different type is a distinct connection, not a dupe.
+      {
+        type: "task",
+        id: "bm-1",
+      },
+    ],
+    "r-1",
+  );
+  assert.deepStrictEqual(
+    rows.map(r => `${r.connectedType}:${r.connectedId}`),
+    ["bookmark:bm-1", "task:bm-1"],
+  );
+  assert.strictEqual(rows[0].cachedTitle, "Pimsleur");
+});
+
+test("buildRoutineConnectionRows skips entries without an id and keeps positions dense", () => {
+  const rows = buildRoutineConnectionRows(
+    [
+      {
+        type: "task",
+        id: "",
+      },
+      taskConnection,
+      bookmarkConnection,
+    ],
+    "r-1",
+  );
+  assert.deepStrictEqual(
+    rows.map(r => [r.connectedId, r.position]),
+    [
+      ["task-1", 0],
+      ["bm-1", 1],
+    ],
+  );
+});

--- a/packages/middleware/src/tests/sharedEntryNames.test.ts
+++ b/packages/middleware/src/tests/sharedEntryNames.test.ts
@@ -1,0 +1,104 @@
+import type { RoutineReferenceItem } from "@emstack/types";
+
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { buildActionableSentence, routineEntryName } from "@emstack/types";
+
+// Direct branch coverage for the two shared @emstack/types functions that the
+// client (schedule rendering) and middleware (completion baking) must both call
+// so they never drift. @emstack/types has no test runner, so they're pinned
+// here (see routineActionParts.test.ts for the projection that wraps them).
+
+const taskNames = new Map([["task-1", "Spanish drills"]]);
+
+test("routineEntryName uses a freeform entry's id as its text", () => {
+  const freeform: RoutineReferenceItem = {
+    type: "freeform",
+    id: "Stretch",
+  };
+  assert.strictEqual(routineEntryName(freeform, taskNames), "Stretch");
+});
+
+test("routineEntryName uses a bookmark entry's cached title", () => {
+  const bookmark: RoutineReferenceItem = {
+    type: "bookmark",
+    id: "bm-1",
+    title: "Pimsleur",
+  };
+  assert.strictEqual(routineEntryName(bookmark, taskNames), "Pimsleur");
+});
+
+test("routineEntryName falls back to the id for an untitled bookmark", () => {
+  const bookmark: RoutineReferenceItem = {
+    type: "bookmark",
+    id: "bm-untitled",
+  };
+  assert.strictEqual(routineEntryName(bookmark, taskNames), "bm-untitled");
+});
+
+test("routineEntryName resolves a task entry through the name map", () => {
+  const task: RoutineReferenceItem = {
+    type: "task",
+    id: "task-1",
+  };
+  assert.strictEqual(routineEntryName(task, taskNames), "Spanish drills");
+});
+
+test("routineEntryName falls back to the raw id for a deleted task", () => {
+  const task: RoutineReferenceItem = {
+    type: "task",
+    id: "task-gone",
+  };
+  assert.strictEqual(routineEntryName(task, taskNames), "task-gone");
+});
+
+test("buildActionableSentence joins prepend, name, and append with spaces", () => {
+  assert.strictEqual(
+    buildActionableSentence({
+      prependText: "Review",
+      name: "Spanish flashcards",
+      appendText: "for 10 minutes",
+    }),
+    "Review Spanish flashcards for 10 minutes",
+  );
+});
+
+test("buildActionableSentence returns the bare name when affixes are absent", () => {
+  assert.strictEqual(
+    buildActionableSentence({
+      name: "Spanish flashcards",
+    }),
+    "Spanish flashcards",
+  );
+  assert.strictEqual(
+    buildActionableSentence({
+      prependText: null,
+      name: "Spanish flashcards",
+      appendText: null,
+    }),
+    "Spanish flashcards",
+  );
+});
+
+test("buildActionableSentence trims whitespace-only affixes away", () => {
+  assert.strictEqual(
+    buildActionableSentence({
+      prependText: "  ",
+      name: " Spanish flashcards ",
+      appendText: "\t",
+    }),
+    "Spanish flashcards",
+  );
+});
+
+test("buildActionableSentence drops a blank name and keeps real affixes", () => {
+  assert.strictEqual(
+    buildActionableSentence({
+      prependText: "Review",
+      name: "",
+      appendText: "for 10 minutes",
+    }),
+    "Review for 10 minutes",
+  );
+});

--- a/packages/middleware/src/tests/taskProjectionMap.test.ts
+++ b/packages/middleware/src/tests/taskProjectionMap.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert";
+import { test } from "node:test";
+
+import { mapTask } from "../utils/taskProjection.ts";
+
+// A fully-populated, minimal-but-valid row. Tests spread this and override the
+// field under test so each case stays focused on one behavior (mirrors
+// dailyProjection.test.ts).
+const baseRow = {
+  id: "task-1",
+  name: "Learn Spanish",
+  description: null,
+  taskTypeId: null,
+  taskType: null,
+  tasksToTags: [],
+  bookmarks: [],
+  todos: [],
+};
+
+const bookmarkRow = {
+  id: "tb-1",
+  bookmarkId: "bm-1",
+  title: "Pimsleur",
+  url: null,
+  sectionId: null,
+  sectionLabel: null,
+  position: null,
+};
+
+test("mapTask maps base fields and defaults empty collections", () => {
+  assert.deepStrictEqual(mapTask(baseRow), {
+    id: "task-1",
+    name: "Learn Spanish",
+    description: null,
+    taskTypeId: null,
+    taskType: null,
+    tags: [],
+    bookmarks: [],
+    todos: [],
+  });
+});
+
+test("mapTask maps the task type and defaults its tags to an empty array", () => {
+  const result = mapTask({
+    ...baseRow,
+    taskTypeId: "tt-1",
+    taskType: {
+      id: "tt-1",
+      name: "Language",
+      tags: null,
+    },
+  });
+  assert.deepStrictEqual(result.taskType, {
+    id: "tt-1",
+    name: "Language",
+    tags: [],
+  });
+  assert.strictEqual(result.taskTypeId, "tt-1");
+});
+
+test("mapTask flattens tag junction rows into tags", () => {
+  const tag = {
+    id: "tag-1",
+    groupId: "tg-1",
+    name: "language",
+  };
+  const result = mapTask({
+    ...baseRow,
+    tasksToTags: [{
+      tag,
+    }],
+  });
+  assert.deepStrictEqual(result.tags, [tag]);
+});
+
+test("mapTask sorts bookmarks by position, treating null as 0", () => {
+  const result = mapTask({
+    ...baseRow,
+    bookmarks: [
+      {
+        ...bookmarkRow,
+        id: "tb-b",
+        bookmarkId: "bm-b",
+        position: 2,
+      },
+      {
+        ...bookmarkRow,
+        id: "tb-a",
+        bookmarkId: "bm-a",
+        position: null,
+      },
+      {
+        ...bookmarkRow,
+        id: "tb-m",
+        bookmarkId: "bm-m",
+        position: 1,
+      },
+    ],
+  });
+  assert.deepStrictEqual(
+    (result.bookmarks ?? []).map(b => b.id),
+    ["tb-a", "tb-m", "tb-b"],
+  );
+});
+
+test("mapTask does not mutate the input bookmark order", () => {
+  const bookmarks = [
+    {
+      ...bookmarkRow,
+      id: "tb-b",
+      position: 1,
+    },
+    {
+      ...bookmarkRow,
+      id: "tb-a",
+      position: 0,
+    },
+  ];
+  mapTask({
+    ...baseRow,
+    bookmarks,
+  });
+  assert.deepStrictEqual(
+    bookmarks.map(b => b.id),
+    ["tb-b", "tb-a"],
+  );
+});
+
+test("mapTask maps todos with null fallbacks and sorted nested bookmarks", () => {
+  const result = mapTask({
+    ...baseRow,
+    todos: [
+      {
+        id: "td-1",
+        taskId: "task-1",
+        name: "Unit 1",
+        status: "incomplete",
+        dueDate: null,
+        note: null,
+        location: null,
+        url: null,
+        position: 0,
+        bookmarks: [
+          {
+            ...bookmarkRow,
+            id: "tb-2",
+            position: 1,
+          },
+          {
+            ...bookmarkRow,
+            id: "tb-1",
+            position: 0,
+          },
+        ],
+      },
+    ],
+  });
+  assert.deepStrictEqual(result.todos, [
+    {
+      id: "td-1",
+      taskId: "task-1",
+      name: "Unit 1",
+      status: "incomplete",
+      dueDate: null,
+      note: null,
+      location: null,
+      url: null,
+      position: 0,
+      bookmarks: [
+        {
+          ...bookmarkRow,
+          id: "tb-1",
+          position: 0,
+        },
+        {
+          ...bookmarkRow,
+          id: "tb-2",
+          position: 1,
+        },
+      ],
+    },
+  ]);
+});
+
+test("mapTask sorts todos by position", () => {
+  const todo = {
+    taskId: "task-1",
+    name: "Unit",
+    status: "incomplete" as const,
+    dueDate: null,
+    note: null,
+    location: null,
+    url: null,
+    bookmarks: [],
+  };
+  const result = mapTask({
+    ...baseRow,
+    todos: [
+      {
+        ...todo,
+        id: "td-late",
+        position: 5,
+      },
+      {
+        ...todo,
+        id: "td-early",
+        position: 1,
+      },
+    ],
+  });
+  assert.deepStrictEqual(
+    (result.todos ?? []).map(t => t.id),
+    ["td-early", "td-late"],
+  );
+});

--- a/packages/middleware/src/utils/errors.ts
+++ b/packages/middleware/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { FastifyReply } from "fastify";
+import type { FastifyReply } from "fastify";
 
 export function sendNotFound(reply: FastifyReply, resource: string) {
   return reply.status(404).send({

--- a/packages/middleware/src/utils/resolveRoutineConnections.ts
+++ b/packages/middleware/src/utils/resolveRoutineConnections.ts
@@ -1,5 +1,6 @@
-import { db } from "@/db";
 import type { RoutineConnectionType } from "@/db/schema";
+
+import { taskNamesByIds } from "@/utils/taskNames";
 
 import type { RoutineConnection } from "@emstack/types";
 
@@ -37,23 +38,11 @@ export async function resolveRoutineConnections<
     }
   }
 
-  const taskRows = taskIds.size
-    ? await db.query.tasks.findMany({
-      where: (t, {
-        inArray,
-      }) => inArray(t.id, [...taskIds]),
-      columns: {
-        id: true,
-        name: true,
-      },
-    })
-    : [];
-
   const nameByType: Record<
     Exclude<RoutineConnectionType, "bookmark">,
     Map<string, string>
   > = {
-    task: new Map(taskRows.map(r => [r.id, r.name])),
+    task: await taskNamesByIds(taskIds),
   };
 
   return rows.map((row) => {

--- a/packages/middleware/src/utils/taskNames.ts
+++ b/packages/middleware/src/utils/taskNames.ts
@@ -1,0 +1,22 @@
+import { db } from "@/db";
+
+// Batch-resolve task display names for a set of ids in one query (avoids N+1).
+// Ids whose task no longer exists are simply absent from the map, so callers
+// fall back per their own rules (e.g. routineEntryName's raw-id fallback).
+export async function taskNamesByIds(
+  taskIds: ReadonlySet<string>,
+): Promise<Map<string, string>> {
+  if (!taskIds.size) {
+    return new Map();
+  }
+  const rows = await db.query.tasks.findMany({
+    where: (t, {
+      inArray,
+    }) => inArray(t.id, [...taskIds]),
+    columns: {
+      id: true,
+      name: true,
+    },
+  });
+  return new Map(rows.map(r => [r.id, r.name]));
+}


### PR DESCRIPTION
Autonomous overnight health sweep (`/overnight-cleanup`), one iteration; the loop stopped on the "score unchanged" rule (details below).

## Numbers

| Metric | Before | After | Target |
|---|---|---|---|
| fallow health score | 7.86 (B) | 7.86 (B) | 8.0 |
| Dead-code issues | 0 | 0 | 0 |
| Duplication | 1.25 % (7 groups) | **0.88 % (4 groups)** | < 6.5 % |
| Complexity findings above caps | 0 | 0 | 0 |
| Middleware tests | 57 | **81** | — |
| Client tests (unit + stories) | 648 | **664** | — |

## Per-phase changes

- **Phase 1 — dead code:** already 0 at baseline; kept at 0 (pruned barrel re-exports orphaned by the Phase 5 split).
- **Phase 2 — tests:** +24 middleware tests: direct branch coverage for the shared `@emstack/types` functions `routineEntryName` / `buildActionableSentence` (from a middleware `node --test` file, per convention), `mapTask` (taskProjection), `buildRoutineConnectionRows`, and the `errors.ts` reply helpers. The `errors.ts` test exposed a latent value-import of `FastifyReply` that fails Node type-stripping — fixed to `import type`. De-flake: pinned the clock in the `getTodayKey` test (it raced midnight rollover).
- **Phase 3 — duplicates:** extracted `taskNamesByIds` (batched task-name lookup repeated in `bakeRoutineCompletions`, `convertToTaskList`, `resolveRoutineConnections`), shared the bookmark-row builder core in `taskRows.ts`, lifted the duplicated Bookmarks form block into `BookmarksFieldGroup`. Remaining 4 clone groups are one-shot `db/migrate*.ts` files that stay standalone by design.
- **Phase 4 — complexity:** zero findings above the cyclomatic/cognitive caps, before and after.
- **Phase 5 — large components:** split `Dashboard` (extracted `useDashboardTileSaver` + `LayoutManagerDialogs`), `TodosEditor` (extracted `TodoReadRow`, hoisted the display comparator), `DailyCompletionsManager` (extracted `CompletionsMonthNav` + `DailyCompletionEntryRow`, retiring a `fallow-ignore complexity` suppression). All verbatim, behavior-preserving moves under the existing story/test net.
- **Phase 6 — stories:** 5 new story files (16 story tests) covering every component this sweep extracted.
- **Phase 7 — skills:** reconciled 8 repo skills + the add-entity checklist with the #552–#554 subsystem removals, folder-based routes, and the sidebar nav.

## Why the score didn't move (hand-off)

The two remaining penalties are pinned at their caps and aren't reachable by safe mechanical cleanup:

- **hotspots (−10):** `packages/client/src/utils/queryKeys.ts` — the score is churn-history × density; the file is a 53-line flat key registry whose "complexity" is 18 one-line arrows. Splitting it would hurt readability; fallow's suggestion (split into per-domain files behind a barrel) is a design call for a human. Otherwise it ages out as churn decays.
- **unit_size (−10):** ~130 functions over 60 lines (top remaining: `-RoutineDetailsContent.tsx` 238, `ui/calendar.tsx` 229 (vendored), `RoutineBox.tsx` 221, `SingleTaskEdit` route 220). The penalty is capped, so it only moves after mass decomposition — best done incrementally as those areas are touched.

Also noted: `resolveRoutineConnections` still has no test (imports the live `db`; needs a harness decision), and one full-suite run hung in the storybook Vitest project before passing clean on re-run — the parallelism flake already tracked in #504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST

---
_Generated by [Claude Code](https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST)_