### PR TITLE
refactor(client): decompose BookmarkPicker, dailies list row, and template sections

### DIFF
--- a/packages/client/src/components/bookmarks/BookmarkChip.stories.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkChip.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { BookmarkChip } from "./BookmarkChip";
+
+import { QueryStub } from "@/test-utils/QueryStub";
+import { seededQueryClient } from "@/test-utils/seededQueryClient";
+import { queryStoryDecorator } from "@/test-utils/storyDecorators";
+import { smokeText } from "@/test-utils/storyPlay";
+import { queryKeys } from "@/utils/queryKeys";
+
+const association = {
+  id: "tb-1",
+  bookmarkId: "bm-1",
+  title: "Pimsleur Spanish",
+  url: "https://example.com/pimsleur",
+};
+
+const meta: Meta<typeof BookmarkChip> = {
+  component: BookmarkChip,
+  args: {
+    association,
+    onRemove: fn(),
+    onChangeSection: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// No sections cached: just the title link, open-page and remove buttons.
+export const NoSections: Story = {
+  decorators: [
+    Story => (
+      <QueryStub>
+        <ul className="flex flex-wrap gap-2">
+          <Story />
+        </ul>
+      </QueryStub>
+    ),
+  ],
+  play: smokeText("Pimsleur Spanish"),
+};
+
+// Seeded sections: the section-narrowing select appears.
+export const WithSections: Story = {
+  decorators: [
+    queryStoryDecorator(
+      seededQueryClient([
+        [
+          queryKeys.bookmarks.sections("bm-1"),
+          [
+            {
+              id: "sec-1",
+              label: "Unit 3",
+            },
+          ],
+        ],
+      ]),
+    ),
+    Story => (
+      <ul className="flex flex-wrap gap-2">
+        <Story />
+      </ul>
+    ),
+  ],
+  play: smokeText("Pimsleur Spanish", "Whole bookmark", "Unit 3"),
+};

--- a/packages/client/src/components/bookmarks/BookmarkChip.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkChip.tsx
@@ -1,0 +1,108 @@
+import type { TaskBookmark } from "@emstack/types";
+
+import { useQuery } from "@tanstack/react-query";
+import { ExternalLinkIcon, XIcon } from "lucide-react";
+
+import { OpenBookmarkPageButton } from "./OpenBookmarkPageButton";
+
+import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
+import { fetchBookmarkSections, queryKeys } from "@/utils";
+
+interface BookmarkChipProps {
+  association: TaskBookmark;
+  onRemove: () => void;
+  onChangeSection: (
+    sectionId: string | null,
+    sectionLabel: string | null,
+  ) => void;
+}
+
+// A single associated-bookmark chip: title link, remove, and — when the bookmark
+// has sections — a live-fetched dropdown to narrow the association to one section.
+export function BookmarkChip({
+  association,
+  onRemove,
+  onChangeSection,
+}: BookmarkChipProps) {
+  const {
+    data: sections = [],
+  } = useQuery({
+    queryKey: queryKeys.bookmarks.sections(association.bookmarkId),
+    queryFn: () => fetchBookmarkSections(association.bookmarkId),
+  });
+
+  const {
+    resolveHref,
+  } = useBookmarkLinking();
+  const linkable = {
+    externalId: association.bookmarkId,
+    url: association.url,
+  };
+  const href = resolveHref(linkable);
+
+  return (
+    <li
+      className="
+        flex items-center gap-1.5 rounded-md border border-border bg-muted px-2
+        py-1 text-sm
+      "
+    >
+      {href
+        ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="
+              inline-flex items-center gap-1
+              hover:underline
+            "
+          >
+            {association.title}
+            <ExternalLinkIcon className="size-3" />
+          </a>
+        )
+        : (
+          <span>{association.title}</span>
+        )}
+      <OpenBookmarkPageButton linkable={linkable} />
+
+      {sections.length > 0 && (
+        <select
+          aria-label={`Section of ${association.title}`}
+          value={association.sectionId ?? ""}
+          onChange={(e) => {
+            const id = e.target.value || null;
+            const label = id
+              ? (sections.find(s => s.id === id)?.label ?? null)
+              : null;
+            onChangeSection(id, label);
+          }}
+          className="rounded-sm border bg-background px-1 py-0.5 text-xs"
+        >
+          <option value="">Whole bookmark</option>
+          {sections.map(s => (
+            <option
+              key={s.id}
+              value={s.id}
+            >
+              {s.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${association.title}`}
+        className="
+          text-muted-foreground
+          hover:text-foreground
+        "
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </li>
+  );
+}

--- a/packages/client/src/components/bookmarks/BookmarkPicker.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkPicker.tsx
@@ -1,126 +1,38 @@
-import type { BookmarkSummary, TaskBookmark } from "@emstack/types";
+import type { TaskBookmark } from "@emstack/types";
 
-import { useEffect, useState } from "react";
-
-import { useQuery } from "@tanstack/react-query";
-import { ExternalLinkIcon, Loader2, PlusIcon, XIcon } from "lucide-react";
-
-import { OpenBookmarkPageButton } from "./OpenBookmarkPageButton";
+import { BookmarkChip } from "./BookmarkChip";
+import { BookmarkSearchDropdown } from "./BookmarkSearchDropdown";
 
 import { Input } from "@/components/ui/input";
-import { useBookmarkLinking } from "@/hooks/useBookmarkLinking";
-import {
-  createBookmark,
-  fetchBookmarkSections,
-  isHttpUrl,
-  queryKeys,
-  resolveBookmark,
-  searchBookmarks,
-} from "@/utils";
+import { useBookmarkPicker } from "@/hooks/useBookmarkPicker";
 
 interface BookmarkPickerProps {
   value: TaskBookmark[];
   onChange: (next: TaskBookmark[]) => void;
 }
 
-function toAssociation(b: BookmarkSummary): TaskBookmark {
-  return {
-    bookmarkId: b.id,
-    title: b.title,
-    url: b.url,
-  };
-}
-
 // Associates a task with Simple Bookmarks bookmarks. Search existing bookmarks
 // by title/URL, or paste a URL to resolve it (creating the bookmark in Simple
-// Bookmarks when it isn't saved yet). Coexists with the local Resources model
-// during the incremental migration to bookmark-backed links.
+// Bookmarks when it isn't saved yet).
 export function BookmarkPicker({
   value, onChange,
 }: BookmarkPickerProps) {
-  const [inputValue, setInputValue] = useState("");
-  const [debounced, setDebounced] = useState("");
-  const [isAdding, setIsAdding] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const handle = setTimeout(() => setDebounced(inputValue.trim()), 250);
-    return () => clearTimeout(handle);
-  }, [inputValue]);
-
-  const trimmed = inputValue.trim();
-  const looksLikeUrl = isHttpUrl(trimmed);
-  const selectedIds = new Set(value.map(v => v.bookmarkId));
-
   const {
-    data: results = [],
+    inputValue,
+    setInputValue,
+    trimmed,
+    looksLikeUrl,
+    isAdding,
+    error,
     isFetching,
     isError,
-  } = useQuery({
-    queryKey: queryKeys.bookmarks.search(debounced),
-    queryFn: () => searchBookmarks(debounced),
-    // Skip the search while a URL is being pasted — that path resolves/creates
-    // instead of listing matches.
-    enabled: debounced.length > 0 && !isHttpUrl(debounced),
-  });
-
-  function add(bookmark: BookmarkSummary) {
-    if (!selectedIds.has(bookmark.id)) {
-      onChange([...value, toAssociation(bookmark)]);
-    }
-    setInputValue("");
-    setDebounced("");
-    setError(null);
-  }
-
-  function remove(bookmarkId: string) {
-    onChange(value.filter(v => v.bookmarkId !== bookmarkId));
-  }
-
-  function setSection(
-    bookmarkId: string,
-    sectionId: string | null,
-    sectionLabel: string | null,
-  ) {
-    onChange(
-      value.map(v =>
-        v.bookmarkId === bookmarkId
-          ? {
-            ...v,
-            sectionId,
-            sectionLabel,
-          }
-          : v),
-    );
-  }
-
-  async function addByUrl() {
-    if (!trimmed) return;
-    setIsAdding(true);
-    setError(null);
-    try {
-      // Resolve first so we reuse an existing bookmark instead of duplicating it;
-      // create only when the URL isn't saved yet.
-      const {
-        bookmark,
-      } = await resolveBookmark(trimmed);
-      const resolved
-        = bookmark
-          ?? (await createBookmark({
-            url: trimmed,
-          }));
-      add(resolved);
-    }
-    catch {
-      setError("Couldn't reach Simple Bookmarks. Try again.");
-    }
-    finally {
-      setIsAdding(false);
-    }
-  }
-
-  const availableResults = results.filter(r => !selectedIds.has(r.id));
-  const showDropdown = trimmed.length > 0;
+    availableResults,
+    showDropdown,
+    add,
+    remove,
+    setSection,
+    addByUrl,
+  } = useBookmarkPicker(value, onChange);
 
   return (
     <div className="flex flex-col gap-2">
@@ -152,193 +64,20 @@ export function BookmarkPicker({
         />
 
         {showDropdown && (
-          <div
-            className="
-              mt-1 rounded-md border border-border bg-popover p-1 text-sm
-              shadow-md
-            "
-          >
-            {looksLikeUrl
-              ? (
-                <button
-                  type="button"
-                  disabled={isAdding}
-                  onClick={() => void addByUrl()}
-                  className="
-                    flex w-full items-center gap-2 rounded-sm p-2 text-left
-                    hover:bg-accent hover:text-accent-foreground
-                    disabled:opacity-50
-                  "
-                >
-                  {isAdding
-                    ? (
-                      <Loader2 className="size-4 animate-spin" />
-                    )
-                    : (
-                      <PlusIcon className="size-4" />
-                    )}
-                  <span>
-                    Add bookmark for
-                    {" "}
-                    <strong className="break-all">{trimmed}</strong>
-                  </span>
-                </button>
-              )
-              : isFetching
-                ? (
-                  <div
-                    className="
-                      flex items-center gap-2 p-2 text-muted-foreground
-                    "
-                  >
-                    <Loader2 className="size-4 animate-spin" />
-                    Searching…
-                  </div>
-                )
-                : isError
-                  ? (
-                    <div className="p-2 text-muted-foreground">
-                      Simple Bookmarks is unreachable.
-                    </div>
-                  )
-                  : availableResults.length === 0
-                    ? (
-                      <div className="p-2 text-muted-foreground">
-                        No bookmarks found. Paste a URL to add one.
-                      </div>
-                    )
-                    : (
-                      <ul>
-                        {availableResults.map(r => (
-                          <li key={r.id}>
-                            <button
-                              type="button"
-                              onClick={() => add(r)}
-                              className="
-                                flex w-full flex-col items-start rounded-sm p-2
-                                text-left
-                                hover:bg-accent hover:text-accent-foreground
-                              "
-                            >
-                              <span>{r.title}</span>
-                              {r.url && (
-                                <span
-                                  className="
-                                    text-xs break-all text-muted-foreground
-                                  "
-                                >
-                                  {r.url}
-                                </span>
-                              )}
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-          </div>
+          <BookmarkSearchDropdown
+            trimmed={trimmed}
+            looksLikeUrl={looksLikeUrl}
+            isAdding={isAdding}
+            isFetching={isFetching}
+            isError={isError}
+            results={availableResults}
+            onAddByUrl={() => void addByUrl()}
+            onSelect={add}
+          />
         )}
       </div>
 
       {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
-  );
-}
-
-interface BookmarkChipProps {
-  association: TaskBookmark;
-  onRemove: () => void;
-  onChangeSection: (
-    sectionId: string | null,
-    sectionLabel: string | null,
-  ) => void;
-}
-
-// A single associated-bookmark chip: title link, remove, and — when the bookmark
-// has sections — a live-fetched dropdown to narrow the association to one section.
-function BookmarkChip({
-  association,
-  onRemove,
-  onChangeSection,
-}: BookmarkChipProps) {
-  const {
-    data: sections = [],
-  } = useQuery({
-    queryKey: queryKeys.bookmarks.sections(association.bookmarkId),
-    queryFn: () => fetchBookmarkSections(association.bookmarkId),
-  });
-
-  const {
-    resolveHref,
-  } = useBookmarkLinking();
-  const linkable = {
-    externalId: association.bookmarkId,
-    url: association.url,
-  };
-  const href = resolveHref(linkable);
-
-  return (
-    <li
-      className="
-        flex items-center gap-1.5 rounded-md border border-border bg-muted px-2
-        py-1 text-sm
-      "
-    >
-      {href
-        ? (
-          <a
-            href={href}
-            target="_blank"
-            rel="noreferrer"
-            className="
-              inline-flex items-center gap-1
-              hover:underline
-            "
-          >
-            {association.title}
-            <ExternalLinkIcon className="size-3" />
-          </a>
-        )
-        : (
-          <span>{association.title}</span>
-        )}
-      <OpenBookmarkPageButton linkable={linkable} />
-
-      {sections.length > 0 && (
-        <select
-          aria-label={`Section of ${association.title}`}
-          value={association.sectionId ?? ""}
-          onChange={(e) => {
-            const id = e.target.value || null;
-            const label = id
-              ? (sections.find(s => s.id === id)?.label ?? null)
-              : null;
-            onChangeSection(id, label);
-          }}
-          className="rounded-sm border bg-background px-1 py-0.5 text-xs"
-        >
-          <option value="">Whole bookmark</option>
-          {sections.map(s => (
-            <option
-              key={s.id}
-              value={s.id}
-            >
-              {s.label}
-            </option>
-          ))}
-        </select>
-      )}
-
-      <button
-        type="button"
-        onClick={onRemove}
-        aria-label={`Remove ${association.title}`}
-        className="
-          text-muted-foreground
-          hover:text-foreground
-        "
-      >
-        <XIcon className="size-3.5" />
-      </button>
-    </li>
   );
 }

--- a/packages/client/src/components/bookmarks/BookmarkSearchDropdown.stories.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkSearchDropdown.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { BookmarkSearchDropdown } from "./BookmarkSearchDropdown";
+
+import { smokeText } from "@/test-utils/storyPlay";
+
+const meta: Meta<typeof BookmarkSearchDropdown> = {
+  component: BookmarkSearchDropdown,
+  args: {
+    trimmed: "spanish",
+    looksLikeUrl: false,
+    isAdding: false,
+    isFetching: false,
+    isError: false,
+    results: [],
+    onAddByUrl: fn(),
+    onSelect: fn(),
+  },
+  decorators: [
+    Story => (
+      <div className="max-w-md">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithResults: Story = {
+  args: {
+    results: [
+      {
+        id: "bm-1",
+        title: "Pimsleur Spanish",
+        url: "https://example.com/pimsleur",
+      },
+    ],
+  },
+  play: smokeText("Pimsleur Spanish"),
+};
+
+export const Empty: Story = {
+  play: smokeText("No bookmarks found. Paste a URL to add one."),
+};
+
+export const Searching: Story = {
+  args: {
+    isFetching: true,
+  },
+  play: smokeText(/Searching/),
+};
+
+export const Unreachable: Story = {
+  args: {
+    isError: true,
+  },
+  play: smokeText("Simple Bookmarks is unreachable."),
+};
+
+export const AddByUrl: Story = {
+  args: {
+    trimmed: "https://example.com/new-page",
+    looksLikeUrl: true,
+  },
+  play: smokeText(/Add bookmark for/),
+};

--- a/packages/client/src/components/bookmarks/BookmarkSearchDropdown.tsx
+++ b/packages/client/src/components/bookmarks/BookmarkSearchDropdown.tsx
@@ -1,0 +1,111 @@
+import type { BookmarkSummary } from "@emstack/types";
+
+import { Loader2, PlusIcon } from "lucide-react";
+
+interface BookmarkSearchDropdownProps {
+  // The trimmed input text (shown in the add-by-URL row).
+  trimmed: string;
+  looksLikeUrl: boolean;
+  isAdding: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  results: BookmarkSummary[];
+  onAddByUrl: () => void;
+  onSelect: (bookmark: BookmarkSummary) => void;
+}
+
+// The BookmarkPicker's results dropdown: an add-by-URL action when the input
+// looks like a URL, otherwise the search states (loading / unreachable /
+// empty / matches).
+export function BookmarkSearchDropdown({
+  trimmed,
+  looksLikeUrl,
+  isAdding,
+  isFetching,
+  isError,
+  results,
+  onAddByUrl,
+  onSelect,
+}: BookmarkSearchDropdownProps) {
+  return (
+    <div
+      className="
+        mt-1 rounded-md border border-border bg-popover p-1 text-sm shadow-md
+      "
+    >
+      {looksLikeUrl
+        ? (
+          <button
+            type="button"
+            disabled={isAdding}
+            onClick={onAddByUrl}
+            className="
+              flex w-full items-center gap-2 rounded-sm p-2 text-left
+              hover:bg-accent hover:text-accent-foreground
+              disabled:opacity-50
+            "
+          >
+            {isAdding
+              ? (
+                <Loader2 className="size-4 animate-spin" />
+              )
+              : (
+                <PlusIcon className="size-4" />
+              )}
+            <span>
+              Add bookmark for
+              {" "}
+              <strong className="break-all">{trimmed}</strong>
+            </span>
+          </button>
+        )
+        : isFetching
+          ? (
+            <div
+              className="flex items-center gap-2 p-2 text-muted-foreground"
+            >
+              <Loader2 className="size-4 animate-spin" />
+              Searching…
+            </div>
+          )
+          : isError
+            ? (
+              <div className="p-2 text-muted-foreground">
+                Simple Bookmarks is unreachable.
+              </div>
+            )
+            : results.length === 0
+              ? (
+                <div className="p-2 text-muted-foreground">
+                  No bookmarks found. Paste a URL to add one.
+                </div>
+              )
+              : (
+                <ul>
+                  {results.map(r => (
+                    <li key={r.id}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(r)}
+                        className="
+                          flex w-full flex-col items-start rounded-sm p-2
+                          text-left
+                          hover:bg-accent hover:text-accent-foreground
+                        "
+                      >
+                        <span>{r.title}</span>
+                        {r.url && (
+                          <span
+                            className="text-xs break-all text-muted-foreground"
+                          >
+                            {r.url}
+                          </span>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+    </div>
+  );
+}

--- a/packages/client/src/components/dailies/DailiesActiveListView.tsx
+++ b/packages/client/src/components/dailies/DailiesActiveListView.tsx
@@ -1,29 +1,6 @@
 import type { Daily, DailyCompletionStatus } from "@emstack/types";
 
-import { Fragment } from "react";
-
-import { Link } from "@tanstack/react-router";
-import { FlameIcon, LaughIcon } from "lucide-react";
-
-import {
-  DailyCommentPopover,
-  DailyLocationCell,
-  DailyProgressCell,
-  DailyStatusCircle,
-  DailyStatusConnector,
-  DailyTaskIndicator,
-  DailyTitle,
-  TodayStatusCell,
-} from "./dailyCells";
-
-import { cn } from "@/lib/utils";
-import {
-  findStatusForDate,
-  getCurrentChain,
-  getRecentDays,
-  getReferenceDateKey,
-  getTotalCompletedDays,
-} from "@/utils";
+import { DailyActiveRow } from "./DailyActiveRow";
 
 interface DailiesActiveListViewProps {
   dailies: Daily[];
@@ -51,187 +28,16 @@ export function DailiesActiveListView({
         lg:grid-cols-2 lg:divide-y-0
       "
     >
-      {dailies.map((daily) => {
-        const currentStatus = findStatusForDate(daily, todayKey);
-        const chain = getCurrentChain(daily, todayKey);
-        const total = getTotalCompletedDays(daily);
-        const referenceKey = getReferenceDateKey(daily, todayKey);
-        const recentDays = getRecentDays(
-          daily,
-          recentDaysCount + 1,
-          referenceKey,
-          "mmdd",
-        )
-          .slice(0, -1)
-          .reverse();
-        const mostRecentPast = recentDays[0] ?? null;
-        return (
-          <li
-            key={daily.id}
-            className="
-              flex flex-col gap-2.5 border-b py-3
-              lg:border-b
-              lg:even:border-l lg:even:pl-6
-            "
-          >
-            <div className="flex w-full min-w-0 flex-row items-start gap-3">
-              <div className="mt-0.5 shrink-0">
-                <DailyProgressCell daily={daily} />
-              </div>
-              <div className="flex w-full min-w-0 flex-col gap-1">
-                {daily.kind === "todo" && daily.taskId
-                  ? (
-                    <Link
-                      to="/tasks/$id"
-                      params={{
-                        id: daily.taskId,
-                      }}
-                      className="
-                        truncate font-medium
-                        hover:text-blue-600
-                      "
-                    >
-                      <DailyTitle daily={daily} />
-                    </Link>
-                  )
-                  : (
-                    <Link
-                      to="/routines/$id"
-                      params={{
-                        id: daily.id,
-                      }}
-                      className="
-                        truncate font-medium
-                        hover:text-blue-600
-                      "
-                    >
-                      <DailyTitle daily={daily} />
-                    </Link>
-                  )}
-                <div
-                  className="
-                    flex w-full flex-row flex-wrap items-center justify-between
-                    gap-x-4 gap-y-2 text-sm
-                  "
-                >
-                  <div className="flex flex-row items-center gap-6">
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1.5",
-                        currentStatus === "incomplete"
-                          ? "text-muted-foreground"
-                          : chain > 0
-                            ? "text-orange-600"
-                            : "text-muted-foreground",
-                      )}
-                      title={
-                        chain > 0 ? `${chain}-day chain` : "No active chain"
-                      }
-                    >
-                      <FlameIcon className="size-4" />
-                      {chain}
-                    </span>
-                    <span
-                      className={cn(
-                        "inline-flex items-center gap-1.5",
-                        total > 0
-                          ? "text-emerald-600"
-                          : "text-muted-foreground",
-                      )}
-                      title={`${total} total day${total === 1 ? "" : "s"} completed`}
-                    >
-                      <LaughIcon className="size-4" />
-                      {total}
-                    </span>
-                    <span
-                      className="
-                        inline-flex items-center gap-2
-                        [&_a>svg]:size-5
-                      "
-                    >
-                      <DailyTaskIndicator daily={daily} />
-                    </span>
-                  </div>
-                  <span
-                    className="
-                      [&_a]:px-2.5 [&_a]:py-1.5 [&_a]:text-sm
-                      [&_svg]:size-4
-                    "
-                  >
-                    <DailyLocationCell
-                      location={daily.location}
-                      taskId={daily.taskId ?? daily.task?.id ?? null}
-                    />
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex w-full flex-col items-start">
-              <div
-                className="
-                  flex w-full flex-row items-center justify-between gap-2
-                "
-              >
-                <div
-                  className="
-                    w-full
-                    [&_button]:px-3 [&_button]:py-1 [&_button]:text-sm
-                    [&_svg]:size-4
-                  "
-                >
-                  <TodayStatusCell
-                    daily={daily}
-                    currentStatus={currentStatus}
-                    disabled={mutationPending}
-                    onChange={(status, note) =>
-                      onChangeStatus(daily, status, note)}
-                  />
-                </div>
-                {currentStatus !== null && (
-                  <DailyCommentPopover
-                    daily={daily}
-                    buttonClassName="size-9 [&_svg]:size-4"
-                  />
-                )}
-              </div>
-              <DailyStatusConnector
-                orientation="vertical"
-                left={currentStatus}
-                right={mostRecentPast?.status ?? null}
-                className="ml-[11px] h-3 shrink-0"
-              />
-              <div className="flex w-full flex-row items-start">
-                {recentDays.map((day, i) => (
-                  <Fragment key={day.dateKey}>
-                    {i > 0 && (
-                      <DailyStatusConnector
-                        left={recentDays[i - 1].status}
-                        right={day.status}
-                        className="mt-[11px] w-full min-w-2.5"
-                      />
-                    )}
-                    <div className="flex shrink-0 flex-col items-center gap-0.5">
-                      <DailyStatusCircle
-                        status={day.status}
-                        size="sm"
-                        title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
-                      />
-                      <span
-                        className="
-                          text-[0.65rem] leading-none text-muted-foreground
-                        "
-                      >
-                        {day.dayLabel}
-                      </span>
-                    </div>
-                  </Fragment>
-                ))}
-              </div>
-            </div>
-          </li>
-        );
-      })}
+      {dailies.map(daily => (
+        <DailyActiveRow
+          key={daily.id}
+          daily={daily}
+          todayKey={todayKey}
+          onChangeStatus={onChangeStatus}
+          mutationPending={mutationPending}
+          recentDaysCount={recentDaysCount}
+        />
+      ))}
     </ul>
   );
 }

--- a/packages/client/src/components/dailies/DailyActiveRow.stories.tsx
+++ b/packages/client/src/components/dailies/DailyActiveRow.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { DailyActiveRow } from "./DailyActiveRow";
+
+import {
+  makeDaily,
+  makeRecentCompletions,
+  makeTask,
+} from "@/test-utils/dailiesFixtures";
+import { QueryStub } from "@/test-utils/QueryStub";
+import { RouterStub } from "@/test-utils/RouterStub";
+import { smokeText } from "@/test-utils/storyPlay";
+import { getTodayKey } from "@/utils";
+
+const meta: Meta<typeof DailyActiveRow> = {
+  component: DailyActiveRow,
+  args: {
+    daily: makeDaily({
+      id: "d1",
+      name: "Spanish practice",
+      location: "https://duolingo.com",
+      task: makeTask({
+        name: "Duolingo Spanish",
+      }),
+      completions: makeRecentCompletions(["goal", "touched", "goal", "goal"]),
+    }),
+    todayKey: getTodayKey(),
+    mutationPending: false,
+    recentDaysCount: 6,
+    onChangeStatus: fn(),
+  },
+  decorators: [
+    Story => (
+      <RouterStub>
+        <QueryStub>
+          <ul className="max-w-xl">
+            <Story />
+          </ul>
+        </QueryStub>
+      </RouterStub>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const WithHistory: Story = {
+  play: smokeText("Spanish practice"),
+};
+
+export const NoCompletions: Story = {
+  args: {
+    daily: makeDaily({
+      id: "d2",
+      name: "Morning stretch",
+      completions: [],
+    }),
+  },
+  play: smokeText("Morning stretch"),
+};

--- a/packages/client/src/components/dailies/DailyActiveRow.tsx
+++ b/packages/client/src/components/dailies/DailyActiveRow.tsx
@@ -1,0 +1,224 @@
+import type { Daily, DailyCompletionStatus } from "@emstack/types";
+
+import { Fragment } from "react";
+
+import { Link } from "@tanstack/react-router";
+import { FlameIcon, LaughIcon } from "lucide-react";
+
+import {
+  DailyCommentPopover,
+  DailyLocationCell,
+  DailyProgressCell,
+  DailyStatusCircle,
+  DailyStatusConnector,
+  DailyTaskIndicator,
+  DailyTitle,
+  TodayStatusCell,
+} from "./dailyCells";
+
+import { cn } from "@/lib/utils";
+import {
+  findStatusForDate,
+  getCurrentChain,
+  getRecentDays,
+  getReferenceDateKey,
+  getTotalCompletedDays,
+} from "@/utils";
+
+interface DailyActiveRowProps {
+  daily: Daily;
+  todayKey: string;
+  onChangeStatus: (
+    daily: Daily,
+    status: DailyCompletionStatus,
+    note: string | null,
+  ) => void;
+  mutationPending: boolean;
+  recentDaysCount: number;
+}
+
+// One daily's card in the active-list view: progress ring, title link,
+// chain/total stats, location, today's status control, and the recent-days
+// mini strip with connectors.
+export function DailyActiveRow({
+  daily,
+  todayKey,
+  onChangeStatus,
+  mutationPending,
+  recentDaysCount,
+}: DailyActiveRowProps) {
+  const currentStatus = findStatusForDate(daily, todayKey);
+  const chain = getCurrentChain(daily, todayKey);
+  const total = getTotalCompletedDays(daily);
+  const referenceKey = getReferenceDateKey(daily, todayKey);
+  const recentDays = getRecentDays(
+    daily,
+    recentDaysCount + 1,
+    referenceKey,
+    "mmdd",
+  )
+    .slice(0, -1)
+    .reverse();
+  const mostRecentPast = recentDays[0] ?? null;
+  return (
+    <li
+      className="
+        flex flex-col gap-2.5 border-b py-3
+        lg:border-b
+        lg:even:border-l lg:even:pl-6
+      "
+    >
+      <div className="flex w-full min-w-0 flex-row items-start gap-3">
+        <div className="mt-0.5 shrink-0">
+          <DailyProgressCell daily={daily} />
+        </div>
+        <div className="flex w-full min-w-0 flex-col gap-1">
+          {daily.kind === "todo" && daily.taskId
+            ? (
+              <Link
+                to="/tasks/$id"
+                params={{
+                  id: daily.taskId,
+                }}
+                className="
+                  truncate font-medium
+                  hover:text-blue-600
+                "
+              >
+                <DailyTitle daily={daily} />
+              </Link>
+            )
+            : (
+              <Link
+                to="/routines/$id"
+                params={{
+                  id: daily.id,
+                }}
+                className="
+                  truncate font-medium
+                  hover:text-blue-600
+                "
+              >
+                <DailyTitle daily={daily} />
+              </Link>
+            )}
+          <div
+            className="
+              flex w-full flex-row flex-wrap items-center justify-between
+              gap-x-4 gap-y-2 text-sm
+            "
+          >
+            <div className="flex flex-row items-center gap-6">
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1.5",
+                  currentStatus === "incomplete"
+                    ? "text-muted-foreground"
+                    : chain > 0
+                      ? "text-orange-600"
+                      : "text-muted-foreground",
+                )}
+                title={
+                  chain > 0 ? `${chain}-day chain` : "No active chain"
+                }
+              >
+                <FlameIcon className="size-4" />
+                {chain}
+              </span>
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1.5",
+                  total > 0
+                    ? "text-emerald-600"
+                    : "text-muted-foreground",
+                )}
+                title={`${total} total day${total === 1 ? "" : "s"} completed`}
+              >
+                <LaughIcon className="size-4" />
+                {total}
+              </span>
+              <span
+                className="
+                  inline-flex items-center gap-2
+                  [&_a>svg]:size-5
+                "
+              >
+                <DailyTaskIndicator daily={daily} />
+              </span>
+            </div>
+            <span
+              className="
+                [&_a]:px-2.5 [&_a]:py-1.5 [&_a]:text-sm
+                [&_svg]:size-4
+              "
+            >
+              <DailyLocationCell
+                location={daily.location}
+                taskId={daily.taskId ?? daily.task?.id ?? null}
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col items-start">
+        <div
+          className="flex w-full flex-row items-center justify-between gap-2"
+        >
+          <div
+            className="
+              w-full
+              [&_button]:px-3 [&_button]:py-1 [&_button]:text-sm
+              [&_svg]:size-4
+            "
+          >
+            <TodayStatusCell
+              daily={daily}
+              currentStatus={currentStatus}
+              disabled={mutationPending}
+              onChange={(status, note) =>
+                onChangeStatus(daily, status, note)}
+            />
+          </div>
+          {currentStatus !== null && (
+            <DailyCommentPopover
+              daily={daily}
+              buttonClassName="size-9 [&_svg]:size-4"
+            />
+          )}
+        </div>
+        <DailyStatusConnector
+          orientation="vertical"
+          left={currentStatus}
+          right={mostRecentPast?.status ?? null}
+          className="ml-[11px] h-3 shrink-0"
+        />
+        <div className="flex w-full flex-row items-start">
+          {recentDays.map((day, i) => (
+            <Fragment key={day.dateKey}>
+              {i > 0 && (
+                <DailyStatusConnector
+                  left={recentDays[i - 1].status}
+                  right={day.status}
+                  className="mt-[11px] w-full min-w-2.5"
+                />
+              )}
+              <div className="flex shrink-0 flex-col items-center gap-0.5">
+                <DailyStatusCircle
+                  status={day.status}
+                  size="sm"
+                  title={`${day.dateKey}${day.status ? ` — ${day.status}` : " — no entry"}`}
+                />
+                <span
+                  className="text-[0.65rem] leading-none text-muted-foreground"
+                >
+                  {day.dayLabel}
+                </span>
+              </div>
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/packages/client/src/hooks/useBookmarkPicker.ts
+++ b/packages/client/src/hooks/useBookmarkPicker.ts
@@ -1,0 +1,128 @@
+import type { BookmarkSummary, TaskBookmark } from "@emstack/types";
+
+import { useEffect, useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  createBookmark,
+  isHttpUrl,
+  queryKeys,
+  resolveBookmark,
+  searchBookmarks,
+} from "@/utils";
+
+function toAssociation(b: BookmarkSummary): TaskBookmark {
+  return {
+    bookmarkId: b.id,
+    title: b.title,
+    url: b.url,
+  };
+}
+
+// The BookmarkPicker's input state machine: debounced title/URL search against
+// Simple Bookmarks, add/remove/section mutations on the association list, and
+// the paste-a-URL path (resolve an existing bookmark, else create it). Returns
+// presentational-ready flags so the component renders only JSX.
+export function useBookmarkPicker(
+  value: TaskBookmark[],
+  onChange: (next: TaskBookmark[]) => void,
+) {
+  const [inputValue, setInputValue] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(inputValue.trim()), 250);
+    return () => clearTimeout(handle);
+  }, [inputValue]);
+
+  const trimmed = inputValue.trim();
+  const looksLikeUrl = isHttpUrl(trimmed);
+  const selectedIds = new Set(value.map(v => v.bookmarkId));
+
+  const {
+    data: results = [],
+    isFetching,
+    isError,
+  } = useQuery({
+    queryKey: queryKeys.bookmarks.search(debounced),
+    queryFn: () => searchBookmarks(debounced),
+    // Skip the search while a URL is being pasted — that path resolves/creates
+    // instead of listing matches.
+    enabled: debounced.length > 0 && !isHttpUrl(debounced),
+  });
+
+  function add(bookmark: BookmarkSummary) {
+    if (!selectedIds.has(bookmark.id)) {
+      onChange([...value, toAssociation(bookmark)]);
+    }
+    setInputValue("");
+    setDebounced("");
+    setError(null);
+  }
+
+  function remove(bookmarkId: string) {
+    onChange(value.filter(v => v.bookmarkId !== bookmarkId));
+  }
+
+  function setSection(
+    bookmarkId: string,
+    sectionId: string | null,
+    sectionLabel: string | null,
+  ) {
+    onChange(
+      value.map(v =>
+        v.bookmarkId === bookmarkId
+          ? {
+            ...v,
+            sectionId,
+            sectionLabel,
+          }
+          : v),
+    );
+  }
+
+  async function addByUrl() {
+    if (!trimmed) return;
+    setIsAdding(true);
+    setError(null);
+    try {
+      // Resolve first so we reuse an existing bookmark instead of duplicating it;
+      // create only when the URL isn't saved yet.
+      const {
+        bookmark,
+      } = await resolveBookmark(trimmed);
+      const resolved
+        = bookmark
+          ?? (await createBookmark({
+            url: trimmed,
+          }));
+      add(resolved);
+    }
+    catch {
+      setError("Couldn't reach Simple Bookmarks. Try again.");
+    }
+    finally {
+      setIsAdding(false);
+    }
+  }
+
+  return {
+    inputValue,
+    setInputValue,
+    trimmed,
+    looksLikeUrl,
+    isAdding,
+    error,
+    isFetching,
+    isError,
+    availableResults: results.filter(r => !selectedIds.has(r.id)),
+    showDropdown: trimmed.length > 0,
+    add,
+    remove,
+    setSection,
+    addByUrl,
+  };
+}

--- a/packages/client/src/routes/settings/-components/routineTemplates/-CriteriaTemplatesSection.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-CriteriaTemplatesSection.tsx
@@ -1,19 +1,15 @@
 import type { DailyCriteriaTemplate } from "@emstack/types";
 
-import { useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
-import { toast } from "sonner";
-
 import { DailyCriteriaTemplateEditModal } from "./-DailyCriteriaTemplateEditModal";
+import { TemplateListSection } from "./-TemplateListSection";
+import { useTemplateSectionCrud } from "./-useTemplateSectionCrud";
 
-import { Button } from "@/components/ui/button";
 import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createDailyCriteriaTemplate,
   deleteSingleDailyCriteriaTemplate,
   fetchDailyCriteriaTemplates,
+  queryKeys,
   upsertDailyCriteriaTemplate,
 } from "@/utils";
 
@@ -29,178 +25,87 @@ function makeEmptyCriteriaTemplate(): DailyCriteriaTemplate {
   };
 }
 
+function toCriteriaBody(template: DailyCriteriaTemplate) {
+  return {
+    label: template.label,
+    incomplete: template.incomplete,
+    touched: template.touched,
+    goal: template.goal,
+    exceeded: template.exceeded,
+    freeze: template.freeze,
+  };
+}
+
 export function CriteriaTemplatesSection() {
-  const queryClient = useQueryClient();
-
-  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(
-    null,
-  );
-  const [creatingNewTemplate, setCreatingNewTemplate] = useState(false);
-
-  const criteriaTemplatesQuery = useQuery({
-    queryKey: ["dailyCriteriaTemplates"],
-    queryFn: () => fetchDailyCriteriaTemplates(),
+  const {
+    templates,
+    isPending,
+    editingId,
+    setEditingId,
+    creatingNew,
+    setCreatingNew,
+    editingTemplate,
+    saveTemplate,
+    createTemplate,
+    deleteTemplate,
+    isSaving,
+    isCreating,
+    isDeleting,
+  } = useTemplateSectionCrud<DailyCriteriaTemplate>({
+    queryKey: queryKeys.dailyCriteriaTemplates.list(),
+    fetchFn: fetchDailyCriteriaTemplates,
+    createFn: template => createDailyCriteriaTemplate(toCriteriaBody(template)),
+    upsertFn: template =>
+      upsertDailyCriteriaTemplate(template.id, toCriteriaBody(template)),
+    deleteFn: deleteSingleDailyCriteriaTemplate,
+    entityLabel: "Template",
   });
-
-  const upsertTemplateMutation = useMutation({
-    mutationFn: (template: DailyCriteriaTemplate) =>
-      upsertDailyCriteriaTemplate(template.id, {
-        label: template.label,
-        incomplete: template.incomplete,
-        touched: template.touched,
-        goal: template.goal,
-        exceeded: template.exceeded,
-        freeze: template.freeze,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["dailyCriteriaTemplates"],
-      });
-      setEditingTemplateId(null);
-      toast.success("Template saved");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const createTemplateMutation = useMutation({
-    mutationFn: (template: DailyCriteriaTemplate) =>
-      createDailyCriteriaTemplate({
-        label: template.label,
-        incomplete: template.incomplete,
-        touched: template.touched,
-        goal: template.goal,
-        exceeded: template.exceeded,
-        freeze: template.freeze,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["dailyCriteriaTemplates"],
-      });
-      setCreatingNewTemplate(false);
-      toast.success("Template created");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const deleteTemplateMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleDailyCriteriaTemplate(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["dailyCriteriaTemplates"],
-      });
-      setEditingTemplateId(null);
-      toast.success("Template deleted");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const criteriaTemplates = criteriaTemplatesQuery.data ?? [];
-  const editingCriteriaTemplate = editingTemplateId
-    ? (criteriaTemplates.find(t => t.id === editingTemplateId) ?? null)
-    : null;
 
   return (
     <>
-      <section className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="text-xl font-semibold">Status Criteria Templates</h2>
-          <Button
-            variant="outline"
-            onClick={() => setCreatingNewTemplate(true)}
-          >
-            <PlusIcon />
-            New Template
-          </Button>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Prefill options for the Status Criteria Quick Fill on a daily.
-        </p>
-        {criteriaTemplatesQuery.isPending
-          ? (
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          )
-          : criteriaTemplates.length === 0
+      <TemplateListSection
+        title="Status Criteria Templates"
+        description="Prefill options for the Status Criteria Quick Fill on a daily."
+        templates={templates}
+        isPending={isPending}
+        renderMeta={t =>
+          t.goal
             ? (
-              <p className="text-sm text-muted-foreground">
-                No templates yet. Create one to use it as a Quick Fill option.
-              </p>
+              <span className="line-clamp-1 text-xs text-muted-foreground">
+                Goal: {t.goal}
+              </span>
             )
-            : (
-              <ul className="flex flex-col divide-y rounded-md border">
-                {criteriaTemplates.map(t => (
-                  <li
-                    key={t.id}
-                    className="
-                      flex flex-wrap items-center justify-between gap-2 p-3
-                    "
-                  >
-                    <div className="flex flex-col gap-1">
-                      <span className="font-medium">{t.label}</span>
-                      {t.goal && (
-                        <span
-                          className="line-clamp-1 text-xs text-muted-foreground"
-                        >
-                          Goal: {t.goal}
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => setEditingTemplateId(t.id)}
-                      >
-                        <PencilIcon className="size-4" />
-                        Edit
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => deleteTemplateMutation.mutate(t.id)}
-                        disabled={deleteTemplateMutation.isPending}
-                      >
-                        <Trash2Icon className="size-4" />
-                        Delete
-                      </Button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-      </section>
-
-      <DailyCriteriaTemplateEditModal
-        open={editingTemplateId !== null}
-        template={editingCriteriaTemplate}
-        onOpenChange={(open) => {
-          if (!open) setEditingTemplateId(null);
-        }}
-        onSave={t => upsertTemplateMutation.mutate(t)}
-        onDelete={
-          editingCriteriaTemplate
-            ? () => deleteTemplateMutation.mutate(editingCriteriaTemplate.id)
-            : undefined
-        }
-        isSaving={
-          upsertTemplateMutation.isPending || deleteTemplateMutation.isPending
-        }
+            : null}
+        onNew={() => setCreatingNew(true)}
+        onEdit={setEditingId}
+        onDelete={deleteTemplate}
+        isDeleting={isDeleting}
       />
 
       <DailyCriteriaTemplateEditModal
-        open={creatingNewTemplate}
-        template={creatingNewTemplate ? makeEmptyCriteriaTemplate() : null}
+        open={editingId !== null}
+        template={editingTemplate}
+        onOpenChange={(open) => {
+          if (!open) setEditingId(null);
+        }}
+        onSave={saveTemplate}
+        onDelete={
+          editingTemplate
+            ? () => deleteTemplate(editingTemplate.id)
+            : undefined
+        }
+        isSaving={isSaving}
+      />
+
+      <DailyCriteriaTemplateEditModal
+        open={creatingNew}
+        template={creatingNew ? makeEmptyCriteriaTemplate() : null}
         isNew
         onOpenChange={(open) => {
-          if (!open) setCreatingNewTemplate(false);
+          if (!open) setCreatingNew(false);
         }}
-        onSave={t => createTemplateMutation.mutate(t)}
-        isSaving={createTemplateMutation.isPending}
+        onSave={createTemplate}
+        isSaving={isCreating}
       />
     </>
   );

--- a/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplatesSection.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-RoutineTemplatesSection.tsx
@@ -1,20 +1,18 @@
 import type { RoutineTemplate } from "@emstack/types";
 
-import { useState } from "react";
-
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 
 import { RoutineTemplateEditModal } from "./-RoutineTemplateEditModal";
+import { TemplateListSection } from "./-TemplateListSection";
+import { useTemplateSectionCrud } from "./-useTemplateSectionCrud";
 
-import { Button } from "@/components/ui/button";
 import { NEW_ROW_ID } from "@/constants/sentinels";
 import {
   createRoutineTemplate,
   deleteSingleRoutineTemplate,
   fetchRoutineTemplates,
   fetchTasks,
+  queryKeys,
   toOptions,
   upsertRoutineTemplate,
 } from "@/utils";
@@ -28,180 +26,87 @@ function makeEmptyRoutineTemplate(): RoutineTemplate {
 }
 
 export function RoutineTemplatesSection() {
-  const queryClient = useQueryClient();
-
-  const [editingRoutineTemplateId, setEditingRoutineTemplateId] = useState<
-    string | null
-  >(null);
-  const [creatingNewRoutineTemplate, setCreatingNewRoutineTemplate]
-    = useState(false);
-
-  const routineTemplatesQuery = useQuery({
-    queryKey: ["routineTemplates"],
-    queryFn: () => fetchRoutineTemplates(),
-  });
-
-  const tasksQuery = useQuery({
-    queryKey: ["tasks"],
-    queryFn: () => fetchTasks(),
-  });
-
-  const upsertRoutineTemplateMutation = useMutation({
-    mutationFn: (template: RoutineTemplate) =>
-      upsertRoutineTemplate(template.id, {
-        label: template.label,
-        weekly: template.weekly,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["routineTemplates"],
-      });
-      setEditingRoutineTemplateId(null);
-      toast.success("Routine template saved");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
-  });
-
-  const createRoutineTemplateMutation = useMutation({
-    mutationFn: (template: RoutineTemplate) =>
+  const {
+    templates,
+    isPending,
+    editingId,
+    setEditingId,
+    creatingNew,
+    setCreatingNew,
+    editingTemplate,
+    saveTemplate,
+    createTemplate,
+    deleteTemplate,
+    isSaving,
+    isCreating,
+    isDeleting,
+  } = useTemplateSectionCrud<RoutineTemplate>({
+    queryKey: queryKeys.routineTemplates.list(),
+    fetchFn: fetchRoutineTemplates,
+    createFn: template =>
       createRoutineTemplate({
         label: template.label,
         weekly: template.weekly,
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["routineTemplates"],
-      });
-      setCreatingNewRoutineTemplate(false);
-      toast.success("Routine template created");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
+    upsertFn: template =>
+      upsertRoutineTemplate(template.id, {
+        label: template.label,
+        weekly: template.weekly,
+      }),
+    deleteFn: deleteSingleRoutineTemplate,
+    entityLabel: "Routine template",
   });
 
-  const deleteRoutineTemplateMutation = useMutation({
-    mutationFn: (id: string) => deleteSingleRoutineTemplate(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["routineTemplates"],
-      });
-      setEditingRoutineTemplateId(null);
-      toast.success("Routine template deleted");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message);
-    },
+  const tasksQuery = useQuery({
+    queryKey: queryKeys.tasks.list(),
+    queryFn: () => fetchTasks(),
   });
-
-  const routineTemplates = routineTemplatesQuery.data ?? [];
-  const editingRoutineTemplate = editingRoutineTemplateId
-    ? (routineTemplates.find(t => t.id === editingRoutineTemplateId) ?? null)
-    : null;
   const taskOptions = toOptions(tasksQuery.data);
 
   return (
     <>
-      <section className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="text-xl font-semibold">Routine Templates</h2>
-          <Button
-            variant="outline"
-            onClick={() => setCreatingNewRoutineTemplate(true)}
-          >
-            <PlusIcon />
-            New Template
-          </Button>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          Prefill options for the Weekly Schedule Quick Fill on a routine.
-        </p>
-        {routineTemplatesQuery.isPending
-          ? (
-            <p className="text-sm text-muted-foreground">Loading...</p>
-          )
-          : routineTemplates.length === 0
-            ? (
-              <p className="text-sm text-muted-foreground">
-                No templates yet. Create one to use it as a Quick Fill option.
-              </p>
-            )
-            : (
-              <ul className="flex flex-col divide-y rounded-md border">
-                {routineTemplates.map(t => (
-                  <li
-                    key={t.id}
-                    className="
-                      flex flex-wrap items-center justify-between gap-2 p-3
-                    "
-                  >
-                    <div className="flex flex-col gap-1">
-                      <span className="font-medium">{t.label}</span>
-                      <span
-                        className="line-clamp-1 text-xs text-muted-foreground"
-                      >
-                        {Object.keys(t.weekly ?? {}).length} day(s) scheduled
-                      </span>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => setEditingRoutineTemplateId(t.id)}
-                      >
-                        <PencilIcon className="size-4" />
-                        Edit
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        onClick={() => deleteRoutineTemplateMutation.mutate(t.id)}
-                        disabled={deleteRoutineTemplateMutation.isPending}
-                      >
-                        <Trash2Icon className="size-4" />
-                        Delete
-                      </Button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-      </section>
-
-      <RoutineTemplateEditModal
-        open={editingRoutineTemplateId !== null}
-        template={editingRoutineTemplate}
-        taskOptions={taskOptions}
-        onOpenChange={(open) => {
-          if (!open) setEditingRoutineTemplateId(null);
-        }}
-        onSave={t => upsertRoutineTemplateMutation.mutate(t)}
-        onDelete={
-          editingRoutineTemplate
-            ? () =>
-              deleteRoutineTemplateMutation.mutate(editingRoutineTemplate.id)
-            : undefined
-        }
-        isSaving={
-          upsertRoutineTemplateMutation.isPending
-          || deleteRoutineTemplateMutation.isPending
-        }
+      <TemplateListSection
+        title="Routine Templates"
+        description="Prefill options for the Weekly Schedule Quick Fill on a routine."
+        templates={templates}
+        isPending={isPending}
+        renderMeta={t => (
+          <span className="line-clamp-1 text-xs text-muted-foreground">
+            {Object.keys(t.weekly ?? {}).length} day(s) scheduled
+          </span>
+        )}
+        onNew={() => setCreatingNew(true)}
+        onEdit={setEditingId}
+        onDelete={deleteTemplate}
+        isDeleting={isDeleting}
       />
 
       <RoutineTemplateEditModal
-        open={creatingNewRoutineTemplate}
-        template={
-          creatingNewRoutineTemplate ? makeEmptyRoutineTemplate() : null
+        open={editingId !== null}
+        template={editingTemplate}
+        taskOptions={taskOptions}
+        onOpenChange={(open) => {
+          if (!open) setEditingId(null);
+        }}
+        onSave={saveTemplate}
+        onDelete={
+          editingTemplate
+            ? () => deleteTemplate(editingTemplate.id)
+            : undefined
         }
+        isSaving={isSaving}
+      />
+
+      <RoutineTemplateEditModal
+        open={creatingNew}
+        template={creatingNew ? makeEmptyRoutineTemplate() : null}
         isNew
         taskOptions={taskOptions}
         onOpenChange={(open) => {
-          if (!open) setCreatingNewRoutineTemplate(false);
+          if (!open) setCreatingNew(false);
         }}
-        onSave={t => createRoutineTemplateMutation.mutate(t)}
-        isSaving={createRoutineTemplateMutation.isPending}
+        onSave={createTemplate}
+        isSaving={isCreating}
       />
     </>
   );

--- a/packages/client/src/routes/settings/-components/routineTemplates/-TemplateListSection.stories.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-TemplateListSection.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { fn } from "storybook/test";
+
+import { TemplateListSection } from "./-TemplateListSection";
+
+import { smokeText } from "@/test-utils/storyPlay";
+
+const templates = [
+  {
+    id: "t-1",
+    label: "Weekday drills",
+  },
+  {
+    id: "t-2",
+    label: "Weekend review",
+  },
+];
+
+const meta: Meta<typeof TemplateListSection> = {
+  component: TemplateListSection,
+  args: {
+    title: "Routine Templates",
+    description: "Prefill options for the Weekly Schedule Quick Fill.",
+    templates,
+    isPending: false,
+    renderMeta: () => null,
+    onNew: fn(),
+    onEdit: fn(),
+    onDelete: fn(),
+    isDeleting: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Populated: Story = {
+  play: smokeText("Routine Templates", "Weekday drills", "Weekend review"),
+};
+
+export const Empty: Story = {
+  args: {
+    templates: [],
+  },
+  play: smokeText(/No templates yet/),
+};
+
+export const Loading: Story = {
+  args: {
+    templates: [],
+    isPending: true,
+  },
+  play: smokeText("Loading..."),
+};

--- a/packages/client/src/routes/settings/-components/routineTemplates/-TemplateListSection.tsx
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-TemplateListSection.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+
+import { PencilIcon, PlusIcon, Trash2Icon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface TemplateListSectionProps<T extends { id: string;
+  label: string; }> {
+  title: string;
+  description: string;
+  templates: T[];
+  isPending: boolean;
+  // The optional second line under a template's label.
+  renderMeta: (template: T) => ReactNode;
+  onNew: () => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}
+
+// The template settings sections' shared list shell: heading + New button,
+// blurb, and the pending / empty / list states with per-row Edit and Delete.
+// Shared by the routine-template and criteria-template sections.
+export function TemplateListSection<T extends { id: string;
+  label: string; }>({
+  title,
+  description,
+  templates,
+  isPending,
+  renderMeta,
+  onNew,
+  onEdit,
+  onDelete,
+  isDeleting,
+}: TemplateListSectionProps<T>) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <Button
+          variant="outline"
+          onClick={onNew}
+        >
+          <PlusIcon />
+          New Template
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">{description}</p>
+      {isPending
+        ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        )
+        : templates.length === 0
+          ? (
+            <p className="text-sm text-muted-foreground">
+              No templates yet. Create one to use it as a Quick Fill option.
+            </p>
+          )
+          : (
+            <ul className="flex flex-col divide-y rounded-md border">
+              {templates.map(t => (
+                <li
+                  key={t.id}
+                  className="
+                    flex flex-wrap items-center justify-between gap-2 p-3
+                  "
+                >
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium">{t.label}</span>
+                    {renderMeta(t)}
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onEdit(t.id)}
+                    >
+                      <PencilIcon className="size-4" />
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => onDelete(t.id)}
+                      disabled={isDeleting}
+                    >
+                      <Trash2Icon className="size-4" />
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+    </section>
+  );
+}

--- a/packages/client/src/routes/settings/-components/routineTemplates/-useTemplateSectionCrud.ts
+++ b/packages/client/src/routes/settings/-components/routineTemplates/-useTemplateSectionCrud.ts
@@ -1,0 +1,98 @@
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+interface TemplateSectionCrudArgs<T extends { id: string }> {
+  queryKey: readonly unknown[];
+  fetchFn: () => Promise<T[]>;
+  createFn: (template: T) => Promise<unknown>;
+  upsertFn: (template: T) => Promise<unknown>;
+  deleteFn: (id: string) => Promise<unknown>;
+  // Toast prefix, e.g. "Routine template" -> "Routine template saved".
+  entityLabel: string;
+}
+
+// The template settings sections' shared CRUD machinery: list query,
+// edit/create modal state, and the save / create / delete mutations (each
+// invalidating the list, closing its modal, and toasting). Shared by the
+// routine-template and criteria-template sections so the flow can't drift.
+export function useTemplateSectionCrud<T extends { id: string }>({
+  queryKey,
+  fetchFn,
+  createFn,
+  upsertFn,
+  deleteFn,
+  entityLabel,
+}: TemplateSectionCrudArgs<T>) {
+  const queryClient = useQueryClient();
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [creatingNew, setCreatingNew] = useState(false);
+
+  const listQuery = useQuery({
+    queryKey,
+    queryFn: fetchFn,
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey,
+    });
+
+  const upsertMutation = useMutation({
+    mutationFn: upsertFn,
+    onSuccess: () => {
+      invalidate();
+      setEditingId(null);
+      toast.success(`${entityLabel} saved`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: createFn,
+    onSuccess: () => {
+      invalidate();
+      setCreatingNew(false);
+      toast.success(`${entityLabel} created`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteFn,
+    onSuccess: () => {
+      invalidate();
+      setEditingId(null);
+      toast.success(`${entityLabel} deleted`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const templates = listQuery.data ?? [];
+
+  return {
+    templates,
+    isPending: listQuery.isPending,
+    editingId,
+    setEditingId,
+    creatingNew,
+    setCreatingNew,
+    editingTemplate: editingId
+      ? (templates.find(t => t.id === editingId) ?? null)
+      : null,
+    saveTemplate: upsertMutation.mutate,
+    createTemplate: createMutation.mutate,
+    deleteTemplate: deleteMutation.mutate,
+    isSaving: upsertMutation.isPending || deleteMutation.isPending,
+    isCreating: createMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+  };
+}


### PR DESCRIPTION
Round three of the component-decomposition work (#562 → #563 → #564): the next tier of the long-function backlog, all behavior-preserving.

## Per-component changes

- **`BookmarkPicker`** (245 → 83 lines): the input state machine (debounced search, add/remove/section mutations, paste-a-URL resolve-or-create) moved to a `useBookmarkPicker` hook; the five-state results panel became `BookmarkSearchDropdown`; the inline `BookmarkChip` got its own file. Stories pin the dropdown's five states and the chip with/without a seeded sections query.
- **`DailiesActiveListView`** (237 → 43 lines): the 181-line inline row callback became a named `DailyActiveRow` component — fallow scores nested lambdas separately and the clone detector can't see inline components, so this also makes future duplication detectable. Stories pin the row with and without history.
- **`RoutineTemplatesSection` + `CriteriaTemplatesSection`** (209/208 → 113/112 lines): the two settings sections were structural twins. Extracted `useTemplateSectionCrud` (list query, modal state, save/create/delete mutations with invalidate + close + toast) and the `TemplateListSection` shell; both sections now go through the `queryKeys` factory instead of inline key arrays. One deliberate exactness detail: the edit modals still open on `editingId !== null`, matching the originals.

## Verification

- `pnpm typecheck`, `pnpm lint` — clean (still zero max-dependencies warnings).
- Client Vitest 216 files / **690 tests** (was 678), middleware 81/81 — all pre-existing stories for the touched components pass unchanged.
- `fallow dead-code`: 0 issues, 0 circular dependencies (new barrels re-export leaves only).
- 4 new story files (12 story tests) covering every extracted component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST

---
_Generated by [Claude Code](https://claude.ai/code/session_0167tkmprjEKKPtSGvQEY6ST)_