### PR TITLE
refactor(client): split RoutineDetailsContent into section components

### DIFF
--- a/packages/client/src/routes/routines/$id/-components/-RoutineConnectionsList.stories.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineConnectionsList.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RoutineConnectionsList } from "./-RoutineConnectionsList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta: Meta<typeof RoutineConnectionsList> = {
+  component: RoutineConnectionsList,
+  args: {
+    connections: [
+      {
+        type: "task",
+        id: "task-1",
+        name: "Read a chapter",
+      },
+    ],
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TaskConnection: Story = {
+  play: smokeText("Read a chapter", "task"),
+};
+
+export const BookmarkConnectionWithSection: Story = {
+  args: {
+    connections: [
+      {
+        type: "bookmark",
+        id: "bm-1",
+        name: "Pimsleur Spanish",
+        url: "https://example.com/pimsleur",
+        sectionLabel: "Unit 3",
+      },
+    ],
+  },
+  play: smokeText("Pimsleur Spanish", /Unit 3/),
+};
+
+export const Mixed: Story = {
+  args: {
+    connections: [
+      {
+        type: "task",
+        id: "task-1",
+        name: "Read a chapter",
+      },
+      {
+        type: "bookmark",
+        id: "bm-1",
+        name: "Pimsleur Spanish",
+        url: null,
+      },
+    ],
+  },
+  play: smokeText("Read a chapter", "Pimsleur Spanish"),
+};

--- a/packages/client/src/routes/routines/$id/-components/-RoutineConnectionsList.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineConnectionsList.tsx
@@ -1,0 +1,84 @@
+import type { RoutineConnection } from "@emstack/types";
+
+import { OpenBookmarkPageButton } from "@/components/bookmarks";
+import { EntityLink } from "@/components/boxElements";
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
+import { connectionEntityKind } from "@/utils";
+
+interface RoutineConnectionsListProps {
+  connections: RoutineConnection[];
+}
+
+const linkClass = `
+  font-bold text-blue-800
+  hover:text-blue-600
+  dark:text-blue-300
+`;
+
+// The "Connected To" list on a routine's Details tab: bookmark connections
+// link out to Simple Bookmarks (with optional section suffix), local
+// connections link to their entity page.
+export function RoutineConnectionsList({
+  connections,
+}: RoutineConnectionsListProps) {
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {connections.map(c => (
+        <li key={`${c.type}:${c.id}`}>
+          {c.type === "bookmark"
+            ? (
+              <span className="inline-flex items-center gap-1">
+                <a
+                  href={
+                    resolveHref({
+                      externalId: c.id,
+                      url: c.url ?? null,
+                    }) ?? undefined
+                  }
+                  target="_blank"
+                  rel="noreferrer"
+                  className={linkClass}
+                >
+                  <span
+                    className="mr-2 text-xs text-muted-foreground uppercase"
+                  >
+                    {c.type}
+                  </span>
+                  {c.name ?? c.id}
+                  {c.sectionLabel && (
+                    <span className="ml-1 font-normal opacity-70">
+                      › {c.sectionLabel}
+                    </span>
+                  )}
+                </a>
+                <OpenBookmarkPageButton
+                  linkable={{
+                    externalId: c.id,
+                    url: c.url ?? null,
+                  }}
+                />
+              </span>
+            )
+            : (
+              <EntityLink
+                entity={connectionEntityKind(c.type)}
+                id={c.id}
+                className={linkClass}
+              >
+                <span
+                  className="mr-2 text-xs text-muted-foreground uppercase"
+                >
+                  {c.type}
+                </span>
+                {c.name ?? c.id}
+              </EntityLink>
+            )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineDetailsContent.tsx
@@ -2,20 +2,18 @@ import type { Routine } from "@emstack/types";
 
 import { FlameIcon, LaughIcon } from "lucide-react";
 
-import { OpenBookmarkPageButton } from "@/components/bookmarks";
-import { EntityLink } from "@/components/boxElements";
+import { RoutineConnectionsList } from "./-RoutineConnectionsList";
+import { RoutineScheduleEntryList } from "./-RoutineScheduleEntryList";
+
 import { InfoArea } from "@/components/layout";
 import {
   curatedDateRange,
   DAY_LABELS,
   DAY_ORDER,
   formatCuratedDateLabel,
-  RoutineEntryLabel,
 } from "@/components/routines";
-import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
 import { useTaskResourceNames } from "@/hooks/useTaskResourceNames";
 import {
-  connectionEntityKind,
   getCurrentChain,
   getTodayKey,
   getTotalCompletedDays,
@@ -35,9 +33,6 @@ export function RoutineDetailsContent({
   const {
     taskNames,
   } = useTaskResourceNames();
-  const {
-    resolveHref,
-  } = useBookmarkLinking();
 
   const weekly = data.weekly ?? {};
   const isDaily = data.mode === "daily";
@@ -116,102 +111,22 @@ export function RoutineDetailsContent({
         header="Connected To"
         condition={(data.connections?.length ?? 0) > 0}
       >
-        <ul className="flex flex-col gap-1">
-          {data.connections?.map(c => (
-            <li key={`${c.type}:${c.id}`}>
-              {c.type === "bookmark"
-                ? (
-                  <span className="inline-flex items-center gap-1">
-                    <a
-                      href={
-                        resolveHref({
-                          externalId: c.id,
-                          url: c.url ?? null,
-                        }) ?? undefined
-                      }
-                      target="_blank"
-                      rel="noreferrer"
-                      className={`
-                        font-bold text-blue-800
-                        hover:text-blue-600
-                        dark:text-blue-300
-                      `}
-                    >
-                      <span
-                        className="mr-2 text-xs text-muted-foreground uppercase"
-                      >
-                        {c.type}
-                      </span>
-                      {c.name ?? c.id}
-                      {c.sectionLabel && (
-                        <span className="ml-1 font-normal opacity-70">
-                          › {c.sectionLabel}
-                        </span>
-                      )}
-                    </a>
-                    <OpenBookmarkPageButton
-                      linkable={{
-                        externalId: c.id,
-                        url: c.url ?? null,
-                      }}
-                    />
-                  </span>
-                )
-                : (
-                  <EntityLink
-                    entity={connectionEntityKind(c.type)}
-                    id={c.id}
-                    className={`
-                      font-bold text-blue-800
-                      hover:text-blue-600
-                      dark:text-blue-300
-                    `}
-                  >
-                    <span
-                      className="mr-2 text-xs text-muted-foreground uppercase"
-                    >
-                      {c.type}
-                    </span>
-                    {c.name ?? c.id}
-                  </EntityLink>
-                )}
-            </li>
-          ))}
-        </ul>
+        <RoutineConnectionsList connections={data.connections ?? []} />
       </InfoArea>
       {!isDaily && !isCurated && (
         <InfoArea
           header="Weekly Schedule"
           condition={true}
         >
-          <ul className="flex flex-col gap-1">
-            {DAY_ORDER.map((day) => {
-              const entry = weekly[day];
-              return (
-                <li
-                  key={day}
-                  className="
-                    grid grid-cols-[120px_1fr] items-center gap-2 border-b
-                    border-border/60 py-1
-                  "
-                >
-                  <span className="text-sm font-medium">{DAY_LABELS[day]}</span>
-                  {entry
-                    ? (
-                      <RoutineEntryLabel
-                        entry={entry}
-                        taskNames={taskNames}
-                      />
-                    )
-                    : (
-                      <span className="text-sm text-muted-foreground italic">
-                        Nothing scheduled
-                      </span>
-                    )}
-                </li>
-              );
-            })}
-          </ul>
+          <RoutineScheduleEntryList
+            rows={DAY_ORDER.map(day => ({
+              key: day,
+              label: DAY_LABELS[day],
+              entry: weekly[day],
+            }))}
+            taskNames={taskNames}
+            gridClass="grid grid-cols-[120px_1fr]"
+          />
         </InfoArea>
       )}
       {isCurated && (
@@ -226,36 +141,15 @@ export function RoutineDetailsContent({
           )}
           {curatedDates.length > 0
             ? (
-              <ul className="flex flex-col gap-1">
-                {curatedDates.map((dateKey) => {
-                  const entry = data.curated?.entries?.[dateKey];
-                  return (
-                    <li
-                      key={dateKey}
-                      className="
-                        grid grid-cols-[150px_1fr] items-center gap-2 border-b
-                        border-border/60 py-1
-                      "
-                    >
-                      <span className="text-sm font-medium">
-                        {formatCuratedDateLabel(dateKey)}
-                      </span>
-                      {entry
-                        ? (
-                          <RoutineEntryLabel
-                            entry={entry}
-                            taskNames={taskNames}
-                          />
-                        )
-                        : (
-                          <span className="text-sm text-muted-foreground italic">
-                            Nothing scheduled
-                          </span>
-                        )}
-                    </li>
-                  );
-                })}
-              </ul>
+              <RoutineScheduleEntryList
+                rows={curatedDates.map(dateKey => ({
+                  key: dateKey,
+                  label: formatCuratedDateLabel(dateKey),
+                  entry: data.curated?.entries?.[dateKey],
+                }))}
+                taskNames={taskNames}
+                gridClass="grid grid-cols-[150px_1fr]"
+              />
             )
             : (
               <span className="text-sm text-muted-foreground italic">

--- a/packages/client/src/routes/routines/$id/-components/-RoutineScheduleEntryList.stories.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineScheduleEntryList.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RoutineScheduleEntryList } from "./-RoutineScheduleEntryList";
+
+import { RouterStub } from "@/test-utils/RouterStub";
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta: Meta<typeof RoutineScheduleEntryList> = {
+  component: RoutineScheduleEntryList,
+  args: {
+    rows: [
+      {
+        key: "1",
+        label: "Monday",
+        entry: {
+          type: "task",
+          id: "task-1",
+        },
+      },
+      {
+        key: "2",
+        label: "Tuesday",
+        entry: undefined,
+      },
+    ],
+    taskNames: new Map([["task-1", "Read a chapter"]]),
+    gridClass: "grid grid-cols-[120px_1fr]",
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <Story />
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A scheduled weekday plus an unscheduled one (the "Nothing scheduled" arm).
+export const WeekdayRows: Story = {
+  play: smokeText("Monday", "Read a chapter", "Nothing scheduled"),
+};
+
+// Date-keyed rows as the curated schedule renders them (wider label column).
+export const DateRows: Story = {
+  args: {
+    rows: [
+      {
+        key: "2026-07-17",
+        label: "Thu, Jul 17",
+        entry: {
+          type: "bookmark",
+          id: "bm-1",
+          title: "Reference doc",
+        },
+      },
+    ],
+    gridClass: "grid grid-cols-[150px_1fr]",
+  },
+  play: smokeText("Thu, Jul 17", "Reference doc"),
+};

--- a/packages/client/src/routes/routines/$id/-components/-RoutineScheduleEntryList.tsx
+++ b/packages/client/src/routes/routines/$id/-components/-RoutineScheduleEntryList.tsx
@@ -1,0 +1,57 @@
+import type { RoutineReferenceItem } from "@emstack/types";
+
+import { RoutineEntryLabel } from "@/components/routines";
+import { cn } from "@/lib/utils";
+
+export interface ScheduleEntryListRow {
+  key: string;
+  label: string;
+  entry: RoutineReferenceItem | undefined;
+}
+
+interface RoutineScheduleEntryListProps {
+  rows: ScheduleEntryListRow[];
+  // Resolves task ids referenced by schedule entries.
+  taskNames: Map<string, string>;
+  // Literal Tailwind grid template so both label widths stay statically
+  // analyzable ("grid-cols-[120px_1fr]" for weekdays, wider for dates).
+  gridClass: string;
+}
+
+// One label + scheduled-entry row per line, shared by the weekly (per-weekday)
+// and curated (per-date) schedule sections of the routine Details tab.
+export function RoutineScheduleEntryList({
+  rows,
+  taskNames,
+  gridClass,
+}: RoutineScheduleEntryListProps) {
+  return (
+    <ul className="flex flex-col gap-1">
+      {rows.map(({
+        key, label, entry,
+      }) => (
+        <li
+          key={key}
+          className={cn(
+            "items-center gap-2 border-b border-border/60 py-1",
+            gridClass,
+          )}
+        >
+          <span className="text-sm font-medium">{label}</span>
+          {entry
+            ? (
+              <RoutineEntryLabel
+                entry={entry}
+                taskNames={taskNames}
+              />
+            )
+            : (
+              <span className="text-sm text-muted-foreground italic">
+                Nothing scheduled
+              </span>
+            )}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
Companion to the overnight sweep (#562), kept separate per the sweep's risky-item rule: a focused decomposition of the largest remaining non-vendored component (`-RoutineDetailsContent.tsx`, a 238-line function).

## What changed

- **`RoutineConnectionsList`** — the "Connected To" list body, with its two arms (external bookmark link + `OpenBookmarkPageButton` + optional section suffix, vs. local `EntityLink`). The repeated link class string is hoisted to one constant.
- **`RoutineScheduleEntryList`** — the label + scheduled-entry row list that the weekly (per-weekday) and curated (per-date) sections previously duplicated; both now feed it pre-built `{ key, label, entry }` rows, with the grid template passed as a literal class so Tailwind can see it.
- `RoutineDetailsContent` is now tiles + composition (~160 lines, from 269).

## Verification

- Behavior-preserving JSX moves only; no logic changes.
- New stories pin both extracted components (5 story tests); the existing `RoutineDetailsContent` stories (Default / Weekly / Curated) pin the composed result.
- `pnpm typecheck`, `pnpm lint`, client Vitest 203 files / 653 tests, middleware 57/57 — all green on this branch.

Branched directly off `master` — independent of #562; the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST

---
_Generated by [Claude Code](https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST)_